### PR TITLE
Fix scalar binding for function output

### DIFF
--- a/test/datahike/test/attribute_refs/query_pull.cljc
+++ b/test/datahike/test/attribute_refs/query_pull.cljc
@@ -99,7 +99,6 @@
 
 (deftest test-find-spec-input
   (let [pattern '[*]]
-    (println "pull 1" (d/pull test-db pattern 1))
     (is (= (d/pull test-db pattern 1)
            (d/q '[:find (pull ?e ?p) .
                   :in $ ?p

--- a/test/datahike/test/attribute_refs/query_rules.cljc
+++ b/test/datahike/test/attribute_refs/query_rules.cljc
@@ -104,7 +104,6 @@
                     [4 :f1 5]
                     [5 :f2 6]]
             db2 (d/db-with ref-db (wrap-ref-datoms ref-db ref-e0 :db/add datoms))]
-        (println "datoms" (d/datoms db :eavt))
         (is (= (shift-in #{[0 1] [0 3] [0 5]
                            [1 3] [1 5]
                            [2 3] [2 5]

--- a/test/datahike/test/query_fns.cljc
+++ b/test/datahike/test/query_fns.cljc
@@ -9,15 +9,6 @@
   #?(:clj
      (:import [clojure.lang ExceptionInfo])))
 
-(let [db (-> (d/empty-db {:parent {:db/valueType :db.type/ref}})
-             (d/db-with [{:db/id 1, :name  "Ivan",  :age   15}
-                         {:db/id 2, :name  "Petr",  :age   22, :height 240, :parent 1}
-                         {:db/id 3, :name  "Slava", :age   37, :parent 2}]))]
-  (d/q '[:find  ?e1 ?e2
-         :where [?e1 :age ?a1]
-         [?e2 :age ?a2]
-         [(< ?a1 18 ?a2)]] db))
-
 (deftest test-query-fns
   (testing "predicate without free variables"
     (is (= (d/q '[:find ?x
@@ -80,6 +71,14 @@
                     :where [(count ?x) ?c]]
                   ["a" "abc"])
              #{["a" 1] ["abc" 3]})))
+
+    (testing "Function binding filtered by input argument"
+      (is (= (d/q '[:find  ?x
+                    :in    [?x ...] ?c
+                    :where [(count ?x) ?c]]
+                  ["a" "abc"]
+                  3)
+             #{["abc"]})))
 
     (testing "Built-in vector, hashmap"
       (is (= (d/q '[:find [?tx-data ...]


### PR DESCRIPTION
The current direct replacement of vars in queries with scalars given as arguments caused joins on those vars not being possible anymore. Furthermore, the output of functions was not filtered to allow only those with vars set as required by the argument.

This PR  removes the replacement from `-resolve-clause` and instead moves the required logic to `lookup-pattern-db` and `bind-by-fn` so joins are possible again and the knowledge of scalars is still being used to tweak performance.