### PR TITLE
Configure database name with environ

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -28,6 +28,7 @@ That means passing a config as argument overwrites java system properties and us
          :path     nil         ;string
          :host     nil         ;string
          :port     nil}        ;int
+ :name (generated)             ;string
  :schema-flexibility :write    ;keyword
  :keep-history?      true}}    ;boolean
 ```
@@ -40,6 +41,7 @@ datahike.store.backend      | DATAHIKE_STORE_BACKEND
 datahike.store.username     | DATAHIKE_STORE_USERNAME
 datahike.schema.flexibility | DATAHIKE_SCHEMA_FLEXIBILITY
 datahike.keep.history       | DATAHIKE_KEEP_HISTORY
+datahike.name               | DATAHIKE_NAME
 etc.
 
 *Do not use `:` in the keyword strings, it will be added automatically.*
@@ -92,6 +94,13 @@ At the moment we support two different backends from within Datahike: [in-memory
 - example: `{:store {:backend :pg :host "localhost" :port 5432 :username "alice" :password "foobar" :path "/pg_example"}}`
 - uri example: `datahike:pg://alice:foobar@localhost:5432/pg_example`
 
+## Name
+
+By default datahike generates a name for your database for you. If you want to set
+the name yourself just set a name for it in your config. It helps to specify the
+database you want to use, in case you are using multiple datahike databases in
+your application (to be seen in datahike-server).
+
 ## Schema Flexibility
 
 By default the datahike api uses a schema on `:write` approach with strict value
@@ -137,4 +146,3 @@ Starting from version `0.3.0` it is encouraged to use the new hashmap configurat
 - all backend configuration remains the same except for `:mem`
 - naming attribute for `:mem` backend is moved to `:id` from `:host` or `:path`
 - optional `clojure.spec` validation has been added
-

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -120,11 +120,11 @@
          config {:store store-config
                  :initial-tx (:datahike-intial-tx env)
                  :keep-history? (bool-from-env :datahike-keep-history true)
-                 :name (:name config-as-arg (z/rand-german-mammal))
+                 :name (:datahike-name env (z/rand-german-mammal))
                  :schema-flexibility (keyword (:datahike-schema-flexibility env :write))
                  :index (keyword "datahike.index" (:datahike-index env "hitchhiker-tree"))}
          merged-config ((comp remove-nils deep-merge) config config-as-arg)
-         _             (log/info "Using config " merged-config)
+         _             (log/debug "Using config " merged-config)
          {:keys [keep-history? name schema-flexibility index initial-tx store]} merged-config
          config-spec (ds/config-spec store)]
      (when config-spec


### PR DESCRIPTION
For a use case where there are multiple databases running like in
datahike-server there it is useful to have named databases to
specify the database you want to use in each operation. This
feature was added but there was no way to specify the names in
using environment or others, only via config file. I added the
option to use environ to specify names equal to the other config
values.

Besides that I set the logging of the config to debug-level
because it is logging each time the config is called for exists?,
 create and connect and each time maybe with a different name.
That is confusing when name is not set and I want it to not
confuse users. Documenation is adapted.

- Closes #217