### PR TITLE
Add comment that datahike.migrate is meant to be a temporary solution

### DIFF
--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -5,6 +5,8 @@
             [datahike.db :as db]
             [clj-cbor.core :as cbor]))
 
+;; Note: the code here is intended to be a temporary solution, pending developments in Wanderung
+
 (defn export-db
   "Export the database in a flat-file of datoms at path."
   [conn path]


### PR DESCRIPTION
#### SUMMARY
Add comment [suggested](https://github.com/replikativ/datahike/pull/501#discussion_r841258863) in discussion on PR 501 (migration with attribute refs causes error).