### PR TITLE
DynamoDB+S3 support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,14 +12,15 @@
                  [io.replikativ/hitchhiker-tree "0.1.5-SNAPSHOT"]
                  [io.replikativ/superv.async "0.2.9"]
                  [io.replikativ/konserve-leveldb "0.1.2" :scope "provided"]
-                 [io.lambdaforge/datalog-parser "0.1.0"]]
+                 [io.lambdaforge/datalog-parser "0.1.0"]
+                 [com.github.csm/konserve-ddb-s3 "0.1.1" :scope "provided"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]]
 
   :global-vars {*warn-on-reflection*   true
-                *print-namespace-maps* false
+                *print-namespace-maps* false}
 ;;     *unchecked-math* :warn-on-boxed
-                }
+
   :jvm-opts ["-Xmx2g" "-server"]
 
   :aliases {"test-clj"     ["run" "-m" "datahike.test/test-clj"]

--- a/src/datahike/ddb_s3_store.clj
+++ b/src/datahike/ddb_s3_store.clj
@@ -1,0 +1,53 @@
+(ns datahike.ddb-s3-store
+  (:require [datahike.config :refer [uri->config*]]
+            [datahike.store :refer [empty-store delete-store connect-store scheme->index release-store]]
+            [hitchhiker.tree.bootstrap.konserve :as kons]
+            [konserve-ddb-s3.core :as ddb-s3]
+            [superv.async :as sv]
+            [clojure.string :as string])
+  (:import [java.net URI]))
+
+(def ^:dynamic *ddb-client* nil)
+(def ^:dynamic *s3-client* nil)
+
+(defmethod uri->config* :ddb+s3
+  [{:keys [uri] :as config}]
+  (let [sub-uri (URI. (.getSchemeSpecificPart (URI. uri)))
+        region (.getHost sub-uri)
+        [table bucket database & etc] (->> (string/split (.getPath sub-uri) #"/")
+                                           (remove string/blank?))]
+    (when (or (nil? region) (nil? table) (nil? bucket) (not-empty etc))
+      (throw (ex-info "URI does not conform to ddb+s3 scheme" {:uri uri})))
+    (assoc config
+      :region region
+      :table table
+      :bucket bucket
+      :consistent-key #{:db}
+      :database (or database :datahike))))
+
+(defn merge-clients
+  [config]
+  (merge config
+         (when *ddb-client* {:ddb-client *ddb-client*})
+         (when *s3-client* {:s3-client *s3-client*})))
+
+(defmethod empty-store :ddb+s3
+  [config]
+  (kons/add-hitchhiker-tree-handlers
+    (sv/<?? sv/S (ddb-s3/empty-store (merge-clients config)))))
+
+(defmethod delete-store :ddb+s3
+  [config]
+  (sv/<?? sv/S (ddb-s3/delete-store (merge-clients config))))
+
+(defmethod connect-store :ddb+s3
+  [config]
+  (sv/<?? sv/S (ddb-s3/connect-store (merge-clients config))))
+
+(defmethod release-store :ddb+s3
+  [_ store]
+  (.close store))
+
+(defmethod scheme->index :ddb+s3
+  [_]
+  :datahike.index/hitchhiker-tree)


### PR DESCRIPTION
Via [konserve-ddb-s3](https://github.com/csm/konserve-ddb-s3), the `:db` key is stored in DynamoDB, and is atomically updated. All other keys are stored in S3.

This doesn't include some other changes I was trying out in datahike, namely always using an index node for the root of the tree, out of concerns for item size in DynamoDB. It might be necessary to use an index node for the root if the data node size is increased -- fewer, larger objects is generally better for S3 -- since there's a good chance that a large root data node will overflow the 400KB limit for items in DynamoDB.

* src/datahike/config.cljc (`::backend`): add `:ddb+s3`.
  (`::region`, `::table`, `::bucket`, `::database`): new specs.
  (`:datahike/config`): add `::region`, `::table`, `::bucket`, `::database`.
  (`uri->config*`): new multimethod, dispatch on `:backend`. Add default implementation.
  (`uri->config`): defer to `uri->config*`.
* src/datahike/ddb_s3_store.clj: new namespace.
* project.clj: add konserve-ddb-s3 dependency.