### PR TITLE
String comparator fix

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -204,10 +204,17 @@
 
 (defmulti -lesser?
   {:arglists '([value & more])}
-  (fn [value & more] (class value)))
+  (fn [value & more] 
+    (class value)))
 
-(defmethod -lesser? String [^String s0 ^String s1]
-  (neg? (compare s0 s1)))
+(defmethod -lesser? java.lang.String [^String s0 & more]
+  (reduce (fn [res [s1 ^String s2]]
+            (if (neg? (compare s1 s2))
+              res
+              (reduced false)))
+          true
+          (partition 2 1 (cons s0 more))))
+
 
 (defmethod -lesser? java.util.Date [^Date d0 ^Date d1]
   #?(:clj  (.before ^Date d0 ^Date d1)
@@ -217,10 +224,14 @@
   (apply < value more))
 
 (defmulti -greater? {:arglists '([value & more])}
-  (fn [value & more] (class value)))
+  (fn [value & _more] (class value)))
 
-(defmethod -lesser? String [^String s0 ^String s1]
-  (pos? (compare s0 s1)))
+(defmethod -greater? java.lang.String [^String s0 & more]
+  (reduce (fn [res [s1 ^String s2]] (if (pos? (compare s1 s2))
+                                      res
+                                      (reduced false)))
+          true
+          (partition 2 1 (cons s0 more))))
 
 (defmethod -greater? java.util.Date [^Date d0 ^Date d1]
   #?(:clj  (.after ^Date d0 ^Date d1)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -206,6 +206,9 @@
   {:arglists '([value & more])}
   (fn [value & more] (class value)))
 
+(defmethod -lesser? String [^String s0 ^String s1]
+  (neg? (compare s0 s1)))
+
 (defmethod -lesser? java.util.Date [^Date d0 ^Date d1]
   #?(:clj  (.before ^Date d0 ^Date d1)
      :cljs (< d0 d1)))
@@ -215,6 +218,9 @@
 
 (defmulti -greater? {:arglists '([value & more])}
   (fn [value & more] (class value)))
+
+(defmethod -lesser? String [^String s0 ^String s1]
+  (pos? (compare s0 s1)))
 
 (defmethod -greater? java.util.Date [^Date d0 ^Date d1]
   #?(:clj  (.after ^Date d0 ^Date d1)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -204,8 +204,7 @@
 
 (defmulti -lesser?
   {:arglists '([value & more])}
-  (fn [value & more]
-    (class value)))
+  (fn [value & _more] (class value)))
 
 (defmethod -lesser? java.lang.String [^String s0 & more]
   (reduce (fn [res [s1 ^String s2]]

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -204,7 +204,7 @@
 
 (defmulti -lesser?
   {:arglists '([value & more])}
-  (fn [value & more] 
+  (fn [value & more]
     (class value)))
 
 (defmethod -lesser? java.lang.String [^String s0 & more]
@@ -214,7 +214,6 @@
               (reduced false)))
           true
           (partition 2 1 (cons s0 more))))
-
 
 (defmethod -lesser? java.util.Date [^Date d0 ^Date d1]
   #?(:clj  (.before ^Date d0 ^Date d1)

--- a/test/datahike/test/query_fns.cljc
+++ b/test/datahike/test/query_fns.cljc
@@ -269,7 +269,7 @@
        :where [?e :name ?n]
        [(> "M" ?n)]]
       #{[1 "Ivan"] [2 "Ivan"]})
-    
+
     (let [pred (fn [db e a]
                  (= a (:age (d/entity db e))))]
       (is (= (d/q '[:find ?e
@@ -277,25 +277,7 @@
                     :where [?e :age ?a]
                     [(?pred $ ?e 10)]]
                   db pred)
-             #{[1] [3]})))
-
-             ))
- #_(comment
-
-      ;; greater predicate for string
-   [:find  ?e ?n
-    :where [?e :name ?n]
-    [(> ?n "M")]]
-   #{[3 "Oleg"] [4 "Oleg"]}
-
-       ;; lesser predicate for string
-   [:find  ?e ?n
-    :where [?e :name ?n]
-    [(> "M" ?n)]]
-   #{[1 "Ivan"] [2 "Ivan"]}
-
-     
-     )
+             #{[1] [3]})))))
 
 (deftest test-exceptions
   (is (thrown-with-msg? ExceptionInfo #"Unknown predicate 'fun in \[\(fun \?e\)\]"

--- a/test/datahike/test/query_fns.cljc
+++ b/test/datahike/test/query_fns.cljc
@@ -205,7 +205,7 @@
                   {:db/id 4 :name "Oleg" :age 20}]
         db (d/db-with (d/empty-db) entities)]
     (are [q res] (= (d/q (quote q) db) res)
-      ;; plain predicate
+      ;; plain predicate for integer
       [:find  ?e ?a
        :where [?e :age ?a]
        [(> ?a 10)]]
@@ -244,7 +244,32 @@
        :where [?e :name "Ivan"]
        [?e :age 20]
        [(= ?e 1)]]
-      #{})
+      #{}
+
+      ;; lesser predicate for string
+      [:find  ?e ?n
+       :where [?e :name ?n]
+       [(< ?n "M")]]
+      #{[1 "Ivan"] [2 "Ivan"]}
+
+      ;; lesser predicate for string
+      [:find  ?e ?n
+       :where [?e :name ?n]
+       [(< "M" ?n)]]
+      #{[3 "Oleg"] [4 "Oleg"]}
+
+      ;; greater predicate for string
+      [:find  ?e ?n
+       :where [?e :name ?n]
+       [(> ?n "M")]]
+      #{[3 "Oleg"] [4 "Oleg"]}
+
+      ;; greater predicate for string
+      [:find  ?e ?n
+       :where [?e :name ?n]
+       [(> "M" ?n)]]
+      #{[1 "Ivan"] [2 "Ivan"]})
+    
     (let [pred (fn [db e a]
                  (= a (:age (d/entity db e))))]
       (is (= (d/q '[:find ?e
@@ -252,7 +277,25 @@
                     :where [?e :age ?a]
                     [(?pred $ ?e 10)]]
                   db pred)
-             #{[1] [3]})))))
+             #{[1] [3]})))
+
+             ))
+ #_(comment
+
+      ;; greater predicate for string
+   [:find  ?e ?n
+    :where [?e :name ?n]
+    [(> ?n "M")]]
+   #{[3 "Oleg"] [4 "Oleg"]}
+
+       ;; lesser predicate for string
+   [:find  ?e ?n
+    :where [?e :name ?n]
+    [(> "M" ?n)]]
+   #{[1 "Ivan"] [2 "Ivan"]}
+
+     
+     )
 
 (deftest test-exceptions
   (is (thrown-with-msg? ExceptionInfo #"Unknown predicate 'fun in \[\(fun \?e\)\]"


### PR DESCRIPTION
This PR enables queries with `<` and `>` predicates for strings. `=` seems to be working already. There might be a better way to solve this, but at least it works now.