### PR TITLE
Fix if-then and -else clause order in build.clj retry with backoff function

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -50,12 +50,12 @@
   (loop [idle-times (take retries (fib 1 2))]
     (let [result (exec-fn)]
       (if (test-fn result)
-        result
         (when-let [sleep-ms (first idle-times)]
           (println "Returned: " result)
           (println "Retrying with remaining back-off times (in s): " idle-times)
           (Thread/sleep (* 1000 sleep-ms))
-          (recur (rest idle-times)))))))
+          (recur (rest idle-times)))
+        result))))
 
 (defn try-release []
   (try (gh/overwrite-asset {:org "replikativ"


### PR DESCRIPTION
#### SUMMARY
The order is inverted, which I noticed in datahike-server code taken from here

#### Checks
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked
- [ ] `CHANGELOG.md` updated
