### PR TITLE
Get max-eid from index if not present in db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Switch to GitHub Flow and using main branch
 - Switch to tools.build for building and deploying
 - Persist max-eid
+- Init max-eid from index for older db versions https://github.com/replikativ/datahike/issues/465 https://github.com/replikativ/datahike/pull/481
 - Allow attribute access to historical db records
 - Allow keyword keys for queries
 


### PR DESCRIPTION
#### SUMMARY
This fixes #465 by getting the max-eid from the index if it is not present in the db record.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
   - I am not sure how to add this. 
- [ ] ~~Architecture Decision Record added if design changes necessary~~
- [x] Formatting checked
- [x] `CHANGELOG.md` updated
   - The same as: "Persist max-eid"?