### PR TITLE
Add specs for the `datahike.api` namespace

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
-{:deps {org.clojure/clojure                         {:mvn/version "1.10.1"}
-        org.clojure/clojurescript                   {:mvn/version "1.10.597"}
+{:deps {org.clojure/clojure                         {:mvn/version "1.10.3"}
+        org.clojure/clojurescript                   {:mvn/version "1.10.758"}
         io.replikativ/hitchhiker-tree               {:mvn/version "0.1.11"}
         persistent-sorted-set/persistent-sorted-set {:mvn/version "0.1.2"}
         org.clojure/tools.reader                    {:mvn/version "1.3.3"}
@@ -8,6 +8,8 @@
         io.replikativ/superv.async                  {:mvn/version "0.2.11"}
         io.lambdaforge/datalog-parser               {:mvn/version "0.1.8"}
         io.replikativ/zufall                        {:mvn/version "0.1.0"}
+        metosin/spec-tools                          {:mvn/version "0.10.5"}
+        orchestra/orchestra                         {:mvn/version "2021.01.01-1"}
         junit/junit                                 {:mvn/version "4.13.1"}}
 
  :paths ["src" "target/classes"]
@@ -27,7 +29,7 @@
 
            :test {:extra-paths ["test"]
                   :extra-deps {org.clojure/clojurescript {:mvn/version "1.10.516"}
-                               lambdaisland/kaocha       {:mvn/version "1.0.632"}
+                               lambdaisland/kaocha       {:mvn/version "1.0.829"}
                                lambdaisland/kaocha-cljs  {:mvn/version "0.0-71"}
                                io.replikativ/datahike-leveldb {:mvn/version "0.1.0"}
                                io.replikativ/datahike-postgres {:mvn/version "0.3.1-SNAPSHOT"}}}

--- a/src/datahike/spec.cljc
+++ b/src/datahike/spec.cljc
@@ -1,0 +1,97 @@
+(ns datahike.spec
+  (:require
+    [datahike.db :as db]
+    [spec-tools.data-spec :as ds]
+    [clojure.spec.alpha :as s])
+  #?(:clj
+      (:import [java.util Date])))
+
+(def non-neg-int? (s/or :zero zero? :posint pos-int?))
+
+(defn set-of [pred] (s/every pred :kind set?))
+
+(defn date? [d]
+  #?(:cljs (instance? js/Date d)
+     :clj  (instance? Date d)))
+
+(def time-point? (s/or :int int? :date date?))
+
+;; TODO: there's lots of runtime logic to conform these transactions - it would
+;; be nice to spec them accurately, and then conform them at runtime through spec
+(def Transactions
+  (s/coll-of (s/or :seq coll? :map map?)))
+
+;; TODO: deduplicate this Spec with the one in datahike.config
+(def Config
+  (ds/spec
+    {:name ::config
+     :keys-default ds/opt
+     :spec {:store map?
+            :name string?
+            :keep-history? boolean?
+            :schema-flexibility (s/spec #{:write :read})
+            :initial-tx Transactions}}))
+
+(def ConnectionAtom
+  (fn [x]
+    (and
+      (instance? clojure.lang.IAtom x)
+      (s/valid? db/db? @x))))
+
+(def EId (s/or :coll coll? :int non-neg-int?))
+
+(def PullOptions
+  (ds/spec
+    {:name ::pull-options
+     :keys-default ds/req
+     :spec {:selector coll? ;; TODO: spec more of selector
+            :eid EId}}))
+
+(def Datom
+  (fn [x] (instance? datahike.datom.Datom x)))
+
+(def Datoms
+  (s/coll-of Datom))
+
+(def TxMeta (s/nilable coll?))
+
+(def TransactionReport
+  (ds/spec
+    {:name ::transaction-report
+     :keys-default ds/req
+     :spec {:db-before db/db?
+            :db-after db/db?
+            :tx-data Datoms
+            :tempids map?
+            :tx-meta TxMeta}}))
+
+(def QueryArgs
+  (ds/spec
+    {:name ::query-args
+     :keys-default ds/req
+     :spec {:query (s/or :vec vector? :map map? :str string? )
+            :args (s/coll-of (set-of vector?))
+            (ds/opt :limit) int?
+            (ds/opt :offset) int?}}))
+
+(def WithArgs
+  (ds/spec
+    {:name ::with-args
+     :keys-default ds/opt
+     :spec {:tx-data Transactions
+            :tx-meta TxMeta}}))
+
+(def IndexRangeArgs
+  (ds/spec
+    {:name ::index-range-args
+     :keys-default ds/req
+     :spec {:attrid keyword?
+            :start any?
+            :end any?}}))
+
+(def IndexLookupArgs
+  (ds/spec
+    {:name ::index-lookup-args
+     :keys-default ds/req
+     :spec {:index keyword?
+            (ds/opt :components) (s/coll-of any?)}}))

--- a/test/datahike/test/attribute_refs/entity.cljc
+++ b/test/datahike/test/attribute_refs/entity.cljc
@@ -77,9 +77,6 @@
                                  [{:db/id 1, :name "Ivan"}
                                   {:db/id 2, :name "Oleg"}])
         db (d/db-with ref-db entities)]
