### PR TITLE
Fix typo in comparison predicate in benchmark query

### DIFF
--- a/benchmark/src/benchmark/config.clj
+++ b/benchmark/src/benchmark/config.clj
@@ -169,7 +169,7 @@
   {:query (conj '[:find ?e :where]
                 (conj '[?e] attr '?v)
                 (conj '[]
-                      (sequence (conj '[= ?v] comp-val))))
+                      (sequence (conj '[< ?v] comp-val))))
    :args [db]})
 
 (defn equals-query-1-fixed [db attr comp-val]


### PR DESCRIPTION
Based on the names and contents of the benchmarking functions `less-than-query-1-fixed` and `equals-query-1-fixed`, it seems `=` was used where `<` was intended in the former.