### PR TITLE
Allow more schema attributes to be updated

### DIFF
--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -178,8 +178,11 @@
                      (not= :db.cardinality/one (:db/cardinality attr-schema)))
              (assoc m attr-def [old-value new-value]))
             
-           ;; Always allow docs to be updated. 
+           ;; Always allow these attributes to be updated. 
            :db/doc nil
+           :db/noHistory nil
+           :db/isComponent nil
+
            (assoc m attr-def [old-value new-value])))))
    {}
    (dissoc entity :db/id)))

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -175,6 +175,7 @@
            :db/unique (when-not (get-in attr-schema [:db/unique])
                         (when-not (= (get-in attr-schema [:db/cardinality]) :db.cardinality/one)
                           (assoc m attr-def [old-value new-value])))
+           :db/doc nil
            (assoc m attr-def [old-value new-value])))))
    {}
    (dissoc entity :db/id)))

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -164,7 +164,8 @@
   (reduce-kv
    (fn [m attr-def new-value]
      (let [old-value (get-in attr-schema [attr-def])]
-       (when-not (= old-value new-value)
+       (when (and (not= old-value new-value) 
+                  (= "db" (namespace attr-def)))
          (case attr-def
            :db/cardinality (if (= new-value :db.cardinality/many)
                              (if (get-in attr-schema [:db/unique])

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -164,8 +164,7 @@
   (reduce-kv
    (fn [m attr-def new-value]
      (let [old-value (get-in attr-schema [attr-def])]
-       (when (and (not= old-value new-value) 
-                  (= "db" (namespace attr-def)))
+       (when (not= old-value new-value)
          (case attr-def
            :db/cardinality 
            ;; Prohibit update from :db.cardinality/one to :db.cardinality/many, if there is a :db/unique constraint.


### PR DESCRIPTION
This MR allows the update of any non-`db` namespaced attribute key

- [x] ~~any non-`db` namespaced attribute key~~ (There are other places that need changes, other than the validation fn)
- [x] The `:db/doc` key
- [x] The `:db/isComponent`key
- [x] The `:db/noHistory` key

Closes https://github.com/replikativ/datahike/issues/345