### PR TITLE
Implemented automated releases to Clojars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,37 +1,137 @@
-version: 2.0
-jobs:
-  build:
-    working_directory: ~/datahike
+version: 2.1
 
+executors:
+  leiningen:
     docker:
-      - image: circleci/clojure:lein-2.9.3
+      - image: circleci/clojure:openjdk-8-lein
+    environment:
+      LEIN_ROOT: nbd
+      JVM_OPTS: -Xmx3200m
+    working_directory: /home/circleci/datahike
+
+jobs:
+  setup:
+    executor: leiningen
+    steps:
+      - restore_cache:
+          keys:
+            - source-{{ .Branch }}-{{ .Revision }}
+            - source-{{ .Branch }}
+            - source-
+      - checkout
+      - save_cache:
+          key: source-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
+      - restore_cache:
+          keys:
+            - deps-{{ checksum "project.clj" }}
+            - deps-
+      - run: lein deps
+      - save_cache:
+          key: deps-{{ checksum "project.clj" }}
+          paths:
+            - /home/circleci/.m2
+            - /home/circleci/.lein
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - .m2
+            - datahike
+            - bin
+
+  unittest:
+    executor: leiningen
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Run Unittests
+          command: ./bin/run-unit-tests
+          no_output_timeout: 5m
+
+  integrationtest:
+    executor: leiningen
+    docker:
+      - image: mopedtobias/cimg:1.10
       - image: circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: alice
           POSTGRES_PASSWORD: foo
           POSTGRES_DB: config-test
