### PR TITLE
Switched the type to store the entity id in a Datom from `int` to `long`

### DIFF
--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -10,7 +10,7 @@
   (datom-tx [this])
   (datom-added [this]))
 
-(deftype Datom #?(:clj  [^int e a v ^long tx ^:unsynchronized-mutable ^int _hash]
+(deftype Datom #?(:clj  [^long e a v ^long tx ^:unsynchronized-mutable ^int _hash]
                   :cljs [^number e a v ^number tx ^:mutable ^number _hash])
   IDatom
   (datom-tx [d] (if (pos? tx) tx (- tx)))
@@ -181,7 +181,7 @@
 
 (defn cmp-datoms-eavt [^Datom d1, ^Datom d2]
   (combine-cmp
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (cmp (.-a d1) (.-a d2))
     (cmp (.-v d1) (.-v d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
@@ -191,7 +191,7 @@
 (defn cmp-datoms-aevt [^Datom d1, ^Datom d2]
   (combine-cmp
     (cmp (.-a d1) (.-a d2))
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (cmp (.-v d1) (.-v d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
 
@@ -199,7 +199,7 @@
   (combine-cmp
     (cmp (.-a d1) (.-a d2))
     (cmp (.-v d1) (.-v d2))
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
 
 ;; fast versions without nil checks
@@ -215,7 +215,7 @@
 
 (defn cmp-datoms-eavt-quick [^Datom d1, ^Datom d2]
   (combine-cmp
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (cmp-attr-quick (.-a d1) (.-a d2))
     (compare (.-v d1) (.-v d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
@@ -223,7 +223,7 @@
 (defn cmp-datoms-aevt-quick [^Datom d1, ^Datom d2]
   (combine-cmp
     (cmp-attr-quick (.-a d1) (.-a d2))
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (compare (.-v d1) (.-v d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
 
@@ -231,7 +231,7 @@
   (combine-cmp
     (cmp-attr-quick (.-a d1) (.-a d2))
     (compare (.-v d1) (.-v d2))
-    (#?(:clj Integer/compare :cljs -) (.-e d1) (.-e d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
 
 (defn diff-sorted [a b cmp]


### PR DESCRIPTION
This will probably cause breakage for existing Datahike installations. Therefore this PR is only a starting point for a discussion, if this type switch is reasonable or not. The main reason for the switch is to be able to important existing Datomic data into Datahike.

I'm happy to do the other required tasks to avoid breakage or write a migration tool. But I would need some guidance to figure out what tasks are necessary :sweat_smile:

Closes #221 