### PR TITLE
Compute rolling hash of datoms

### DIFF
--- a/src/datahike/core.cljc
+++ b/src/datahike/core.cljc
@@ -206,6 +206,7 @@
    - All operations on filtered database are proxied to original DB, then filter pred is applied.
    - Not cached. You pay filter penalty every time.
    - Supports entities, pull, queries, index access.
+   - Does not support hashing of DB.
    - Does not support [[with]] and [[db-with]]."
   [db pred]
   {:pre [(db/db? db)]}
@@ -213,8 +214,8 @@
     (let [^FilteredDB fdb db
           orig-pred (.-pred fdb)
           orig-db   (.-unfiltered-db fdb)]
-      (FilteredDB. orig-db #(and (orig-pred %) (pred orig-db %)) (atom 0)))
-    (FilteredDB. db #(pred db %) (atom 0))))
+      (FilteredDB. orig-db #(and (orig-pred %) (pred orig-db %))))
+    (FilteredDB. db #(pred db %))))
 
 
 ; Changing DB

--- a/test/datahike/test/db.cljc
+++ b/test/datahike/test/db.cljc
@@ -19,15 +19,6 @@
 (deftest test-defrecord-updatable
   (is (= 0xBEEF (-> (map->HashBeef {:x :ignored}) hash))))
 
-
-
-;; whitebox test to confirm that hash cache caches
-(deftest test-db-hash-cache
-  (let [db (db/empty-db)]
-    (is (= 0         @(.-hash db)))
-    (let [h (hash db)]
-      (is (= h @(.-hash db))))))
-
 (defn- now []
   #?(:clj  (System/currentTimeMillis)
      :cljs (.getTime (js/Date.))))
@@ -58,3 +49,9 @@
         r1 (d/db-with db [[:db.fn/retractEntity 1]])
         r2 (d/db-with db [[:db.fn/retractEntity 1]])]
     (is (= (hash r1) (hash r2)))))
+
+(deftest test-equiv-db-hash
+  (let [db (d/db-with (d/empty-db)
+                      [{:db/id 1 :name "Konrad"}])
+        r1 (d/db-with db [[:db.fn/retractEntity 1]])]
+    (is (= (hash (d/empty-db)) (hash r1)))))

--- a/test/datahike/test/filter.cljc
+++ b/test/datahike/test/filter.cljc
@@ -62,15 +62,7 @@
              (d/filter db remove-ivan)))
       (is (= empty-db
              (d/filter empty-db (constantly true))
-             (d/filter db (constantly false)))))
-
-    ;; TODO: fix hashing for equivalent functions, see https://github.com/replikativ/datahike/issues/38
-    #_(testing "hash"
-      (is (= (hash (d/db-with db [[:db.fn/retractEntity 2]]))
-             (hash (d/filter db remove-ivan))))
-      (is (= (hash empty-db)
-             (hash (d/filter empty-db (constantly true)))
-             (hash (d/filter db (constantly false)))))))
+             (d/filter db (constantly false))))))
   
   (testing "double filtering"
     (let [db       (d/db-with (d/empty-db {})


### PR DESCRIPTION
- Hashes form a commutative group under addition
- A datom hash is computed using EAV so on retraction we substract the hash
- Remove hashing support from `FilteredDB`