### PR TITLE
Require datahike.datom in schema namespace

### DIFF
--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -1,5 +1,6 @@
 (ns ^:no-doc datahike.schema
-  (:require [clojure.spec.alpha :as s])
+  (:require [clojure.spec.alpha :as s]
+            [datahike.datom])
   (:import [datahike.datom Datom]))
 
 (s/def :db.type/id #(or (= (class %) java.lang.Long) string?))


### PR DESCRIPTION
#### SUMMARY
So that `schema` is self-contained and can be required on its own. Without it, a ClassNotFoundException is thrown when requiring `schema` without first requiring `datom`.

#### Checks

##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked
- [ ] `CHANGELOG.md` updated