### PR TITLE
Restrict hht namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Allow keyword keys for queries
 - Fix tx-meta on transact through api-ns
 - Improve code samples using transact with arg-map @podgorniy
+- Refactor index namespaces
 
 ## 0.4.0
 

--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
         environ/environ                             {:mvn/version "1.2.0"}
         com.taoensso/timbre                         {:mvn/version "5.1.2"}
         io.replikativ/superv.async                  {:mvn/version "0.3.43"}
-        io.lambdaforge/datalog-parser               {:mvn/version "0.1.10"}
+        io.lambdaforge/datalog-parser               {:mvn/version "0.1.11"}
         io.replikativ/zufall                        {:mvn/version "0.1.0"}
         junit/junit                                 {:mvn/version "4.13.2"}}
 
@@ -26,12 +26,12 @@
                               incanter/incanter-charts    {:mvn/version "1.9.3"}}}
 
            :test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha         {:mvn/version "1.60.945"}
+                  :extra-deps {lambdaisland/kaocha         {:mvn/version "1.63.998"}
                                lambdaisland/kaocha-cljs    {:mvn/version "1.0.107"}
                                io.replikativ/datahike-jdbc {:mvn/version "0.1.2-SNAPSHOT"}
-                               org.clojure/test.check      {:mvn/version "0.9.0"}}}
+                               org.clojure/test.check      {:mvn/version "1.1.1"}}}
 
