### PR TITLE
Refactor integration tests

### DIFF
--- a/src/datahike/integration_test.cljc
+++ b/src/datahike/integration_test.cljc
@@ -1,0 +1,65 @@
+(ns datahike.integration-test
+  (:require [datahike.api :as d]
+            #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all :include-macros true])))
+
+(defn integration-test-fixture [config]
+  (d/delete-database config)
+  (d/create-database config)
+  (let [conn (d/connect config)]
+    (d/transact conn [{:db/ident :name
+                       :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :age
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+
+    ;; lets add some data and wait for the transaction
+    (d/transact conn [{:name  "Alice", :age   20}
+                      {:name  "Bob", :age   30}
+                      {:name  "Charlie", :age   40}
+                      {:age 15}])
+    (d/release conn)))
+
+(defn integration-test [config]
+  (let [conn (d/connect config)]
+    ;; search the data
+    (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
+           (d/q '[:find ?e ?n ?a
+                  :where
+                  [?e :name ?n]
+                  [?e :age ?a]]
+                @conn)))
+
+    ;; add new entity data using a hash map
+    (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
+
+    ;; if you want to work with queries like in
+    ;; https://grishaev.me/en/datomic-query/,
+    ;; you may use a hashmap
+    (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
+           (d/q {:query '{:find [?e ?n ?a]
+                          :where [[?e :name ?n]
+                                  [?e :age ?a]]}
+                 :args [@conn]})))
+
+    ;; query the history of the data
+    (is (= #{[20] [25]}
+           (d/q '[:find ?a
+                  :where
+                  [?e :name "Alice"]
+                  [?e :age ?a]]
+                (d/history @conn))))
+
+    ;; you might need to release the connection, e.g. for leveldb
+    (is (= nil (d/release conn)))
+
+    ;; database should exist
+    (is (d/database-exists? config))
+
+    ;; clean up the database if it is not needed any more
+    (d/delete-database config)
+
+    ;; database should not exist
+    (is (not (d/database-exists? config)))))
+

--- a/test/datahike/integration_test/config_record_file_test.clj
+++ b/test/datahike/integration_test/config_record_file_test.clj
@@ -1,64 +1,14 @@
 (ns datahike.integration-test.config-record-file-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]))
+  (:require [clojure.test :refer :all]
+            [datahike.integration-test :as it]))
 
 (def config {:store {:backend :file :path "/tmp/file-test-1"}})
 
 (defn config-record-file-test-fixture [f]
-  (d/delete-database config)
-  (d/create-database config)
-  (def conn (d/connect config))
-    ;; the first transaction will be the schema we are using
-  (d/transact conn [{:db/ident :name
-                     :db/valueType :db.type/string
-                     :db/cardinality :db.cardinality/one}
-                    {:db/ident :age
-                     :db/valueType :db.type/long
-                     :db/cardinality :db.cardinality/one}])
-
-    ;; lets add some data and wait for the transaction
-  (d/transact conn [{:name  "Alice", :age   20}
-                    {:name  "Bob", :age   30}
-                    {:name  "Charlie", :age   40}
-                    {:age 15}])
-
+  (it/integration-test-fixture config)
   (f))
 
 (use-fixtures :once config-record-file-test-fixture)
 
-(deftest config-record-file-test
-  (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
-         (d/q '[:find ?e ?n ?a
-                :where
-                [?e :name ?n]
-                [?e :age ?a]]
-              @conn)))
-
-    ;; add new entity data using a hash map
-  (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
-
-    ;; if you want to work with queries like in
-    ;; https://grishaev.me/en/datomic-query/,
-    ;; you may use a hashmap
-  (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
-         (d/q {:query '{:find [?e ?n ?a]
-                        :where [[?e :name ?n]
-                                [?e :age ?a]]}
-               :args [@conn]})))
-
-    ;; query the history of the data
-  (is (= #{[20] [25]}
-         (d/q '[:find ?a
-                :where
-                [?e :name "Alice"]
-                [?e :age ?a]]
-              (d/history @conn))))
-
-  (d/release conn)
-
-  (is (d/database-exists? config))
-
-  (d/delete-database config)
-
-  (is (not (d/database-exists? config))))
+(deftest ^:integration config-record-file-test []
+  (it/integration-test config))

