### PR TITLE
Generic transactor interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,6 @@ feature, please let us know.
 
 ## License
 
-Copyright © 2014–2020 Konrad Kühne, Christian Weilbach, Chrislain Razafimahefa, Timo Kramer, Judith Massa, Nikita Prokopov
+Copyright © 2014–2021 Konrad Kühne, Christian Weilbach, Chrislain Razafimahefa, Timo Kramer, Judith Massa, Nikita Prokopov, Ryan Sundberg
 
 Licensed under Eclipse Public License (see [LICENSE](LICENSE)).

--- a/deps.edn
+++ b/deps.edn
@@ -48,6 +48,11 @@
            :build {:extra-deps {seancorfield/depstar {:mvn/version "1.1.136"}}
                    :main-opts ["-m" "hf.depstar.jar" "replikativ-datahike.jar"]}
 
+           :install {:extra-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
+                     :exec-fn deps-deploy.deps-deploy/deploy
+                     :exec-args {:installer :local
+                                 :artifact "replikativ-datahike.jar"}}
+
            :format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
                     :main-opts ["-m" "cljfmt.main" "check"]}
 

--- a/src/datahike/api.cljc
+++ b/src/datahike/api.cljc
@@ -56,6 +56,7 @@
             - `:read` validates the data when your read data from the database, `:write` validates the data when you transact new data.
           - `:index` defines the data type of the index. Available are `:datahike.index/hitchhiker-tree`, `:datahike.index/persistent-set` (only available with in-memory storage)
           - `:name` defines your database name optionally, if not set, a random name is created
