### PR TITLE
Remove search lookup on hot insertion path.

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1473,9 +1473,7 @@
         v (if (ref? db a) (entid-strict db v) v)
         new-datom (datom e a v tx)]
     (if (multival? db a)
-      (if (empty? (-search db [e a v]))
-        (transact-report report new-datom)
-        report)
+      (transact-report report new-datom)
       (transact-report-upsert report new-datom))))
 
 (defn- transact-retract-datom [report ^Datom d]


### PR DESCRIPTION
This PR resolves performance for inserts with schema `:db.cardinality/many` #335.