### PR TITLE
Add framework for config testing

### DIFF
--- a/bin/run-fast-unittests
+++ b/bin/run-fast-unittests
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+TIMBRE_LEVEL=':fatal' ./bin/kaocha --focus :quick "$@"

--- a/src/datahike/store.cljc
+++ b/src/datahike/store.cljc
@@ -112,7 +112,7 @@
 
 (defmethod default-config :file [{:keys [id] :as config}]
   (merge
-   {:path (:datahike-store-path env)}
+   {:path (:datahike-store-path env "datahike-db")}
    config))
 
 (s/def :datahike.store.file/path string?)

--- a/test/datahike/test/config.clj
+++ b/test/datahike/test/config.clj
@@ -1,0 +1,44 @@
+(ns datahike.test.config
+  (:require [clojure.test :refer :all]
+            [datahike.index :refer [init-index]]
+            [datahike.store :refer [default-config]]))
+
+;; Can be set via kaocha config in tests.edn
+;; e.g.
+;; - '[{:backend :mem :index :datahike.index/persistent-set}]' to only run on in-memory database with persistent-set index
+;; - '[{:backend :mem} {:index :datahike.index/persistent-set}]' to run all configs with either in-memory backend, or persistent-set index
+(def ^:dynamic user-filter-maps [])
+
+;; For now disables configurations the tests are not adjusted for
+;; Should eventually not filter out anything
+;; Configs can also be filtered on a test-to-test basis
+(def system-config-filter
+  (fn [config] (and (not (and (= :datahike.index/persistent-set (:index config))
+                              (= :file (get-in config [:store :backend]))))
+                    (= :attribute-refs? false)
+                    (= :keep-history? false)
+                    (= :schema-flexibility :write))))
+
+(def configs
+  (->> (for [index (keys (methods init-index))
+             backend (keys (methods default-config))
+             history? [true false]
+             refs? [true false]
+             schema [:read :write]]
+         {:keep-history? history?
+          :attribute-refs? refs?
+          :schema-flexibility schema
+          :index index
+          :store (default-config {:backend backend})})
+       (filter system-config-filter)
+       (filter (fn [config] (some (fn [m] (every? #(fn [[k v]] (= (k config) v))
+                                                  m))
+                                  user-filter-maps)))))
+
+(defn config-str [{:keys [keep-history? attribute-refs? schema-flexibility index store] :as _config}]
+  (str "schema-on-" (name schema-flexibility)
+       (when attribute-refs? " reference")
+       " database with "
+       (when keep-history? "history, ")
+       (subs (name index) 15) " index, and "
+       (:backend store) " backend"))

--- a/tests.edn
+++ b/tests.edn
@@ -3,6 +3,12 @@
                     #_{:id :cljs
                        :type :kaocha.type/cljs
                        :ns-patterns ["datahike.test."]}
+                    {:id :quick
+                     :ns-patterns ["datahike.test."]
+                     :bindings {datahike.test.config/*user-filter-map* [{:index :datahike.index/persistent-set
+                                                                         :backend :mem
+                                                                         :schema-flexibility :read
+                                                                         }]}}
                     {:id :integration
                      :test-paths ["test/datahike/integration_test"]}]
             :reporter kaocha.report/documentation}


### PR DESCRIPTION
#### SUMMARY
Introduction of a way to configure running all vs. one fast running database configuration.

#### Checks
##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [x] Formatting checked
- [ ] `CHANGELOG.md` updated

