### PR TITLE
Added a spec for db.type/number

### DIFF
--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -10,6 +10,7 @@
 (s/def :db.type/boolean boolean?)
 (s/def :db.type/double double?)
 (s/def :db.type/float float?)
+(s/def :db.type/number number?)
 (s/def :db.type/instant #(= (class %) java.util.Date))
 (s/def :db.type/keyword keyword?)
 (s/def :db.type/long #(= (class %) java.lang.Long))
@@ -24,6 +25,7 @@
     :db.type/boolean
     :db.type/double
     :db.type/float
+    :db.type/number
     :db.type/instant
     :db.type/keyword
     :db.type/long


### PR DESCRIPTION
As discussed on the #datahike slack channel, sometimes you expect number data but aren't sure whether it is going to be float or int. For that I added a spec db.type/number and added it to the spec db.type/value spec.