### PR TITLE
478 migration with attribute refs causes error

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,7 @@ Datahike version you can use
 
 to reimport your data into the new format.
 
-The datoms are stored as strings in a line-based format, so you can easily check
-whether your dump is containing reasonable data. You can also use it to do some
-string based editing of the DB. You can also use the export as a backup.
+The datoms are stored in the CBOR format, enabling migration of binary data, such as the byte array data type now supported by Datahike. You can also use the export as a backup.
 
 If you are upgrading from pre `0.1.2` where we have not had the migration code
 yet, then just evaluate the `datahike.migrate` namespace manually in your

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The database can be exported to a flat file with:
 
 ```clojure
 (require '[datahike.migrate :refer [export-db import-db]])
-(export-db @conn "/tmp/eavt-dump")
+(export-db conn "/tmp/eavt-dump")
 ```
 
 You must do so before upgrading to a Datahike version that has changed the

--- a/benchmark/test/measure.clj
+++ b/benchmark/test/measure.clj
@@ -11,7 +11,14 @@
              :query :all 
              :db-entity-counts [0 10]})
 
-(deftest connection-test 
+(deftest transaction-test
+  (is (= 12 (count (b/get-measurements (assoc config :function :transaction))))))
+
+;; (+ (* 3 (* 2 8)) (* 3 (+ (* 2 8) (* 4 6) (* 4 2) 6))) = (+ 48 162) = 210
+(deftest query-test
+  (is (= 210 (count (b/get-measurements (assoc config :function :query))))))
+
+(deftest connection-test
   (let [measurements (b/get-measurements (assoc config :function :connection))]
     (is (= #{:mean :median :std :count :observations}
            (set (keys (:time (first measurements))))))
@@ -58,10 +65,3 @@
               :db-entities 10
               :db-datoms 40})
            (map :context measurements)))))
-
-(deftest transaction-test
-  (is (= 12 (count (b/get-measurements (assoc config :function :transaction))))))
-
-;; (+ (* 3 (* 2 8)) (* 3 (+ (* 2 8) (* 4 6) (* 4 2) 6))) = (+ 48 162) = 210
-(deftest query-test
-  (is (= 210 (count (b/get-measurements (assoc config :function :query))))))

--- a/benchmark/test/measure.clj
+++ b/benchmark/test/measure.clj
@@ -2,53 +2,67 @@
   (:require [clojure.test :as t :refer [is deftest]]
             [benchmark.measure :as b]))
 
-(def config {:output-format "edn"
+(def config {:config-name :all
+             :output-format "edn"
              :data-types [:int :str]
-             :iterations 1
+             :iterations 1, 
              :data-found-opts :all
              :tx-entity-counts [0 10]
              :tag #{test} 
              :query :all 
              :db-entity-counts [0 10]})
 
-(deftest transaction-test
-  (is (= 24 (count (b/get-measurements (assoc config :function :transaction))))))
-
-;; (+ (* 6 (* 2 8)) (* 6 (+ (* 2 8) (* 4 6) (* 4 2) 6))) = (+ 96 324) = 420
-(deftest query-test
-  (is (= 420 (count (b/get-measurements (assoc config :function :query))))))
-
-(defn- dh-config
-  ([cfg-name] (dh-config cfg-name true))
-  ([cfg-name hist] (dh-config cfg-name hist :mem))
-  ([cfg-name hist backend] (dh-config cfg-name hist backend :datahike.index/hitchhiker-tree))
-  ([cfg-name hist backend index] {:schema-flexibility :write
-                                  :keep-history? hist
-                                  :index index
-                                  :name cfg-name
-                                  :backend backend}))
-
-(defn- test-samples [dh-config]
-  #{{:dh-config dh-config
-     :function :connection
-     :db-entities 0
-     :db-datoms 0}
-    {:dh-config dh-config
-     :function :connection
-     :db-entities 10
-     :db-datoms 40}})
-
-(deftest connection-test
+(deftest connection-test 
   (let [measurements (b/get-measurements (assoc config :function :connection))]
     (is (= #{:mean :median :std :count :observations}
            (set (keys (:time (first measurements))))))
     (is (= 1
            (get-in (first measurements) [:time :count])))
-    (is (= (clojure.set/union
-            (test-samples (dh-config "file" false :file))
-            (test-samples (dh-config "mem-hht" false))
-            (test-samples (dh-config "mem-set" false :mem :datahike.index/persistent-set))
-            (test-samples (dh-config "file-with-history" true :file))
-            (test-samples (dh-config "mem-hht-with-history"))
-            (test-samples (dh-config "mem-set-with-history" true :mem :datahike.index/persistent-set)))
-           (set (map :context measurements))))))
+    (is (= '({:dh-config {:schema-flexibility :write
+                          :keep-history? false
+                          :index :datahike.index/persistent-set
+                          :name "mem-set", :backend :mem}
+              :function :connection
+              :db-entities 0
+              :db-datoms 0}
+             {:dh-config {:schema-flexibility :write
+                          :keep-history? false
+                          :index :datahike.index/persistent-set
+                          :name "mem-set", :backend :mem}
+              :function :connection
+              :db-entities 10
+              :db-datoms 40}
+             {:dh-config {:schema-flexibility :write
+                          :keep-history? false, :index
+                          :datahike.index/hitchhiker-tree
+                          :name "mem-hht", :backend :mem}
+              :function :connection
+              :db-entities 0
+              :db-datoms 0}
+             {:dh-config {:schema-flexibility :write
+                          :keep-history? false
+                          :index :datahike.index/hitchhiker-tree
+                          :name "mem-hht", :backend :mem}
+              :function :connection, :db-entities 10, :db-datoms 40}
+             {:dh-config {:schema-flexibility :write
+                          :keep-history? false
+                          :index :datahike.index/hitchhiker-tree
+                          :name "file", :backend :file}
+              :function :connection
+              :db-entities 0
+              :db-datoms 0}
+             {:dh-config {:schema-flexibility :write
+                          :keep-history? false
+                          :index :datahike.index/hitchhiker-tree
+                          :name "file", :backend :file}
+              :function :connection
+              :db-entities 10
+              :db-datoms 40})
+           (map :context measurements)))))
+
+(deftest transaction-test
+  (is (= 12 (count (b/get-measurements (assoc config :function :transaction))))))
+
+;; (+ (* 3 (* 2 8)) (* 3 (+ (* 2 8) (* 4 6) (* 4 2) 6))) = (+ 48 162) = 210
+(deftest query-test
+  (is (= 210 (count (b/get-measurements (assoc config :function :query))))))

