### PR TITLE
Array support

### DIFF
--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,0 +1,32 @@
+(ns datahike.array
+  (:require [hitchhiker.tree.key-compare :as kc]
+            [hitchhiker.tree.node :as n]))
+
+(defn compare-arrays [a b]
+  ;; TODO can avoid some of these safety checks?
+  (def foo [a b])
+  (if (not (and (bytes? a) (bytes? b)))
+    (try
+      (compare a b)
+      (catch ClassCastException _
+        (- (n/-order-on-edn-types a)
+           (n/-order-on-edn-types b))))
+    (let [lc (compare (alength a) (alength b))]
+      (if (not (zero? lc))
+        lc
+        (loop [step (alength a)]
+          (if-not (zero? step)
+            (let [ec (compare (aget a (dec step)) (aget b (dec step)))]
+              (if (not (zero? ec))
+                ec
+                (recur (dec step))))
+            0))))))
+
+(defn a=
+  "Extension of Clojure's equality to things we also want to treat like values,
+  e.g. certain array types."
+  [a b]
+  (or (= a b)
+      (and (bytes? a)
+           (bytes? b)
+           (zero? (compare-arrays a b)))))

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,10 +1,8 @@
 (ns datahike.array
-  (:require [hitchhiker.tree.key-compare :as kc]
-            [hitchhiker.tree.node :as n]))
+  (:require [hitchhiker.tree.node :as n]))
 
 (defn compare-arrays [a b]
   ;; TODO can avoid some of these safety checks?
-  (def foo [a b])
   (if (not (and (bytes? a) (bytes? b)))
     (try
       (compare a b)

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,24 +1,33 @@
 (ns datahike.array
   (:require [hitchhiker.tree.node :as n]))
 
-(defn compare-arrays [a b]
-  ;; TODO can avoid some of these safety checks?
+(defn compare-arrays
+  "Compare two arrays a and b element-wise in ascending order. If one array is a
+  prefix of another then it comes first."
+  [a b]
   (if (not (and (bytes? a) (bytes? b)))
     (try
       (compare a b)
       (catch ClassCastException _
         (- (n/-order-on-edn-types a)
            (n/-order-on-edn-types b))))
-    (let [lc (compare (alength a) (alength b))]
-      (if (not (zero? lc))
-        lc
-        (loop [step (alength a)]
-          (if-not (zero? step)
-            (let [ec (compare (aget a (dec step)) (aget b (dec step)))]
-              (if (not (zero? ec))
-                ec
-                (recur (dec step))))
-            0))))))
+    (let [bl (alength b)
+          al (alength a)]
+      (loop [i 1]
+        (cond (and (> i bl) (> i al))
+              0
+
+              (> i bl)
+              1 ;; b is a prefix of a
+
+              (> i al)
+              -1 ;; a is a prefix of b
+
+              :else
+              (let [ec (compare (aget a (dec i)) (aget b (dec i)))]
+                (if (not (zero? ec))
+                  ec
+                  (recur (inc i)))))))))
 
 (defn a=
   "Extension of Clojure's equality to things we also want to treat like values,

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -2,6 +2,37 @@
   (:require [hitchhiker.tree.node :as n])
   (:import [java.util Arrays]))
 
+
+#?(:clj
+   (defn java8? []
+     (try
+       (= 8 (Integer/parseInt (subs (System/getProperty "java.specification.version") 2)))
+       (catch Exception _
+         false))))
+
+#?(:clj
+  (defmacro raw-array-compare [a b]
+    (if (java8?)
+      ;; slow fallback for Java 8, but has same semantics
+      `(let [bl# (alength ~b)
+            al# (alength ~a)]
+        (loop [i# 1]
+          (cond (and (> i# bl#) (> i# al#))
+                0
+
+                (> i# bl#)
+                1 ;; b is a prefix of a
+
+                (> i# al#)
+                -1 ;; a is a prefix of b
+
+                :else
+                (let [ec# (compare (aget ~a (dec i#)) (aget ~b (dec i#)))]
+                  (if (not (zero? ec#))
+                    ec#
+                    (recur (inc i#)))))))
+      `(Arrays/compare ~a ~b))))
+
 (defn compare-arrays
   "Compare two arrays a and b element-wise in ascending order. If one array is a
   prefix of another then it comes first."
@@ -12,7 +43,7 @@
       (catch ClassCastException _
         (- (n/-order-on-edn-types a)
            (n/-order-on-edn-types b))))
