### PR TITLE
Add some missing information to schema docs

### DIFF
--- a/doc/schema.md
+++ b/doc/schema.md
@@ -88,6 +88,11 @@ Additionally, the following optional attributes are supported:
   the value for this attribute with upsert enabled)
 - `db/index`: indicates whether an index for the attribute's value should be
   created as a boolean
+- `db/isComponent`: indicates that an attribute of type `:db.type/ref` references a subcomponent of the entity that has the attribute (for cascading retractions)
+- if `:db/valueType` is `:db.type/tuple`, one of:
+  - `db/tupleAttrs`: a collection of attributes that make up the tuple (for [composite tuples](https://docs.datomic.com/on-prem/schema/schema.html#composite-tuples))
+  - `db/tupleTypes`: a collection of 2-8 types that make up the tuple (for [heterogeneous fixed length tuples](https://docs.datomic.com/on-prem/schema/schema.html#heterogeneous-tuples))
+  - `db/tupleType`: the type of the tuple elements (for [homogeneous variable length tuples](https://docs.datomic.com/on-prem/schema/schema.html#homogeneous-tuples))
 
 ### Supported value types
 
@@ -107,6 +112,7 @@ The following types are currently support in datahike:
 | `db.type/string`  | String               |
 | `db.type/symbol`  | clojure.lang.Symbol  |
 | `db.type/uuid`    | java.util.UUID       |
+| `db.type/tuple`   | clojure.lang.Vector  |
 
 The schema is validated using [clojure.spec](https://clojure.org/guides/spec).
 See `src/datahike/schema.cljc` for the implementation details.


### PR DESCRIPTION
#### SUMMARY
This PR adds some more information to the `schema.md` documentation file. In its current state, the file can be misleading with regards to the set of features supported by datahike. I stumbled across this today when I made a schema that used tuple attributes and couldn't find a mention of this in this documentation file. The way it's described there led me to believe that they're not supported (yet), even though they are.

The only thing I've done here is add tuple-related optional key descriptions/mentions as well as `:db.isComponent` to the schema description section and `:db.type/tuple` to the table of supported types.

#### Checks
Neither a bugfix nor a feature, so no predefined checks.


#### ADDITIONAL INFORMATION
/
