### PR TITLE
Consistent upsert for hitchhiker-tree and persistent-sorted-set indexes

### DIFF
--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -218,26 +218,47 @@
      :clj
      (.compareTo ^Comparable a1 a2)))
 
-(defn cmp-datoms-eavt-quick [^Datom d1, ^Datom d2]
-  (combine-cmp
-   (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
-   (cmp-attr-quick (.-a d1) (.-a d2))
-   (compare (.-v d1) (.-v d2))
-   (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
+(defn cmp-datoms-eavt-quick
+  ([^Datom d1, ^Datom d2] (cmp-datoms-eavt-quick d1 d2 true))
+  ([^Datom d1, ^Datom d2, abs-txid?]
+   (combine-cmp
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
+    (cmp-attr-quick (.-a d1) (.-a d2))
+    (compare (.-v d1) (.-v d2))
+    (if abs-txid?
+      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
 
-(defn cmp-datoms-aevt-quick [^Datom d1, ^Datom d2]
-  (combine-cmp
-   (cmp-attr-quick (.-a d1) (.-a d2))
-   (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
-   (compare (.-v d1) (.-v d2))
-   (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
+(defn cmp-datoms-aevt-quick
+  ([^Datom d1, ^Datom d2] (cmp-datoms-aevt-quick d1 d2 true))
+  ([^Datom d1, ^Datom d2, abs-txid?]
+   (combine-cmp
+    (cmp-attr-quick (.-a d1) (.-a d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
+    (compare (.-v d1) (.-v d2))
+    (if abs-txid?
+      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
 
-(defn cmp-datoms-avet-quick [^Datom d1, ^Datom d2]
-  (combine-cmp
-   (cmp-attr-quick (.-a d1) (.-a d2))
-   (compare (.-v d1) (.-v d2))
-   (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
-   (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))))
+(defn cmp-datoms-avet-quick
+  ([^Datom d1, ^Datom d2] (cmp-datoms-avet-quick d1 d2 true))
+  ([^Datom d1, ^Datom d2, abs-txid?]
+   (combine-cmp
+    (cmp-attr-quick (.-a d1) (.-a d2))
+    (compare (.-v d1) (.-v d2))
+    (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
+    (if abs-txid?
+      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
+
+(defn cmp-datoms-eavt-quick-raw-txid [^Datom d1, ^Datom d2]
+  (cmp-datoms-eavt-quick d1 d2 false))
+
+(defn cmp-datoms-aevt-quick-raw-txid [^Datom d1, ^Datom d2]
+  (cmp-datoms-aevt-quick d1 d2 false))
+
+(defn cmp-datoms-avet-quick-raw-txid [^Datom d1, ^Datom d2]
+  (cmp-datoms-avet-quick d1 d2 false))
 
 (defn diff-sorted [a b cmp]
   (loop [only-a []

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -91,8 +91,8 @@
     (dip/-temporal-upsert set datom index-type))
   (-remove [set datom index-type op-count]
     (dip/-remove set datom index-type))
-  (-slice [set from to _]
-    (dip/-slice set from to))
+  (-slice [set from to index-type]
+    (dip/-slice set from to index-type))
   (-flush [set _]
     (dip/-flush set))
   (-transient [set]

--- a/src/datahike/index/utils.cljc
+++ b/src/datahike/index/utils.cljc
@@ -1,0 +1,44 @@
+(ns datahike.index.utils
+  (:require [datahike.constants :refer [e0 tx0 emax txmax]]
+            [datahike.datom :as dd])
+  #?(:clj (:import [datahike.datom Datom])))
+
+(defn datom-to-vec [^Datom datom index-type start?]
+  (let [e (fn [datom] (when-not (or (and start? (= e0 (.-e datom)))
+                                    (and (not start?) (= emax (.-e datom))))
+                        (.-e datom)))
+        tx (fn [datom] (when-not (or (and start? (= tx0 (.-tx datom)))
+                                     (and (not start?) (= txmax (.-tx datom))))
+                         (.-tx datom)))
+        datom-seq (case index-type
+                    :aevt (list (.-a datom) (e datom) (.-v datom) (tx datom))
+                    :avet (list (.-a datom) (.-v datom) (e datom) (tx datom))
+                    (list (e datom) (.-a datom) (.-v datom) (tx datom)))]
+    (->> datom-seq
+         (take-while some?)
+         vec)))
+
+(defn- slice-datom-compare [cmp]
+  (fn [v1 v2] (-> (filter #(not (= % 0)) (map cmp v1 v2))
+                  first
+                  (or 0))))
+
+(defn prefix-scan [cmp [e f g h]]
+  (let [datom-vec-compare (slice-datom-compare cmp)]
+    (fn [[i j k l]]
+      (< (cond (and e f g h)  (datom-vec-compare [i j k l] [e f g h])
+               (and e f g)    (datom-vec-compare [i j k] [e f g])
+               (and e f)      (datom-vec-compare [i j] [e f])
+               e              (cmp i e)
+               :else          0)
+         1))))
+
+(defn equals-on-indices?
+  "Returns true if 'k1' and 'k2' have the same value at positions indicated by 'indices'"
+  [k1, k2, indices]
+  (reduce (fn [_ i]
+            (if (= (nth k1 i) (nth k2 i))
+              true
+              (reduced false)))
+          true
+          indices))

--- a/test/datahike/test/index_test.cljc
+++ b/test/datahike/test/index_test.cljc
@@ -158,84 +158,92 @@
             [5 :age 20]
             [4 :age 45]]))))
 
-(deftest test-slice
-  (let [dvec #(vector (:e %) (:a %) (:v %))
-        db (d/db-with
-            (db/empty-db {:name {:db/index true}
-                          :age  {:db/index true}})
-            [{:db/id 1 :name "Ivan"   :age 15}
-             {:db/id 2 :name "Oleg"   :age 20}
-             {:db/id 3 :name "Sergey" :age 7}
-             {:db/id 4 :name "Pavel"  :age 45}
-             {:db/id 5 :name "Petr"   :age 20}])
-        eavt (:eavt db)
-        aevt (:aevt db)
-        avet (:avet db)]
+(defn test-slice [cfg]
+  (testing "Test index -slice"
+    (let [dvec #(vector (:e %) (:a %) (:v %))
+          db (d/db-with
+              (db/empty-db {:name {:db/index true}
+                            :age  {:db/index true}}
+                           cfg)
+              [{:db/id 1 :name "Ivan"   :age 15}
+               {:db/id 2 :name "Oleg"   :age 20}
+               {:db/id 3 :name "Sergey" :age 7}
+               {:db/id 4 :name "Pavel"  :age 45}
+               {:db/id 5 :name "Petr"   :age 20}])
+          eavt (:eavt db)
+          aevt (:aevt db)
+          avet (:avet db)]
 
-    (is (= (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom emax nil nil txmax) :eavt)
-           (d/datoms db :eavt)))
-    (is (= (map dvec (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom 2 nil nil tx0) :eavt))
-           [[1 :age 15]
-            [1 :name "Ivan"]
-            [2 :age 20]
-            [2 :name "Oleg"]]))
-    (is (= (map dvec (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom 3 :age 7 txmax) :eavt))
-           [[1 :age 15]
-            [1 :name "Ivan"]
-            [2 :age 20]
-            [2 :name "Oleg"]
-            [3 :age 7]]))
-    (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 3 :name "Timofey" txmax) :eavt))
-           [[1 :age 15]
-            [1 :name "Ivan"]
-            [2 :age 20]
-            [2 :name "Oleg"]
-            [3 :age 7]
-            [3 :name "Sergey"]]))
-    (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 3 :name "Timofey" tx0) :eavt))
-           [[1 :age 15]
-            [1 :name "Ivan"]
-            [2 :age 20]
-            [2 :name "Oleg"]
-            [3 :age 7]
-            [3 :name "Sergey"]]))
-    (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 5 :age nil txmax) :eavt))
-           [[1 :age 15]
-            [1 :name "Ivan"]
-            [2 :age 20]
-            [2 :name "Oleg"]
-            [3 :age 7]
-            [3 :name "Sergey"]
-            [4 :age 45]
-            [4 :name "Pavel"]
-            [5 :age 20]]))
+      (is (= (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom emax nil nil txmax) :eavt)
+             (d/datoms db :eavt)))
+      (is (= (map dvec (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom 2 nil nil tx0) :eavt))
+             [[1 :age 15]
+              [1 :name "Ivan"]
+              [2 :age 20]
+              [2 :name "Oleg"]]))
+      (is (= (map dvec (di/-slice eavt (dd/datom e0 nil nil tx0) (dd/datom 3 :age 7 txmax) :eavt))
+             [[1 :age 15]
+              [1 :name "Ivan"]
+              [2 :age 20]
+              [2 :name "Oleg"]
+              [3 :age 7]]))
+      (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 3 :name "Timofey" txmax) :eavt))
+             [[1 :age 15]
+              [1 :name "Ivan"]
+              [2 :age 20]
+              [2 :name "Oleg"]
+              [3 :age 7]
+              [3 :name "Sergey"]]))
+      (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 3 :name "Timofey" tx0) :eavt))
+             [[1 :age 15]
+              [1 :name "Ivan"]
+              [2 :age 20]
+              [2 :name "Oleg"]
+              [3 :age 7]
+              [3 :name "Sergey"]]))
+      (is (= (map dvec (di/-slice eavt (dd/datom e0 :age nil tx0) (dd/datom 5 :age nil txmax) :eavt))
+             [[1 :age 15]
+              [1 :name "Ivan"]
+              [2 :age 20]
+              [2 :name "Oleg"]
+              [3 :age 7]
+              [3 :name "Sergey"]
+              [4 :age 45]
+              [4 :name "Pavel"]
+              [5 :age 20]]))
 
-    (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 3 :name "Pavel" txmax) :aevt))
-           [[1 :age 15]
-            [2 :age 20]
-            [3 :age 7]
-            [4 :age 45]
-            [5 :age 20]
-            [1 :name "Ivan"]
-            [2 :name "Oleg"]]))
-    (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 5 :age 18 txmax) :aevt))
-           [[1 :age 15]
-            [2 :age 20]
-            [3 :age 7]
-            [4 :age 45]]))
-    (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 3 :name nil txmax) :aevt))
-           [[1 :age 15]
-            [2 :age 20]
-            [3 :age 7]
-            [4 :age 45]
-            [5 :age 20]
-            [1 :name "Ivan"]
-            [2 :name "Oleg"]
-            [3 :name "Sergey"]]))
+      (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 3 :name "Pavel" txmax) :aevt))
+             [[1 :age 15]
+              [2 :age 20]
+              [3 :age 7]
+              [4 :age 45]
+              [5 :age 20]
+              [1 :name "Ivan"]
+              [2 :name "Oleg"]]))
+      (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 5 :age 18 txmax) :aevt))
+             [[1 :age 15]
+              [2 :age 20]
+              [3 :age 7]
+              [4 :age 45]]))
+      (is (= (map dvec (di/-slice aevt (dd/datom e0 nil nil tx0) (dd/datom 3 :name nil txmax) :aevt))
+             [[1 :age 15]
+              [2 :age 20]
+              [3 :age 7]
+              [4 :age 45]
+              [5 :age 20]
+              [1 :name "Ivan"]
+              [2 :name "Oleg"]
+              [3 :name "Sergey"]]))
 