--- a/benchmark/test/measure.clj
+++ b/benchmark/test/measure.clj
@@ -19,15 +19,15 @@
            (get-in (first measurements) [:time :count])))
     (is (= '({:dh-config {:schema-flexibility :write
                           :keep-history? false
-                          :index :datahike.index/persistent-set
-                          :name "mem-set", :backend :mem}
+                          :index :datahike.index/hitchhiker-tree
+                          :name "file", :backend :file}
               :function :connection
               :db-entities 0
               :db-datoms 0}
              {:dh-config {:schema-flexibility :write
                           :keep-history? false
-                          :index :datahike.index/persistent-set
-                          :name "mem-set", :backend :mem}
+                          :index :datahike.index/hitchhiker-tree
+                          :name "file", :backend :file}
               :function :connection
               :db-entities 10
               :db-datoms 40}
@@ -45,15 +45,15 @@
               :function :connection, :db-entities 10, :db-datoms 40}
              {:dh-config {:schema-flexibility :write
                           :keep-history? false
-                          :index :datahike.index/hitchhiker-tree
-                          :name "file", :backend :file}
+                          :index :datahike.index/persistent-set
+                          :name "mem-set", :backend :mem}
               :function :connection
               :db-entities 0
               :db-datoms 0}
              {:dh-config {:schema-flexibility :write
                           :keep-history? false
-                          :index :datahike.index/hitchhiker-tree
-                          :name "file", :backend :file}
+                          :index :datahike.index/persistent-set
+                          :name "mem-set", :backend :mem}
               :function :connection
               :db-entities 10
               :db-datoms 40})

--- a/benchmark/test/measure.clj
+++ b/benchmark/test/measure.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :as t :refer [is deftest]]
             [benchmark.measure :as b]))
 