-    (Arrays/compare a b)))
+    (raw-array-compare a b)))
 
 (defn a=
   "Extension of Clojure's equality to things we also want to treat like values,

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,5 +1,6 @@
 (ns datahike.array
-  (:require [hitchhiker.tree.node :as n]))
+  (:require [hitchhiker.tree.node :as n])
+  (:import [java.util Arrays]))
 
 (defn compare-arrays
   "Compare two arrays a and b element-wise in ascending order. If one array is a
@@ -11,23 +12,7 @@
       (catch ClassCastException _
         (- (n/-order-on-edn-types a)
            (n/-order-on-edn-types b))))
-    (let [bl (alength b)
-          al (alength a)]
-      (loop [i 1]
-        (cond (and (> i bl) (> i al))
-              0
-
-              (> i bl)
-              1 ;; b is a prefix of a
-
-              (> i al)
-              -1 ;; a is a prefix of b
-
-              :else
-              (let [ec (compare (aget a (dec i)) (aget b (dec i)))]
-                (if (not (zero? ec))
-                  ec
-                  (recur (inc i)))))))))
+    (Arrays/compare a b)))
 
 (defn a=
   "Extension of Clojure's equality to things we also want to treat like values,

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -15,22 +15,22 @@
     (if (java8?)
       ;; slow fallback for Java 8, but has same semantics
       `(let [bl# (alength ~b)
-            al# (alength ~a)]
-        (loop [i# 1]
-          (cond (and (> i# bl#) (> i# al#))
-                0
+             al# (alength ~a)]
+         (loop [i# 1]
+           (cond (and (> i# bl#) (> i# al#))
+                 0
 
-                (> i# bl#)
-                1 ;; b is a prefix of a
+                 (> i# bl#)
+                 1 ;; b is a prefix of a
 
-                (> i# al#)
-                -1 ;; a is a prefix of b
+                 (> i# al#)
+                 -1 ;; a is a prefix of b
 
-                :else
-                (let [ec# (compare (aget ~a (dec i#)) (aget ~b (dec i#)))]
-                  (if (not (zero? ec#))
-                    ec#
-                    (recur (inc i#)))))))
+                 :else
+                 (let [ec# (compare (aget ~a (dec i#)) (aget ~b (dec i#)))]
+                   (if (not (zero? ec#))
+                     ec#
+                     (recur (inc i#)))))))
       `(Arrays/compare ~a ~b))))
 
 (defn compare-arrays

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -11,27 +11,27 @@
          false))))
 
 #?(:clj