-    (is (nil? (d/entity db nil)))
-    (is (nil? (d/entity db "abc")))
-    (is (nil? (d/entity db :keyword)))
     (is (nil? (d/entity db [:name "Petr"])))
     (is (= 777 (:db/id (d/entity db 777))))
     (is (thrown-msg? "Lookup ref attribute should be marked as :db/unique: [:not-an-attr 777]"

--- a/test/datahike/test/schema.cljc
+++ b/test/datahike/test/schema.cljc
@@ -346,7 +346,7 @@
 (deftest test-update-schema
   (let [cfg "datahike:mem://test-empty-db"
         _ (d/delete-database cfg)
-        _ (d/create-database cfg :initial-schema [name-schema personal-id-schema])
+        _ (d/create-database cfg :initial-tx [name-schema personal-id-schema])
         conn (d/connect cfg)
         db (d/db conn)
 

--- a/tests.edn
+++ b/tests.edn
@@ -1,4 +1,10 @@
-#kaocha/v1 {:tests [{:id :clj
+#kaocha/v1 {:plugins [:orchestra
+                      :preloads]
+            ;; We preload the namespaces that have specs, so they can be instrumented
+            :kaocha.plugin.preloads/ns-names [datahike.api]
+            ;; More verbose than the default reporter, and with prettier errors
+            :kaocha/reporter [kaocha.report/documentation]
+            :tests [{:id :clj
                      :ns-patterns ["datahike.test."]}
                     #_{:id :cljs
                        :type :kaocha.type/cljs


### PR DESCRIPTION
This PR aims to add type signatures (as Clojure Specs) for the whole `datahike.api` namespace. ~It's marked as WIP because we're not there yet.~

A few notes and questions:
- I spent some time evaluating [malli](https://github.com/metosin/malli) as well, but went with specs in the end due to the wider ecosystem support: we in fact use [Orchestra](https://github.com/jeaye/orchestra) (which is notably integrated in Kaocha) for instrumentation and pretty errors, and [spec-tools](https://github.com/metosin/spec-tools/blob/master/docs/02_data_specs.md) to be able to declare record specs in a less awkward way (and closer to literature) than with vanilla specs (I can ditch `spec-tools` though if you'd not like to pull that in, as the existing specs don't use it)
- There are some failing tests due to the tests passing varargs as configuration, which I understand it's deprecated at this point. This leads to issues like `:initial-tx` being accepted as a key in the `Config` map and as a vararg in certain functions, which as a user might be surprising and raise questions around precedence. So the main question before I can move forward is: __should we spec these varargs?__
  Doing so might be fairly time consuming, and not doing so will require changing the tests to not use them. We wouldn't require a breaking change removing them right away, but these code paths will not be exercised anymore.