### PR TITLE
Fix attribute reference maps after reconnection

### DIFF
--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -21,7 +21,7 @@
 
 (defn update-and-flush-db [connection tx-data update-fn]
   (let [{:keys [db-after] :as tx-report} @(update-fn connection tx-data)
-        {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema ident-ref-map ref-ident-map config max-tx op-count hash]} db-after
+        {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema system-entities ident-ref-map ref-ident-map config max-tx op-count hash]} db-after
         store (:store @connection)
         backend (kons/->KonserveBackend store)
         eavt-flushed (di/-flush eavt backend)
@@ -35,6 +35,7 @@
                        (merge
                         {:schema schema
                          :rschema rschema
+                         :system-entities system-entities
                          :ident-ref-map ident-ref-map
                          :ref-ident-map ref-ident-map
                          :config config
@@ -149,7 +150,7 @@
               (ds/release-store store-config store)
               (dt/raise "Database does not exist." {:type :db-does-not-exist
                                                     :config config}))
-          {:keys [eavt-key aevt-key avet-key temporal-eavt-key temporal-aevt-key temporal-avet-key schema rschema ref-ident-map ident-ref-map config max-tx op-count hash]
+          {:keys [eavt-key aevt-key avet-key temporal-eavt-key temporal-aevt-key temporal-avet-key schema rschema system-entities ref-ident-map ident-ref-map config max-tx op-count hash]
            :or {op-count 0}} stored-db
           empty (db/empty-db nil config)
           conn (d/conn-from-db (assoc empty
@@ -166,6 +167,7 @@
                                       :temporal-aevt temporal-aevt-key
                                       :temporal-avet temporal-avet-key
                                       :rschema rschema
+                                      :system-entities system-entities
                                       :ident-ref-map ident-ref-map
                                       :ref-ident-map ref-ident-map
                                       :store store))]
@@ -181,7 +183,7 @@
           stored-db (<?? S (k/get-in store [:db]))
           _ (when stored-db
               (dt/raise "Database already exists." {:type :db-already-exists :config store-config}))
-          {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema ref-ident-map ident-ref-map config max-tx op-count hash]}
+          {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema system-entities ref-ident-map ident-ref-map config max-tx op-count hash]}
           (db/empty-db nil config)
           backend (kons/->KonserveBackend store)]
       (<?? S (k/assoc-in store [:db]
@@ -190,6 +192,7 @@
                                  :op-count op-count
                                  :hash hash
                                  :rschema rschema
+                                 :system-entities system-entities
                                  :ident-ref-map ident-ref-map
                                  :ref-ident-map ref-ident-map
                                  :config config

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -21,7 +21,7 @@
 
 (defn update-and-flush-db [connection tx-data update-fn]
   (let [{:keys [db-after] :as tx-report} @(update-fn connection tx-data)
-        {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema config max-tx op-count hash]} db-after
+        {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema ident-ref-map ref-ident-map config max-tx op-count hash]} db-after
         store (:store @connection)
         backend (kons/->KonserveBackend store)
         eavt-flushed (di/-flush eavt backend)
@@ -35,6 +35,8 @@
                        (merge
                         {:schema schema
                          :rschema rschema
+                         :ident-ref-map ident-ref-map
+                         :ref-ident-map ref-ident-map
                          :config config
                          :hash hash
                          :max-tx max-tx
@@ -147,7 +149,7 @@
               (ds/release-store store-config store)
               (dt/raise "Database does not exist." {:type :db-does-not-exist
                                                     :config config}))
-          {:keys [eavt-key aevt-key avet-key temporal-eavt-key temporal-aevt-key temporal-avet-key schema rschema config max-tx op-count hash]
+          {:keys [eavt-key aevt-key avet-key temporal-eavt-key temporal-aevt-key temporal-avet-key schema rschema ref-ident-map ident-ref-map config max-tx op-count hash]
            :or {op-count 0}} stored-db
           empty (db/empty-db nil config)
           conn (d/conn-from-db (assoc empty
@@ -164,6 +166,8 @@
                                       :temporal-aevt temporal-aevt-key
                                       :temporal-avet temporal-avet-key
                                       :rschema rschema
+                                      :ident-ref-map ident-ref-map
+                                      :ref-ident-map ref-ident-map
                                       :store store))]
       (swap! conn assoc :transactor (t/create-transactor (:transactor config) conn update-and-flush-db))
       conn))
@@ -177,7 +181,7 @@
           stored-db (<?? S (k/get-in store [:db]))
           _ (when stored-db
               (dt/raise "Database already exists." {:type :db-already-exists :config store-config}))
-          {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema config max-tx op-count hash]}
+          {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema ref-ident-map ident-ref-map config max-tx op-count hash]}
           (db/empty-db nil config)
           backend (kons/->KonserveBackend store)]
       (<?? S (k/assoc-in store [:db]
@@ -186,6 +190,8 @@
                                  :op-count op-count
                                  :hash hash
                                  :rschema rschema
+                                 :ident-ref-map ident-ref-map
+                                 :ref-ident-map ref-ident-map
                                  :config config
                                  :eavt-key (di/-flush eavt backend)
                                  :aevt-key (di/-flush aevt backend)

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -1259,7 +1259,6 @@
            {:error :transact/syntax, :attribute ident})))
 
 (defn validate-datom [db ^Datom datom]
-  #_(println "validate datom" datom)
   (when (and (datom-added datom)
              (is-attr? db (.-a datom) :db/unique))
     (when-let [found (not-empty (-datoms db :avet [(.-a datom) (.-v datom)]))]
@@ -2067,7 +2066,6 @@
               (= op :db.history.purge/before)
               (if (-keep-history? db)
                 (let [history (HistoricalDB. db)
-                      ;    _ (println "purge before")
                       into-sorted-set #(apply sorted-set-by dd/cmp-datoms-eavt-quick %)
                       e-datoms (-> (clojure.set/difference
                                     (into-sorted-set (search-temporal-indices db nil))


### PR DESCRIPTION
The fields ident-ref-map and ref-ident-map were not imported on reconnection. This PR fixes this. 