### PR TITLE
Allow `:db/retract` to be used without specifying a value (Fix #241)

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1758,13 +1758,13 @@
 
               (= op :db/retract)
               (if-some [e (entid db e)]
-                (let [v (if (ref? db a) (entid-strict db v) v)]
-                  (validate-attr a entity db)
-                  (validate-val v entity db)
-                  (if-some [old-datom (first (-search db [e a v]))]
-                    (recur (transact-retract-datom report old-datom) entities)
-                    (recur report
-                           entities)))
+                (let [_ (validate-attr a entity db)
+                      pattern (if (nil? v)
+                                [e a]
+                                (let [v (if (ref? db a) (entid-strict db v) v)]
+                                  (validate-val v entity db)
+                                  [e a v]))]
+                  (recur (reduce transact-retract-datom report (-search db pattern)) entities))
                 (recur report entities))
 
               (= op :db.fn/retractAttribute)


### PR DESCRIPTION
`[:db/retract e a]` is not simply an alias for `[:db.fn/retractAttribute e a]` because the latter also retracts any referenced component attributes.