-
-    filters:
-      branches:
-        only:
-          - master
-          - development
-
-    environment:
-      LEIN_ROOT: "true"
-      JVM_OPTS: -Xmx3200m
-
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - datahike-{{ checksum "project.clj" }}
-      - run: lein deps
-      - save_cache:
-          paths:
-            - ~/.m2
-            - ~/.lein
-          key: datahike-{{ checksum "project.clj" }}
-      - run: ./bin/run-unit-tests
-      - run: lein uberjar
-      - run: ./bin/run-integration-tests
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Run Integrationtests
+          command: ./bin/run-integration-tests
+          no_output_timeout: 5m
+
+  build:
+    executor: leiningen
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Build
+          command: lein uberjar
+          no_output_timeout: 5m
+
+  deploy-snapshot:
+    executor: leiningen
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          command: |
+            VERSION=$(head -n 1 project.clj | awk '{print $3}' | tr -d \")
+            if [[ ${VERSION} =~ .*-SNAPSHOT ]]; then
+                lein deploy clojars
+            else
+                exit 0
+            fi
+  deploy-release:
+    executor: leiningen
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Deploy Release to Clojars
+          command: |
+            VERSION=$(head -n 1 project.clj | awk '{print $3}' | tr -d \")
+            if [[ ${VERSION} =~ .*-SNAPSHOT ]]; then
+                exit 0
+            else
+                lein deploy clojars
+            fi
+workflows:
+  build_test_and_deploy:
+    jobs:
+      - setup
+      - unittest:
+          requires:
+            - setup
+      - integrationtest:
+          requires:
+            - setup
+      - build:
+          requires:
+            - setup
+      - deploy-snapshot:
+          filters:
+            branches:
+              only: development
+          requires:
+            - setup
+            - unittest
+            - integrationtest
+            - build
+      - deploy-release:
+          filters:
+            branches:
+              only: master
+          requires:
+            - setup
+            - unittest
+            - integrationtest
+            - build

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
     Datahike
 </h1>
 <p align="center">
-<a href="https://clojurians.slack.com/archives/CB7GJAN0L"><img src="https://img.shields.io/badge/clojurians%20slack-join%20channel-blueviolet"/></a> 
-<a href="https://gitter.im/replikativ/replikativ?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667" alt="Gitter" data-canonical-src="https://badges.gitter.im/Join%20Chat.svg" style="max-width:100%;"></a> 
-<a href="https://clojars.org/io.replikativ/datahike"> <img src="https://img.shields.io/clojars/v/io.replikativ/datahike.svg" /></a> 
+<a href="https://clojurians.slack.com/archives/CB7GJAN0L"><img src="https://img.shields.io/badge/clojurians%20slack-join%20channel-blueviolet"/></a>
+<a href="https://gitter.im/replikativ/replikativ?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667" alt="Gitter" data-canonical-src="https://badges.gitter.im/Join%20Chat.svg" style="max-width:100%;"></a>
+<a href="https://clojars.org/io.replikativ/datahike"> <img src="https://img.shields.io/clojars/v/io.replikativ/datahike.svg" /></a>
 <a href="https://circleci.com/gh/replikativ/datahike"><img src="https://circleci.com/gh/replikativ/datahike.svg?style=shield"/></a>
 <a href="https://github.com/replikativ/datahike/tree/development"><img src="https://img.shields.io/github/last-commit/replikativ/datahike/development"/></a>
+<a href="https://versions.deps.co/replikativ/datahike" title="Dependencies Status"><img src="https://versions.deps.co/replikativ/datahike/status.svg" /></a>
 </p>
 
 Datahike is a durable [Datalog](https://en.wikipedia.org/wiki/Datalog) database
@@ -114,6 +115,7 @@ Refer to the docs for more information:
 - [time variance](./doc/time_variance.md)
 - [differences from Datomic](./doc/datomic_differences.md)
 - [backend development](./doc/backend-development.md)
+- [releasing Datahike](./doc/release.md)
 
 For simple examples have a look at the projects in the `examples` folder.
 

--- a/bin/run-integration-tests
+++ b/bin/run-integration-tests
@@ -3,14 +3,23 @@
 set -o errexit
 set -o pipefail
 
-if [ -z ${CIRCLECI} ]; then
-    CONTAINER_NAME=$(docker run --detach --publish 5432:5432 --env POSTGRES_DB=config-test --env POSTGRES_USER=alice --env POSTGRES_PASSWORD=foo postgres:alpine)
-fi
+trap teardown EXIT
+
+function setup() {
+    if [ -z ${CIRCLECI} ]; then
+        echo $(docker run --detach --publish 5432:5432 --env POSTGRES_DB=config-test --env POSTGRES_USER=alice --env POSTGRES_PASSWORD=foo postgres:alpine)
+    fi
+}
+
+function teardown() {
+    if [ -z ${CIRCLECI} ]; then
+        docker rm -f ${CONTAINER_NAME}
+    fi
+}
+
+CONTAINER_NAME=$(setup)
 
 lein kaocha integration
 
 DATAHIKE_STORE_BACKEND=pg DATAHIKE_STORE_HOST=localhost DATAHIKE_STORE_PORT=5432 DATAHIKE_STORE_USER=alice DATAHIKE_STORE_PASSWORD=foo DATAHIKE_STORE_DBNAME=config-test lein kaocha integration --focus datahike.integration-test.config-record-test
 
-if [ -z ${CIRCLECI} ]; then
-    docker rm -f ${CONTAINER_NAME}
-fi

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,0 +1,61 @@
+# How to do a release for Datahike
+## SNAPSHOT
+To create a snapshot of Datahike and upload it to Clojars the version in
+`project.clj` needs to end on *-SNAPSHOT*. Snapshots can and will be overwritten
+if a snapshot with the current version is already present. There is no easy way
+to recognize that there is a new snapshot available on Clojars.
+
+A snapshot in Datahike is created by committing/merging on and pushing to the
+*development* branch. Then the snapshot gets validated. This means the version
+string from `project.clj` is extracted and it needs to end on *-SNAPSHOT* and
+the current branch needs to be *development*. Only then a snapshot gets released
+to Clojars.
+
+## Release
+To create a release of Datahike and upload it to Clojars the version in `project.clj`
+needs to be incremented at the respective position. Then you can commit and push the
+current version to GitHub. CircleCI will then unittest, integrationtest and build
+this version of Datahike. When this succeeds it releases the new version to Clojars
+only if the version string does *not* end on *-SNAPSHOT* and the current branch is
+*master*.
+
+The deploy to Clojars will fail if this version is already present on Clojars. It is
+not possible to overwrite a release, only snapshots can be overwritten.
+
+## CircleCI
+On CircleCI there will be run unittests, integrationtests, Datahike will be compiled and
+released. The official CircleCI jdk-8 image is used and the secret key to release to
+Clojars needs to be stored as an environment variable on CircleCI. There needs to be a
+variable `LEIN_USERNAME` set to your Clojars username and a variable `LEIN_PASSWORD` set
+to the password that permits to deploy on clojars.
+
+## Git tags
+It is nice to have git tags for releases, especially for non-snapshot releases. Therefor
+you can use following small hook that must be copied into the folder `.git/hooks/` as
+`post-commit` and a duplicate as `post-merge`. It creates annotated tags when committing
+on or merging into master.
+
+Snapshots should not be tagged because it might be necessary to publish multiple
+snapshots and then you would have to force-push them.
+
+```bash
+#!/bin/bash
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+REMOTE=$(git config --get remote.origin.url)
+TAG=$(head -n 1 project.clj | awk '{print $3}' | tr -d \")
+
+# tag current release
+if [[ ${BRANCH} == master ]] \
+    && [[ ${REMOTE} =~ "replikativ/datahike.git" ]] \
+    && [[ ! ${TAG} =~ "-SNAPSHOT" ]]; then
+    echo "tagging release ${TAG}"
+    git tag -a -m "${TAG}" ${TAG}
+fi
+```
+
+For this to work you need to set following option at the [appropriate level](https://www.git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_git_config):
+```
+git config push.followTags true
+```
+Only then the tag will be pushed without a second push with the `--tags` option.

--- a/project.clj
+++ b/project.clj
@@ -8,14 +8,14 @@
                  [org.clojure/clojurescript "1.10.597" :scope "provided"]
                  [persistent-sorted-set     "0.1.2"]
                  [org.clojure/tools.reader "1.3.2"]
-                 [environ "1.1.0"]
+                 [environ "1.2.0"]
                  [io.replikativ/hitchhiker-tree "0.1.7"]
                  [io.replikativ/superv.async "0.2.9"]
-                 [io.lambdaforge/datalog-parser "0.1.5"]
+                 [io.lambdaforge/datalog-parser "0.1.7"]
                  [io.replikativ/zufall "0.1.0"]
                  [junit/junit "4.12"]]
 
-  :plugins [[lein-cljsbuild "1.1.7"]]
+  :plugins [[lein-cljsbuild "1.1.8"]]
 
   :global-vars {*warn-on-reflection*   true
                 *print-namespace-maps* false}
@@ -98,4 +98,9 @@
 
   :clean-targets ^{:protect false} ["target"
                                     "release-js/datahike.bare.js"
-                                    "release-js/datahike.js"])
+                                    "release-js/datahike.js"]
+
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
+                                    :username :env
+                                    :password :env
+                                    :sign-releases false}]])


### PR DESCRIPTION
Since our goal is to release more often I implemented a first draft
to automate the releases. Releases are a very individual thing and
I tried to cover datahikes previous manual process as far as
possible. This means that a commit to development creates a release
if there is a SNAPSHOT-version specified in project.clj and a
commit to master creates a release if there is a non-SNAPSHOT-version
specified in project.clj.

Besides that there is some streamlining of the steps happening in
the usual testing and building procedure. Furthermore I introduced
the new workflow-feature of CircleCI and now the steps are able to
run concurrently. This seems to be quite a bit faster.

The decision is to keep it simple but avoiding manual work in the
future. Therefor I am sticking with CircleCI even if there are
other good options. Another decision is to continue keeping the
current version in project.clj. This has downsides since you can
not easily tag a commit with git and get a new release because you
would have to adjust the version manually in project.clj and tag
it. This is error prone.

Either tagging continues to be manually or it is solved with a
git hook. That way is described in doc/release.md. It is not the
nicest way to do it but I did not want to use a leiningen plugin
or upload a write-key to CircleCI. There should be sufficient
documentation in the release.md.

- Refers https://github.com/replikativ/datahike/issues/167