### PR TITLE
Add type hints to toArray

### DIFF
--- a/src/datahike/btset.cljc
+++ b/src/datahike/btset.cljc
@@ -553,7 +553,7 @@
     (size        [_]      cnt)
     (isEmpty     [_]      (== 0 cnt))
     (toArray     [this]   (clojure.lang.RT/seqToArray (.seq this)))
-    (toArray     [this a] (clojure.lang.RT/seqToPassedArray (.seq this) a))
+    (^"[Ljava.lang.Object;" toArray [this ^"[Ljava.lang.Object;" a] (clojure.lang.RT/seqToPassedArray (.seq this) a))
 
     java.util.Set
     java.io.Serializable


### PR DESCRIPTION
Should fix missing type hint When used with Java 11 as shown in https://github.com/replikativ/datahike/issues/27#issuecomment-468812099