### PR TITLE
#133 postgres connection ssl

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -22,14 +22,17 @@ The sources are resolved in following order:
 That means passing a config as argument overwrites java system properties and using java system properties overwrite environment variables etc. Currently the configuration map looks like this per default:
 
 ```
-{:store {:backend  :mem     ;keyword
-         :username nil      ;string
-         :password nil      ;string
-         :path     nil      ;string
-         :host     nil      ;string
-         :port     nil}     ;int
- :schema-on-read   false    ;boolean
- :temporal-index   true}}   ;boolean
+{:store {:backend    :mem     ;keyword
+         :username   nil      ;string
+         :password   nil      ;string
+         :path       nil      ;string
+         :host       nil      ;string
+         :port       nil      ;int
+         :dbname     nil      ;string
+         :ssl        false    ;boolean
+         :sslfactory nil      ;string
+ :schema-on-read     false    ;boolean
+ :temporal-index     true}}   ;boolean
 ```
 
 Please refer to the documentation of the [environ library](https://github.com/weavejester/environ) on how to use it. When you want to pass a map to the configuration you can pass the above map or parts of it to the reload-config function in the datahike.config namespace like this:
@@ -54,6 +57,21 @@ datahike.temporal.index | DATAHIKE_TEMPORAL_INDEX
 etc.
 
 *Do not use `:` in the keyword strings, it will be added automatically.*
+
+Example configuration for connecting to postgresql locally with ssl:
+```
+{:store {:backend    :pg
+         :username   "datahike"
+         :password   "password"
+         :path       nil
+         :host       "localhost"
+         :port       5432
+         :dbname     "datahike"
+         :ssl        true
+         :sslfactory "org.postgresql.ssl.NonValidatingFactory"}
+ :schema-on-read     false
+ :temporal-index     true}}
+```
 
 ## Storage Backend
 

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -7,16 +7,19 @@
 (s/def ::backend #{:mem :file :level :pg})
 (s/def ::username (s/nilable string?))
 (s/def ::password (s/nilable string?))
-(s/def ::path (s/nilable string?))
 (s/def ::host (s/nilable string?))
 (s/def ::port (s/nilable int?))
+(s/def ::path (s/nilable string?))
+(s/def ::dbname (s/nilable string?))
+(s/def ::ssl (s/nilable boolean?))
+(s/def ::sslfactory (s/nilable string?))
 
 (s/def ::schema-on-read boolean?)
 (s/def ::temporal-index boolean?)
 (s/def ::index #{:datahike.index/hitchhiker-tree :datahike.index/persistent-set})
 
 (s/def :datahike/store (s/keys :req-un [::backend]
-                               :opt-un [::username ::password ::path ::host ::port]))
+                               :opt-un [::username ::password ::host ::port ::path ::dbname ::ssl ::sslfactory]))
 (s/def :datahike/config (s/keys :req-un [:datahike/store]
                                 :opt-un [::schema-on-read ::temporal-index]))
 
@@ -24,7 +27,7 @@
   :args (s/cat :config-str string?)
   :ret :datahike/config)
 
-(defrecord Store [backend username password path host port])
+(defrecord Store [backend username password path host port dbname ssl sslfactory])
 (defrecord Configuration [store schema-on-read temporal-index index])
 
 (defn int-from-env
@@ -63,14 +66,17 @@
   ([]
    (load-config nil))
   ([config-as-arg]
-   (let [config        (Configuration.
-                        (Store.
+   (let [config        (->Configuration
+                        (->Store
                          (keyword (:datahike-store-backend env :mem))
                          (:datahike-store-username env)
                          (:datahike-store-password env)
                          (:datahike-store-path env)
                          (:datahike-store-host env)
-                         (int-from-env :datahike-store-port nil))
+                         (int-from-env :datahike-store-port nil)
+                         (:datahike-store-dbname env)
+                         (bool-from-env :datahike-store-ssl false)
+                         (:datahike-store-sslfactory env))
                         (bool-from-env :datahike-schema-on-read false)
                         (bool-from-env :datahike-temporal-index true)
                         (keyword (bool-from-env :datahike-index :datahike.index/hitchhiker-tree)))

--- a/test/datahike/test/config.cljc
+++ b/test/datahike/test/config.cljc
@@ -15,9 +15,9 @@
   (is (bool-from-env :foo true)))
 
 (deftest deep-merge-test
-  (is (= (Configuration. (Store. :pg "foobar" nil "/tmp/testfoo" nil nil)
+  (is (= (->Configuration (->Store :pg "foobar" nil "/tmp/testfoo" nil nil nil nil nil)
                          true true :datahike.index/hitchhiker-tree)
-         (deep-merge (Configuration. (Store. :file nil nil "/tmp/testfoo" nil nil)
+         (deep-merge (->Configuration (->Store :file nil nil "/tmp/testfoo" nil nil nil nil nil)
                                      false true :datahike.index/hitchhiker-tree)
                      {:store {:backend :pg :username "foobar"}
                       :schema-on-read true}))))
@@ -45,13 +45,13 @@
 
 (deftest load-config-test
   (testing "Loading configuration defaults"
-    (is (= (Configuration. (Store. :mem nil nil nil nil nil)
+    (is (= (Configuration. (Store. :mem nil nil nil nil nil nil false nil)
                            false true :datahike.index/hitchhiker-tree)
            (reload-config)))))
 
 (deftest reload-config-test
   (testing "Reloading configuration"
-    (is (= (Configuration. (Store. :file nil nil "/tmp/testfoo" nil nil)
+    (is (= (Configuration. (Store. :file nil nil "/tmp/testfoo" nil nil nil false nil)
                            true true :datahike.index/hitchhiker-tree)
            (reload-config {:store {:backend :file
                                    :path "/tmp/testfoo"}


### PR DESCRIPTION
### Datahike now supports ssl-connections

Since PostgreSQL supports encrypted connections there is the
need to add this option to datahike as well. I added the
configuration and adapted the datahike-postgres
to the new options and the new configuration format.

seemed to make more sense to switch datahike-postgres
pass the configuration as map because konserve-pg is able
handle a map anyways. Converting a string to map to string
not seem reasonable so I switched the lib to use map as
without breaking the api.

- PR #6 in replikative/datahike-postgres
- Closes #133
