### PR TITLE
Implement lazy sequence for transact

### DIFF
--- a/src/datahike/api.cljc
+++ b/src/datahike/api.cljc
@@ -84,87 +84,92 @@ Connect to a database with persistent store:
   delete-database
   dc/delete-database)
 
-(def ^{:arglists '([conn tx-data])
-       :doc      "Applies transaction the underlying database value and atomically updates connection reference to point to the result of that transaction, new db value.
-  Returns transaction report, a map:
+(def ^{:arglists '([conn arg-map])
+       :doc      "Applies transaction to the underlying database value and atomically updates the connection reference to point to the result of that transaction, the new db value.
 
-       { :db-before ...       ; db value before transaction
-         :db-after  ...       ; db value after transaction
-         :tx-data   [...]     ; plain datoms that were added/retracted from db-before
-         :tempids   {...}     ; map of tempid from tx-data => assigned entid in db-after
-         :tx-meta   tx-meta } ; the exact value you passed as `tx-meta`
+                  Accepts the connection and a map or a vector as argument, specifying the transaction data.
 
-  Note! `conn` will be updated in-place and is not returned from [[transact]].
-  
-  Usage:
+                  Returns transaction report, a map:
 
-      ; add a single datom to an existing entity (1)
-      (transact conn [[:db/add 1 :name \"Ivan\"]])
-  
-      ; retract a single datom
-      (transact conn [[:db/retract 1 :name \"Ivan\"]])
-  
-      ; retract single entity attribute
-      (transact conn [[:db.fn/retractAttribute 1 :name]])
-      
-      ; retract all entity attributes (effectively deletes entity)
-      (transact conn [[:db.fn/retractEntity 1]])
-  
-      ; create a new entity (`-1`, as any other negative value, is a tempid
-      ; that will be replaced with DataScript to a next unused eid)
-      (transact conn [[:db/add -1 :name \"Ivan\"]])
-  
-      ; check assigned id (here `*1` is a result returned from previous `transact` call)
-      (def report *1)
-      (:tempids report) ; => {-1 296}
-  
-      ; check actual datoms inserted
-      (:tx-data report) ; => [#datahike/Datom [296 :name \"Ivan\"]]
-  
-      ; tempid can also be a string
-      (transact conn [[:db/add \"ivan\" :name \"Ivan\"]])
-      (:tempids *1) ; => {\"ivan\" 297}
-  
-      ; reference another entity (must exist)
-      (transact conn [[:db/add -1 :friend 296]])
-  
-      ; create an entity and set multiple attributes (in a single transaction
-      ; equal tempids will be replaced with the same unused yet entid)
-      (transact conn [[:db/add -1 :name \"Ivan\"]
-                       [:db/add -1 :likes \"fries\"]
-                       [:db/add -1 :likes \"pizza\"]
-                       [:db/add -1 :friend 296]])
-  
-      ; create an entity and set multiple attributes (alternative map form)
-      (transact conn [{:db/id  -1
-                        :name   \"Ivan\"
-                        :likes  [\"fries\" \"pizza\"]
-                        :friend 296}])
-      
-      ; update an entity (alternative map form). Can’t retract attributes in
-      ; map form. For cardinality many attrs, value (fish in this example)
-      ; will be added to the list of existing values
-      (transact conn [{:db/id  296
-                        :name   \"Oleg\"
-                        :likes  [\"fish\"]}])
+                      {:db-before ...       ; db value before transaction
+                       :db-after  ...       ; db value after transaction
+                       :tx-data   [...]     ; plain datoms that were added/retracted from db-before
+                       :tempids   {...}     ; map of tempid from tx-data => assigned entid in db-after
+                       :tx-meta   tx-meta } ; the exact value you passed as `tx-meta`
 
-      ; ref attributes can be specified as nested map, that will create netsed entity as well
-      (transact conn [{:db/id  -1
-                        :name   \"Oleg\"
-                        :friend {:db/id -2
-                                 :name \"Sergey\"}])
-                                 
-      ; reverse attribute name can be used if you want created entity to become
-      ; a value in another entity reference
-      (transact conn [{:db/id  -1
-                        :name   \"Oleg\"
-                        :_friend 296}])
-      ; equivalent to
-      (transact conn [{:db/id  -1, :name   \"Oleg\"}
-                       {:db/id 296, :friend -1}])
-      ; equivalent to
-      (transact conn [[:db/add  -1 :name   \"Oleg\"]
-                       {:db/add 296 :friend -1]])"}
+                  Note! `conn` will be updated in-place and is not returned from [[transact]].
+
+                  Usage:
+
+                      ;; add a single datom to an existing entity (1)
+                      (transact conn {:tx-data [[:db/add 1 :name \"Ivan\"]]})
+
+                      ;; retract a single datom
+                      (transact conn {:tx-data [[:db/retract 1 :name \"Ivan\"]]})
+
+                      ;; retract single entity attribute
+                      (transact conn {:tx-data [[:db.fn/retractAttribute 1 :name]]})
+
+                      ;; retract all entity attributes (effectively deletes entity)
+                      (transact conn {:tx-data [[:db.fn/retractEntity 1]]})
+
+                      ;; create a new entity (`-1`, as any other negative value, is a tempid
+                      ;; that will be replaced with DataScript to a next unused eid)
+                      (transact conn {:tx-data [[:db/add -1 :name \"Ivan\"]]})
+
+                      ;; check assigned id (here `*1` is a result returned from previous `transact` call)
+                      (def report *1)
+                      (:tempids report) ; => {-1 296}
+
+                      ;; check actual datoms inserted
+                      (:tx-data report) ; => [#datahike/Datom [296 :name \"Ivan\"]]
+
+                      ;; tempid can also be a string
+                      (transact conn {:tx-data [[:db/add \"ivan\" :name \"Ivan\"]]})
+                      (:tempids *1) ; => {\"ivan\" 297}
+
+                      ;; reference another entity (must exist)
+                      (transact conn {:tx-data [[:db/add -1 :friend 296]]})
+
+                      ;; create an entity and set multiple attributes (in a single transaction
+                      ;; equal tempids will be replaced with the same unused yet entid)
+                      (transact conn {:tx-data [[:db/add -1 :name \"Ivan\"]
+                                                [:db/add -1 :likes \"fries\"]
+                                                [:db/add -1 :likes \"pizza\"]
+                                                [:db/add -1 :friend 296]]})
+
+                      ;; create an entity and set multiple attributes (alternative map form)
+                      (transact conn {:tx-data [{:db/id  -1
+                                                 :name   \"Ivan\"
+                                                 :likes  [\"fries\" \"pizza\"]
+                                                 :friend 296}]})
+
+                      ;; update an entity (alternative map form). Can’t retract attributes in
+                      ;; map form. For cardinality many attrs, value (fish in this example)
+                      ;; will be added to the list of existing values
+                      (transact conn {:tx-data [{:db/id  296
+                                                 :name   \"Oleg\"
+                                                 :likes  [\"fish\"]}]})
+
+                      ;; ref attributes can be specified as nested map, that will create a nested entity as well
+                      (transact conn {:tx-data [{:db/id  -1
+                                                 :name   \"Oleg\"
+                                                 :friend {:db/id -2
+                                                 :name \"Sergey\"}}]})
+
+                      ;; schema is needed for using a reverse attribute
+                      (is (transact conn {:tx-data [{:db/valueType :db.type/ref
+                                                     :db/cardinality :db.cardinality/one
+                                                     :db/ident :friend}]}))
+
+                      ;; reverse attribute name can be used if you want a created entity to become
+                      ;; a value in another entity reference
+                      (transact conn {:tx-data [{:db/id  -1
+                                                 :name   \"Oleg\"
+                                                 :_friend 296}]})
+                      ;; equivalent to
+                      (transact conn {:tx-data [{:db/add  -1 :name   \"Oleg\"}
+                                                {:db/add 296 :friend -1]}])"}
   transact
   dc/transact)
 

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -16,15 +16,6 @@
 
 (s/def ::connection #(instance? clojure.lang.Atom %))
 
-(defmulti transact!
-  "Transacts new data to database"
-  {:arglists '([conn tx-data])}
-  (fn [conn tx-data] (type tx-data)))
-
-(defmethod transact! clojure.lang.PersistentVector
-  [connection tx-data]
-  (transact! connection {:tx-data tx-data}))
-
 (defn update-and-flush-db [connection tx-data update-fn]
   (let [{:keys [db-after] :as tx-report} @(update-fn connection tx-data)
         {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema config max-tx hash]} db-after
@@ -60,19 +51,27 @@
                               :temporal-avet temporal-avet-flushed))
     tx-report))
 
-(defmethod transact! clojure.lang.IPersistentMap
+(defn transact!
   [connection {:keys [tx-data]}]
   {:pre [(d/conn? connection)]}
   (future
     (locking connection
       (update-and-flush-db connection tx-data d/transact))))
 
-(defn transact [connection tx-data]
-  (try
-    (deref (transact! connection tx-data))
-    (catch Exception e
-      (log/errorf "Error during transaction %s" (.getMessage e))
-      (throw (.getCause e)))))
+(defn transact [connection arg-map]
+  (let [arg (cond
+              (and (map? arg-map) (contains? arg-map :tx-data)) arg-map
+              (vector? arg-map) {:tx-data arg-map}
+              (seq? arg-map) {:tx-data arg-map}
+              :else (dt/raise "Bad argument to transact, expected map with :tx-data as key.
+                               Vector and sequence are allowed as argument but deprecated."
+                              {:error :transact/syntax :argument arg-map}))
+        _ (log/debugf "Transacting with arguments: " arg)]
+    (try
+      (deref (transact! connection arg))
+      (catch Exception e
+        (log/errorf "Error during transaction %s" (.getMessage e))
+        (throw (.getCause e))))))
 
 (defn load-entities [connection entities]
   (future

--- a/test/datahike/test/api.cljc
+++ b/test/datahike/test/api.cljc
@@ -5,6 +5,105 @@
    [datahike.test.core]
    [datahike.api :as d]))
 
+(deftest test-transact-query-docs
+  (let [cfg {:store {:backend :mem
+                     :id "hashing"}
+             :keep-history? false
+             :schema-flexibility :read}
+        _ (d/delete-database cfg)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    ;;;;;;;;;;;;;;;;;;;;;;;;;
+    ;; TESTING TRANSACT API
+    ;; add a single datom to an existing entity (1)
+    (is (d/transact conn {:tx-data [[:db/add 1 :name "Ivan"]]}))
+
+    ;; retract a single datom
+    (is (d/transact conn {:tx-data [[:db/retract 1 :name "Ivan"]]}))
+
+    ;; retract single entity attribute
+    (is (d/transact conn {:tx-data [[:db.fn/retractAttribute 1 :name]]}))
+
+    ;; retract all entity attributes (effectively deletes entity)
+    (is (d/transact conn {:tx-data [[:db.fn/retractEntity 1]]}))
+
+    ;; create a new entity (`-1`, as any other negative value, is a tempid
+    ;; that will be replaced with DataScript to a next unused eid)
+    (is (d/transact conn {:tx-data [[:db/add -1 :name "Ivan"]]}))
+
+    ;; check assigned id (here `*1` is a result returned from previous `transact` call)
+    (def report *1)
+    (:tempids report) ; => {-1 296}
+
+    ;; check actual datoms inserted
+    (:tx-data report) ; => [#datahike/Datom [296 :name "Ivan"]]
+
+    ;; tempid can also be a string
+    (is (d/transact conn {:tx-data [[:db/add "ivan" :name "Ivan"]]}))
+    (:tempids *1) ; => {"ivan" 297}
+
+    ;; reference another entity (must exist)
+    (is (d/transact conn {:tx-data [[:db/add -1 :friend 296]]}))
+
+    ;; create an entity and set multiple attributes (in a single transaction
+    ;; equal tempids will be replaced with the same unused yet entid)
+    (is (d/transact conn {:tx-data [[:db/add -1 :name "Ivan"]
+                                    [:db/add -1 :likes "fries"]
+                                    [:db/add -1 :likes "pizza"]
+                                    [:db/add -1 :friend 296]]}))
+
+    ;; create an entity and set multiple attributes (alternative map form)
+    (is (d/transact conn {:tx-data [{:db/id  -1
+                                     :name   "Ivan"
+                                     :likes  ["fries" "pizza"]
+                                     :friend 296}]}))
+
+    ;; update an entity (alternative map form). Can’t retract attributes in
+    ;; map form. For cardinality many attrs, value (fish in this example)
+    ;; will be added to the list of existing values
+    (is (d/transact conn {:tx-data [{:db/id  296
+                                     :name   "Oleg"
+                                     :likes  ["fish"]}]}))
+
+    ;; ref attributes can be specified as nested map, that will create netsed entity as well
+    (is (d/transact conn {:tx-data [{:db/id  -1
+                                     :name   "Oleg"
+                                     :friend {:db/id -2
+                                              :name "Sergey"}}]}))
+
+    ;; schema is needed for using a reverse attribute
+    (is (d/transact conn {:tx-data [{:db/valueType :db.type/ref
+                                     :db/cardinality :db.cardinality/one
+                                     :db/ident :friend}]}))
+
+    ;; reverse attribute name can be used if you want created entity to become
+    ;; a value in another entity reference
+    (is (d/transact conn {:tx-data [{:db/id  -1
+                                     :name   "Oleg"
+                                     :_friend 296}]}))
+
+    ;; equivalent to
+    (is (d/transact conn {:tx-data [{:db/id  -1, :name   "Oleg"}
+                                    {:db/id 296, :friend -1}]}))
+
+    ;; deprecated api
+    (is (d/transact conn [[:db/add -1 :name "Oleg"]
+                          [:db/add -1 :likes "pie"]
+                          [:db/add -1 :likes "dates"]
+                          [:db/add -1 :friend 297]]))
+
+    ;; lazy sequence
+    (is (d/transact conn (take 4 [[:db/add -1 :name "Oleg"]
+                                  [:db/add -1 :likes "pie"]
+                                  [:db/add -1 :likes "dates"]
+                                  [:db/add -1 :friend 297]])))
+
+    ;; incorrect arguments
+    (is (thrown? clojure.lang.ExceptionInfo (d/transact conn nil)))
+    (is (thrown? clojure.lang.ExceptionInfo (d/transact conn :foo)))
+    (is (thrown? clojure.lang.ExceptionInfo (d/transact conn 1)))
+    (is (thrown? clojure.lang.ExceptionInfo (d/transact conn {:foo "bar"})))))
+
 (deftest test-database-hash
   (testing "Hashing without history"
     (let [cfg {:store {:backend :mem


### PR DESCRIPTION
The actual implementation is not complex since one can just feed
a sequence to Datahike. It was just a matter of accepting this.
The connector namespace is now a bit slimmer since I abstained
from using a multimethod. Instead I am checking the input data
in a simple cond.

Adapted the api documentation to match Datomic so only a map with
:tx-data as a key is allowed. Passing a vector or sequence is
still working but not documented anymore. The examples from the
documentation are added to the test.api namespace for testing if
our API works.

- Refers #196
- Closes #151