### PR TITLE
docs: improve docs and add prep step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next minor/major release
 
+- Improve docs
+- Add prep-step to deps
 - Refactor test-namespaces
   - move tests to use datahike.api
   - move namespaces to `-test` format

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
   </a>
 </p>
 <p align="center">
-<a href="https://discord.com/invite/kEBzMvb"><img src="https://img.shields.io/discord/735146089241509909?label=discord&logo=Discord"/></a>
 <a href="https://clojurians.slack.com/archives/CB7GJAN0L"><img src="https://badgen.net/badge/-/slack?icon=slack&label"/></a>
 <a href="https://clojars.org/io.replikativ/datahike"> <img src="https://img.shields.io/clojars/v/io.replikativ/datahike.svg" /></a>
 <a href="https://circleci.com/gh/replikativ/datahike"><img src="https://circleci.com/gh/replikativ/datahike.svg?style=shield"/></a>

--- a/build.clj
+++ b/build.clj
@@ -44,6 +44,7 @@
 
 (defn release
   [_]
+  (Thread/sleep 1000)
   (-> (gh/overwrite-asset {:org "replikativ"
                            :repo (name lib)
                            :tag version

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,21 @@
-{:deps {org.clojure/clojure                         {:mvn/version "1.10.3"}
+{:deps {org.clojure/clojure                         {:mvn/version "1.11.1"}
         org.clojure/clojurescript                   {:mvn/version "1.11.4"}
         io.replikativ/hitchhiker-tree               {:mvn/version "0.1.11"}
         persistent-sorted-set/persistent-sorted-set {:mvn/version "0.1.4"}
         org.clojure/tools.reader                    {:mvn/version "1.3.6"}
         environ/environ                             {:mvn/version "1.2.0"}
-        com.taoensso/timbre                         {:mvn/version "5.1.2"}
+        com.taoensso/timbre                         {:mvn/version "5.2.1"}
         io.replikativ/superv.async                  {:mvn/version "0.3.43"}
-        io.lambdaforge/datalog-parser               {:mvn/version "0.1.10"}
+        io.lambdaforge/datalog-parser               {:mvn/version "0.1.11"}
         io.replikativ/zufall                        {:mvn/version "0.1.0"}
         junit/junit                                 {:mvn/version "4.13.2"}
         mvxcvi/clj-cbor                             {:mvn/version "1.1.0"}}
 
  :paths ["src" "target/classes"]
+
+ :deps/prep-lib {:ensure "target/classes"
+                 :alias :build
+                 :fn compile}
 
  :aliases {:1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
 
@@ -19,20 +23,18 @@
 
            :dev {:extra-paths ["dev" "benchmark/src"]
                  :extra-deps {org.clojure/tools.namespace {:mvn/version "1.2.0"}
-                              cider/cider-nrepl           {:mvn/version "0.28.1"}
-                              nrepl/nrepl                 {:mvn/version "0.9.0"}
                               clj-http/clj-http           {:mvn/version "3.12.3"}
                               org.clojure/tools.cli       {:mvn/version "1.0.206"}
                               incanter/incanter-core      {:mvn/version "1.9.3"}
                               incanter/incanter-charts    {:mvn/version "1.9.3"}}}
 
            :test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha         {:mvn/version "1.60.945"}
+                  :extra-deps {lambdaisland/kaocha         {:mvn/version "1.64.1010"}
                                lambdaisland/kaocha-cljs    {:mvn/version "1.0.107"}
                                io.replikativ/datahike-jdbc {:mvn/version "0.1.2-SNAPSHOT"}
-                               org.clojure/test.check      {:mvn/version "0.9.0"}}}
+                               org.clojure/test.check      {:mvn/version "1.1.1"}}}
 
-           :repl {:extra-deps {cider/cider-nrepl           {:mvn/version "0.28.1"}
+           :repl {:extra-deps {cider/cider-nrepl           {:mvn/version "0.28.3"}
                                nrepl/nrepl                 {:mvn/version "0.9.0"}
                                org.clojure/tools.namespace {:mvn/version "1.2.0"}}
                   :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
@@ -64,11 +66,11 @@
            :ffix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
                   :main-opts ["-m" "cljfmt.main" "fix"]}
 
-           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.7.5" :git/sha "2526f58"}
+           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.8.1" :git/sha "7d40500"}
                           slipset/deps-deploy {:mvn/version "0.2.0"}
                           borkdude/gh-release-artifact {:git/url "https://github.com/borkdude/gh-release-artifact"
                                                         :sha "a83ee8da47d56a80b6380cbb6b4b9274048067bd"}
-                          babashka/babashka.curl {:mvn/version "0.1.1"}
-                          babashka/fs {:mvn/version "0.1.2"}
+                          babashka/babashka.curl {:mvn/version "0.1.2"}
+                          babashka/fs {:mvn/version "0.1.4"}
                           cheshire/cheshire {:mvn/version "5.10.2"}}
                    :ns-default build}}}

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,20 +1,25 @@
 # Contributing to Datahike
-## Starting a REPL
+## Compile Java classes
+```
+clj -T:build compile
+```
+
+## Start a REPL
 
 ```
 clj -M:repl
 ```
 
-## Running the tests
+## Run the tests
 - `./bin/run-unittests` or `./bin/run-unittests --watch`
 - `./bin/run-integrationtests` (Docker needed)
 
-## Starting the benchmarks
+## Start the benchmarks
 ```
 TIMBRE_LEVEL=':info' clj -M:benchmark run
 ```
 
-## Building a Datahike jar
+## Build a Datahike jar
 ```
 clj -T:build jar
 ```
@@ -24,7 +29,7 @@ clj -T:build jar
 clj -T:build install
 ```
 
-## Formatting
+## Format
 Check the formatting:
 ```
 clj -M:format
@@ -34,7 +39,7 @@ or fix the formatting:
 clj -M:ffix
 ```
 
-## Releasing Datahike
+## Release Datahike
 ### Deploying Datahike to Clojars manually
 #### Manually
 **Should only be done in case of emergency**
@@ -58,7 +63,7 @@ two variables `GITHUB_TOKEN` and `GITHUB_USER` need to be set in a context calle
 `github-token` in the CircleCI UI for the organisation.
 
 ### Git tags and GitHub releases
-Each merge to `main` creates a release entry in GitHub and a git tag to point to the merge commit
+Each merge to `main` creates a draft release on GitHub and a git tag to point to the merge commit
 made when merging a branch into `main`. The jar is appended to the Github-release.
 
 ### The release process step by step

--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,4 +1,4 @@
-(ns datahike.array
+(ns ^:no-doc datahike.array
   (:require [hitchhiker.tree.node :as n])
   (:import [java.util Arrays]))
 

--- a/src/datahike/integration_test.cljc
+++ b/src/datahike/integration_test.cljc
@@ -1,4 +1,4 @@
-(ns datahike.integration-test
+(ns ^:no-doc datahike.integration-test
   "This namespace is the minimum test a Datahike backend needs to pass for compatibility assessment."
   (:require [datahike.api :as d]
             #?(:clj [clojure.test :refer :all]

--- a/src/datahike/transactor.cljc
+++ b/src/datahike/transactor.cljc
@@ -1,4 +1,4 @@
-(ns datahike.transactor
+(ns ^:no-doc datahike.transactor
   (:require [superv.async :refer [<??- S thread-try]]
             [taoensso.timbre :as log]
             [clojure.core.async :refer [>!! chan close! promise-chan put!]])

--- a/test/datahike/test.cljc
+++ b/test/datahike/test.cljc
@@ -4,6 +4,7 @@
       :clj  [clojure.test :as t :refer        [is are deftest testing]])
    #?(:clj [clojure.java.shell :as sh])
    datahike.test.core-test
+   datahike.test.cache-test
    datahike.test.components-test
    datahike.test.config-test
    datahike.test.db-test

--- a/test/datahike/test/cache_test.cljc
+++ b/test/datahike/test/cache_test.cljc
@@ -1,4 +1,4 @@
-(ns datahike.test.cache
+(ns datahike.test.cache-test
   (:require
    #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]]
       :clj  [clojure.test :as t :refer [is are deftest testing use-fixtures]])


### PR DESCRIPTION
#### SUMMARY
Improve docs as mentioned in #489 to make it clearer that there needs to be a compilation for working on the source code. This is something a lot of people are tripping over when starting to work on our source. I also added a prepare-step to our deps.edn like it is described here: https://clojure.org/reference/deps_and_cli#prep. 

#### Checks

##### Docs
- [ ] Related issues linked using `fixes #number`
- [ ] `CHANGELOG.md` updated