### PR TITLE
Update read handlers for index insert and upsert ops.

### DIFF
--- a/src/datahike/index/hitchhiker_tree/insert.cljc
+++ b/src/datahike/index/hitchhiker_tree/insert.cljc
@@ -70,7 +70,7 @@
           (fn [{:keys [key op-count ts]}]
             (map->InsertOp {:key key :op-count (or op-count ts)}))
 
-          'datahike.index.hitchhiker_tree.insert.temporal-InsertOp
+          'datahike.index.hitchhiker_tree.insert.temporal_InsertOp
           (fn [{:keys [key op-count ts]}]
             (map->temporal-InsertOp {:key key :op-count (or op-count ts)}))})
   store)

--- a/src/datahike/index/hitchhiker_tree/upsert.cljc
+++ b/src/datahike/index/hitchhiker_tree/upsert.cljc
@@ -130,7 +130,7 @@
           (fn [{:keys [key value op-count ts indices]}]
             (map->UpsertOp {:key key :value value :op-count (or op-count ts) :indices (or indices [0 1])}))
 
-          'datahike.index.hitchhiker_tree.upsert.temporal-UpsertOp
+          'datahike.index.hitchhiker_tree.upsert.temporal_UpsertOp
           (fn [{:keys [key value op-count ts indices]}]
             (map->temporal-UpsertOp {:key key :value value :op-count (or op-count ts) :indices (or indices [0 1])}))})
   store)


### PR DESCRIPTION
#### SUMMARY

Addresses https://github.com/replikativ/datahike/issues/527. I'm not familiar enough with datahike to know if this is a complete fix. Although I was able to reproduce the issue reliably, I was never able to figure out exactly which circumstances trigger the event.

The read handlers for `datahike.index.hitchhiker_tree.insert.temporal_InsertOp` and `'datahike.index.hitchhiker_tree.upsert.temporal_UpsertOp` incorrectly had a `-` instead of `_` which meant that the default read handler was used instead.

