### PR TITLE
Add migration tests

### DIFF
--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -132,81 +132,43 @@
           (d/delete-database old-cfg)
           (d/delete-database new-cfg))))
 
-    #_(testing "Export keyword database, import reference database"
-        (let [old-cfg (-> base-config
-                          (assoc-in [:store :path] old-path)
-                          (assoc :attribute-refs? false))
-              old-conn (utils/setup-db old-cfg)
-              new-cfg (-> base-config
-                          (assoc-in [:store :path] new-path)
-                          (assoc :attribute-refs? true))
-              new-conn (utils/setup-db new-cfg)]
-          (d/transact old-conn schema)
-          (d/transact old-conn tx-data)
-          (m/export-db old-conn export-path)
-          (m/import-db new-conn export-path)
-          (is (= (d/datoms @old-conn :eavt)
-                 (filter #(< (:e %) (:max-tx @new-conn))
-                         (d/datoms @new-conn :eavt))))
-          (d/delete-database old-cfg)
-          (d/delete-database new-cfg)))
+    (testing "Export history database, import non-history database"
+      (let [old-cfg (-> base-config
+                        (assoc-in [:store :path] old-path)
+                        (assoc :keep-history? true))
+            old-conn (utils/setup-db old-cfg)
+            new-cfg (-> base-config
+                        (assoc-in [:store :path] new-path)
+                        (assoc :keep-history? false))
+            new-conn (utils/setup-db new-cfg)]
+        (d/transact old-conn schema)
+        (d/transact old-conn tx-data)
+        (m/export-db old-conn export-path)
+        (m/import-db new-conn export-path)
+        (is (= (d/datoms @old-conn :eavt)
+               (filter #(< (:e %) (:max-tx @new-conn))
+                       (d/datoms @new-conn :eavt))))
+        (d/delete-database old-cfg)
+        (d/delete-database new-cfg)))
 
-    #_(testing "Export reference database, import keyword database"
-        (let [old-cfg (-> base-config
-                          (assoc-in [:store :path] old-path)
-                          (assoc :attribute-refs? true))
-              old-conn (utils/setup-db old-cfg)
-              new-cfg (-> base-config
-                          (assoc-in [:store :path] new-path)
-                          (assoc :attribute-refs? false))
-              new-conn (utils/setup-db new-cfg)]
-          (d/transact old-conn schema)
-          (d/transact old-conn tx-data)
-          (m/export-db old-conn export-path)
-          (m/import-db new-conn export-path)
-          (is (= (d/datoms @old-conn :eavt)
-                 (filter #(< (:e %) (:max-tx @new-conn))
-                         (d/datoms @new-conn :eavt))))
-          (d/delete-database old-cfg)
-          (d/delete-database new-cfg)))
-
-    #_(testing "Export history database, import non-history database"
-        (let [old-cfg (-> base-config
-                          (assoc-in [:store :path] old-path)
-                          (assoc :keep-history? true))
-              old-conn (utils/setup-db old-cfg)
-              new-cfg (-> base-config
-                          (assoc-in [:store :path] new-path)
-                          (assoc :keep-history? false))
-              new-conn (utils/setup-db new-cfg)]
-          (d/transact old-conn schema)
-          (d/transact old-conn tx-data)
-          (m/export-db old-conn export-path)
-          (m/import-db new-conn export-path)
-          (is (= (d/datoms @old-conn :eavt)
-                 (filter #(< (:e %) (:max-tx @new-conn))
-                         (d/datoms @new-conn :eavt))))
-          (d/delete-database old-cfg)
-          (d/delete-database new-cfg)))
-
-    #_(testing "Export non-history database, import history database"
-        (let [old-cfg (-> base-config
-                          (assoc-in [:store :path] old-path)
-                          (assoc :keep-history? true))
-              old-conn (utils/setup-db old-cfg)
-              new-cfg (-> base-config
-                          (assoc-in [:store :path] new-path)
-                          (assoc :keep-history? false))
-              new-conn (utils/setup-db new-cfg)]
-          (d/transact old-conn schema)
-          (d/transact old-conn tx-data)
-          (m/export-db old-conn export-path)
-          (m/import-db new-conn export-path)
-          (is (= (d/datoms @old-conn :eavt)
-                 (filter #(< (:e %) (:max-tx @new-conn))
-                         (d/datoms @new-conn :eavt))))
-          (d/delete-database old-cfg)
-          (d/delete-database new-cfg)))))
+    (testing "Export non-history database, import history database"
+      (let [old-cfg (-> base-config
+                        (assoc-in [:store :path] old-path)
+                        (assoc :keep-history? true))
+            old-conn (utils/setup-db old-cfg)
+            new-cfg (-> base-config
+                        (assoc-in [:store :path] new-path)
+                        (assoc :keep-history? false))
+            new-conn (utils/setup-db new-cfg)]
+        (d/transact old-conn schema)
+        (d/transact old-conn tx-data)
+        (m/export-db old-conn export-path)
+        (m/import-db new-conn export-path)
+        (is (= (d/datoms @old-conn :eavt)
+               (filter #(< (:e %) (:max-tx @new-conn))
+                       (d/datoms @new-conn :eavt))))
+        (d/delete-database old-cfg)
+        (d/delete-database new-cfg)))))
 
 (defn load-entities-test [cfg]
   (testing "Test migrate simple datoms without attribute refs"

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -146,19 +146,18 @@
         (m/export-db old-conn export-path)
         (m/import-db new-conn export-path)
         (is (= (d/datoms @old-conn :eavt)
-               (filter #(< (:e %) (:max-tx @new-conn))
-                       (d/datoms @new-conn :eavt))))
+               (d/datoms @new-conn :eavt)))
         (d/delete-database old-cfg)
         (d/delete-database new-cfg)))
 
     (testing "Export non-history database, import history database"
       (let [old-cfg (-> base-config
                         (assoc-in [:store :path] old-path)
-                        (assoc :keep-history? true))
+                        (assoc :keep-history? false))
             old-conn (utils/setup-db old-cfg)
             new-cfg (-> base-config
                         (assoc-in [:store :path] new-path)
-                        (assoc :keep-history? false))
+                        (assoc :keep-history? true))
             new-conn (utils/setup-db new-cfg)]
         (d/transact old-conn schema)
         (d/transact old-conn tx-data)


### PR DESCRIPTION
Just 2 tests added to test config compatibility for migrations. Also tried attribute references to/from keyword databases but that wouldn't work, so I removed them. Would also be harder to implement here, but will be provided with wanderung