### PR TITLE
Create general Datahike JDBC backend

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [persistent-sorted-set     "0.1.2"]
                  [org.clojure/tools.reader "1.3.2"]
                  [environ "1.1.0"]
+                 [com.taoensso/timbre "4.10.0"]
                  [io.replikativ/hitchhiker-tree "0.1.7"]
                  [io.replikativ/superv.async "0.2.9"]
                  [io.lambdaforge/datalog-parser "0.1.5"]

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -3,6 +3,7 @@
             [clojure.spec.alpha :as s]
             [zufall.core :as z]
             [environ.core :refer [env]]
+            [taoensso.timbre :as log]
             [datahike.store :as ds])
   (:import [java.net URI]))
 
@@ -62,6 +63,11 @@
     (Boolean/parseBoolean (get env key default))
     (catch Exception _ default)))
 
+(defn map-from-env [key default]
+  (try
+    (edn/read-string (get env key (str default)))
+    (catch Exception _ default)))
+
 (defn deep-merge
   "Recursively merges maps and records."
   [& maps]
@@ -118,6 +124,7 @@
                  :schema-flexibility (keyword (:datahike-schema-flexibility env :write))
                  :index (keyword "datahike.index" (:datahike-index env "hitchhiker-tree"))}
          merged-config ((comp remove-nils deep-merge) config config-as-arg)
+         _             (log/info "Using config " merged-config)
          {:keys [keep-history? name schema-flexibility index initial-tx store]} merged-config
          config-spec (ds/config-spec store)]
      (when config-spec


### PR DESCRIPTION
This commit includes a helper function that reads a map
from environ. It works in the case of the integration
test of datahike-jdbc
https://github.com/replikativ/datahike-jdbc/blob/development/bin/run-integration-tests#L32

Furthermore I am introducing timbre for logging so that
we can now see via info level log message what configuration
we are loading. That is helpful for more complex use
cases in JDBC.

- Closes https://github.com/replikativ/datahike/issues/161
- Needs to be merged together with
  https://github.com/replikativ/datahike-jdbc/pull/1
- introduces timbre as dependency