### PR TITLE
Support walking through entities

### DIFF
--- a/src/datahike/impl/entity.cljc
+++ b/src/datahike/impl/entity.cljc
@@ -130,7 +130,7 @@
        (containsKey [e k] (not= ::nf (lookup-entity e k ::nf)))
        (entryAt [e k]     (some->> (lookup-entity e k) (clojure.lang.MapEntry. k)))
 
-       (empty [e]         (throw (UnsupportedOperationException.)))
+       (empty [e]         {})
        (assoc [e k v]     (throw (UnsupportedOperationException.)))
        (cons  [e [k v]]   (throw (UnsupportedOperationException.)))
        (count [e]         (touch e) (count @(.-cache e)))

--- a/test/datahike/test/entity.cljc
+++ b/test/datahike/test/entity.cljc
@@ -91,3 +91,12 @@
     (is (= 777 (:db/id (d/entity db 777))))
     (is (thrown-msg? "Lookup ref attribute should be marked as :db/unique: [:not-an-attr 777]"
           (d/entity db [:not-an-attr 777])))))
+
+(deftest test-entity-walk
+  (let [ivan {:name "Ivan", :age 19, :aka #{"X" "Y"}}
+        db (-> (d/empty-db {:aka {:db/cardinality :db.cardinality/many}})
+               (d/db-with [(assoc ivan :db/id 1)]))
+        e  (d/entity db 1)]
+    (is (= (clojure.walk/walk identity identity e) ivan))
+    (is (= (clojure.walk/postwalk identity e) ivan))
+    (is (= (clojure.walk/prewalk identity e) ivan))))


### PR DESCRIPTION
From #59 

> also, possibly related, when i use (walk/postwalk identity entity) this throws an error. this is something that works in datomic.

I'm not sure why `empty` was not supported in entities, but is the only thing needed to enable the walking functions in the `clojure.walk` namespace IIUC.