### PR TITLE
519 temporal upsert and retract for pset

### DIFF
--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -219,46 +219,49 @@
      (.compareTo ^Comparable a1 a2)))
 
 (defn cmp-datoms-eavt-quick
-  ([^Datom d1, ^Datom d2] (cmp-datoms-eavt-quick d1 d2 true))
-  ([^Datom d1, ^Datom d2, abs-txid?]
+  ([^Datom d1, ^Datom d2] (cmp-datoms-eavt-quick d1 d2 false))
+  ([^Datom d1, ^Datom d2, cmp-added]
    (combine-cmp
     (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (cmp-attr-quick (.-a d1) (.-a d2))
     (compare (.-v d1) (.-v d2))
-    (if abs-txid?
-      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
-      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
+    (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+    (if cmp-added
+      (compare (datom-added d1) (datom-added d2))
+      0))))
 
 (defn cmp-datoms-aevt-quick
-  ([^Datom d1, ^Datom d2] (cmp-datoms-aevt-quick d1 d2 true))
-  ([^Datom d1, ^Datom d2, abs-txid?]
+  ([^Datom d1, ^Datom d2] (cmp-datoms-aevt-quick d1 d2 false))
+  ([^Datom d1, ^Datom d2, cmp-added]
    (combine-cmp
     (cmp-attr-quick (.-a d1) (.-a d2))
     (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
     (compare (.-v d1) (.-v d2))
-    (if abs-txid?
-      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
-      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
+    (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+    (if cmp-added
+      (compare (datom-added d1) (datom-added d2))
+      0))))
 
 (defn cmp-datoms-avet-quick
-  ([^Datom d1, ^Datom d2] (cmp-datoms-avet-quick d1 d2 true))
-  ([^Datom d1, ^Datom d2, abs-txid?]
+  ([^Datom d1, ^Datom d2] (cmp-datoms-avet-quick d1 d2 false))
+  ([^Datom d1, ^Datom d2, cmp-added]
    (combine-cmp
     (cmp-attr-quick (.-a d1) (.-a d2))
     (compare (.-v d1) (.-v d2))
     (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2))
-    (if abs-txid?
-      (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
-      (#?(:clj Long/compare :cljs -) (.-tx d1) (.-tx d2))))))
+    (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2))
+    (if cmp-added
+      (compare (datom-added d1) (datom-added d2))
+      0))))
 
-(defn cmp-datoms-eavt-quick-raw-txid [^Datom d1, ^Datom d2]
-  (cmp-datoms-eavt-quick d1 d2 false))
+(defn cmp-datoms-eavt-quick-cmp-added [^Datom d1, ^Datom d2]
+  (cmp-datoms-eavt-quick d1 d2 true))
 
-(defn cmp-datoms-aevt-quick-raw-txid [^Datom d1, ^Datom d2]
-  (cmp-datoms-aevt-quick d1 d2 false))
+(defn cmp-datoms-aevt-quick-cmp-added [^Datom d1, ^Datom d2]
+  (cmp-datoms-aevt-quick d1 d2 true))
 
-(defn cmp-datoms-avet-quick-raw-txid [^Datom d1, ^Datom d2]
-  (cmp-datoms-avet-quick d1 d2 false))
+(defn cmp-datoms-avet-quick-cmp-added [^Datom d1, ^Datom d2]
+  (cmp-datoms-avet-quick d1 d2 true))
 
 (defn diff-sorted [a b cmp]
   (loop [only-a []

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -87,7 +87,7 @@
                               index-type))]
     (if (diu/equals-on-indices? datom old [0 1 2])
       set
-      (-> (set/conj set (dd/datom (.-e old) (.-a old) (.-v old) (.-tx old) false)
+      (-> (set/conj set (dd/datom (.-e old) (.-a old) (.-v old) (.-tx datom) false)
                     (index-type->cmp-quick index-type false))
           (set/conj datom (index-type->cmp-quick index-type))))
     (set/conj set datom (index-type->cmp-quick index-type))))

--- a/src/datahike/index/utils.cljc
+++ b/src/datahike/index/utils.cljc
@@ -11,7 +11,7 @@
                          (.-e datom)))
          tx (fn [datom] (when-not (or (and start? (= tx0 (.-tx datom)))
                                       (and (not start?) (= txmax (.-tx datom))))
-                          (dd/datom-tx datom)))
+                          (if incl-added? (dd/datom-tx datom) (.-tx datom))))
          datom-seq (cond-> (case index-type
                              :aevt (list (.-a datom) (e datom) (.-v datom) (tx datom))
                              :avet (list (.-a datom) (.-v datom) (e datom) (tx datom))

--- a/src/datahike/index/utils.cljc
+++ b/src/datahike/index/utils.cljc
@@ -3,34 +3,39 @@
             [datahike.datom :as dd])
   #?(:clj (:import [datahike.datom Datom])))
 
-(defn datom-to-vec [^Datom datom index-type start?]
-  (let [e (fn [datom] (when-not (or (and start? (= e0 (.-e datom)))
-                                    (and (not start?) (= emax (.-e datom))))
-                        (.-e datom)))
-        tx (fn [datom] (when-not (or (and start? (= tx0 (.-tx datom)))
-                                     (and (not start?) (= txmax (.-tx datom))))
-                         (.-tx datom)))
-        datom-seq (case index-type
-                    :aevt (list (.-a datom) (e datom) (.-v datom) (tx datom))
-                    :avet (list (.-a datom) (.-v datom) (e datom) (tx datom))
-                    (list (e datom) (.-a datom) (.-v datom) (tx datom)))]
-    (->> datom-seq
-         (take-while some?)
-         vec)))
+(defn datom-to-vec
+  ([^Datom datom index-type start?] (datom-to-vec datom index-type start? false))
+  ([^Datom datom index-type start? incl-added?]
+   (let [e (fn [datom] (when-not (or (and start? (= e0 (.-e datom)))
+                                     (and (not start?) (= emax (.-e datom))))
+                         (.-e datom)))
+         tx (fn [datom] (when-not (or (and start? (= tx0 (.-tx datom)))
+                                      (and (not start?) (= txmax (.-tx datom))))
+                          (dd/datom-tx datom)))
+         datom-seq (cond-> (case index-type
+                             :aevt (list (.-a datom) (e datom) (.-v datom) (tx datom))
+                             :avet (list (.-a datom) (.-v datom) (e datom) (tx datom))
+                             (list (e datom) (.-a datom) (.-v datom) (tx datom)))
+                     incl-added? (concat (list (dd/datom-added datom))))]
+     (->> datom-seq
+          (take-while some?)
+          vec))))
 
 (defn- slice-datom-compare [cmp]
   (fn [v1 v2] (-> (filter #(not (= % 0)) (map cmp v1 v2))
                   first
                   (or 0))))
 
-(defn prefix-scan [cmp [e f g h]]
+(defn prefix-scan [cmp [e f g h i]]
   (let [datom-vec-compare (slice-datom-compare cmp)]
-    (fn [[i j k l]]
-      (< (cond (and e f g h)  (datom-vec-compare [i j k l] [e f g h])
-               (and e f g)    (datom-vec-compare [i j k] [e f g])
-               (and e f)      (datom-vec-compare [i j] [e f])
-               e              (cmp i e)
-               :else          0)
+    (fn [[j k l m n]]
+      (< (cond
+           (and e f g h i)  (datom-vec-compare [j k l m n] [e f g h i])
+           (and e f g h)  (datom-vec-compare [j k l m] [e f g h])
+           (and e f g)    (datom-vec-compare [j k l] [e f g])
+           (and e f)      (datom-vec-compare [j k] [e f])
+           e              (cmp j e)
+           :else          0)
          1))))
 
 (defn equals-on-indices?


### PR DESCRIPTION
#### SUMMARY
Fix temporal upsert and retract for persistent sorted set index #519

##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked
- [ ] `CHANGELOG.md` updated