### PR TITLE
Fix cljdoc documentation

### DIFF
--- a/bin/run-cljdoc-preview
+++ b/bin/run-cljdoc-preview
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+rm -rf /tmp/cljdoc
+mkdir -p /tmp/cljdoc
+version=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)
+
+clj -A:build
+clj -A:install
+
+echo "---- cljdoc preview: ingesting datahike"
+docker run --rm
+       --volume "$PWD:/repo-to-import" \
+       --volume "$HOME/.m2:/root/.m2" \
+       --volume /tmp/cljdoc:/app/data \
+       --entrypoint "clojure" \
+       cljdoc/cljdoc
+       -A:cli ingest -p io.replikativ/datahike -v "$version" --git /repo-to-import
+
+echo "---- cljdoc preview: starting server on port 8000"
+docker run --rm -p 8000:8000 -v /tmp/cljdoc:/app/data cljdoc/cljdoc

--- a/deps.edn
+++ b/deps.edn
@@ -42,8 +42,11 @@
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}
 
-           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "0.0.9"}}
+           :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.1.0"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy" "replikativ-datahike.jar"]}
+
+           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.1.0"}}
+                     :main-opts ["-m" "deps-deploy.deps-deploy" "install" "replikativ-datahike.jar"]}
 
            :build {:extra-deps {seancorfield/depstar {:mvn/version "1.1.116"}}
                    :main-opts ["-m" "hf.depstar.jar" "replikativ-datahike.jar"]}

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,10 @@
     </license>
   </licenses>
   <scm>
-    <tag>c67c37eb13f55b5ef514749b56bd5bddd1475b2b</tag>
+    <connection>scm:git:git@github.com:replikativ/datahike.git</connection>
+    <developerConnection>scm:git:git@git@github.com/replikativ/datahike.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>git@github.com:replikativ/datahike</url>
   </scm>
   <properties>
     <java.version>1.8</java.version>

--- a/src/datahike/api.cljc
+++ b/src/datahike/api.cljc
@@ -294,37 +294,37 @@
                         Find all datoms for entity id == 1 (any attrs and values) sort by attribute, then value
 
                             (datoms @db {:index :eavt
-                                        :components [1]}) ; => (#datahike/Datom [1 :friends 2]
-                                                                #datahike/Datom [1 :likes \"fries\"]
-                                                                #datahike/Datom [1 :likes \"pizza\"]
-                                                                #datahike/Datom [1 :name \"Ivan\"])
+                                         :components [1]}) ; => (#datahike/Datom [1 :friends 2]
+                                                           ;     #datahike/Datom [1 :likes \"fries\"]
+                                                           ;     #datahike/Datom [1 :likes \"pizza\"]
+                                                           ;     #datahike/Datom [1 :name \"Ivan\"])
 
                         Find all datoms for entity id == 1 and attribute == :likes (any values) sorted by value
 
                             (datoms @db {:index :eavt
-                                        :components [1 :likes]}) ; => (#datahike/Datom [1 :likes \"fries\"]
-                                                                     #datahike/Datom [1 :likes \"pizza\"])
+                                         :components [1 :likes]}) ; => (#datahike/Datom [1 :likes \"fries\"]
+                                                                  ;     #datahike/Datom [1 :likes \"pizza\"])
 
                         Find all datoms for entity id == 1, attribute == :likes and value == \"pizza\"
 
                             (datoms @db {:index :eavt
-                                        :components [1 :likes \"pizza\"]}) ; => (#datahike/Datom [1 :likes \"pizza\"])
+                                         :components [1 :likes \"pizza\"]}) ; => (#datahike/Datom [1 :likes \"pizza\"])
 
                         Find all datoms for attribute == :likes (any entity ids and values) sorted by entity id, then value
 
                             (datoms @db {:index :aevt
-                                        :components [:likes]}) ; => (#datahike/Datom [1 :likes \"fries\"]
-                                                                     #datahike/Datom [1 :likes \"pizza\"]
-                                                                     #datahike/Datom [2 :likes \"candy\"]
-                                                                     #datahike/Datom [2 :likes \"pie\"]
-                                                                     #datahike/Datom [2 :likes \"pizza\"])
+                                         :components [:likes]}) ; => (#datahike/Datom [1 :likes \"fries\"]
+                                                                ;     #datahike/Datom [1 :likes \"pizza\"]
+                                                                ;     #datahike/Datom [2 :likes \"candy\"]
+                                                                ;     #datahike/Datom [2 :likes \"pie\"]
+                                                                ;     #datahike/Datom [2 :likes \"pizza\"])
 
                         Find all datoms that have attribute == `:likes` and value == `\"pizza\"` (any entity id)
                         `:likes` must be a unique attr, reference or marked as `:db/index true`
 
                             (datoms @db {:index :avet
-                                        :components [:likes \"pizza\"]}) ; => (#datahike/Datom [1 :likes \"pizza\"]
-                                                                               #datahike/Datom [2 :likes \"pizza\"])
+                                         :components [:likes \"pizza\"]}) ; => (#datahike/Datom [1 :likes \"pizza\"]
+                                                                          ;     #datahike/Datom [2 :likes \"pizza\"])
 
                         Find all datoms sorted by entity id, then attribute, then value
 
@@ -336,38 +336,38 @@
                         Get all values of :db.cardinality/many attribute
 
                             (->> (datoms @db {:index :eavt
-                                             :components [eid attr]})
+                                              :components [eid attr]})
                                  (map :v))
 
                         Lookup entity ids by attribute value
 
                             (->> (datoms @db {:index :avet
-                                             :components [attr value]})
+                                              :components [attr value]})
                                  (map :e))
 
                         Find all entities with a specific attribute
 
                             (->> (datoms @db {:index :aevt
-                                             :components [attr]})
+                                              :components [attr]})
                                  (map :e))
 
                         Find “singleton” entity by its attr
 
                             (->> (datoms @db {:index :aevt
-                                             :components [attr]})
+                                              :components [attr]})
                                  first
                                  :e)
 
                         Find N entities with lowest attr value (e.g. 10 earliest posts)
 
                             (->> (datoms @db {:index :avet
-                                             :components [attr]})
+                                              :components [attr]})
                                  (take N))
 
                         Find N entities with highest attr value (e.g. 10 latest posts)
 
                             (->> (datoms @db {:index :avet
-                                             :components [attr]})
+                                              :components [attr]})
                                  (reverse)
                                  (take N))
 