+          - `:transactor` optionally configures a transactor as a hash map. If not set, the default local transactor is used.
 
           Default configuration has in-memory store, keeps history with write schema flexibility, and has no initial transaction:
           {:store {:backend :mem :id \"default\"} :keep-history? true :schema-flexibility :write}

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -59,7 +59,7 @@
   {:pre [(d/conn? connection)]}
   (let [p (throwable-promise)]
     (go
-      (let [tx-report (<! (t/send-transaction! (:transactor @connection) tx-data d/transact))]
+      (let [tx-report (<! (t/send-transaction! (:transactor @connection) tx-data 'datahike.core/transact))]
         (deliver p tx-report)))
     p))
 
@@ -81,7 +81,7 @@
 (defn load-entities [connection entities]
   (let [p (throwable-promise)]
     (go
-      (let [tx-report (<! (t/send-transaction! (:transactor @connection) entities d/load-entities))]
+      (let [tx-report (<! (t/send-transaction! (:transactor @connection) entities 'datahike.core/load-entities))]
         (deliver p tx-report)))
     p))
 

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -4,14 +4,16 @@
             [datahike.index :as di]
             [datahike.store :as ds]
             [datahike.config :as dc]
-            [datahike.tools :as dt]
+            [datahike.tools :as dt :refer [throwable-promise]]
             [datahike.index.hitchhiker-tree.upsert :as ups]
+            [datahike.transactor :as t]
             [hitchhiker.tree.bootstrap.konserve :as kons]
             [konserve.core :as k]
             [konserve.cache :as kc]
             [superv.async :refer [<?? S]]
             [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
+            [clojure.core.async :refer [go <!]]
             [clojure.core.cache :as cache])
   (:import [java.net URI]))
 
@@ -55,9 +57,11 @@
 (defn transact!
   [connection {:keys [tx-data]}]
   {:pre [(d/conn? connection)]}
-  (future
-    (locking connection
-      (update-and-flush-db connection tx-data d/transact))))
+  (let [p (throwable-promise)]
+    (go
+      (let [tx-report (<! (t/send-transaction! (:transactor @connection) tx-data d/transact))]
+        (deliver p tx-report)))
+    p))
 
 (defn transact [connection arg-map]
   (let [arg (cond
@@ -75,11 +79,14 @@
         (throw (.getCause e))))))
 
 (defn load-entities [connection entities]
-  (future
-    (locking connection
-      (update-and-flush-db connection entities d/load-entities))))
+  (let [p (throwable-promise)]
+    (go
+      (let [tx-report (<! (t/send-transaction! (:transactor @connection) entities d/load-entities))]
+        (deliver p tx-report)))
+    p))
 
 (defn release [connection]
+  (<?? S (t/shutdown (:transactor @connection)))
   (ds/release-store (get-in @connection [:config :store]) (:store @connection)))
 
 ;; deprecation begin
@@ -140,22 +147,23 @@
               (dt/raise "Database does not exist." {:type :db-does-not-exist
                                                     :config config}))
           {:keys [eavt-key aevt-key avet-key temporal-eavt-key temporal-aevt-key temporal-avet-key schema rschema config max-tx hash]} stored-db
-          empty (db/empty-db nil config)]
-      (d/conn-from-db
-       (assoc empty
-              :max-tx max-tx
-              :config config
-              :schema schema
-              :hash hash
-              :max-eid (db/init-max-eid eavt-key)
-              :eavt eavt-key
-              :aevt aevt-key
-              :avet avet-key
-              :temporal-eavt temporal-eavt-key
-              :temporal-aevt temporal-aevt-key
-              :temporal-avet temporal-avet-key
-              :rschema rschema
-              :store store))))
+          empty (db/empty-db nil config)
+          conn (d/conn-from-db (assoc empty
+            :max-tx max-tx
+            :config config
+            :schema schema
+            :hash hash
+            :max-eid (db/init-max-eid eavt-key)
+            :eavt eavt-key
+            :aevt aevt-key
+            :avet avet-key
+            :temporal-eavt temporal-eavt-key
+            :temporal-aevt temporal-aevt-key
+            :temporal-avet temporal-avet-key
+            :rschema rschema
+            :store store))]
+      (swap! conn assoc :transactor (t/create-transactor (:transactor config) conn update-and-flush-db))
+      conn))
 
   (-create-database [config & deprecated-config]
     (let [{:keys [keep-history? initial-tx] :as config} (dc/load-config config deprecated-config)

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -37,14 +37,21 @@
           `(throw #?(:clj  (ex-info (str ~@(map (fn [m#] (if (string? m#) m# (list 'pr-str m#))) msgs)) ~data)
                      :cljs (error (str ~@(map (fn [m#] (if (string? m#) m# (list 'pr-str m#))) msgs)) ~data))))))
 
+; (throwable-promise) derived from (promise) in clojure/core.clj.
+; *   Clojure
+; *   Copyright (c) Rich Hickey. All rights reserved.
+; *   The use and distribution terms for this software are covered by the
+; *   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+; *   which can be found in the file epl-v10.html at the root of this distribution.
+; *   By using this software in any fashion, you are agreeing to be bound by
+; * 	 the terms of this license.
+; *   You must not remove this notice, or any other, from this software.
 (defn throwable-promise
   "Returns a promise object that can be read with deref/@, and set,
   once only, with deliver. Calls to deref/@ prior to delivery will
   block, unless the variant of deref with timeout is used. All
   subsequent derefs will return the same delivered value without
-  blocking. See also - realized?."
-  {:added "1.1"
-   :static true}
+  blocking. Exceptions delivered to the promise will throw on deref."
   []
   (let [d (java.util.concurrent.CountDownLatch. 1)
         v (atom d)]

--- a/src/datahike/transactor.cljc
+++ b/src/datahike/transactor.cljc
@@ -2,7 +2,7 @@
   (:require [datahike.core :as d]
             [superv.async :refer [<?? <??- S thread-try]]
             [taoensso.timbre :as log]
-            [clojure.core.async :refer [>!! chan close! promise-chan]]))
+            [clojure.core.async :refer [>!! chan close! promise-chan put!]]))
 
 (defprotocol PTransactor
   ; Send a transaction. Returns a channel that resolves when the transaction finalizes.
@@ -36,7 +36,7 @@
                                  ; Any other exceptions should crash the transactor and signal the supervisor.
                                  (catch clojure.lang.ExceptionInfo e e))]
               (when (some? callback)
-                (>!! callback tx-report)))
+                (put! callback tx-report)))
             (recur))
           (do
             (log/debug "Transactor rx thread gracefully closed")))))))

--- a/src/datahike/transactor.cljc
+++ b/src/datahike/transactor.cljc
@@ -6,38 +6,40 @@
 
 (defprotocol PTransactor
   ; Send a transaction. Returns a channel that resolves when the transaction finalizes.
-  (send-transaction! [_ tx-data update-fn])
+  (send-transaction! [_ tx-data tx-fn])
   ; Returns a channel that resolves when the transactor has shut down.
   (shutdown [_]))
 
 (defrecord LocalTransactor
   [rx-queue rx-thread]
   PTransactor
-  (send-transaction! [_ tx-data update-fn]
+  (send-transaction! [_ tx-data tx-fn]
     (let [p (promise-chan)]
-      (>!! rx-queue {:tx-data tx-data :callback p :update-fn update-fn})
+      (>!! rx-queue {:tx-data tx-data :callback p :tx-fn tx-fn})
       p))
 
   (shutdown [_]
     (close! rx-queue)
     rx-thread))
 
-(defn- create-rx-thread
+(defn create-rx-thread
   [connection rx-queue update-and-flush-db]
   (thread-try
     S
-    (loop []
-      (if-let [{:keys [tx-data callback update-fn]} (<??- rx-queue)]
-        (do
-          (let [tx-report (try (update-and-flush-db connection tx-data update-fn)
-                               ; Only catch ExceptionInfo here (intentionally rejected transactions).
-                               ; Any other exceptions should crash the transactor and signal the supervisor.
-                               (catch clojure.lang.ExceptionInfo e e))]
-            (when (some? callback)
-              (>!! callback tx-report)))
-          (recur))
-        (do
-          (log/debug "Transactor rx thread gracefully closed"))))))
+    (let [resolve-fn (memoize resolve)]
+      (loop []
+        (if-let [{:keys [tx-data callback tx-fn]} (<??- rx-queue)]
+          (do
+            (let [update-fn (resolve-fn tx-fn)
+                  tx-report (try (update-and-flush-db connection tx-data update-fn)
+                                 ; Only catch ExceptionInfo here (intentionally rejected transactions).
+                                 ; Any other exceptions should crash the transactor and signal the supervisor.
+                                 (catch clojure.lang.ExceptionInfo e e))]
+              (when (some? callback)
+                (>!! callback tx-report)))
+            (recur))
+          (do
+            (log/debug "Transactor rx thread gracefully closed")))))))
 
 (defmulti create-transactor
   (fn [transactor-config conn update-and-flush-db]

--- a/src/datahike/transactor.cljc
+++ b/src/datahike/transactor.cljc
@@ -39,7 +39,11 @@
         (do
           (log/debug "Transactor rx thread gracefully closed"))))))
 
-(defn create-transactor
+(defmulti create-transactor
+  (fn [transactor-config conn update-and-flush-db]
+    (or (:backend transactor-config) :local)))
+
+(defmethod create-transactor :local
   [{:keys [rx-buffer-size]} connection update-and-flush-db]
   (let [rx-queue (chan rx-buffer-size)
         rx-thread (create-rx-thread connection rx-queue update-and-flush-db)]

--- a/src/datahike/transactor.cljc
+++ b/src/datahike/transactor.cljc
@@ -1,0 +1,48 @@
+(ns datahike.transactor
+  (:require [datahike.core :as d]
+            [superv.async :refer [<?? <??- S thread-try]]
+            [taoensso.timbre :as log]
+            [clojure.core.async :refer [>!! chan close! promise-chan]]))
+
+(defprotocol PTransactor
+  ; Send a transaction. Returns a channel that resolves when the transaction finalizes.
+  (send-transaction! [_ tx-data update-fn])
+  ; Returns a channel that resolves when the transactor has shut down.
+  (shutdown [_]))
+
+(defrecord LocalTransactor
+  [rx-queue rx-thread]
+  PTransactor
+  (send-transaction! [_ tx-data update-fn]
+    (let [p (promise-chan)]
+      (>!! rx-queue {:tx-data tx-data :callback p :update-fn update-fn})
+      p))
+
+  (shutdown [_]
+    (close! rx-queue)
+    rx-thread))
+
+(defn- create-rx-thread
+  [connection rx-queue update-and-flush-db]
+  (thread-try
+    S
+    (loop []
+      (if-let [{:keys [tx-data callback update-fn]} (<??- rx-queue)]
+        (do
+          (let [tx-report (try (update-and-flush-db connection tx-data update-fn)
+                               ; Only catch ExceptionInfo here (intentionally rejected transactions).
+                               ; Any other exceptions should crash the transactor and signal the supervisor.
+                               (catch clojure.lang.ExceptionInfo e e))]
+            (when (some? callback)
+              (>!! callback tx-report)))
+          (recur))
+        (do
+          (log/debug "Transactor rx thread gracefully closed"))))))
+
+(defn create-transactor
+  [{:keys [rx-buffer-size]} connection update-and-flush-db]
+  (let [rx-queue (chan rx-buffer-size)
+        rx-thread (create-rx-thread connection rx-queue update-and-flush-db)]
+    (map->LocalTransactor
+      {:rx-queue  rx-queue
+       :rx-thread rx-thread})))


### PR DESCRIPTION
Hello Datahike Developers!

This adds a pluggable transaction processing engine to the datahike core with minimal interference on the rest of the code base. The transactor is now configurable, with a :transactor key in the main config. If not set, it defaults to a local transaction processor which handles all transactions in a dedicated thread. All existing unit tests pass without modification.

Along with this local implementation, I have developed a proof of concept [transaction processor plugin for Apache Pulsar](https://github.com/arctype-co/datahike-pulsar) (feel free to copy and republish it if you wish to make it an official plugin.) It should be relatively simple to implement something similar using AMQP or Kafka as the centralized transaction log. 

The core idea behind this development is to enable replication of the datahike database in such a way that all instances of a datahike can share a single (distributed) transaction log with a consistent ordering. Thus a transaction applied to any instance will apply to all instances with consistent results. Consistency is only guaranteed to the extent that the backend log service guarantees log message ordering (e.g. running in a Pulsar or Kafka topic with more than one partition may break consistency.)

In the future to address the limitations of a single-partition backend topic, a `:tx-key` option on the `transact` interface could provide a way to guarantee ordering on multi-partition transaction logs. 

This code is quite experimental, your feedback is welcome!