-  (defmacro raw-array-compare [a b]
-    (if (java8?)
-      ;; slow fallback for Java 8, but has same semantics
-      `(let [bl# (alength ~b)
-             al# (alength ~a)]
-         (loop [i# 1]
-           (cond (and (> i# bl#) (> i# al#))
-                 0
+   (defmacro raw-array-compare [a b]
+     (if (java8?)
+       ;; slow fallback for Java 8, but has same semantics
+       `(let [bl# (alength ~b)
+              al# (alength ~a)]
+          (loop [i# 1]
+            (cond (and (> i# bl#) (> i# al#))
+                  0
 
-                 (> i# bl#)
-                 1 ;; b is a prefix of a
+                  (> i# bl#)
+                  1 ;; b is a prefix of a
 
-                 (> i# al#)
-                 -1 ;; a is a prefix of b
+                  (> i# al#)
+                  -1 ;; a is a prefix of b
 
-                 :else
-                 (let [ec# (compare (aget ~a (dec i#)) (aget ~b (dec i#)))]
-                   (if (not (zero? ec#))
-                     ec#
-                     (recur (inc i#)))))))
-      `(Arrays/compare ~a ~b))))
+                  :else
+                  (let [ec# (compare (aget ~a (dec i#)) (aget ~b (dec i#)))]
+                    (if (not (zero? ec#))
+                      ec#
+                      (recur (inc i#)))))))
+       `(Arrays/compare ~a ~b))))
 
 (defn compare-arrays
   "Compare two arrays a and b element-wise in ascending order. If one array is a

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -2,7 +2,6 @@
   (:require [hitchhiker.tree.node :as n])
   (:import [java.util Arrays]))
 
-
 #?(:clj
    (defn java8? []
      (try

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -4,6 +4,7 @@
    [clojure.walk]
    [clojure.data]
    #?(:clj [clojure.pprint :as pp])
+   [datahike.array :refer [a=]]
    [datahike.index :refer [-slice -seq -count -all -persistent! -transient] :as di]
    [datahike.datom :as dd :refer [datom datom-tx datom-added datom?]]
    [datahike.constants :refer [e0 tx0 emax txmax]]
@@ -170,10 +171,10 @@
                        (filter (fn [^Datom d] (= tx (datom-tx d)))))
                   (-slice eavt (datom e a nil tx0) (datom e a nil txmax) :eavt) ;; e a _ _
                   (->> (-slice eavt (datom e nil nil tx0) (datom e nil nil txmax) :eavt) ;; e _ v tx
-                       (filter (fn [^Datom d] (and (= v (.-v d))
+                       (filter (fn [^Datom d] (and (a= v (.-v d))
                                                    (= tx (datom-tx d))))))
                   (->> (-slice eavt (datom e nil nil tx0) (datom e nil nil txmax) :eavt) ;; e _ v _
-                       (filter (fn [^Datom d] (= v (.-v d)))))
+                       (filter (fn [^Datom d] (a= v (.-v d)))))
                   (->> (-slice eavt (datom e nil nil tx0) (datom e nil nil txmax) :eavt) ;; e _ _ tx
                        (filter (fn [^Datom d] (= tx (datom-tx d)))))
                   (-slice eavt (datom e nil nil tx0) (datom e nil nil txmax) :eavt) ;; e _ _ _
@@ -181,17 +182,17 @@
                     (->> (-slice avet (datom e0 a v tx0) (datom emax a v txmax) :avet)
                          (filter (fn [^Datom d] (= tx (datom-tx d)))))
                     (->> (-slice aevt (datom e0 a nil tx0) (datom emax a nil txmax) :aevt)
-                         (filter (fn [^Datom d] (and (= v (.-v d))
+                         (filter (fn [^Datom d] (and (a= v (.-v d))
                                                      (= tx (datom-tx d)))))))
                   (if indexed?                              ;; _ a v _
                     (-slice avet (datom e0 a v tx0) (datom emax a v txmax) :avet)
                     (->> (-slice aevt (datom e0 a nil tx0) (datom emax a nil txmax) :aevt)
-                         (filter (fn [^Datom d] (= v (.-v d))))))
+                         (filter (fn [^Datom d] (a= v (.-v d))))))
                   (->> (-slice aevt (datom e0 a nil tx0) (datom emax a nil txmax) :aevt) ;; _ a _ tx
                        (filter (fn [^Datom d] (= tx (datom-tx d)))))
                   (-slice aevt (datom e0 a nil tx0) (datom emax a nil txmax) :aevt) ;; _ a _ _
-                  (filter (fn [^Datom d] (and (= v (.-v d)) (= tx (datom-tx d)))) (-all eavt)) ;; _ _ v tx
-                  (filter (fn [^Datom d] (= v (.-v d))) (-all eavt)) ;; _ _ v _
+                  (filter (fn [^Datom d] (and (a= v (.-v d)) (= tx (datom-tx d)))) (-all eavt)) ;; _ _ v tx
+                  (filter (fn [^Datom d] (a= v (.-v d))) (-all eavt)) ;; _ _ v _
                   (filter (fn [^Datom d] (= tx (datom-tx d))) (-all eavt)) ;; _ _ _ tx
                   (-all eavt)]))))
 

--- a/src/datahike/index/hitchhiker_tree.cljc
+++ b/src/datahike/index/hitchhiker_tree.cljc
@@ -4,6 +4,7 @@
             [hitchhiker.tree.messaging :as hmsg]
             [hitchhiker.tree.key-compare :as kc]
             [hitchhiker.tree :as tree]
+            [datahike.array :refer [compare-arrays]]
             [datahike.datom :as dd]
             [datahike.constants :refer [e0 tx0 emax txmax]]
             [hasch.core :as h])
@@ -34,6 +35,11 @@
   (-compare [key1 key2]
     (if (nil? key2)
       0 -1)))
+
+(extend-protocol kc/IKeyCompare
+  (Class/forName "[B")
+  (-compare [key1 key2]
+    (compare-arrays key1 key2)))
 
 (def ^:const br 300) ;; TODO name better, total node size; maybe(!) make configurable
 (def ^:const br-sqrt (long (Math/sqrt br))) ;; branching factor

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -8,6 +8,7 @@
 (s/def :db.type/bigdec decimal?)
 (s/def :db.type/bigint integer?)
 (s/def :db.type/boolean boolean?)
+(s/def :db.type/bytes bytes?)
 (s/def :db.type/double double?)
 (s/def :db.type/float float?)
 (s/def :db.type/number number?)
@@ -24,6 +25,7 @@
   #{:db.type/bigdec
     :db.type/bigint
     :db.type/boolean
+    :db.type/bytes
     :db.type/double
     :db.type/float
     :db.type/number

--- a/test/datahike/test/array.cljc
+++ b/test/datahike/test/array.cljc
@@ -1,0 +1,30 @@
+(ns datahike.test.array
+  (:require
+   #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]]
+      :clj  [clojure.test :as t :refer [is are deftest testing use-fixtures]])
+   [datahike.array :refer [compare-arrays a=]]))
+
+(deftest test-array-ordering
+  (testing "Array value indexing support."
+
+    ;; empty arrays
+    (is (zero? (compare-arrays (byte-array []) (byte-array []))))
+
+    ;; ordering is by dimensionality first
+    (is (= -1 (compare-arrays (byte-array []) (byte-array [5 2 3 5]))))
+    (is (=  1 (compare-arrays (byte-array [5 2 3 5]) (byte-array []))))
+    (is (= -1 (compare-arrays (byte-array [5 2 3]) (byte-array [5 2 3 5]))))
+    (is (=  1 (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3]))))
+
+    ;; for equal length arrays we do an element-wise comparison
+    (is (zero? (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3 5]))))
+    (is (=  1 (compare-arrays (byte-array [5 2 2 5]) (byte-array [5 2 3 1]))))
+    (is (= -1 (compare-arrays (byte-array [6 2 2 5]) (byte-array [5 2 3 5]))))))
+
+(deftest test-extended-equality
+  (testing "Testing extended equality with support for arrays."
+    ;; some Clojure semantics safety checks
+    (is (a= 0 0))
+    (is (a= "foo" "foo"))
+    (is (not (a= "foo" "bar")))
+    (is (a= [{:a 5} 4 "bar"] [{:a 5} 4 "bar"]))))

--- a/test/datahike/test/array.cljc
+++ b/test/datahike/test/array.cljc
@@ -11,15 +11,15 @@
     (is (zero? (compare-arrays (byte-array []) (byte-array []))))
 
     ;; ordering is by dimensionality first
-    (is (= -1 (compare-arrays (byte-array []) (byte-array [5 2 3 5]))))
-    (is (=  1 (compare-arrays (byte-array [5 2 3 5]) (byte-array []))))
-    (is (= -1 (compare-arrays (byte-array [5 2 3]) (byte-array [5 2 3 5]))))
-    (is (=  1 (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3]))))
+    (is (neg? (compare-arrays (byte-array []) (byte-array [5 2 3 5]))))
+    (is (pos? (compare-arrays (byte-array [5 2 3 5]) (byte-array []))))
+    (is (neg? (compare-arrays (byte-array [5 2 3]) (byte-array [5 2 3 5]))))
+    (is (pos? (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3]))))
 
     ;; for equal length arrays we do an element-wise comparison
     (is (zero? (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3 5]))))
-    (is (= -1 (compare-arrays (byte-array [5 2 2 5]) (byte-array [5 2 3 1]))))
-    (is (=  1 (compare-arrays (byte-array [6 2 2 5]) (byte-array [5 2 3 5]))))))
+    (is (neg?  (compare-arrays (byte-array [5 2 2 5]) (byte-array [5 2 3 1]))))
+    (is (pos?  (compare-arrays (byte-array [6 2 2 5]) (byte-array [5 2 3 5]))))))
 
 (deftest test-extended-equality
   (testing "Testing extended equality with support for arrays."

--- a/test/datahike/test/array.cljc
+++ b/test/datahike/test/array.cljc
@@ -18,8 +18,8 @@
 
     ;; for equal length arrays we do an element-wise comparison
     (is (zero? (compare-arrays (byte-array [5 2 3 5]) (byte-array [5 2 3 5]))))
-    (is (=  1 (compare-arrays (byte-array [5 2 2 5]) (byte-array [5 2 3 1]))))
-    (is (= -1 (compare-arrays (byte-array [6 2 2 5]) (byte-array [5 2 3 5]))))))
+    (is (= -1 (compare-arrays (byte-array [5 2 2 5]) (byte-array [5 2 3 1]))))
+    (is (=  1 (compare-arrays (byte-array [6 2 2 5]) (byte-array [5 2 3 5]))))))
 
 (deftest test-extended-equality
   (testing "Testing extended equality with support for arrays."

--- a/test/datahike/test/schema.cljc
+++ b/test/datahike/test/schema.cljc
@@ -84,7 +84,7 @@
 
     (testing "insert schema with incorrect value type"
       (is (thrown-msg?
-           "Bad entity value :string at [:db/add 3 :db/valueType :string], value does not match schema definition. Must be conform to: #{:db.type/number :db.type/instant :db.type/tuple :db.type/boolean :db.type/uuid :db.type/value :db.type/string :db.type/keyword :db.type/ref :db.type/bigdec :db.type/float :db.type/bigint :db.type/double :db.type/long :db.type/symbol}"
+           "Bad entity value :string at [:db/add 3 :db/valueType :string], value does not match schema definition. Must be conform to: #{:db.type/number :db.type/instant :db.type/tuple :db.type/boolean :db.type/bytes :db.type/uuid :db.type/value :db.type/string :db.type/keyword :db.type/ref :db.type/bigdec :db.type/float :db.type/bigint :db.type/double :db.type/long :db.type/symbol}"
            (d/transact conn [{:db/ident       :phone
                               :db/cardinality :db.cardinality/one
                               :db/valueType   :string}]))))))