@@ -408,29 +408,29 @@
 
                                  (seek-datoms @db {:index :eavt
                                                    :components [1]}) ; => (#datahike/Datom [1 :friends 2]
-                                                                           #datahike/Datom [1 :likes \"fries\"]
-                                                                           #datahike/Datom [1 :likes \"pizza\"]
-                                                                           #datahike/Datom [1 :name \"Ivan\"]
-                                                                           #datahike/Datom [2 :likes \"candy\"]
-                                                                           #datahike/Datom [2 :likes \"pie\"]
-                                                                           #datahike/Datom [2 :likes \"pizza\"])
+                                                                     ;     #datahike/Datom [1 :likes \"fries\"]
+                                                                     ;     #datahike/Datom [1 :likes \"pizza\"]
+                                                                     ;     #datahike/Datom [1 :name \"Ivan\"]
+                                                                     ;     #datahike/Datom [2 :likes \"candy\"]
+                                                                     ;     #datahike/Datom [2 :likes \"pie\"]
+                                                                     ;     #datahike/Datom [2 :likes \"pizza\"])
 
                                  (seek-datoms @db {:index :eavt
                                                    :components [1 :name]}) ; => (#datahike/Datom [1 :name \"Ivan\"]
-                                                                                 #datahike/Datom [2 :likes \"candy\"]
-                                                                                 #datahike/Datom [2 :likes \"pie\"]
-                                                                                 #datahike/Datom [2 :likes \"pizza\"])
+                                                                           ;     #datahike/Datom [2 :likes \"candy\"]
+                                                                           ;     #datahike/Datom [2 :likes \"pie\"]
+                                                                           ;     #datahike/Datom [2 :likes \"pizza\"])
 
                                  (seek-datoms @db {:index :eavt
                                                    :components [2]}) ; => (#datahike/Datom [2 :likes \"candy\"]
-                                                                           #datahike/Datom [2 :likes \"pie\"]
-                                                                           #datahike/Datom [2 :likes \"pizza\"])
+                                                                     ;     #datahike/Datom [2 :likes \"pie\"]
+                                                                     ;     #datahike/Datom [2 :likes \"pizza\"])
 
                              No datom `[2 :likes \"fish\"]`, so starts with one immediately following such in index
 
                                  (seek-datoms @db {:index :eavt
                                                    :components [2 :likes \"fish\"]}) ; => (#datahike/Datom [2 :likes \"pie\"]
-                                                                                           #datahike/Datom [2 :likes \"pizza\"])"}
+                                                                                     ;     #datahike/Datom [2 :likes \"pizza\"])"}
   (fn
     ([db arg-map]
      (type arg-map))
@@ -545,17 +545,17 @@
              Accepts tx-data and tx-meta as a map.
 
                  (with @conn {:tx-data [[:db/add 1 :name \"Ivan\"]]}) ; => {:db-before #datahike/DB {:max-tx 536870912 :max-eid 0},
-                                                                            :db-after #datahike/DB {:max-tx 536870913 :max-eid 1},
-                                                                            :tx-data [#datahike/Datom [1 :name \"Ivan\" 536870913]],
-                                                                            :tempids #:db{:current-tx 536870913},
-                                                                            :tx-meta nil}
+                                                                      ;     :db-after #datahike/DB {:max-tx 536870913 :max-eid 1},
+                                                                      ;     :tx-data [#datahike/Datom [1 :name \"Ivan\" 536870913]],
+                                                                      ;     :tempids #:db{:current-tx 536870913},
+                                                                      ;     :tx-meta nil}
 
                  (with @conn {:tx-data [[:db/add 1 :name \"Ivan\"]]
                               :tx-meta {:foo :bar}}) ; => {:db-before #datahike/DB {:max-tx 536870912 :max-eid 0},
-                                                           :db-after #datahike/DB {:max-tx 536870913 :max-eid 1},
-                                                           :tx-data [#datahike/Datom [1 :name \"Ivan\" 536870913]],
-                                                           :tempids #:db{:current-tx 536870913},
-                                                           :tx-meta {:foo :bar}}"}
+                                                     ;     :db-after #datahike/DB {:max-tx 536870913 :max-eid 1},
+                                                     ;     :tx-data [#datahike/Datom [1 :name \"Ivan\" 536870913]],
+                                                     ;     :tempids #:db{:current-tx 536870913},
+                                                     ;     :tx-meta {:foo :bar}}"}
   with
   (fn
     ([db arg-map]
@@ -579,71 +579,9 @@
   [conn]
   @conn)
 
-(def ^{:arglists '([db])
-       :doc "Returns the full historical state of the database you may interact with.
-
-
-                 (transact conn {:tx-data [{:db/ident :name
-                                            :db/valueType :db.type/string
-                                            :db/unique :db.unique/identity
-                                            :db/index true
-                                            :db/cardinality :db.cardinality/one}
-                                           {:db/ident :age
-                                            :db/valueType :db.type/long
-                                            :db/cardinality :db.cardinality/one}]})
-
-                 (transact conn {:tx-data [{:name \"Alice\" :age 25} {:name \"Bob\" :age 30}]})
-
-                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
-                     :args [(history @conn)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}
-
-                 (transact conn {:tx-data [{:db/id [:name \"Alice\"] :age 35}]})
-
-                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
-                     :args [@conn]}) ; => #{[\"Alice\" 35] [\"Bob\" 30]}
-
-                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
-                       :args [(history @conn)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}"}
-  history
-  (fn [db]
-    (if (db/-temporal-index? db)
-      (HistoricalDB. db)
-      (throw (ex-info "history is only allowed on temporal indexed databases." {:config (db/-config db)})))))
-
 (defn- ^:no-doc date? [d]
   #?(:cljs (instance? js/Date d)
      :clj  (instance? Date d)))
-
-(def ^{:arglists '([db time-point])
-       :doc "Returns the database state at given point in time (you may use either java.util.Date or transaction ID as long).
-
-
-                 (transact conn {:tx-data [{:db/ident :name
-                                            :db/valueType :db.type/string
-                                            :db/unique :db.unique/identity
-                                            :db/index true
-                                            :db/cardinality :db.cardinality/one}
-                                           {:db/ident :age
-                                            :db/valueType :db.type/long
-                                            :db/cardinality :db.cardinality/one}]})
-
-                 (transact conn {:tx-data [{:name \"Alice\" :age 25} {:name \"Bob\" :age 30}]})
-
-                 (def date (java.util.Date.))
-
-                 (transact conn {:tx-data [{:db/id [:name \"Alice\"] :age 35}]})
-
-                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
-                     :args [(as-of @conn date)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}
-
-                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
-                     :args [@conn]}) ; => #{[\"Alice\" 35] [\"Bob\" 30]}"}
-  as-of
-  (fn [db time-point]
-    {:pre [(or (int? time-point) (date? time-point))]}
-    (if (db/-temporal-index? db)
-      (AsOfDB. db time-point)
-      (throw (ex-info "as-of is only allowed on temporal indexed databases." {:config (db/-config db)})))))
 
 (def ^{:arglists '([db time-point])
        :doc "Returns the database state since a given point in time (you may use either java.util.Date or a transaction ID as long).
@@ -682,6 +620,68 @@
       (SinceDB. db time-point)
       (throw (ex-info "since is only allowed on temporal indexed databases." {:config (db/-config db)})))))
 
+(def ^{:arglists '([db time-point])
+       :doc "Returns the database state at given point in time (you may use either java.util.Date or transaction ID as long).
+
+
+                 (transact conn {:tx-data [{:db/ident :name
+                                            :db/valueType :db.type/string
+                                            :db/unique :db.unique/identity
+                                            :db/index true
+                                            :db/cardinality :db.cardinality/one}
+                                           {:db/ident :age
+                                            :db/valueType :db.type/long
+                                            :db/cardinality :db.cardinality/one}]})
+
+                 (transact conn {:tx-data [{:name \"Alice\" :age 25} {:name \"Bob\" :age 30}]})
+
+                 (def date (java.util.Date.))
+
+                 (transact conn {:tx-data [{:db/id [:name \"Alice\"] :age 35}]})
+
+                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
+                     :args [(as-of @conn date)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}
+
+                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
+                     :args [@conn]}) ; => #{[\"Alice\" 35] [\"Bob\" 30]}"}
+  as-of
+  (fn [db time-point]
+    {:pre [(or (int? time-point) (date? time-point))]}
+    (if (db/-temporal-index? db)
+      (AsOfDB. db time-point)
+      (throw (ex-info "as-of is only allowed on temporal indexed databases." {:config (db/-config db)})))))
+
+(def ^{:arglists '([db])
+       :doc "Returns the full historical state of the database you may interact with.
+
+
+                 (transact conn {:tx-data [{:db/ident :name
+                                            :db/valueType :db.type/string
+                                            :db/unique :db.unique/identity
+                                            :db/index true
+                                            :db/cardinality :db.cardinality/one}
+                                           {:db/ident :age
+                                            :db/valueType :db.type/long
+                                            :db/cardinality :db.cardinality/one}]})
+
+                 (transact conn {:tx-data [{:name \"Alice\" :age 25} {:name \"Bob\" :age 30}]})
+
+                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
+                     :args [(history @conn)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}
+
+                 (transact conn {:tx-data [{:db/id [:name \"Alice\"] :age 35}]})
+
+                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
+                     :args [@conn]}) ; => #{[\"Alice\" 35] [\"Bob\" 30]}
+
+                 (q {:query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]
+                       :args [(history @conn)]}) ; => #{[\"Alice\" 25] [\"Bob\" 30]}"}
+  history
+  (fn [db]
+    (if (db/-temporal-index? db)
+      (HistoricalDB. db)
+      (throw (ex-info "history is only allowed on temporal indexed databases." {:config (db/-config db)})))))
+
 (def ^{:arglists '([db arg-map])
        :doc "Returns part of `:avet` index between `[_ attr start]` and `[_ attr end]` in AVET sort order.
 
@@ -715,15 +715,15 @@
                  (index-range db {:attrid :likes
                                   :start  \"a\"
                                   :end    \"zzzzzzzzz\"}) ; => '(#datahike/Datom [2 :likes \"candy\"]
-                                                                 #datahike/Datom [1 :likes \"fries\"]
-                                                                 #datahike/Datom [2 :likes \"pie\"]
-                                                                 #datahike/Datom [1 :likes \"pizza\"]
-                                                                 #datahike/Datom [2 :likes \"pizza\"])
+                                                          ;      #datahike/Datom [1 :likes \"fries\"]
+                                                          ;      #datahike/Datom [2 :likes \"pie\"]
+                                                          ;      #datahike/Datom [1 :likes \"pizza\"]
+                                                          ;      #datahike/Datom [2 :likes \"pizza\"])
 
                  (index-range db {:attrid :likes
                                   :start  \"egg\"
                                   :end    \"pineapple\"}) ; => '(#datahike/Datom [1 :likes \"fries\"]
-                                                                 #datahike/Datom [2 :likes \"pie\"])
+                                                          ;      #datahike/Datom [2 :likes \"pie\"])
 
              Useful patterns:
 

--- a/src/datahike/index/hitchhiker_tree/upsert.cljc
+++ b/src/datahike/index/hitchhiker_tree/upsert.cljc
@@ -1,4 +1,4 @@
-(ns datahike.index.hitchhiker-tree.upsert
+(ns ^:no-doc datahike.index.hitchhiker-tree.upsert
   (:require [hitchhiker.tree :as tree]
             [hitchhiker.tree.op :as op]))
 


### PR DESCRIPTION
The documentation on cljdoc is broken because of multiple things

1. We switched to Clojure CLI tools and did not yet provide a
   backlink to the SCM repository so cljdoc can not get docs
   out of it.
2. Some parts of the api namespace do not render correctly.
3. A no doc tag is missing in a newly added namespace.