### PR TITLE
149 query does not support returning maps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,16 +11,16 @@
                  [environ "1.1.0"]
                  [io.replikativ/hitchhiker-tree "0.1.7"]
                  [io.replikativ/superv.async "0.2.9"]
-                 [io.lambdaforge/datalog-parser "0.1.3"]
+                 [io.lambdaforge/datalog-parser "0.1.5"]
                  [io.replikativ/zufall "0.1.0"]
                  [junit/junit "4.12"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]]
 
   :global-vars {*warn-on-reflection*   true
-                *print-namespace-maps* false
+                *print-namespace-maps* false}
 ;;     *unchecked-math* :warn-on-boxed
-                }
+
   :jvm-opts ["-Xmx2g" "-server"]
 
   :java-source-paths ["java/src"]


### PR DESCRIPTION
### Query now supports returning maps

Since mid 2019 Datomic supports returning maps and since Datahike
wants to map Datomics Query-API I added it. The most changes were
made on the datalog-parser:
lambdaforge/datalog-parser#9

The changes made to datahike are a function convert-to-return-maps
that takes a set and maps the given keys on its values and returns
a vector of the created maps. The changes made to the function q
are - besides formatting - a check if returnmaps are parsed and if
so calling aforemention function to convert the result.

Besides adding another parse-step and the check if there are
returnmaps parsed there should not be too much of a performance
impact as far as I can see it. The behaviour should now map
Datomics.

- Closes #149
- Depends on lambdaforge/datalog-parser#9

Thanks to vlaad for bringing this up