### PR TITLE
267 error on removing schema

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1214,8 +1214,8 @@
         v (.-v datom)]
     (if (= a :db/ident)
       (if-not (schema v)
-        (raise (str "Schema with attribute " v " does not exist")
-               {:error :retract/schema :attribute v})
+        (throw (ex-info (str "Schema with attribute " v " does not exist")
+                 {:error :retract/schema :attribute v}))
         (-> (assoc-in db [:schema e] (dissoc (schema v) a))
             (update-in [:schema] #(dissoc % v))))
       (if-let [schema-entry (schema e)]

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1222,8 +1222,8 @@
         (if (schema schema-entry)
           (update-in db [:schema schema-entry] #(dissoc % a))
           (update-in db [:schema e] #(dissoc % a v)))
-        (raise (str "Schema with entity id " e " does not exist")
-               {:error :retract/schema :entity-id e :attribute a :value e})))))
+        (throw (ex-info (str "Schema with entity id " e " does not exist")
+                 {:error :retract/schema :entity-id e :attribute a :value e}))))))
 
 ;; In context of `with-datom` we can use faster comparators which
 ;; do not check for nil (~10-15% performance gain in `transact`)

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1214,16 +1214,20 @@
         v (.-v datom)]
     (if (= a :db/ident)
       (if-not (schema v)
-        (throw (ex-info (str "Schema with attribute " v " does not exist")
-                 {:error :retract/schema :attribute v}))
+        (let [err-msg (str "Schema with attribute " v " does not exist")
+              err-map {:error :retract/schema :attribute v}]
+          (throw #?(:clj (ex-info err-msg err-map)
+                    :cljs (error err-msg err-map))))
         (-> (assoc-in db [:schema e] (dissoc (schema v) a))
-            (update-in [:schema] #(dissoc % v))))
+          (update-in [:schema] #(dissoc % v))))
       (if-let [schema-entry (schema e)]
         (if (schema schema-entry)
           (update-in db [:schema schema-entry] #(dissoc % a))
           (update-in db [:schema e] #(dissoc % a v)))
-        (throw (ex-info (str "Schema with entity id " e " does not exist")
-                 {:error :retract/schema :entity-id e :attribute a :value e}))))))
+        (let [err-msg (str "Schema with entity id " e " does not exist")
+              err-map {:error :retract/schema :entity-id e :attribute a :value e}]
+          (throw #?(:clj (ex-info err-msg err-map)
+                    :cljs (error err-msg err-map))))))))
 
 ;; In context of `with-datom` we can use faster comparators which
 ;; do not check for nil (~10-15% performance gain in `transact`)

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1219,7 +1219,7 @@
           (throw #?(:clj (ex-info err-msg err-map)
                     :cljs (error err-msg err-map))))
         (-> (assoc-in db [:schema e] (dissoc (schema v) a))
-          (update-in [:schema] #(dissoc % v))))
+            (update-in [:schema] #(dissoc % v))))
       (if-let [schema-entry (schema e)]
         (if (schema schema-entry)
           (update-in db [:schema schema-entry] #(dissoc % a))

--- a/test/datahike/test/schema.cljc
+++ b/test/datahike/test/schema.cljc
@@ -5,6 +5,7 @@
    [datahike.api :as d]
    [datahike.schema :as ds]
    [datahike.db :as dd]
+   [datahike.datom :as da]
    [datahike.test.core :as tdc])
   (:import [java.lang System]))
 
@@ -324,3 +325,15 @@
         (d/transact conn [{:message "important" :tag :important} {:message "archive" :tag [:important :archive]}])
         (is (= #{["important" :important] ["archive" :important] ["archive" :archive]}
                (d/q '[:find ?m ?t :where [?e :message ?m] [?e :tag ?te] [?te :db/ident ?t]] (d/db conn))))))))
+
+(deftest test-remove-schema
+  (let [cfg "datahike:mem://test-empty-db"
+        _ (d/delete-database cfg)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        db (d/db conn)]
+    (testing "non existing schema should throw exception"
+      (is (thrown-msg? "Schema with attribute :name does not exist"
+            (dd/remove-schema db (da/datom 1 :db/ident :name)))))
+    (testing "when upserting a non existing schema, it should not throw an exception"
+      (is (d/transact conn [name-schema])))))

--- a/test/datahike/test/schema.cljc
+++ b/test/datahike/test/schema.cljc
@@ -334,6 +334,6 @@
         db (d/db conn)]
     (testing "non existing schema should throw exception"
       (is (thrown-msg? "Schema with attribute :name does not exist"
-            (dd/remove-schema db (da/datom 1 :db/ident :name)))))
+                       (dd/remove-schema db (da/datom 1 :db/ident :name)))))
     (testing "when upserting a non existing schema, it should not throw an exception"
       (is (d/transact conn [name-schema])))))


### PR DESCRIPTION
Fixes the log error produced when upserting a schema entry.

The solution uses 'throw' only instead of the 'raise' macro, which does both log and throw.