### PR TITLE
Benchmarks extension

### DIFF
--- a/benchmark/src/benchmark/compare.clj
+++ b/benchmark/src/benchmark/compare.clj
@@ -49,14 +49,12 @@
                           (map #(assoc % :source filename)
                                (edn/read-string (slurp filename))))
                         filenames)
-
         grouped-benchmarks (->> (apply concat benchmarks)
                                 (map #(assoc % :context
-                                               (merge (dissoc (:context %) :execution)
-                                                      {:dh-config (get-in % [:context :dh-config :name])}
-                                                      (get (:context %) :execution))))
+                                             (merge (dissoc (:context %) :execution)
+                                                    {:dh-config (get-in % [:context :dh-config :name])}
+                                                    (get (:context %) :execution))))
                                 (group-by #(get-in % [:context :function])))
-
         output (str "Connection Measurements (in s):\n"
                     (comparison-table (:connection grouped-benchmarks) filenames)
                     "\n"

--- a/benchmark/src/benchmark/compare.clj
+++ b/benchmark/src/benchmark/compare.clj
@@ -2,9 +2,10 @@
   (:require [clojure.edn :as edn]
             [clojure.string :refer [join]]))
 
-(defn print-comparison [group filenames]
+(defn comparison-table [group filenames]
   (let [grouped (group-by :context group)
-        unique-contexts (sort-by (juxt :function :db :db-size :tx-size) (keys grouped))
+        unique-contexts (sort-by (juxt :function #(get-in % [:dh-config :name]) :db-size :tx-size :data-type :data-in-db?)
+                                 (keys grouped))
         unique-context-keys (->> (map keys unique-contexts) (apply concat) set vec)
         unique-context-key-spaces (map (fn [k] (max (count (name k))
                                                     (apply max (map #(count (str (get % k)))
@@ -21,28 +22,28 @@
                                 (repeat (* 3 (count filenames)) num-space))
         dbl-fmt (str "%" num-space ".2f")
         str-fmt (fn [cw] (str "%-" cw "s"))]
-    (println " Measurements (in s):")
-    (println (str "  | " (join " | " (map #(format (str-fmt %2) %1)    titles title-spaces))    " |"))
-    (println (str "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) title-spaces))    "-|"))
-    (println (str "  | " (join " | " (map #(format (str-fmt %2) %1) subtitles subtitle-spaces)) " |"))
-    (println (str "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) subtitle-spaces)) "-|"))
-    (dorun (for [[context results] (sort-by (fn [[{:keys [db db-size function tx-size]} _]] [function db-size tx-size db])
-                                            grouped)]
-             (let [times (map (fn [filename] (->> results (filter #(= (:source %) filename)) first :time))
-                              filenames)]
-               (println (str "  | " (join " | " (map #(format (str-fmt %2) (get context %1 "")) unique-context-keys unique-context-key-spaces))
-                             " | " (join " | " (map #(str (format dbl-fmt (:median %)) " | " (format dbl-fmt (:mean %)) " | " (format dbl-fmt (:std %)))
-                                                    times)) " |")))))
-    (println "")))
+    (str "  | " (join " | " (map #(format (str-fmt %2) %1)    titles title-spaces))    " |\n"
+         "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) title-spaces))    "-|\n"
+         "  | " (join " | " (map #(format (str-fmt %2) %1) subtitles subtitle-spaces)) " |\n"
+         "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) subtitle-spaces)) "-|\n"
+         (join "\n" (for [[context results] (sort-by (fn [[{:keys [db db-size function tx-size]} _]] [function db-size tx-size db])
+                                                     grouped)]
+                      (let [times (map (fn [filename] (->> results (filter #(= (:source %) filename)) first :time))
+                                       filenames)
+                            context-cells (map #(format (str-fmt %2) (get context %1 ""))
+                                               unique-context-keys unique-context-key-spaces)
+                            measurement-cells (map (fn [measurements] (join " | " (map (fn [stat] (format dbl-fmt (stat measurements)))
+                                                                                       [:median :mean :std])))
+                                                   times)]
+                        (str "  | " (join " | " (concat context-cells measurement-cells)) " |"))))
+         "\n")))
 
 
 (defn check-file-format [filename]
-  (println "fn" filename)
   (when-not (.endsWith filename ".edn")
     (throw (Exception. (str "File " filename "has an unsupported file type. Supported are only edn files.")))))
 
 (defn compare-benchmarks [filenames]
-  (println "fns" filenames)
   (run! check-file-format filenames)
 
   (let [benchmarks (map (fn [filename]
@@ -51,19 +52,21 @@
                         filenames)
 
         grouped-benchmarks (->> (apply concat benchmarks)
-                                (map #(assoc-in % [:context :db] (get-in % [:context :db :name])))
-                                ; (group-by :context)
-                                (group-by #(get-in % [:context :function])))]
-    (println "gp" grouped-benchmarks)
+                                (map #(assoc % :context
+                                               (merge (dissoc (:context %) :execution)
+                                                      {:dh-config (get-in % [:context :dh-config :name])}
+                                                      (get (:context %) :execution))))
+                                (group-by #(get-in % [:context :function])))
 
-    (println "Connection Statistics:")
-    (print-comparison (:connection grouped-benchmarks) filenames)
-
-    (println "Transaction Statistics:")
-    (print-comparison (:transaction grouped-benchmarks) filenames)
-
-    (println "Query Statistics:")
-    (let [query-benchmarks (->> (dissoc grouped-benchmarks :connection :transaction)
-                                vals
-                                (apply concat))]
-      (print-comparison query-benchmarks filenames))))
+        output (str "Connection Measurements (in s):\n"
+                    (comparison-table (:connection grouped-benchmarks) filenames)
+                    "\n"
+                    "Transaction Measurements (in s):\n"
+                    (comparison-table (:transaction grouped-benchmarks) filenames)
+                    "\n"
+                    "Query Measurements (in s):\n"
+                    (let [query-benchmarks (->> (dissoc grouped-benchmarks :connection :transaction)
+                                                vals
+                                                (apply concat))]
+                      (comparison-table query-benchmarks filenames)))]
+    (println output)))

--- a/benchmark/src/benchmark/compare.clj
+++ b/benchmark/src/benchmark/compare.clj
@@ -1,0 +1,69 @@
+(ns benchmark.compare
+  (:require [clojure.edn :as edn]
+            [clojure.string :refer [join]]))
+
+(defn print-comparison [group filenames]
+  (let [grouped (group-by :context group)
+        unique-contexts (sort-by (juxt :function :db :db-size :tx-size) (keys grouped))
+        unique-context-keys (->> (map keys unique-contexts) (apply concat) set vec)
+        unique-context-key-spaces (map (fn [k] (max (count (name k))
+                                                    (apply max (map #(count (str (get % k)))
+                                                                    unique-contexts))))
+                                       unique-context-keys)
+        num-space 8
+        col-width (+ 6 (* 3 num-space))
+        titles (concat (map name unique-context-keys) filenames)
+        title-spaces (concat unique-context-key-spaces (repeat (count filenames) col-width))
+        subtitles (concat (repeat (count unique-context-keys) "")
+                          (apply concat (repeat (count filenames)
+                                                ["median" "mean" "std"])))
+        subtitle-spaces (concat unique-context-key-spaces
+                                (repeat (* 3 (count filenames)) num-space))
+        dbl-fmt (str "%" num-space ".2f")
+        str-fmt (fn [cw] (str "%-" cw "s"))]
+    (println " Measurements (in s):")
+    (println (str "  | " (join " | " (map #(format (str-fmt %2) %1)    titles title-spaces))    " |"))
+    (println (str "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) title-spaces))    "-|"))
+    (println (str "  | " (join " | " (map #(format (str-fmt %2) %1) subtitles subtitle-spaces)) " |"))
+    (println (str "  |-" (join "-+-" (map (fn [s] (apply str (repeat s "-"))) subtitle-spaces)) "-|"))
+    (dorun (for [[context results] (sort-by (fn [[{:keys [db db-size function tx-size]} _]] [function db-size tx-size db])
+                                            grouped)]
+             (let [times (map (fn [filename] (->> results (filter #(= (:source %) filename)) first :time))
+                              filenames)]
+               (println (str "  | " (join " | " (map #(format (str-fmt %2) (get context %1 "")) unique-context-keys unique-context-key-spaces))
+                             " | " (join " | " (map #(str (format dbl-fmt (:median %)) " | " (format dbl-fmt (:mean %)) " | " (format dbl-fmt (:std %)))
+                                                    times)) " |")))))
+    (println "")))
+
+
+(defn check-file-format [filename]
+  (println "fn" filename)
+  (when-not (.endsWith filename ".edn")
+    (throw (Exception. (str "File " filename "has an unsupported file type. Supported are only edn files.")))))
+
+(defn compare-benchmarks [filenames]
+  (println "fns" filenames)
+  (run! check-file-format filenames)
+
+  (let [benchmarks (map (fn [filename]
+                          (map #(assoc % :source filename)
+                               (edn/read-string (slurp filename))))
+                        filenames)
+
+        grouped-benchmarks (->> (apply concat benchmarks)
+                                (map #(assoc-in % [:context :db] (get-in % [:context :db :name])))
+                                ; (group-by :context)
+                                (group-by #(get-in % [:context :function])))]
+    (println "gp" grouped-benchmarks)
+
+    (println "Connection Statistics:")
+    (print-comparison (:connection grouped-benchmarks) filenames)
+
+    (println "Transaction Statistics:")
+    (print-comparison (:transaction grouped-benchmarks) filenames)
+
+    (println "Query Statistics:")
+    (let [query-benchmarks (->> (dissoc grouped-benchmarks :connection :transaction)
+                                vals
+                                (apply concat))]
+      (print-comparison query-benchmarks filenames))))

--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -152,11 +152,11 @@
       :query (simple-query db :i1 (rand-nth known-i1))
       :details {:data-type :int :data-in-db? true}}
      {:function :simple-query
-      :query (simple-query db :s1 (rand-nth known-s1))
-      :details {:data-type :str :data-in-db? true}}
-     {:function :simple-query
       :query (simple-query db :i1 (rand-int-not-in known-i1-set))
       :details {:data-type :int :data-in-db? false}}
+     {:function :simple-query
+      :query (simple-query db :s1 (rand-nth known-s1))
+      :details {:data-type :str :data-in-db? true}}
      {:function :simple-query
       :query (simple-query db :s1 (rand-str-not-in known-i1-set))
       :details {:data-type :str :data-in-db? false}}
@@ -166,7 +166,7 @@
       :details {:data-type :int}}
      {:function :one-join-query
       :query (one-join-query db :s1 :s2)
-      :details {:data-type :int}}
+      :details {:data-type :str}}
 
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :i1 (rand-nth known-i1) :i2)
@@ -199,40 +199,40 @@
       :details {:data-type :int :data-in-db? true}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :i1 (rand-int-not-in known-i1-set))
-      :details {:data-type :int :data-in-db? true}}
+      :details {:data-type :int :data-in-db? false}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :s1 (rand-nth known-s1))
       :details {:data-type :str :data-in-db? true}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :s1 (rand-str-not-in known-s1-set))
-      :details {:data-type :str :data-in-db? true}}
+      :details {:data-type :str :data-in-db? false}}
 
      {:function :vector-arg-query
       :query (vector-arg-query db :i1 (vec-of 1 #(rand-nth known-i1)))
       :details {:data-type :int :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :i1 (vec-of 1 #(rand-int-not-in known-i1-set)))
-      :details {:data-type :int :data-in-db? true}}
+      :details {:data-type :int :data-in-db? false}}
      {:function :vector-arg-query
       :query (vector-arg-query db :s1 (vec-of 1 #(rand-nth known-s1)))
       :details {:data-type :str :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :s1 (vec-of 1 #(rand-str-not-in known-s1-set)))
-      :details {:data-type :str :data-in-db? true}}
+      :details {:data-type :str :data-in-db? false}}
 
      {:function :equals-query
       :query (equals-query db :i1)
       :details {:data-type :int}}
      {:function :equals-query
       :query (equals-query db :s1)
-      :details {:data-type :int}}
+      :details {:data-type :str}}
 
      {:function :less-than-query
       :query (less-than-query db :i1)
       :details {:data-type :int}}
-     #_{:function :less-than-query                          ;; class cast error
+     #_{:function :less-than-query                          ;; class cast error due comparator
       :query (less-than-query db :s1)
-      :details {:data-type "str"}}
+      :details {:data-type :str}}
 
      {:function :equals-query-1-fixed
       :query (equals-query-1-fixed db :i1 (int (/ max-int 2.0)))
@@ -241,9 +241,9 @@
       :query (equals-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
       :details {:data-type :str}}
 
-     {:function :less-than-query
+     {:function :less-than-query-1-fixed
       :query (less-than-query-1-fixed db :i1 (int (/ max-int 2.0)))
       :details {:data-type :int}}
-     {:function :less-than-query
+     {:function :less-than-query-1-fixed
       :query (less-than-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
       :details {:data-type :str}}]))

--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -139,7 +139,44 @@
                       (sequence (conj '[= ?v] comp-val))))
    :args [db]})
 
-(defn queries [db entities]
+
+(defn non-var-queries [db]
+  [{:function :one-join-query
+    :query (one-join-query db :i1 :i2)
+    :details {:data-type :int}}
+   {:function :one-join-query
+    :query (one-join-query db :s1 :s2)
+    :details {:data-type :str}}
+
+   {:function :equals-query
+    :query (equals-query db :i1)
+    :details {:data-type :int}}
+   {:function :equals-query
+    :query (equals-query db :s1)
+    :details {:data-type :str}}
+
+   {:function :less-than-query
+    :query (less-than-query db :i1)
+    :details {:data-type :int}}
+   #_{:function :less-than-query                          ;; class cast error due comparator
+      :query (less-than-query db :s1)
+      :details {:data-type :str}}
+
+   {:function :equals-query-1-fixed
+    :query (equals-query-1-fixed db :i1 (int (/ max-int 2.0)))
+    :details {:data-type :int}}
+   {:function :equals-query-1-fixed
+    :query (equals-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
+    :details {:data-type :str}}
+
+   {:function :less-than-query-1-fixed
+    :query (less-than-query-1-fixed db :i1 (int (/ max-int 2.0)))
+    :details {:data-type :int}}
+   {:function :less-than-query-1-fixed
+    :query (less-than-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
+    :details {:data-type :str}}])
+
+(defn var-queries [db entities]
   (let [known-s1 (mapv :s1 entities)
         known-s2 (mapv :s2 entities)
         known-i1 (mapv :i1 entities)
@@ -160,13 +197,6 @@
      {:function :simple-query
       :query (simple-query db :s1 (rand-str-not-in known-i1-set))
       :details {:data-type :str :data-in-db? false}}
-
-     {:function :one-join-query
-      :query (one-join-query db :i1 :i2)
-      :details {:data-type :int}}
-     {:function :one-join-query
-      :query (one-join-query db :s1 :s2)
-      :details {:data-type :str}}
 
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :i1 (rand-nth known-i1) :i2)
@@ -218,32 +248,8 @@
       :details {:data-type :str :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :s1 (vec-of 1 #(rand-str-not-in known-s1-set)))
-      :details {:data-type :str :data-in-db? false}}
+      :details {:data-type :str :data-in-db? false}}]))
 
-     {:function :equals-query
-      :query (equals-query db :i1)
-      :details {:data-type :int}}
-     {:function :equals-query
-      :query (equals-query db :s1)
-      :details {:data-type :str}}
-
-     {:function :less-than-query
-      :query (less-than-query db :i1)
-      :details {:data-type :int}}
-     #_{:function :less-than-query                          ;; class cast error due comparator
-      :query (less-than-query db :s1)
-      :details {:data-type :str}}
-
-     {:function :equals-query-1-fixed
-      :query (equals-query-1-fixed db :i1 (int (/ max-int 2.0)))
-      :details {:data-type :int}}
-     {:function :equals-query-1-fixed
-      :query (equals-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
-      :details {:data-type :str}}
-
-     {:function :less-than-query-1-fixed
-      :query (less-than-query-1-fixed db :i1 (int (/ max-int 2.0)))
-      :details {:data-type :int}}
-     {:function :less-than-query-1-fixed
-      :query (less-than-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
-      :details {:data-type :str}}]))
+(defn all-queries [db entities]
+  (concat (non-var-queries db)
+          (var-queries db entities)))

--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -1,10 +1,23 @@
 (ns benchmark.config)
 
-
-(def datom-counts [1 10 100 1000])                                                    ;; later 100,000
-(def iterations 10)
 (def max-int 1000000)
-(def initial-datoms [0 1000])                                                         ;; later 100,000
+
+(def context-cell-order [:function :dh-config :db-datoms :tx-datoms :data-type :data-in-db? :tag])
+
+(def csv-cols
+  [{:title "Function"                  :path [:context :function]}
+   {:title "DB"                        :path [:context :dh-config :name]}
+   {:title "DB Datoms"                 :path [:context :db-datoms]}
+   {:title "DB Entities"               :path [:context :db-entities]}
+   {:title "TX Datoms"                 :path [:context :execution :tx-datoms]}
+   {:title "TX Entities"               :path [:context :execution :tx-entities]}
+   {:title "Data Type"                 :path [:context :execution :data-type]}
+   {:title "Queried Data in Database?" :path [:context :execution :data-in-db?]}
+   {:title "Mean Time"                 :path [:time :mean]}
+   {:title "Median Time"               :path [:time :median]}
+   {:title "Time Std"                  :path [:time :std]}
+   {:title "Time Count"                :path [:time :count]}
+   {:title "Tags"                      :path [:tag]}])
 
 (def db-configs
   [{:config-name "mem-set"

--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -7,17 +7,18 @@
 (def initial-datoms [0 1000])                                                         ;; later 100,000
 
 (def db-configs
-  [{:name "mem-set"
-    :config {:store {:backend :mem :id "performance-hht"}
+  [{:config-name "mem-set"
+    :config {:store {:backend :mem :id "performance-set"}
              :schema-flexibility :write
              :keep-history? true
-             :index :datahike.index/persistent-set}}
-   {:name "mem-hht"
+             :index :datahike.index/persistent-set
+             :name "mem-set"}}
+   {:config-name "mem-hht"
     :config {:store {:backend :mem :id "performance-hht"}
              :schema-flexibility :write
              :keep-history? true
              :index :datahike.index/hitchhiker-tree}}
-   {:name "file"
+   {:config-name "file"
     :config {:store {:backend :file :path "/tmp/performance-hht"}
              :schema-flexibility :write
              :keep-history? true
@@ -136,100 +137,100 @@
         known-s2-set (set known-s2)]
     [{:function :simple-query
       :query (simple-query db :i1 (rand-nth known-i1))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :simple-query
       :query (simple-query db :s1 (rand-nth known-s1))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
      {:function :simple-query
       :query (simple-query db :i1 (rand-int-not-in known-i1-set))
-      :details {:data-type "int" :data-in-db? false}}
+      :details {:data-type :int :data-in-db? false}}
      {:function :simple-query
       :query (simple-query db :s1 (rand-str-not-in known-i1-set))
-      :details {:data-type "str" :data-in-db? false}}
+      :details {:data-type :str :data-in-db? false}}
 
      {:function :one-join-query
       :query (one-join-query db :i1 :i2)
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
      {:function :one-join-query
       :query (one-join-query db :s1 :s2)
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
 
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :i1 (rand-nth known-i1) :i2)
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :i1 (rand-int-not-in known-i1-set) :i2)
-      :details {:data-type "int" :data-in-db? false}}
+      :details {:data-type :int :data-in-db? false}}
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :s1 (rand-nth known-s1) :s2)
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
      {:function :one-join-query-first-fixed
       :query (one-join-query-first-fixed db :s1 (rand-str-not-in known-s1-set) :s2)
-      :details {:data-type "str" :data-in-db? false}}
+      :details {:data-type :str :data-in-db? false}}
 
      {:function :one-join-query-second-fixed
       :query (one-join-query-second-fixed db :i1 :i2 (rand-nth known-i2))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :one-join-query-second-fixed
       :query (one-join-query-second-fixed db :i1 :i2 (rand-int-not-in known-i2-set))
-      :details {:data-type "int" :data-in-db? false}}
+      :details {:data-type :int :data-in-db? false}}
      {:function :one-join-query-second-fixed
       :query (one-join-query-second-fixed db :s1 :s2 (rand-nth known-s2))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
      {:function :one-join-query-second-fixed
       :query (one-join-query-second-fixed db :s1 :s2 (rand-str-not-in known-s2-set))
-      :details {:data-type "str" :data-in-db? false}}
+      :details {:data-type :str :data-in-db? false}}
 
      {:function :scalar-arg-query
       :query (scalar-arg-query db :i1 (rand-nth known-i1))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :i1 (rand-int-not-in known-i1-set))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :s1 (rand-nth known-s1))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
      {:function :scalar-arg-query
       :query (scalar-arg-query db :s1 (rand-str-not-in known-s1-set))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
 
      {:function :vector-arg-query
       :query (vector-arg-query db :i1 (vec-of 1 #(rand-nth known-i1)))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :i1 (vec-of 1 #(rand-int-not-in known-i1-set)))
-      :details {:data-type "int" :data-in-db? true}}
+      :details {:data-type :int :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :s1 (vec-of 1 #(rand-nth known-s1)))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
      {:function :vector-arg-query
       :query (vector-arg-query db :s1 (vec-of 1 #(rand-str-not-in known-s1-set)))
-      :details {:data-type "str" :data-in-db? true}}
+      :details {:data-type :str :data-in-db? true}}
 
      {:function :equals-query
       :query (equals-query db :i1)
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
      {:function :equals-query
       :query (equals-query db :s1)
-      :details {:data-type "str"}}
+      :details {:data-type :int}}
 
      {:function :less-than-query
       :query (less-than-query db :i1)
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
      #_{:function :less-than-query                          ;; class cast error
       :query (less-than-query db :s1)
       :details {:data-type "str"}}
 
      {:function :equals-query-1-fixed
       :query (equals-query-1-fixed db :i1 (int (/ max-int 2.0)))
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
      {:function :equals-query-1-fixed
       :query (equals-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
-      :details {:data-type "str"}}
+      :details {:data-type :str}}
 
      {:function :less-than-query
       :query (less-than-query-1-fixed db :i1 (int (/ max-int 2.0)))
-      :details {:data-type "int"}}
+      :details {:data-type :int}}
      {:function :less-than-query
       :query (less-than-query-1-fixed db :s1 (format "%15d" (int (/ max-int 2.0))))
-      :details {:data-type "str"}}]))
+      :details {:data-type :str}}]))

--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -20,7 +20,13 @@
    [{:db/ident       :s1
      :db/valueType   :db.type/string
      :db/cardinality :db.cardinality/one}
+    {:db/ident       :s2
+     :db/valueType   :db.type/string
+     :db/cardinality :db.cardinality/one}
     {:db/ident       :i1
+     :db/valueType   :db.type/bigint
+     :db/cardinality :db.cardinality/one}
+    {:db/ident       :i2
      :db/valueType   :db.type/bigint
      :db/cardinality :db.cardinality/one}])
 
@@ -28,10 +34,196 @@
    {:s1 (format "%15d" (rand-int max-int))
     :i1 (rand-int max-int)})
 
-(defn q1 [string-val]
-  (conj '[:find ?e :where]
-        (conj '[?e :s1] string-val)))
+(defn rand-int-not-in [int-set]
+  (loop [i (rand-int max-int)]
+    (if (contains? int-set i)
+      i
+      (recur (rand-int max-int)))))
 
-(defn q2 [int-val]
-  (conj '[:find ?a :where [?e :s1 ?a]]
-        (conj '[?e :i1] int-val)))
+(defn rand-str-not-in [str-set]
+  (loop [s (format "%15d" (rand-int max-int))]
+    (if (contains? str-set s)
+      s
+      (recur (rand-int max-int)))))
+
+(defn vec-of [n f]
+  (vec (repeatedly n (f))))
+
+;;; Queries
+
+(defn simple-query [db attr val]
+  {:query (conj '[:find ?e :where]
+                (conj '[?e] attr val))
+   :args [db]})
+
+(defn one-join-query [db attr1 attr2]
+  {:query (conj '[:find ?v1 ?v2 :where]
+                (conj '[?e] attr1 '?v1)
+                (conj '[?e] attr2 '?v2))
+   :args [db]})
+
+(defn one-join-query-first-fixed [db attr1 val1 attr2]
+  {:query (conj '[:find ?v2 :where]
+                (conj '[?e] attr1 val1)
+                (conj '[?e] attr2 '?v2))
+   :args [db]})
+
+(defn one-join-query-second-fixed [db attr1 attr2 val2]
+  {:query (conj '[:find ?v1 :where]
+                (conj '[?e] attr1 '?v1)
+                (conj '[?e] attr2 val2))
+   :args [db]})
+
+(defn scalar-arg-query [db attr val]
+  {:query (conj '[:find ?e
+                  :in $ ?v
+                  :where]
+                (conj '[?e] attr '?v))
+   :args [db val]})
+
+(defn vector-arg-query [db attr vals]
+  {:query (conj '[:find ?e
+                  :in $ ?v
+                  :where]
+                (conj '[?e] attr '?v))
+   :args [db vals]})
+
+(defn less-than-query-1-fixed [db attr comp-val]
+  {:query (conj '[:find ?e :where]
+                (conj '[?e] attr '?v)
+                (conj '[]
+                      (conj '(< ?v) comp-val)))
+   :args [db]})
+
+(defn equals-query-1-fixed [db attr comp-val]
+  {:query (conj '[:find ?e :where]
+                (conj '[?e] attr '?v)
+                (conj '[]
+                      (conj '(= ?v) comp-val)))
+   :args [db]})
+
+
+(defn less-than-query [db attr]
+  {:query (conj '[:find ?e1 ?e2 :where]
+                (conj '[?e1] attr '?v1)
+                (conj '[?e2] attr '?v2)
+                (conj '[]
+                      (conj '(< ?v1 ?v2))))
+   :args [db]})
+
+(defn equals-query [db attr]
+  {:query (conj '[:find ?e1 ?e2 :where]
+                (conj '[?e1] attr '?v1)
+                (conj '[?e2] attr '?v2)
+                (conj '[]
+                      (conj '(= ?v1 ?v2))))
+   :args [db]})
+
+(defn queries [db entities]
+  (let [known-s1 (mapv :s1 entities)
+        known-s2 (mapv :s2 entities)
+        known-i1 (mapv :i1 entities)
+        known-i2 (mapv :i2 entities)
+        known-i1-set (set known-i1)
+        known-i2-set (set known-i2)
+        known-s1-set (set known-s1)
+        known-s2-set (set known-s2)]
+    [{:function :simple-query
+      :query (simple-query db :i1 (rand-nth known-i1))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :simple-query
+      :query (simple-query db :s1 (rand-nth known-s1))
+      :details {:data-type "str" :data-in-db? true}}
+     {:function :simple-query
+      :query (simple-query db :i1 (rand-int-not-in known-i1-set))
+      :details {:data-type "int" :data-in-db? false}}
+     {:function :simple-query
+      :query (simple-query db :s1 (rand-str-not-in known-i1-set))
+      :details {:data-type "str" :data-in-db? false}}
+
+     {:function :one-join-query
+      :query (one-join-query db :i1 :i2)
+      :details {:data-type "int"}}
+     {:function :one-join-query
+      :query (one-join-query db :s1 :s2)
+      :details {:data-type "int"}}
+
+     {:function :one-join-query-first-fixed
+      :query (one-join-query-first-fixed db :i1 (rand-nth known-i1) :i2)
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :one-join-query-first-fixed
+      :query (one-join-query-first-fixed db :i1 (rand-int-not-in known-i1-set) :i2)
+      :details {:data-type "int" :data-in-db? false}}
+     {:function :one-join-query-first-fixed
+      :query (one-join-query-first-fixed db :s1 (rand-nth known-s1) :s2)
+      :details {:data-type "str" :data-in-db? true}}
+     {:function :one-join-query-first-fixed
+      :query (one-join-query-first-fixed db :s1 (rand-str-not-in known-s1-set) :s2)
+      :details {:data-type "str" :data-in-db? false}}
+
+     {:function :one-join-query-second-fixed
+      :query (one-join-query-second-fixed db :i1 :i2 (rand-nth known-i2))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :one-join-query-second-fixed
+      :query (one-join-query-second-fixed db :i1 :i2 (rand-int-not-in known-i2-set))
+      :details {:data-type "int" :data-in-db? false}}
+     {:function :one-join-query-second-fixed
+      :query (one-join-query-second-fixed db :s1 :s2 (rand-nth known-s2))
+      :details {:data-type "str" :data-in-db? true}}
+     {:function :one-join-query-second-fixed
+      :query (one-join-query-second-fixed db :s1 :s2 (rand-str-not-in known-s2-set))
+      :details {:data-type "str" :data-in-db? false}}
+
+     {:function :scalar-arg-query
+      :query (scalar-arg-query db :i1 (rand-nth known-i1))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :scalar-arg-query
+      :query (scalar-arg-query db :i1 (rand-int-not-in known-i1-set))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :scalar-arg-query
+      :query (scalar-arg-query db :s1 (rand-nth known-s1))
+      :details {:data-type "str" :data-in-db? true}}
+     {:function :scalar-arg-query
+      :query (scalar-arg-query db :s1 (rand-str-not-in known-s1-set))
+      :details {:data-type "str" :data-in-db? true}}
+
+     {:function :vector-arg-query
+      :query (vector-arg-query db :i1 (vec-of 1 #(rand-nth known-i1)))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :vector-arg-query
+      :query (vector-arg-query db :i1 (vec-of 1 #(rand-int-not-in known-i1-set)))
+      :details {:data-type "int" :data-in-db? true}}
+     {:function :vector-arg-query
+      :query (vector-arg-query db :s1 (vec-of 1 #(rand-nth known-s1)))
+      :details {:data-type "str" :data-in-db? true}}
+     {:function :vector-arg-query
+      :query (vector-arg-query db :s1 (vec-of 1 #(rand-str-not-in known-s1-set)))
+      :details {:data-type "str" :data-in-db? true}}
+
+     {:function :equals-query
+      :query (equals-query db :i1)
+      :details {:data-type "int"}}
+     {:function :equals-query
+      :query (equals-query db :s1)
+      :details {:data-type "str"}}
+
+     {:function :less-than-query
+      :query (less-than-query db :i1)
+      :details {:data-type "int"}}
+     {:function :less-than-query
+      :query (less-than-query db :s1)
+      :details {:data-type "str"}}
+
+     {:function :equals-query-1-fixed
+      :query (equals-query-1-fixed db :i1 (/ max-int 2.0))
+      :details {:data-type "int"}}
+     {:function :equals-query-1-fixed
+      :query (equals-query-1-fixed db :s1 (format "%15d" (/ max-int 2.0)))
+      :details {:data-type "str"}}
+
+     {:function :less-than-query
+      :query (less-than-query-1-fixed db :i1 (/ max-int 2.0))
+      :details {:data-type "int"}}
+     {:function :less-than-query
+      :query (less-than-query-1-fixed db :s1 (format "%15d" (/ max-int 2.0)))
+      :details {:data-type "str"}}]))

--- a/benchmark/src/benchmark/core.clj
+++ b/benchmark/src/benchmark/core.clj
@@ -3,8 +3,12 @@
             [benchmark.measure :as m]
             [benchmark.config :as c]
             [benchmark.store :refer [transact-missing-schema transact-results ->RemoteDB]]
+            [clojure.edn :as edn]
+            [clojure.string :refer [join]]
             [clojure.pprint :refer [pprint]]))
 
+(def output-formats #{"remote-db" "edn" "csv"})
+(def config-names #{"mem-set" "mem-hht" "file"})
 
 (def cli-options
   [["-u" "--db-server-url URL" "Base URL for datahike server, e.g. http://localhost:3000"
@@ -14,8 +18,12 @@
    ["-t" "--tag TAG" "Add tag to measurements"
     :default #{}
     :assoc-fn (fn [m k v] (assoc m k (conj (get m k) v)))]
-   ["-d" "--config-name CONFIGNAME" "Name of database configuration to use. Available are 'mem-set' 'mem-hht' and 'file'. If not set all configs will be tested" :default nil]
-
+   ["-o" "--output-format FORMAT" "Determines how the results will be processed. Possible are 'remote-db', 'edn' and 'csv'"
+    :default "edn"
+    :validate [output-formats  #(str "Format " % " has not been implemented. Possible formats are " output-formats)]]
+   ["-d" "--config-name CONFIGNAME" "Name of database configuration to use. Available are 'mem-set' 'mem-hht' and 'file'. If not set all configs will be tested"
+    :default nil
+    :validate [config-names  #(str "A configuration named " % " has not been implemented. Possible configurations are " config-names)]]
    ["-h" "--help"]])
 
 (defn print-usage-info [summary]
@@ -24,27 +32,34 @@
 (defn full-server-description? [server-description]
   (every? #(not (nil? %)) server-description))
 
-(defn partial-server-description? [server-description]
-  (and (some (comp not nil?) server-description)
-       (not (full-server-description? server-description))))
-
 (defn time-statistics [times]
-  (let [mean (/ (apply + times) (count times))
-        median (nth (sort times) (int (/ (count times) 2)))
-        std (->> times
-                 (map #(* (- % mean) (- % mean)))
-                 (apply +)
-                 (* (/ 1.0 (count times)))
-                 Math/sqrt)]
-    {:mean-time mean
-     :median-time median
-     :std-time std}))
+  (let [n (count times)
+        mean (/ (apply + times) n)]
+    {:mean mean
+     :median (nth (sort times) (int (/ n 2)))
+     :std (->> times
+               (map #(* (- % mean) (- % mean)))
+               (apply +)
+               (* (/ 1.0 n))
+               Math/sqrt)}))
+
+(def csv-cols
+  [{:title "DB" :path [:context :db :name]}
+   {:title "Function" :path [:context :function]}
+   {:title "DB Size" :path [:context :db-size]}
+   {:title "TX Size" :path [:context :tx-size]}
+   {:title "Data Type" :path [:context :exec-details :data-type]}
+   {:title "Queried Data in Database?" :path [:context :exec-details :data-in-db?]}
+   {:title "Tags" :path [:tag]}
+   {:title "Mean Time" :path [:time :mean]}
+   {:title "Median Time" :path [:time :median]}
+   {:title "Time Std" :path [:time :std]}])
 
 (defn -main [& args]
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
         server-info-keys [:db-server-url :db-token :db-name]
         server-description (map options server-info-keys)
-        {:keys [tags config-name]} options]
+        {:keys [tag config-name output-format]} options]
 
     (cond
       (some? errors)
@@ -54,7 +69,7 @@
       (:help options)
       (print-usage-info summary)
 
-      (partial-server-description? server-description)
+      (and (= "remote-db" output-format) (not (full-server-description? server-description)))
       (do (println (str "Only partial information for remote connection has been given: "
                         (select-keys options server-info-keys)))
           (println "Please, define URL, database name, and token to save the data on a remote datahike server.")
@@ -71,16 +86,64 @@
             processed (->> measurements
                            (apply concat)
                            (group-by :context)
-                           (map (fn [[context group]]
-                                  (merge context (time-statistics (map :time group))))))
-            tagged (if (empty? tags)
+                           (map (fn [[context group]] {:context context
+                                                       :time (time-statistics (map :time group))})))
+            tagged (if (empty? tag)
                      (vec processed)
-                     (mapv (fn [entity] (assoc entity :tag (vec tags))) processed))]
-        (if (full-server-description? server-description)
-          (let [rdb (apply ->RemoteDB server-description)]
-            (println "Database used:" rdb)
-            (transact-missing-schema rdb)
-            (transact-results rdb tagged))
-          (pprint tagged)))))
+                     (mapv (fn [entity] (assoc entity :tag (join " " tag))) processed))]
+        (case output-format
+          "remote-db" (let [rdb (apply ->RemoteDB server-description)]
+                        (println "Database used:" rdb)
+                        (transact-missing-schema rdb)
+                        (transact-results rdb tagged))
+          "csv" (let [col-paths (map :path csv-cols)
+                      titles (map :title csv-cols)]
+                  (println (join "\t" titles))
+                  (run! (fn [result]
+                           (println (join "\t" (map (fn [path] (get-in result path))
+                                                    col-paths))))
+                         tagged))
+          "edn" (pprint tagged)
+          :default (pprint tagged)))))
 
   (shutdown-agents))
+
+(defn print-comparison [context group filename1 filename2]
+  (let [results (vec group)
+        _ (println "results" results)
+        times1 (->> results (filter #(= (:source %) filename1)) first :time)
+        times2 (->> results (filter #(= (:source %) filename2)) first :time)]
+    (when (and times1 times2)                  ;; benchmark results available from both files
+      (print " Context: ") (pprint context)
+      (println " Times (s): (" filename1 "/" filename2 ")")
+      (println " - Mean: (" (:mean times1) "/" (:mean times2) ")")
+      (println " - Median: (" (:median times1) "/" (:median times2) ")")
+      (println " - Std-Deviation: (" (:std times1) "/" (:std times2) ")"))))
+
+(defn compare-benchmarks [filename1 filename2]
+  (when (not (and (.endsWith filename1 ".edn")
+                  (.endsWith filename2 ".edn")))
+    (println "Both files must be edn files.")
+    (System/exit 1))
+
+  (let [bench1 (map #(assoc % :source filename1)
+                    (edn/read-string (slurp filename1)))
+        bench2 (map #(assoc % :source filename2)
+                    (edn/read-string (slurp filename2)))
+        grouped-benchmarks (->> (concat bench1 bench2)
+                                (group-by :context)
+                                (group-by #(-> % first :function)))]
+
+    (println "Connection Statistics:")
+    (dorun (for [[context group] (:connection grouped-benchmarks)]
+             (print-comparison context group filename1 filename2)))
+
+    (println "Transaction Statistics:")
+    (dorun (for [[context group] (:transaction grouped-benchmarks)]
+             (print-comparison context group filename1 filename2)))
+
+    (println "Query Statistics:")
+    (dorun (for [[context group] (->> (dissoc grouped-benchmarks :connection :transaction)
+                                      vals
+                                      (apply concat))]
+             (print-comparison context group filename1 filename2)))))

--- a/benchmark/src/benchmark/core.clj
+++ b/benchmark/src/benchmark/core.clj
@@ -18,23 +18,23 @@
    ["-t" "--tag TAG" "Add tag to measurements"
     :default #{}
     :assoc-fn (fn [m k v] (assoc m k (conj (get m k) v)))]
-   ["-o" "--output-format FORMAT" "Determines how the results will be processed. Possible are 'remote-db', 'edn' and 'csv'"
+   ["-o" "--output-format FORMAT" "Determines how the results will be processed. Possible are 'remote-db', 'edn' and 'csv'."
     :default "edn"
     :validate [output-formats  #(str "Format " % " has not been implemented. Possible formats are " output-formats)]]
    ["-c" "--config-name CONFIGNAME" "Name of database configuration to use. Available are 'mem-set' 'mem-hht' and 'file'. If not set all configs will be tested"
     :default nil
     :validate [config-names  #(str "A configuration named " % " has not been implemented. Possible configurations are " config-names)]]
-   ["-d" "--db-datom-counts VECTOR" "Numbers of datoms in database for which benchmarks should be run. Used in 'connection' and 'transaction'. Range must be given as triple of integers 'start stop step' which are given as input for range function (range start stop step)"
+   ["-d" "--db-datom-counts VECTOR" "Numbers of datoms in database for which benchmarks should be run. Must be given as a clojure vector of non-negative integers like '[0 10 100 1000]'."
     :default [0 1000]
     :parse-fn read-string
     :validate [vector? "Must be a vector of non-negative integers."
                #(every? nat-int? %) "vector must consist of non-negative integers."]]
-   ["-x" "--tx-datom-counts VECTOR" "Numbers of datoms in database for which benchmarks should be run. Used in 'transaction'. Range must be given as triple of integers 'start stop step' which are given as input for range function (range start stop step)"
+   ["-x" "--tx-datom-counts VECTOR" "Numbers of datoms in database for which benchmarks should be run. Used in 'transaction'. Must be given as a clojure vector of non-negative integers like '[0 10 100 1000]'."
     :default [1 10 100 1000]
     :parse-fn read-string
     :validate [vector? "Must be a vector of non-negative integers." 
                #(every? nat-int? %) "Vector must consist of non-negative integers."]]
-   ["-i" "--iterations ITERATIONS" "Number of iterations of each measurement"
+   ["-i" "--iterations ITERATIONS" "Number of iterations of each measurement."
     :default 10
     :parse-fn read-string
     :validate [nat-int? "Must be a non-negative integer."]]

--- a/benchmark/src/benchmark/core.clj
+++ b/benchmark/src/benchmark/core.clj
@@ -34,8 +34,7 @@
     :parse-fn read-string
     :validate [vector? "Must be a vector of non-negative integers." 
                #(every? nat-int? %) "Vector must consist of non-negative integers."]]
-   ["-i" "--iterations ITERATIONS"
-    "Number of iterations as string of space-separated integers of 1. connection 2. transaction and 3. query measurements (ignored for criterium)"
+   ["-i" "--iterations ITERATIONS" "Number of iterations of each measurement"
     :default 10
     :parse-fn read-string
     :validate [nat-int? "Must be a non-negative integer."]]
@@ -135,4 +134,8 @@
         (throw (Exception. (str "Command '" cmd "' does not exist. Valid commands are 'run' and 'compare'"))))))
 
   (shutdown-agents))
+
+(comment
+  (-main "run" "-x" "[0 10000 5000]" "-t" "test-bench" "-o" "edn" "bench.edn")
+  )
 

--- a/benchmark/src/benchmark/core.clj
+++ b/benchmark/src/benchmark/core.clj
@@ -14,6 +14,7 @@
    ["-t" "--tag TAG" "Add tag to measurements"
     :default #{}
     :assoc-fn (fn [m k v] (assoc m k (conj (get m k) v)))]
+   ["-d" "--config-name CONFIGNAME" "Name of database configuration to use. Available are 'mem-set' 'mem-hht' and 'file'. If not set all configs will be tested" :default nil]
 
    ["-h" "--help"]])
 
@@ -29,19 +30,21 @@
 
 (defn time-statistics [times]
   (let [mean (/ (apply + times) (count times))
+        median (nth (sort times) (int (/ (count times) 2)))
         std (->> times
                  (map #(* (- % mean) (- % mean)))
                  (apply +)
                  (* (/ 1.0 (count times)))
                  Math/sqrt)]
     {:mean-time mean
+     :median-time median
      :std-time std}))
 
 (defn -main [& args]
   (let [{:keys [options errors summary]} (cli/parse-opts args cli-options)
         server-info-keys [:db-server-url :db-token :db-name]
         server-description (map options server-info-keys)
-        tags (:tag options)]
+        {:keys [tags config-name]} options]
 
     (cond
       (some? errors)
@@ -58,7 +61,9 @@
           (print-usage-info summary))
 
       :else
-      (let [measurements (vec (for [config c/db-configs
+      (let [measurements (vec (for [config (if config-name
+                                             (filter #(= (:name %) config-name) c/db-configs)
+                                             c/db-configs)
                                     initial-size c/initial-datoms
                                     n c/datom-counts
                                     _ (range c/iterations)]

--- a/benchmark/src/benchmark/measure.clj
+++ b/benchmark/src/benchmark/measure.clj
@@ -34,10 +34,16 @@
                   " and " n-datoms " datom" (when (not= n-datoms 1) "s") 
                   " in transaction..."))
   (let [unique-config (assoc config :name (str (UUID/randomUUID)))
+        simple-config (-> config
+                          (assoc :name config-name)
+                          (assoc :backend (get-in config [:store :backend]))
+                          (dissoc :store))
+      
         initial-entities (init-db initial-size unique-config)
         initial-datoms (* initial-entities (count c/schema))
 
         {conn :res t-connection-0 :t} (timed (d/connect unique-config))
+
         tx-entities (int (Math/ceil (/ n-datoms (count c/schema))))
         tx-datoms (* tx-entities (count c/schema))
 
@@ -50,22 +56,18 @@
         _ (d/release conn)
         t-connection-0n (:t (timed (d/connect unique-config)))
 
-        simple-config (-> config
-                          (assoc :name config-name)
-                          (assoc :backend (get-in config [:store :backend]))
-                          (dissoc :store))
-        
-        queries (vec (for [{:keys [function query details]} (c/queries @conn tx)]
-                       (do (log/debug (str " Querying with " function " using " details "..."))
-                           {:time (:t (timed (d/q query @conn)))
-                            :context {:dh-config simple-config :function function :db-entities final-entities :db-datoms final-datoms
-                                      :execution details}})))]
-    (d/release conn)
-    (conj queries
-          {:time t-connection-0  :context {:dh-config simple-config :function :connection  :db-entities initial-entities :db-datoms initial-datoms}}
-          {:time t-transaction-n :context {:dh-config simple-config :function :transaction :db-entities initial-entities :db-datoms initial-datoms 
-                                           :execution {:tx-entities tx-entities :tx-datoms tx-datoms}}}
-          {:time t-connection-0n  :context {:dh-config simple-config :function :connection  :db-entities final-entities :db-datoms final-datoms}})))
+
+        queries0n (vec (for [{:keys [function query details]} (c/queries @conn tx)]
+                        (do (log/debug (str " Querying with " function " using " details "..."))
+                            {:time (:t (timed (d/q query @conn)))
+                             :context {:dh-config simple-config :function function :db-entities final-entities :db-datoms final-datoms
+                                       :execution details}})))]
+    (d/release conn) 
+    (concat queries0n
+            [{:time t-connection-0  :context {:dh-config simple-config :function :connection  :db-entities initial-entities :db-datoms initial-datoms}}
+             {:time t-transaction-n :context {:dh-config simple-config :function :transaction :db-entities initial-entities :db-datoms initial-datoms 
+                                              :execution {:tx-entities tx-entities :tx-datoms tx-datoms}}}
+             {:time t-connection-0n  :context {:dh-config simple-config :function :connection  :db-entities final-entities :db-datoms final-datoms}}])))
 
 (defn time-statistics [times]
   (let [n (count times)
@@ -89,5 +91,6 @@
          (measure-performance-full initial-size n config))
        (apply concat)
        (group-by :context)
-       (map (fn [[context group]] {:context context
-                                   :time (time-statistics (map :time group))}))))
+       (map (fn [[context group]]
+              {:context context
+               :time (time-statistics (map :time group))}))))

--- a/benchmark/src/benchmark/measure.clj
+++ b/benchmark/src/benchmark/measure.clj
@@ -57,7 +57,9 @@
         t-connection-0n (:t (timed (d/connect unique-config)))
 
 
-        queries0n (vec (for [{:keys [function query details]} (c/queries @conn tx)]
+        queries0n (vec (for [{:keys [function query details]} (if (pos? (count tx))
+                                                                (c/all-queries @conn tx)
+                                                                (c/non-var-queries @conn))]
                         (do (log/debug (str " Querying with " function " using " details "..."))
                             {:time (:t (timed (d/q query @conn)))
                              :context {:dh-config simple-config :function function :db-entities final-entities :db-datoms final-datoms

--- a/benchmark/src/benchmark/measure.clj
+++ b/benchmark/src/benchmark/measure.clj
@@ -27,27 +27,24 @@
 
 (defn measure-performance-full [initial-size n-datoms config]
   (init-db initial-size config)
-  (let [{conn :res t-connection-0 :t} (timed (d/connect config))
+  (let [simple-config (-> config
+                          (assoc :dh-backend (get-in config [:store :backend]))
+                          (dissoc :store))
+        final-size (+ initial-size n-datoms)
+
+        {conn :res t-connection-0 :t} (timed (d/connect config))
         entity-count (int (Math/ceil (/ n-datoms (count c/schema))))
-        tx           (vec (repeatedly entity-count c/rand-entity))
-        t-transaction-n (:t (timed (d/transact conn tx)))
+        entities (vec (repeatedly entity-count c/rand-entity))
+        t-transaction-n (:t (timed (d/transact conn entities)))
 
         _ (d/release conn)
         t-connection-n (:t (timed (d/connect config)))
 
-        rand-s-val (rand-nth (mapv :s1 tx))
-         t-query1-n (:t (timed (d/q (c/q1 rand-s-val) @conn)))
-
-        rand-i-val (rand-nth (mapv :i1 tx))
-        t-query2-n   (:t (timed (d/q (c/q2 rand-i-val) @conn)))
-
-        final-size (+ initial-size n-datoms)
-        simple-config (-> config
-                          (dissoc :store)
-                          (assoc :dh-backend (get-in config [:store :backend])))]
+        queries (vec (for [{:keys [function query details]} (c/queries @conn entities)]
+                         {:time (:t (timed (d/q (:q query) @conn)))
+                          :context {:db-config simple-config :function function :exec-details details :db-size final-size}}))]
     (d/release conn)
-    [{:time t-connection-0  :context {:db-config simple-config :function :connection  :db-size initial-size}}
-     {:time t-transaction-n :context {:db-config simple-config :function :transaction :db-size initial-size :tx-size n-datoms}}
-     {:time t-connection-n  :context {:db-config simple-config :function :connection  :db-size final-size}}
-     {:time t-query1-n      :context {:db-config simple-config :function :query1      :db-size final-size}}
-     {:time t-query2-n      :context {:db-config simple-config :function :query2      :db-size final-size}}]))
+    (conj queries
+          {:time t-connection-0  :context {:db-config simple-config :function :connection  :db-size initial-size}}
+          {:time t-transaction-n :context {:db-config simple-config :function :transaction :db-size initial-size :tx-size n-datoms}}
+          {:time t-connection-n  :context {:db-config simple-config :function :connection  :db-size final-size}})))

--- a/benchmark/src/benchmark/measure.clj
+++ b/benchmark/src/benchmark/measure.clj
@@ -32,6 +32,7 @@
   (let [unique-config (assoc config :name (str (UUID/randomUUID)))
         _ (init-db initial-size unique-config)
         simple-config (-> config
+                          (assoc :name name)
                           (assoc :dh-backend (get-in config [:store :backend]))
                           (dissoc :store))
         final-size (+ initial-size n-datoms)
@@ -46,11 +47,10 @@
 
         queries (vec (for [{:keys [function query details]} (c/queries @conn entities)]
                        (do (log/debug (str " Querying with " function " using " details "..."))
-                           (println "  Query: " query)
                            {:time (:t (timed (d/q query @conn)))
-                            :context {:db-config simple-config :function function :exec-details details :db-size final-size}})))]
+                            :context {:db simple-config :function function :exec-details details :db-size final-size}})))]
     (d/release conn)
     (conj queries
-          {:time t-connection-0  :context {:db-config simple-config :function :connection  :db-size initial-size}}
-          {:time t-transaction-n :context {:db-config simple-config :function :transaction :db-size initial-size :tx-size n-datoms}}
-          {:time t-connection-n  :context {:db-config simple-config :function :connection  :db-size final-size}})))
+          {:time t-connection-0  :context {:db simple-config :function :connection  :db-size initial-size}}
+          {:time t-transaction-n :context {:db simple-config :function :transaction :db-size initial-size :tx-size n-datoms}}
+          {:time t-connection-n  :context {:db simple-config :function :connection  :db-size final-size}})))

--- a/dev/sandbox_benchmarks.clj
+++ b/dev/sandbox_benchmarks.clj
@@ -8,7 +8,7 @@
 
 ;(b/-main "-t" "test-id" "-t" "test-id2")                    ;; TIMBRE_LEVEL=':fatal' clj -M:benchmark -t test-id -t test-id2
 
-;(b/-main "-t" "test-id" "-u" "http://localhost:3001" "-n" "benchmarks" "-g" "test-token") ;; TIMBRE_LEVEL=':fatal' clj -M:benchmark -t test-id -u http://localhost:3001 -n benchmarks -g test-token
+;(b/-main "-t" "test-id" "-u" "http://localhost:3001" "-n" "benchmarks" "-g" "test-token") ;; TIMBRE_LEVEL=':fatal' clj -M:benchmark run -o remote-db -t test-id -u http://localhost:3001 -n benchmarks -g test-token
 
 
 ;; docker run -d --name datahike-server -p 3001:3000 -e DATAHIKE_SERVER_TOKEN=test-token -e DATAHIKE_SCHEMA_FLEXIBILITY=write -e DATAHIKE_STORE_BACKEND=file -e DATAHIKE_NAME=benchmarks -e DATAHIKE_STORE_PATH=/opt/datahike-server/benchmarks replikativ/datahike-server:snapshot


### PR DESCRIPTION
Adds 
- csv export
- queries
- comparison of benchmarks results 

Try csv export with
`TIMBRE_LEVEL=':fatal' clj -M:benchmark run -d mem-set -t test-bench -o csv > bench-res.tsv`

Try comparison with
`TIMBRE_LEVEL=':fatal' clj -M:benchmark compare bench-res.edn bench-res.edn`