--- a/test/datahike/test/store.cljc
+++ b/test/datahike/test/store.cljc
@@ -57,7 +57,6 @@
       (is (= hitchhiker.tree.DataNode
              (-> @conn :eavt type))))))
 
-
 (deftest test-binary-support
   (doseq [index [:datahike.index/persistent-set :datahike.index/hitchhiker-tree]]
     (let [config {:store {:backend :mem

--- a/test/datahike/test/store.cljc
+++ b/test/datahike/test/store.cljc
@@ -59,21 +59,22 @@
 
 
 (deftest test-binary-support
-  (let [config {:store {:backend :mem
-                        :id "test-hitchhiker-tree-binary-support"}
-                :schema-flexibility :read
-                :keep-history? false
-                :index :datahike.index/hitchhiker-tree}]
-    (d/delete-database config)
-    (d/create-database config)
-    (let [conn (d/connect config)]
-      (d/transact conn [{:db/id 1, :name "Jiayi", :payload (byte-array [0 2 3])}
-                        {:db/id 2, :name "Peter", :payload (byte-array [1 2 3])}])
-      (is (= "Jiayi"
-             (d/q '[:find ?n .
-                    :in $ ?arr
-                    :where
-                    [?e :payload ?arr]
-                    [?e :name ?n]]
-                  @conn
-                  (byte-array [0 2 3])))))))
+  (doseq [index [:datahike.index/persistent-set :datahike.index/hitchhiker-tree]]
+    (let [config {:store {:backend :mem
+                          :id "test-hitchhiker-tree-binary-support"}
+                  :schema-flexibility :read
+                  :keep-history? false
+                  :index index}]
+      (d/delete-database config)
+      (d/create-database config)
+      (let [conn (d/connect config)]
+        (d/transact conn [{:db/id 1, :name "Jiayi", :payload (byte-array [0 2 3])}
+                          {:db/id 2, :name "Peter", :payload (byte-array [1 2 3])}])
+        (is (= "Jiayi"
+               (d/q '[:find ?n .
+                      :in $ ?arr
+                      :where
+                      [?e :payload ?arr]
+                      [?e :name ?n]]
+                    @conn
+                    (byte-array [0 2 3]))))))))

--- a/test/datahike/test/store.cljc
+++ b/test/datahike/test/store.cljc
@@ -56,3 +56,24 @@
       (d/transact conn [{:db/id 1, :name "Alice"}])
       (is (= hitchhiker.tree.DataNode
              (-> @conn :eavt type))))))
+
+
+(deftest test-binary-support
+  (let [config {:store {:backend :mem
+                        :id "test-hitchhiker-tree-binary-support"}
+                :schema-flexibility :read
+                :keep-history? false
+                :index :datahike.index/hitchhiker-tree}]
+    (d/delete-database config)
+    (d/create-database config)
+    (let [conn (d/connect config)]
+      (d/transact conn [{:db/id 1, :name "Jiayi", :payload (byte-array [0 2 3])}
+                        {:db/id 2, :name "Peter", :payload (byte-array [1 2 3])}])
+      (is (= "Jiayi"
+             (d/q '[:find ?n .
+                    :in $ ?arr
+                    :where
+                    [?e :payload ?arr]
+                    [?e :name ?n]]
+                  @conn
+                  (byte-array [0 2 3])))))))


### PR DESCRIPTION
Add (byte) array support with an ordering based on shape and value. Adding support for more array types is easy to add. This PR defines a total ordering over byte arrays that is first by shape (shorter is smaller) and then by element-wise Clojure comparison semantics. This allows pattern matching on binary data while avoiding deep comparisons on objects of different form. Resolves #314.

Different types of indexing can be beneficial depending on the domain. This is also an example of how a new sequential binary type can be added to Datahike.