--- a/test/datahike/integration_test/config_record_level_test.clj
+++ b/test/datahike/integration_test/config_record_level_test.clj
@@ -1,70 +1,15 @@
 (ns datahike.integration-test.config-record-level-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]
-   [datahike-leveldb.core]))
+  (:require [clojure.test :refer :all]
+            [datahike-leveldb.core :as dl]
+            [datahike.integration-test :as it]))
 
 (def config {:store {:backend :level :path "/tmp/level-test"}})
 
 (defn config-record-level-fixture [f]
-  (d/delete-database config)
-  (d/create-database config)
-  (def conn (d/connect config))
-  ;; the first transaction will be the schema we are using
-  (d/transact conn [{:db/ident :name
-                     :db/valueType :db.type/string
-                     :db/cardinality :db.cardinality/one}
-                    {:db/ident :age
-                     :db/valueType :db.type/long
-                     :db/cardinality :db.cardinality/one}])
-
-  ;; lets add some data and wait for the transaction
-  (d/transact conn [{:name  "Alice", :age   20}
-                    {:name  "Bob", :age   30}
-                    {:name  "Charlie", :age   40}
-                    {:age 15}])
-
+  (it/integration-test-fixture config)
   (f))
 
 (use-fixtures :once config-record-level-fixture)
 
-(deftest config-record-level-test
-  ;; search the data
-  (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
-         (d/q '[:find ?e ?n ?a
-                :where
-                [?e :name ?n]
-                [?e :age ?a]]
-              @conn)))
-
-  ;; add new entity data using a hash map
-  (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
-
-  ;; if you want to work with queries like in
-  ;; https://grishaev.me/en/datomic-query/,
-  ;; you may use a hashmap
-  (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
-         (d/q {:query '{:find [?e ?n ?a]
-                        :where [[?e :name ?n]
-                                [?e :age ?a]]}
-               :args [@conn]})))
-
-  ;; query the history of the data
-  (is (= #{[20] [25]}
-         (d/q '[:find ?a
-                :where
-                [?e :name "Alice"]
-                [?e :age ?a]]
-              (d/history @conn))))
-
-  ;; you might need to release the connection, e.g. for leveldb
-  (is (= nil (d/release conn)))
-
-  ;; database should exist
-  (is (= true (d/database-exists? config)))
-
-  ;; clean up the database if it is not needed any more
-  (d/delete-database config)
-
-  ;; database should exist
-  (is (= false (d/database-exists? config))))
+(deftest ^:integration config-record-level-test
+  (it/integration-test config))

--- a/test/datahike/integration_test/config_record_pg_test.clj
+++ b/test/datahike/integration_test/config_record_pg_test.clj
@@ -1,71 +1,20 @@
 (ns datahike.integration-test.config-record-pg-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]
-   [datahike-postgres.core]))
+  (:require [clojure.test :refer :all]
+            [datahike-postgres.core]
+            [datahike.integration-test :as it]))
 
-(def config {:store {:backend :pg :host "localhost" :port 5432 :user "alice" :password "foo" :dbname "config-test"}})
+(def config {:store {:backend :pg
+                     :host "localhost"
+                     :port 5432
+                     :user "alice"
+                     :password "foo"
+                     :dbname "config-test"}})
 
