### PR TITLE
Add config tests to workflow

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,31 @@
+
+name: Check format
+
+on:
+  pull_request
+  
+jobs:
+  
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: 1.10.3.998
+
+      - name: Check formatting
+        run: clojure -M:format
+        shell: bash

--- a/.github/workflows/test-clj-hht.yml
+++ b/.github/workflows/test-clj-hht.yml
@@ -1,0 +1,31 @@
+
+name: Test CLJ
+
+on:
+  push
+  
+jobs:
+  
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: 1.10.3.998
+
+      - name: Run clojure hitchhiker-tree tests
+        run: clojure -M:test -m kaocha.runner --focus :clj-hht
+        shell: bash

--- a/.github/workflows/test-clj-integration.yml
+++ b/.github/workflows/test-clj-integration.yml
@@ -1,0 +1,45 @@
+
+name: Test CLJ integration
+
+on:
+  push
+  
+jobs:
+  
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+      
+      - name: Checkout records
+        uses: actions/checkout@v2
+        with:
+          repository: scarletcomply/records
+          path: records
+          token: ${{ secrets.PATMAN_PAT}}
+
+      - name: Checkout nb-documentation
+        uses: actions/checkout@v2
+        with:
+          repository: scarletcomply/nb-documentation
+          path: nb-documentation
+          token: ${{ secrets.PATMAN_PAT}}
+
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: 1.10.3.998
+
+      - name: Run clj integration tests
+        run: clojure -M:test -m kaocha.runner --focus :integration
+        shell: bash

--- a/.github/workflows/test-clj-pss.yml
+++ b/.github/workflows/test-clj-pss.yml
@@ -1,0 +1,31 @@
+
+name: Test CLJ with persistent sorted set
+
+on:
+  push
+  
+jobs:
+  
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: 1.10.3.998
+
+      - name: Run clojure persistent set tests
+        run: clojure -M:test -m kaocha.runner --focus :clj-pss
+        shell: bash


### PR DESCRIPTION
Most of the tests are written only for the default configuration. With PR #503 some of the default parameters will be dynamic and can be controlled with the test profile. This PR adds separate workflows for testing the different indexes.

Blocked by #503