### PR TITLE
388 no reinsertion of equiv datom

### DIFF
--- a/src/datahike/index/hitchhiker_tree/insert.cljc
+++ b/src/datahike/index/hitchhiker_tree/insert.cljc
@@ -18,7 +18,6 @@
           true
           indices))
 
-
 (defn exists-old?
   "Returns true if 'new' already exists in 'old-keys'."
   [old-keys new]

--- a/src/datahike/index/hitchhiker_tree/insert.cljc
+++ b/src/datahike/index/hitchhiker_tree/insert.cljc
@@ -26,8 +26,7 @@
           mask (mask new indices)]
       (when-let [candidates (subseq old-keys >= mask)]
         (->> candidates
-             (map first)
-             first
+             ffirst
              (equals-at-indices? indices new))))))
 
 (defrecord InsertOp [key op-count]

--- a/test/datahike/test/insert.cljc
+++ b/test/datahike/test/insert.cljc
@@ -8,7 +8,15 @@
 #?(:cljs
    (def Throwable js/Error))
 
-(defn duplicate-test [config]
+
+
+
+;; Test that the second insertion of the same datom does not replace the initial one.
+;; That is similar to Datomic's behaviour.
+;; Note that the 'mem-set' backend does not have this semantics though.
+
+
+(defn duplicate-test [config test-tx-id?]
   (let [_      (d/create-database config)
         conn   (d/connect config)
         schema [{:db/ident       :block/string
@@ -20,22 +28,21 @@
                  :db/cardinality :db.cardinality/many}]
         _     (d/transact conn schema)
         _     (d/transact conn [{:db/id 501 :block/string "one"}])
-        _     (d/transact conn [{:db/id 502 :block/children 501}])
-        expected (d/datoms @conn :eavt 502 :block/children)
-        tx-1   (.-tx (first expected))
-        _ (d/transact conn [{:db/id 502 :block/children 501}])
-        tx-2   (.-tx (first (d/datoms @conn :eavt 502 :block/children)))
-        aevt (d/datoms @conn :aevt :block/children 502)
-        avet (d/datoms @conn :avet :block/children 501)]
-
-    (is (= tx-1 tx-2))
-    (is (= 1 (count expected)))
+        _     (d/transact conn [{:db/id 502 :block/children 501}]) ;; First transacton
+        datom-1 (first (d/datoms @conn :eavt 502 :block/children))
+        _     (d/transact conn [{:db/id 502 :block/children 501}]) ;; Second transaction
+        datom-2 (first (d/datoms @conn :eavt 502 :block/children))
+        aevt  (d/datoms @conn :aevt :block/children 502)
+        avet  (d/datoms @conn :avet :block/children 501)]
+    (when test-tx-id?
+      (is (= (.-tx datom-1) (.-tx datom-2))))
+    (is (= datom-1 datom-2))
 
     (is (= 1 (count aevt)))
-    (is (datom/cmp-datoms-eavt expected (first aevt)))
+    (is (= datom-1 (first aevt)))
 
-    ;; (is (= 1 (count avet)))
-    ;; (is (= expected (first avet)))
+    (is (= 1 (count avet)))
+    (is (= datom-1 (first avet)))
 
     (d/release conn)
     (d/delete-database config)))
@@ -44,22 +51,25 @@
   (let [config {:store {:backend :mem :id "performance-set"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/persistent-set}]
-    (duplicate-test config)))
+                :index :datahike.index/persistent-set}
+        test-tx-id? false]
+    (duplicate-test config test-tx-id?)))
 
 (deftest mem-hht
   (let [config {:store {:backend :mem :id "performance-hht"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/hitchhiker-tree}]
-    (duplicate-test config)))
+                :index :datahike.index/hitchhiker-tree}
+        test-tx-id? true]
+    (duplicate-test config test-tx-id?)))
 
 (deftest file
   (let [config {:store {:backend :file :path "/tmp/performance-hht"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/hitchhiker-tree}]
-    (duplicate-test config)))
+                :index :datahike.index/hitchhiker-tree}
+        test-tx-id? true]
+    (duplicate-test config test-tx-id?)))
 
 (deftest insert-read-handlers
   (let [config {:store {:backend :file :path "/tmp/insert-read-handlers-9"}


### PR DESCRIPTION
Insertion of the same datom shall not replace the original one.
This is to preserve the same semantics as Datomic.
Note that the 'mem-set' backend does not behave this way though.