-(defn config-record-pg-fixture [f]
-  (d/delete-database config)
-  (d/create-database config)
-  (def conn (d/connect config))
-  ;; the first transaction will be the schema we are using
-  (d/transact conn [{:db/ident :name
-                     :db/valueType :db.type/string
-                     :db/cardinality :db.cardinality/one}
-                    {:db/ident :age
-                     :db/valueType :db.type/long
-                     :db/cardinality :db.cardinality/one}])
-
-  ;; lets add some data and wait for the transaction
-  (d/transact conn [{:name  "Alice", :age   20}
-                    {:name  "Bob", :age   30}
-                    {:name  "Charlie", :age   40}
-                    {:age 15}])
-
+(defn config-record-pg-test-fixture [f]
+  (it/integration-test-fixture config)
   (f))
 
-(use-fixtures :once config-record-pg-fixture)
+(use-fixtures :once config-record-pg-test-fixture)
 
-(deftest ^:integration config-record-pg-test
-  ;; search the data
-  (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
-         (d/q '[:find ?e ?n ?a
-                :where
-                [?e :name ?n]
-                [?e :age ?a]]
-              @conn)))
-
-  ;; add new entity data using a hash map
-  (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
-
-  ;; if you want to work with queries like in
-  ;; https://grishaev.me/en/datomic-query/,
-  ;; you may use a hashmap
-  (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
-         (d/q {:query '{:find [?e ?n ?a]
-                        :where [[?e :name ?n]
-                                [?e :age ?a]]}
-               :args [@conn]})))
-
-  ;; query the history of the data
-  (is (= #{[20] [25]}
-         (d/q '[:find ?a
-                :where
-                [?e :name "Alice"]
-                [?e :age ?a]]
-              (d/history @conn))))
-
-  ;; you might need to release the connection, e.g. for leveldb
-  (is (= nil (d/release conn)))
-
-  ;; database should exist
-  (is (= true (d/database-exists? config)))
-
-  ;; clean up the database if it is not needed any more
-  (is (let [deleted? (d/delete-database config)]
-        (= [0] deleted?)))
-
-  ;; database should exist
-  (is (= false (d/database-exists? config))))
+(deftest ^:integration config-record-pg-test []
+  (it/integration-test config))

--- a/test/datahike/integration_test/config_record_test.clj
+++ b/test/datahike/integration_test/config_record_test.clj
@@ -1,68 +1,14 @@
 (ns datahike.integration-test.config-record-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]))
+  (:require [clojure.test :refer :all]
+            [datahike.integration-test :as it]))
+
+(def config {})
 
 (defn config-record-test-fixture [f]
-  (d/delete-database)
-  (d/create-database)
-  (def conn (d/connect))
-  ;; the first transaction will be the schema we are using
-  (d/transact conn [{:db/ident :name
-                     :db/valueType :db.type/string
-                     :db/cardinality :db.cardinality/one}
-                    {:db/ident :age
-                     :db/valueType :db.type/long
-                     :db/cardinality :db.cardinality/one}])
-
-  ;; lets add some data and wait for the transaction
-  (d/transact conn [{:name  "Alice", :age   20}
-                    {:name  "Bob", :age   30}
-                    {:name  "Charlie", :age   40}
-                    {:age 15}])
-
+  (it/integration-test-fixture config)
   (f))
 
 (use-fixtures :once config-record-test-fixture)
 
-(deftest test-config-record-test
-  ;; search the data
-  (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
-         (d/q '[:find ?e ?n ?a
-                :where
-                [?e :name ?n]
-                [?e :age ?a]]
-              @conn)))
-
-  ;; add new entity data using a hash map
-  (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
-
-  ;; if you want to work with queries like in
-  ;; https://grishaev.me/en/datomic-query/,
-  ;; you may use a hashmap
-  (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
-         (d/q {:query '{:find [?e ?n ?a]
-                        :where [[?e :name ?n]
-                                [?e :age ?a]]}
-               :args [@conn]})))
-
-  ;; query the history of the data
-  (is (= #{[20] [25]}
-         (d/q '[:find ?a
-                :where
-                [?e :name "Alice"]
-                [?e :age ?a]]
-              (d/history @conn))))
-
-  ;; you might need to release the connection, e.g. for leveldb
-  (is (= nil (d/release conn)))
-
-  ;; database should exist
-  (is (= true (d/database-exists?)))
-
-  ;; clean up the database if it is not needed any more
-  (d/delete-database)
-
-  ;; database should exist
-  (is (= false (d/database-exists?))))
-
+(deftest ^:integration config-record-test []
+  (it/integration-test config))

