### PR TITLE
Fix retraction for persistent set index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix tx-meta on transact through api-ns
 - Improve code samples using transact with arg-map @podgorniy
 - Insert into persistent sorted set does not replace existing datom with identical EAV
+- Single datom retraction fixed for persistent set index
 
 ## 0.4.0
 

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -2043,8 +2043,9 @@
                                 [e a]
                                 (let [v (if (ref? db a) (entid-strict db v) v)]
                                   (validate-val v entity db)
-                                  [e a v]))]
-                  (recur (reduce transact-retract-datom report (-search db pattern)) entities))
+                                  [e a v]))
+                      datoms (vec (-search db pattern))]
+                  (recur (reduce transact-retract-datom report datoms) entities))
                 (recur report entities))
 
               (= op :db.fn/retractAttribute)


### PR DESCRIPTION
#### SUMMARY
Currently, retracting a single datom via `transact` using the persistent-set index throws following exception:

```
#error {
 :cause Tovarisch, you are iterating and mutating a transient set at the same time!
 :via
 [{:type java.lang.RuntimeException
   :message Tovarisch, you are iterating and mutating a transient set at the same time!
   :at [me.tonsky.persistent_sorted_set.Seq checkVersion Seq.java 31]}]
 :trace
 [[me.tonsky.persistent_sorted_set.Seq checkVersion Seq.java 31]
  [me.tonsky.persistent_sorted_set.Seq advance Seq.java 46]
  [me.tonsky.persistent_sorted_set.Seq reduce Seq.java 117]
  [clojure.core$reduce invokeStatic core.clj 6885]
  [clojure.core$reduce invoke core.clj 6868]
  [datahike.db$transact_tx_data invokeStatic db.cljc 2047]
  [datahike.db$transact_tx_data invoke db.cljc 1826]
  [datahike.core$with invokeStatic core.cljc 130]
  [datahike.core$with invoke core.cljc 123]
  [datahike.core$_transact_BANG_$fn__31496 invoke core.cljc 213]
  [clojure.lang.Atom swap Atom.java 37]
  [clojure.core$swap_BANG_ invokeStatic core.clj 2369]
  [clojure.core$swap_BANG_ invoke core.clj 2362]
  [datahike.core$_transact_BANG_ invokeStatic core.cljc 212]
  [datahike.core$_transact_BANG_ invoke core.cljc 209]
  [datahike.core$transact_BANG_ invokeStatic core.cljc 230]
  [datahike.core$transact_BANG_ invoke core.cljc 226]
  [datahike.core$transact invokeStatic core.cljc 328]
  [datahike.core$transact invoke core.cljc 321]
  [clojure.lang.Var invoke Var.java 393]
  [datahike.connector$update_and_flush_db invokeStatic connector.cljc 25]
  [datahike.connector$update_and_flush_db invoke connector.cljc 24]
  [datahike.transactor$create_rx_thread$fn__31632$fn__31634 invoke transactor.cljc 34]
  [datahike.transactor$create_rx_thread$fn__31632 invoke transactor.cljc 34]
  [clojure.core.async$thread_call$fn__8015 invoke async.clj 484]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1136]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 635]
  [java.lang.Thread run Thread.java 833]]}
```
This PR solves this by iterating over the set before the changes occur.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Formatting checked
- [ ] `CHANGELOG.md` updated