-    (is (= (map dvec (di/-slice avet (dd/datom e0 nil nil tx0) (dd/datom 3 :age 50 txmax) :avet))
-           [[3 :age 7]
-            [1 :age 15]
-            [2 :age 20]
-            [5 :age 20]
-            [4 :age 45]]))))
+      (is (= (map dvec (di/-slice avet (dd/datom e0 nil nil tx0) (dd/datom 3 :age 50 txmax) :avet))
+             [[3 :age 7]
+              [1 :age 15]
+              [2 :age 20]
+              [5 :age 20]
+              [4 :age 45]])))))
+
+(deftest test-slice-hht
+  (test-slice nil))
+
+(deftest test-slice-ps
+  (test-slice {:index :datahike.index/persistent-set}))

--- a/test/datahike/test/upsert_test.cljc
+++ b/test/datahike/test/upsert_test.cljc
@@ -209,16 +209,11 @@
       (d/transact conn {:tx-data [{:name "Alice"
                                    :age  25}]})
       (is (= 1 (count (d/datoms (d/history @conn) :eavt [:name "Alice"] :age)))))
-
     (testing "inserting the exact same datom"
       (d/transact conn {:tx-data [{:db/id [:name "Alice"]
                                    :age 25}]})
-      (testing " does not change the history for any index other than persistent-set"
-        (when (not= (:index cfg) :datahike.index/persistent-set)
-          (is (= 1 (count (d/datoms (d/history @conn) :eavt [:name "Alice"] :age))))))
-      (testing " adds another version of the datom when index is persistent-set"
-        (when (= (:index cfg) :datahike.index/persistent-set)
-          (is (= 2 (count (d/datoms (d/history @conn) :eavt [:name "Alice"] :age)))))))
+      (testing " does not change history"
+        (is (= 1 (count (d/datoms (d/history @conn) :eavt [:name "Alice"] :age))))))
     (testing "changing the datom value increases the history with 2 datoms: the retraction datom and the new value."
       (d/transact conn {:tx-data [{:db/id [:name "Alice"]
                                    :age 26}]})


### PR DESCRIPTION
#### SUMMARY
Upserting datom with identical EAV to an existing one leaves hitchhiker-tree temporal indices unchanged, but adds to persistent-sorted-set temporal indices.

As for upserting a datom matching an existing EA but with a new V, the old V is not negated; rather, the new datom is merely added, so that the entire history for that EA consists only of additions.

#### Checks
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked
- [ ] `CHANGELOG.md` updated

#### ADDITIONAL INFORMATION
The reasons for this:
1. `-slice` always returns zero matches.
2. The comparator used ignores additions and negations, so a negation of an existing datom evaluates as equal and isn't added to the temporal index.

Added a `datahike.index.utils` namespace with helper functions.