### PR TITLE
Allow to work with the benchmarks code in dev. mode.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -35,6 +35,10 @@
                                org.clojure/tools.namespace {:mvn/version "0.2.11"}}
                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
 
+           :bench-dev {:extra-paths ["benchmark/src"]
+                       :extra-deps {clj-http/clj-http     {:mvn/version "3.11.0"}
+                                    org.clojure/tools.cli {:mvn/version "1.0.194"}}}
+
            :benchmark {:main-opts ["-m" "benchmark.core"]
                        :extra-paths ["benchmark/src"]
                        :extra-deps {clj-http/clj-http     {:mvn/version "3.11.0"}


### PR DESCRIPTION
Make it possible to work on the benchmarks code on the repl. 

This was not possible so far with Emacs: trying to do repl development with the benchmarks code would launch the benchmarks but with the wrong parameters and thus would fail.