-(def config {:config-name :all
-             :output-format "edn"
+(def config {:output-format "edn"
              :data-types [:int :str]
              :iterations 1, 
              :data-found-opts :all

--- a/deps.edn
+++ b/deps.edn
@@ -39,9 +39,7 @@
 
            :bench-dev {:extra-paths ["benchmark/src"]
                        :extra-deps {clj-http/clj-http     {:mvn/version "3.12.3"}
-                                    org.clojure/tools.cli {:mvn/version "1.0.206"}
-                                    io.lambdaforge/wanderung {:mvn/version "0.1.1-SNAPSHOT"}
-                                    scicloj/tablecloth {:mvn/version "6.031"}}}
+                                    org.clojure/tools.cli {:mvn/version "1.0.206"}}}
 
            :benchmark {:main-opts ["-m" "benchmark.core"]
                        :extra-paths ["benchmark/src"]

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,6 @@
         com.taoensso/timbre                         {:mvn/version "5.1.2"}
         io.replikativ/superv.async                  {:mvn/version "0.3.43"}
         io.lambdaforge/datalog-parser               {:mvn/version "0.1.10"}
-        io.lambdaforge/wanderung                    {:mvn/version "0.2.54"}
         io.replikativ/zufall                        {:mvn/version "0.1.0"}
         junit/junit                                 {:mvn/version "4.13.2"}
         mvxcvi/clj-cbor                             {:mvn/version "1.1.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -7,6 +7,7 @@
         com.taoensso/timbre                         {:mvn/version "5.1.2"}
         io.replikativ/superv.async                  {:mvn/version "0.3.43"}
         io.lambdaforge/datalog-parser               {:mvn/version "0.1.10"}
+        io.lambdaforge/wanderung                    {:mvn/version "0.2.54"}
         io.replikativ/zufall                        {:mvn/version "0.1.0"}
         junit/junit                                 {:mvn/version "4.13.2"}
         mvxcvi/clj-cbor                             {:mvn/version "1.1.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -39,7 +39,9 @@
 
            :bench-dev {:extra-paths ["benchmark/src"]
                        :extra-deps {clj-http/clj-http     {:mvn/version "3.12.3"}
-                                    org.clojure/tools.cli {:mvn/version "1.0.206"}}}
+                                    org.clojure/tools.cli {:mvn/version "1.0.206"}
+                                    io.lambdaforge/wanderung {:mvn/version "0.1.1-SNAPSHOT"}
+                                    scicloj/tablecloth {:mvn/version "6.031"}}}
 
            :benchmark {:main-opts ["-m" "benchmark.core"]
                        :extra-paths ["benchmark/src"]

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -7,8 +7,9 @@
 
 (defn export-db
   "Export the database in a flat-file of datoms at path."
-  [db path]
-  (let [cfg (:config db)]
+  [conn path]
+  (let [db @conn
+        cfg (:config db)]
     (cbor/spit-all path (cond->> (sort-by
                                   (juxt d/datom-tx :e)
                                   (api/datoms (if (:keep-history? cfg) (api/history db) db) :eavt))

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -1,5 +1,6 @@
 (ns ^:no-doc datahike.migrate
   (:require [datahike.api :as api]
+            [datahike.constants :as c]
             [datahike.datom :as d]
             [datahike.db :as db]
             [clj-cbor.core :as cbor]))
@@ -7,9 +8,12 @@
 (defn export-db
   "Export the database in a flat-file of datoms at path."
   [db path]
-  (cbor/spit-all path (map seq (sort-by
-                                (juxt d/datom-tx :e)
-                                (api/datoms (if (db/-keep-history? db) (api/history db) db) :eavt)))))
+  (let [cfg (:config db)]
+    (cbor/spit-all path (cond->> (sort-by
+                                  (juxt d/datom-tx :e)
+                                  (api/datoms (if (:keep-history? cfg) (api/history db) db) :eavt))
+                          (:attribute-refs? cfg) (remove #(= (d/datom-tx %) c/tx0))
+                          true (map seq)))))
 
 (defn update-max-tx
   "Find bigest tx in datoms and update max-tx of db.

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -120,7 +120,7 @@
                                     {:name "Daisy" :age 20}
                                     {:name "Erhard" :age 20}]})
         (d/transact conn {:tx-data [[:db/retractEntity [:name "Erhard"]]]})
-        (m/export-db @conn export-path)
+        (m/export-db conn export-path)
         (m/import-db new-conn export-path)
         (is (= (d/datoms (if (:keep-history? cfg) (d/history @conn) @conn) :eavt)
                (filter #(< (:e %) (:max-tx @new-conn))
@@ -233,7 +233,7 @@
           import-conn (utils/setup-db)]
       (d/transact conn [{:db/id 1, :name "Jiayi", :payload (byte-array [0 2 3])}
                         {:db/id 2, :name "Peter", :payload (byte-array [1 2 3])}])
-      (m/export-db @conn export-path)
+      (m/export-db conn export-path)
       (m/import-db import-conn export-path)
       (is (utils/all-true? (map #(or (= %1 %2) (utils/all-eq? (nth %1 2) (nth %2 2)))
                                 (d/datoms @conn :eavt)


### PR DESCRIPTION
#### SUMMARY
Fix exception thrown on importing a database export containing attribute refs #478

#### Checks
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked
- [ ] `CHANGELOG.md` updated