--- a/test/datahike/integration_test/depr_config_uri_test.clj
+++ b/test/datahike/integration_test/depr_config_uri_test.clj
@@ -1,69 +1,15 @@
 (ns datahike.integration-test.depr-config-uri-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]))
+  (:require [clojure.test :refer :all]
+            [datahike.integration-test :as it]))
 
 (def config "datahike:file:///tmp/file-test-3")
 
 (defn depr-config-uri-fixture [f]
   (println "deprecated file uri config: " config)
-  (d/delete-database config)
-  (d/create-database config)
-  (def conn (d/connect config))
-  (d/transact conn [{:db/ident :name
-                     :db/valueType :db.type/string
-                     :db/cardinality :db.cardinality/one}
-                    {:db/ident :age
-                     :db/valueType :db.type/long
-                     :db/cardinality :db.cardinality/one}])
-
-  ;; lets add some data and wait for the transaction
-  (d/transact conn [{:name  "Alice", :age   20}
-                    {:name  "Bob", :age   30}
-                    {:name  "Charlie", :age   40}
-                    {:age 15}])
+  (it/integration-test-fixture config)
   (f))
 
 (use-fixtures :once depr-config-uri-fixture)
 
-(deftest depr-config-uri-test []
-  ;; search the data
-  (is (= #{[3 "Alice" 20] [4 "Bob" 30] [5 "Charlie" 40]}
-         (d/q '[:find ?e ?n ?a
-                :where
-                [?e :name ?n]
-                [?e :age ?a]]
-              @conn)))
-
-  ;; add new entity data using a hash map
-  (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
-
-  ;; if you want to work with queries like in
-  ;; https://grishaev.me/en/datomic-query/,
-  ;; you may use a hashmap
-  (is (= #{[5 "Charlie" 40] [4 "Bob" 30] [3 "Alice" 25]}
-         (d/q {:query '{:find [?e ?n ?a]
-                        :where [[?e :name ?n]
-                                [?e :age ?a]]}
-               :args [@conn]})))
-
-  ;; query the history of the data
-  (is (= #{[20] [25]}
-         (d/q '[:find ?a
-                :where
-                [?e :name "Alice"]
-                [?e :age ?a]]
-              (d/history @conn))))
-
-  ;; you might need to release the connection, e.g. for leveldb
-  (is (= nil (d/release conn)))
-
-  ;; database should exist
-  (is (= true (d/database-exists? config)))
-
-  ;; clean up the database if it is not needed any more
-  (is (let [deleted? (d/delete-database config)]
-        (or (= nil deleted?) (= {} deleted?))))
-
-  ;; database should exist
-  (is (= false (d/database-exists? config))))
+(deftest ^:integration depr-config-uri-test []
+  (it/integration-test config))

--- a/test/datahike/integration_test/return_map_test.clj
+++ b/test/datahike/integration_test/return_map_test.clj
@@ -1,7 +1,6 @@
 (ns datahike.integration-test.return-map-test
-  (:require
-   [clojure.test :refer :all]
-   [datahike.api :as d]))
+  (:require [clojure.test :refer :all]
+            [datahike.api :as d]))
 
 (defn return-map-test-fixture [f]
   (d/delete-database)


### PR DESCRIPTION
    With this change a new namespace is introduced that can be used
    to implement integration-tests from all subprojects. This enables
    us to run integration tests everywhere without copying the tests
    around. Like in konserve.