### PR TITLE
Add predicate var binding check and test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -49,4 +49,7 @@
                    :main-opts ["-m" "hf.depstar.jar" "replikativ-datahike.jar"]}
 
            :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
-                    :main-opts ["-m" "cljfmt.main" "check"]}}}
+                    :main-opts ["-m" "cljfmt.main" "check"]}
+
+           :ffix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
+                  :main-opts ["-m" "cljfmt.main" "fix"]}}}

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -759,7 +759,6 @@
                     (keep #(limit-rel % vars)))))
 
 (defn check-bound [context vars form]
-  (println "check" vars " " form)
   (let [bound (into #{} (mapcat #(keys (:attrs %)) (:rels context)))]
     (when-not (set/subset? vars bound)
       (let [missing (set/difference (set vars) bound)]

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -759,6 +759,7 @@
                     (keep #(limit-rel % vars)))))
 
 (defn check-bound [context vars form]
+  (println "check" vars " " form)
   (let [bound (into #{} (mapcat #(keys (:attrs %)) (:rels context)))]
     (when-not (set/subset? vars bound)
       (let [missing (set/difference (set vars) bound)]
@@ -773,7 +774,8 @@
   ([context clause orig-clause]
    (condp looks-like? clause
      [[symbol? '*]]                                         ;; predicate [(pred ?a ?b ?c)]
-     (filter-by-pred context clause)
+     (do (check-bound context (identity (filter free-var? (first clause))) orig-clause)
+         (filter-by-pred context clause))
 
      [[symbol? '*] '_]                                      ;; function [(fn ?a ?b) ?res]
      (bind-by-fn context clause)


### PR DESCRIPTION
In order to avoid erroneous results when predicate clauses precede all clauses that bind vars, an error is thrown and the query is being rejected. Would still be better to introduce an (optional) automatic reordering in a future release