-           :repl {:extra-deps {cider/cider-nrepl           {:mvn/version "0.28.1"}
+           :repl {:extra-deps {cider/cider-nrepl           {:mvn/version "0.28.3"}
                                nrepl/nrepl                 {:mvn/version "0.9.0"}
                                org.clojure/tools.namespace {:mvn/version "1.2.0"}}
                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -6,7 +6,6 @@
             [datahike.config :as dc]
             [datahike.tools :as dt :refer [throwable-promise]]
             [datahike.transactor :as t]
-            [hitchhiker.tree.bootstrap.konserve :as kons]
             [konserve.core :as k]
             [konserve.cache :as kc]
             [superv.async :refer [<?? S]]
@@ -176,10 +175,10 @@
       conn))
 
   (-create-database [config & deprecated-config]
-    (let [{:keys [keep-history? initial-tx index] :as config} (dc/load-config config deprecated-config)
+    (let [{:keys [keep-history? initial-tx] :as config} (dc/load-config config deprecated-config)
           store-config (:store config)
           store (kc/ensure-cache
-                 (ds/empty-store index store-config)
+                 (ds/empty-store store-config)
                  (atom (cache/lru-cache-factory {} :threshold 1000)))
           stored-db (<?? S (k/get-in store [:db]))
           _ (when stored-db

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -5,8 +5,6 @@
             [datahike.store :as ds]
             [datahike.config :as dc]
             [datahike.tools :as dt :refer [throwable-promise]]
-            [datahike.index.hitchhiker-tree.upsert :as ups]
-            [datahike.index.hitchhiker-tree.insert :as ins]
             [datahike.transactor :as t]
             [hitchhiker.tree.bootstrap.konserve :as kons]
             [konserve.core :as k]
@@ -25,7 +23,7 @@
   (let [{:keys [db-after] :as tx-report} @(update-fn connection tx-data tx-meta)
         {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema system-entities ident-ref-map ref-ident-map config max-tx max-eid op-count hash meta]} db-after
         store (:store @connection)
-        backend (kons/->KonserveBackend store)
+        backend (di/konserve-backend (:index config) store)
         eavt-flushed (di/-flush eavt backend)
         aevt-flushed (di/-flush aevt backend)
         avet-flushed (di/-flush avet backend)
@@ -124,12 +122,10 @@
           store-config (:store config)
           raw-store (ds/connect-store store-config)]
       (if (not (nil? raw-store))
-        (let [store (ups/add-upsert-handler
-                     (ins/add-insert-handler
-                      (kons/add-hitchhiker-tree-handlers
-                       (kc/ensure-cache
-                        raw-store
-                        (atom (cache/lru-cache-factory {} :threshold 1000))))))
+        (let [store (di/add-konserve-handlers (:index config)
+                                              (kc/ensure-cache
+                                               raw-store
+                                               (atom (cache/lru-cache-factory {} :threshold 1000))))
               stored-db (<?? S (k/get-in store [:db]))]
           (ds/release-store store-config store)
           (not (nil? stored-db)))
@@ -145,12 +141,10 @@
           _ (when-not raw-store
               (dt/raise "Backend does not exist." {:type :backend-does-not-exist
                                                    :config config}))
-          store (ups/add-upsert-handler
-                 (ins/add-insert-handler
-                  (kons/add-hitchhiker-tree-handlers
-                   (kc/ensure-cache
-                    raw-store
-                    (atom (cache/lru-cache-factory {} :threshold 1000))))))
+          store (di/add-konserve-handlers (:index config)
+                                          (kc/ensure-cache
+                                           raw-store
+                                           (atom (cache/lru-cache-factory {} :threshold 1000))))
           stored-db (<?? S (k/get-in store [:db]))
           _ (when-not stored-db
               (ds/release-store store-config store)
@@ -182,17 +176,17 @@
       conn))
 
   (-create-database [config & deprecated-config]
-    (let [{:keys [keep-history? initial-tx] :as config} (dc/load-config config deprecated-config)
+    (let [{:keys [keep-history? initial-tx index] :as config} (dc/load-config config deprecated-config)
           store-config (:store config)
           store (kc/ensure-cache
-                 (ds/empty-store store-config)
+                 (ds/empty-store index store-config)
                  (atom (cache/lru-cache-factory {} :threshold 1000)))
           stored-db (<?? S (k/get-in store [:db]))
           _ (when stored-db
               (dt/raise "Database already exists." {:type :db-already-exists :config store-config}))
           {:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet schema rschema system-entities ref-ident-map ident-ref-map config max-tx max-eid op-count hash meta]}
           (db/empty-db nil config)
-          backend (kons/->KonserveBackend store)]
+          backend (di/konserve-backend (:index config) store)]
       (<?? S (k/assoc-in store [:db]
                          (merge {:schema schema
                                  :max-tx max-tx

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -6,7 +6,6 @@
    [clojure.data]
    #?(:clj [clojure.pprint :as pp])
    [datahike.array :refer [a=]]
-   #_[datahike.index.interface :as di]
    [datahike.index :as di]
    [datahike.datom :as dd :refer [datom datom-tx datom-added datom?]]
    [datahike.constants :as c :refer [ue0 e0 tx0 utx0 emax txmax system-schema]]

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -22,6 +22,8 @@
 
 (def empty-index di/empty-index)
 (def init-index di/init-index)
+(def add-konserve-handlers di/add-konserve-handlers)
+(def konserve-backend di/konserve-backend)
 
 ;; Other functions
 

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -1,125 +1,28 @@
 (ns ^:no-doc datahike.index
-  (:require [datahike.index.hitchhiker-tree :as dih]
-            [datahike.index.persistent-set :as dip])
-  #?(:clj (:import [hitchhiker.tree DataNode IndexNode]
-                   [me.tonsky.persistent_sorted_set PersistentSortedSet])))
+  (:require [datahike.index.interface :as di]
+            [datahike.index.hitchhiker-tree]
+            [datahike.index.persistent-set]))
 
-;; TODO add doc to each function
-(defprotocol IIndex
-  (-all [index])
-  (-seq [index])
-  (-count [index])
-  (-insert [index datom index-type op-count])
-  (-temporal-insert [index datom index-type op-count])
-  (-upsert [index datom index-type op-count])
-  (-temporal-upsert [index datom index-type op-count])
-  (-remove [index datom index-type op-count])
-  (-slice [index from to index-type])
-  (-flush [index backend])
-  (-transient [index])
-  (-persistent! [index]))
+;; Aliases for protocol functions
 
-(extend-type DataNode
-  IIndex
-  (-all [eavt-tree]
-    (dih/-all eavt-tree :eavt))
-  (-seq [eavt-tree]
-    (dih/-seq eavt-tree :eavt))
-  (-count [eavt-tree]
-    (dih/-count eavt-tree :eavt))
-  (-insert [tree datom index-type op-count]
-    (dih/-insert tree datom index-type op-count))
-  (-temporal-insert [tree datom index-type op-count]
-    (dih/-temporal-insert tree datom index-type op-count))
-  (-upsert [tree datom index-type op-count]
-    (dih/-upsert tree datom index-type op-count))
-  (-temporal-upsert [tree datom index-type op-count]
-    (dih/-temporal-upsert tree datom index-type op-count))
-  (-remove [tree datom index-type op-count]
-    (dih/-remove tree datom index-type op-count))
-  (-slice [tree from to index-type]
-    (dih/-slice tree from to index-type))
-  (-flush [tree backend]
-    (dih/-flush tree backend))
-  (-transient [tree]
-    (dih/-transient tree))
-  (-persistent! [tree]
-    (dih/-persistent! tree)))
+(def -all di/-all)
+(def -seq di/-seq)
+(def -count di/-count)
+(def -insert di/-insert)
+(def -temporal-insert di/-temporal-insert)
+(def -upsert di/-upsert)
+(def -temporal-upsert di/-temporal-upsert)
+(def -remove di/-remove)
+(def -slice di/-slice)
+(def -flush di/-flush)
+(def -transient di/-transient)
+(def -persistent! di/-persistent!)
 
-(extend-type IndexNode
-  IIndex
-  (-all [eavt-tree]
-    (dih/-all eavt-tree :eavt))
-  (-seq [eavt-tree]
-    (dih/-seq eavt-tree :eavt))
-  (-count [eavt-tree]
-    (dih/-count eavt-tree :eavt))
-  (-insert [tree datom index-type op-count]
-    (dih/-insert tree datom index-type op-count))
-  (-temporal-insert [index datom index-type op-count]
-    (dih/-temporal-insert index datom index-type op-count))
-  (-upsert [tree datom index-type op-count]
-    (dih/-upsert tree datom index-type op-count))
-  (-temporal-upsert [tree datom index-type op-count]
-    (dih/-temporal-upsert tree datom index-type op-count))
-  (-remove [tree datom index-type op-count]
-    (dih/-remove tree datom index-type op-count))
-  (-slice [tree from to index-type]
-    (dih/-slice tree from to index-type))
-  (-flush [tree backend]
-    (dih/-flush tree backend))
-  (-transient [tree]
-    (dih/-transient tree))
-  (-persistent! [tree]
-    (dih/-persistent! tree)))
+;; Aliases for multimethods
 
-(extend-type PersistentSortedSet
-  IIndex
-  (-all [eavt-set]
-    (dip/-all eavt-set))
-  (-seq [eavt-set]
-    (dip/-seq eavt-set))
-  (-count [eavt-set]
-    (dip/-count eavt-set))
-  (-insert [set datom index-type op-count]
-    (dip/-insert set datom index-type))
-  (-temporal-insert [set datom index-type op-count]
-    (dip/-temporal-insert set datom index-type))
-  (-upsert [set datom index-type op-count]
-    (dip/-upsert set datom index-type))
-  (-temporal-upsert [set datom index-type op-count]
-    (dip/-temporal-upsert set datom index-type))
-  (-remove [set datom index-type op-count]
-    (dip/-remove set datom index-type))
-  (-slice [set from to _]
-    (dip/-slice set from to))
-  (-flush [set _]
-    (dip/-flush set))
-  (-transient [set]
-    (dip/-transient set))
-  (-persistent! [set]
-    (dip/-persistent! set)))
+(def empty-index di/empty-index)
+(def init-index di/init-index)
 
-(defmulti empty-index
-  "Creates empty index"
-  {:arglists '([index index-type index-config])}
-  (fn [index _ _] index))
+;; Other functions
 
-(defmethod empty-index ::hitchhiker-tree
-  [_ _ {:keys [index-b-factor index-data-node-size index-log-size]}]
-  (dih/empty-tree index-b-factor index-data-node-size index-log-size))
-
-(defmethod empty-index ::persistent-set
-  [_ index-type _]
-  (dip/empty-set index-type))
-
-(defmulti init-index
-  "Initialize index with datoms"
-  {:arglists '([index datoms index-type op-count index-config])}
-  (fn [index _ _ _ _] index))
-
-(defmethod init-index ::hitchhiker-tree [_ datoms index-type op-count {:keys [index-b-factor index-data-node-size index-log-size]}]
-  (dih/init-tree datoms index-type op-count index-b-factor index-data-node-size index-log-size))
-
-(defmethod init-index ::persistent-set [_ datoms index-type _ {:keys [indexed]}]
-  (dip/init-set datoms index-type indexed))
+(def index-types (keys (methods empty-index)))

--- a/src/datahike/index/hitchhiker_tree.cljc
+++ b/src/datahike/index/hitchhiker_tree.cljc
@@ -8,8 +8,10 @@
             [datahike.array :refer [compare-arrays]]
             [datahike.datom :as dd]
             [datahike.constants :refer [e0 tx0 emax txmax]]
-            [hasch.core :as h])
+            [hasch.core :as h]
+            [datahike.index.interface :as di :refer [IIndex]])
   #?(:clj (:import [clojure.lang AMapEntry]
+                   [hitchhiker.tree DataNode IndexNode]
                    [datahike.datom Datom])))
 
 (extend-protocol kc/IKeyCompare
@@ -63,7 +65,7 @@
          (take-while some?)
          vec)))
 
-(defn -slice
+(defn slice
   [tree from to index-type]
   (let [create-datom (index-type->datom-fn index-type)
         [a b c d] (from-datom from index-type true)
@@ -100,13 +102,13 @@
                  seq)]
     new))
 
-(defn -seq [tree index-type]
-  (-slice tree (dd/datom e0 nil nil tx0) (dd/datom emax nil nil txmax) index-type))
+(defn datom-seq [tree index-type]
+  (slice tree (dd/datom e0 nil nil tx0) (dd/datom emax nil nil txmax) index-type))
 
-(defn -count [tree index-type]
-  (count (-seq tree index-type)))
+(defn datom-count [tree index-type]
+  (count (datom-seq tree index-type)))
 
-(defn -all [tree index-type]
+(defn all-datoms [tree index-type]
   (map
    #(apply
      (index-type->datom-fn index-type)
@@ -127,49 +129,98 @@
     :avet [0 2]
     (throw (UnsupportedOperationException. "Unknown index type: " index-type))))
 
-(defn -insert [tree ^Datom datom index-type op-count]
+(defn insert [tree ^Datom datom index-type op-count]
   (let [datom-as-vec (datom->node datom index-type)]
     (async/<?? (hmsg/enqueue tree [(assoc (ins/new-InsertOp datom-as-vec op-count)
                                           :tag (h/uuid))]))))
 
-(defn -temporal-insert [tree ^Datom datom index-type op-count]
+(defn temporal-insert [tree ^Datom datom index-type op-count]
   (let [datom-as-vec (datom->node datom index-type)]
     (async/<?? (hmsg/enqueue tree [(assoc (ins/new-temporal-InsertOp datom-as-vec op-count)
                                           :tag (h/uuid))]))))
 
-(defn -upsert [tree ^Datom datom index-type op-count]
+(defn upsert [tree ^Datom datom index-type op-count]
   (let [datom-as-vec (datom->node datom index-type)]
     (async/<?? (hmsg/enqueue tree [(assoc (ups/new-UpsertOp datom-as-vec op-count (index-type->indices index-type))
                                           :tag (h/uuid))]))))
 
-(defn -temporal-upsert [tree ^Datom datom index-type op-count]
+(defn temporal-upsert [tree ^Datom datom index-type op-count]
   (let [datom-as-vec (datom->node datom index-type)]
     (async/<?? (hmsg/enqueue tree [(assoc (ups/new-temporal-UpsertOp datom-as-vec op-count (index-type->indices index-type))
                                           :tag (h/uuid))]))))
 
-(defn -remove [tree ^Datom datom index-type op-count]
+(defn remove-datom [tree ^Datom datom index-type op-count]
   (async/<?? (hmsg/delete tree (datom->node datom index-type) op-count)))
 
-(defn -flush [tree backend]
+(defn flush-tree [tree backend]
   (:tree (async/<?? (tree/flush-tree-without-root tree backend))))
 
-(def -persistent! identity)
+(extend-type DataNode
+  IIndex
+  (-all [eavt-tree]
+    (all-datoms eavt-tree :eavt))
+  (-seq [eavt-tree]
+    (datom-seq eavt-tree :eavt))
+  (-count [eavt-tree]
+    (datom-count eavt-tree :eavt))
+  (-insert [tree datom index-type op-count]
+    (insert tree datom index-type op-count))
+  (-temporal-insert [tree datom index-type op-count]
+    (temporal-insert tree datom index-type op-count))
+  (-upsert [tree datom index-type op-count]
+    (upsert tree datom index-type op-count))
+  (-temporal-upsert [tree datom index-type op-count]
+    (temporal-upsert tree datom index-type op-count))
+  (-remove [tree datom index-type op-count]
+    (remove-datom tree datom index-type op-count))
+  (-slice [tree from to index-type]
+    (slice tree from to index-type))
+  (-flush [tree backend]
+    (flush-tree tree backend))
+  (-transient [tree]
+    (identity tree))
+  (-persistent! [tree]
+    (identity tree)))
 
-(def -transient identity)
+(extend-type IndexNode
+  IIndex
+  (-all [eavt-tree]
+    (all-datoms eavt-tree :eavt))
+  (-seq [eavt-tree]
+    (datom-seq eavt-tree :eavt))
+  (-count [eavt-tree]
+    (datom-count eavt-tree :eavt))
+  (-insert [tree datom index-type op-count]
+    (insert tree datom index-type op-count))
+  (-temporal-insert [index datom index-type op-count]
+    (temporal-insert index datom index-type op-count))
+  (-upsert [tree datom index-type op-count]
+    (upsert tree datom index-type op-count))
+  (-temporal-upsert [tree datom index-type op-count]
+    (temporal-upsert tree datom index-type op-count))
+  (-remove [tree datom index-type op-count]
+    (remove-datom tree datom index-type op-count))
+  (-slice [tree from to index-type]
+    (slice tree from to index-type))
+  (-flush [tree backend]
+    (flush-tree tree backend))
+  (-transient [tree]
+    (identity tree))
+  (-persistent! [tree]
+    (identity tree)))
 
-;; Functions used in multimethods defined in index.cljc
-
-(defn empty-tree
-  "Create empty hitchhiker tree"
-  [b-factor data-node-size log-size]
+(defn empty-tree [b-factor data-node-size log-size]
   (async/<?? (tree/b-tree (tree/->Config b-factor data-node-size log-size))))
 
-(defn init-tree
-  "Create tree with datoms"
-  [datoms index-type op-count b-factor data-node-size log-size]
+(defmethod di/empty-index :datahike.index/hitchhiker-tree
+  [_ _ {:keys [index-b-factor index-data-node-size index-log-size]}]
+  (empty-tree index-b-factor index-data-node-size index-log-size))
+
+(defmethod di/init-index :datahike.index/hitchhiker-tree
+  [_ datoms index-type op-count {:keys [index-b-factor index-data-node-size index-log-size]}]
   (async/<??
    (async/reduce<
     (fn [tree [idx datom]]
-      (-insert tree datom index-type (+ idx op-count)))
-    (empty-tree b-factor data-node-size log-size)
+      (insert tree datom index-type (+ idx op-count)))
+    (empty-tree index-b-factor index-data-node-size index-log-size)
     (map-indexed (fn [idx datom] [idx datom]) (seq datoms)))))

--- a/src/datahike/index/hitchhiker_tree.cljc
+++ b/src/datahike/index/hitchhiker_tree.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc datahike.index.hitchhiker-tree
   (:require [datahike.index.hitchhiker-tree.upsert :as ups]
             [datahike.index.hitchhiker-tree.insert :as ins]
+            [hitchhiker.tree.bootstrap.konserve :as hk]
             [hitchhiker.tree.utils.async :as async]
             [hitchhiker.tree.messaging :as hmsg]
             [hitchhiker.tree.key-compare :as kc]
@@ -224,3 +225,12 @@
       (insert tree datom index-type (+ idx op-count)))
     (empty-tree index-b-factor index-data-node-size index-log-size)
     (map-indexed (fn [idx datom] [idx datom]) (seq datoms)))))
+
+(defmethod di/add-konserve-handlers :datahike.index/hitchhiker-tree [_ store]
+  (ups/add-upsert-handler
+   (ins/add-insert-handler
+    (hk/add-hitchhiker-tree-handlers
+     store))))
+
+(defmethod di/konserve-backend :datahike.index/hitchhiker-tree  [_index-name store]
+  (hk/->KonserveBackend store))

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -1,0 +1,26 @@
+(ns datahike.index.interface
+  "All the functions in this namespace must be implemented for each index type")
+
+(defprotocol IIndex
+  (-all [index] "Returns a sequence of all datoms in the index")
+  (-seq [index] "Returns a sequence of all datoms in the index")
+  (-count [index] "Returns the number of datoms in the index")
+  (-insert [index datom index-type op-count] "Inserts a datom into the index")
+  (-temporal-insert [index datom index-type op-count] "Inserts a datom in a history index")
+  (-upsert [index datom index-type op-count] "Inserts or updates a datom into the index")
+  (-temporal-upsert [index datom index-type op-count] "Inserts or updates a datom in a history index")
+  (-remove [index datom index-type op-count] "Removes a datom from the index")
+  (-slice [index from to index-type] "Returns a slice of the index")
+  (-flush [index backend] "Saves the changes to the index to the given backend")
+  (-transient [index] "Returns a transient version of the index")
+  (-persistent! [index] "Returns a persistent version of the index"))
+
+(defmulti empty-index
+  "Creates an empty index"
+  (fn [index _index-type _index-config]
+    index))
+
+(defmulti init-index
+  "Creates an index with datoms"
+  (fn [index _datoms _index-type _op-count _index-config]
+    index))

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -11,16 +11,24 @@
   (-temporal-upsert [index datom index-type op-count] "Inserts or updates a datom in a history index")
   (-remove [index datom index-type op-count] "Removes a datom from the index")
   (-slice [index from to index-type] "Returns a slice of the index")
-  (-flush [index backend] "Saves the changes to the index to the given backend")
+  (-flush [index backend] "Saves the changes to the index to the given konserve backend")
   (-transient [index] "Returns a transient version of the index")
   (-persistent! [index] "Returns a persistent version of the index"))
 
 (defmulti empty-index
   "Creates an empty index"
-  (fn [index _index-type _index-config]
-    index))
+  (fn [index-name _index-type _index-config]
+    index-name))
 
 (defmulti init-index
   "Creates an index with datoms"
-  (fn [index _datoms _index-type _op-count _index-config]
-    index))
+  (fn [index-name _datoms _index-type _op-count _index-config]
+    index-name))
+
+(defmulti add-konserve-handlers
+  "Adds read and write handlers for the index data types."
+  (fn [index-name _store] index-name))
+
+(defmulti konserve-backend
+  "Returns a konserve store capable of handling the index. Used for flushing."
+  (fn [index-name _store] index-name))

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -3,7 +3,7 @@
             [me.tonsky.persistent-sorted-set.arrays :as arrays]
             [datahike.datom :as dd]
             [datahike.constants :refer [e0 tx0 emax txmax]]
-            [datahike.index.interface :as i :refer [IIndex]])
+            [datahike.index.interface :as di :refer [IIndex]])
   #?(:clj (:import [datahike.datom Datom]
                    [me.tonsky.persistent_sorted_set PersistentSortedSet])))
 
@@ -63,10 +63,10 @@
   (-persistent! [set]
     (persistent! set)))
 
-(defmethod i/empty-index :datahike.index/persistent-set [_ index-type _]
+(defmethod di/empty-index :datahike.index/persistent-set [_index-name index-type _]
   (set/sorted-set-by (index-type->cmp index-type)))
 
-(defmethod i/init-index :datahike.index/persistent-set [_ datoms index-type _ {:keys [indexed]}]
+(defmethod di/init-index :datahike.index/persistent-set [_index-name datoms index-type _ {:keys [indexed]}]
   (let [arr (if (= index-type :avet)
               (let [avet-datoms (filter (fn [^Datom d] (contains? indexed (.-a d))) datoms)]
                 (to-array avet-datoms))
@@ -75,3 +75,9 @@
                 (arrays/into-array)))
         _ (arrays/asort arr (index-type->cmp-quick index-type))]
     (set/from-sorted-array (index-type->cmp index-type) arr)))
+
+(defmethod di/add-konserve-handlers :datahike.index/persistent-set [_index-name store]
+  store)
+
+(defmethod di/konserve-backend :datahike.index/persistent-set [_index-name store]
+  store)


### PR DESCRIPTION
#### SUMMARY
- Restructures the index namespaces
- Introduces new multimethods for indexes
- Moves all hitchhiker-tree code to the appropriate namespace

#### Checks

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [x] Formatting checked
- [x] `CHANGELOG.md` updated

#### ADDITIONAL INFORMATION
Makes implementing new index types easier. Preparation work for adding the persistence layer for the persistent set.
