### PR TITLE
Consistent insert behaviour for hitchhiker-tree and persistent sorted set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Allow keyword keys for queries
 - Fix tx-meta on transact through api-ns
 - Improve code samples using transact with arg-map @podgorniy
+- Insert into persistent sorted set does not replace existing datom with identical EAV
 
 ## 0.4.0
 

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -56,12 +56,11 @@
   (set/disj set datom (index-type->cmp-quick index-type)))
 
 (defn -insert [set datom index-type]
-  (-> (or (when-let [old (first (-slice set
-                                        (dd/datom (.-e datom) (.-a datom) (.-v datom) tx0)
-                                        (dd/datom (.-e datom) (.-a datom) (.-v datom) txmax)))]
-            (-remove set old index-type))
-          set)
-      (set/conj datom (index-type->cmp-quick index-type))))
+  (if (-slice set
+              (dd/datom (.-e datom) (.-a datom) (.-v datom) tx0)
+              (dd/datom (.-e datom) (.-a datom) (.-v datom) txmax))
+    set
+    (set/conj set datom (index-type->cmp-quick index-type))))
 
 (defn -temporal-insert [set datom index-type]
   (set/conj set datom (index-type->cmp-quick index-type)))

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -31,12 +31,6 @@
     :avet dd/cmp-datoms-avet-quick
     dd/cmp-datoms-eavt-quick))
 
-(defn -insert [set datom index-type]
-  (set/conj set datom (index-type->cmp-quick index-type)))
-
-(defn -remove [set datom index-type]
-  (set/disj set datom (index-type->cmp-quick index-type)))
-
 ;; Functions defined in multimethods in index.cljc
 
 (defn empty-set [index-type]

--- a/test/datahike/test/insert.cljc
+++ b/test/datahike/test/insert.cljc
@@ -10,9 +10,8 @@
 
 ;; Test that the second insertion of the same datom does not replace the initial one.
 ;; That is similar to Datomic's behaviour.
-;; Note that the 'mem-set' backend does not have this semantics though.
 
-(defn duplicate-test [config test-tx-id?]
+(defn duplicate-test [config]
   (let [_      (d/create-database config)
         conn   (d/connect config)
         schema [{:db/ident       :block/string
@@ -30,8 +29,7 @@
         datom-2 (first (d/datoms @conn :eavt 502 :block/children))
         aevt  (d/datoms @conn :aevt :block/children 502)
         avet  (d/datoms @conn :avet :block/children 501)]
-    (when test-tx-id?
-      (is (= (.-tx datom-1) (.-tx datom-2))))
+    (is (= (.-tx datom-1) (.-tx datom-2)))
     (is (= datom-1 datom-2))
 
     (is (= 1 (count aevt)))
@@ -47,25 +45,22 @@
   (let [config {:store {:backend :mem :id "performance-set"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/persistent-set}
-        test-tx-id? false]
-    (duplicate-test config test-tx-id?)))
+                :index :datahike.index/persistent-set}]
+    (duplicate-test config)))
 
 (deftest mem-hht
   (let [config {:store {:backend :mem :id "performance-hht"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/hitchhiker-tree}
-        test-tx-id? true]
-    (duplicate-test config test-tx-id?)))
+                :index :datahike.index/hitchhiker-tree}]
+    (duplicate-test config)))
 
 (deftest file
   (let [config {:store {:backend :file :path "/tmp/performance-hht"}
                 :schema-flexibility :write
                 :keep-history? true
-                :index :datahike.index/hitchhiker-tree}
-        test-tx-id? true]
-    (duplicate-test config test-tx-id?)))
+                :index :datahike.index/hitchhiker-tree}]
+    (duplicate-test config)))
 
 (defn insert-history-test [cfg]
   (let [schema [{:db/ident       :name


### PR DESCRIPTION
#### SUMMARY
Fix persistent sorted set behaviour on insert to be consistent with hitchhiker-tree behaviour, so that a datom doesn't get overwritten when another one with the same EAV values is inserted. #507 

#### Checks
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked
- [ ] `CHANGELOG.md` updated