### PR TITLE
Move config log and avoid password logging

### DIFF
--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -124,7 +124,6 @@
                  :schema-flexibility (keyword (:datahike-schema-flexibility env :write))
                  :index (keyword "datahike.index" (:datahike-index env "hitchhiker-tree"))}
          merged-config ((comp remove-nils deep-merge) config config-as-arg)
-         _             (log/debug "Using config " merged-config)
          {:keys [keep-history? name schema-flexibility index initial-tx store]} merged-config
          config-spec (ds/config-spec store)]
      (when config-spec

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -67,7 +67,7 @@
               :else (dt/raise "Bad argument to transact, expected map with :tx-data as key.
                                Vector and sequence are allowed as argument but deprecated."
                               {:error :transact/syntax :argument arg-map}))
-        _ (log/debugf "Transacting with arguments: " arg)]
+        _ (log/error "Transacting with arguments: " arg)]
     (try
       (deref (transact! connection arg))
       (catch Exception e

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -123,6 +123,7 @@
 
   (-connect [config]
     (let [config (dc/load-config config)
+          _ (log/debug "Using config " (update-in config [:store] dissoc :password))
           store-config (:store config)
           raw-store (ds/connect-store store-config)
           _ (when-not raw-store


### PR DESCRIPTION
- Move the log because it gets logged multiple times currently
- JDBC requires password configuration and this should not be logged
- Closes #263