### PR TITLE
Remove uniqueness constraint for :txInstant

### DIFF
--- a/src/datahike/constants.cljc
+++ b/src/datahike/constants.cljc
@@ -54,7 +54,6 @@
     :db/valueType :db.type/instant
     :db/cardinality :db.cardinality/one
     :db/doc "A transaction's time-point"
-    :db/unique :db.unique/identity
     :db/index true}
    {:db/id 10
     :db/ident :db.cardinality/many}


### PR DESCRIPTION
The uniqueness constraint causes non-deterministic errors for the attribute reference tests. The cause are (almost) simultaneous measurements of transaction times. This PR fixes the error by removing the uniqueness constraint.