### PR TITLE
Ci/disable draft releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@
 - [ ] Integration tests added
 - [ ] Architecture Decision Record added if design changes necessary
 - [ ] Formatting checked
-- [ ] `CHANGELOG.md` updated
 
 ##### Feature
 - [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
@@ -17,7 +16,6 @@
 - [ ] Documentation added
 - [ ] Architecture Decision Record added 
 - [ ] Formatting checked
-- [ ] `CHANGELOG.md` updated
 
 
 #### ADDITIONAL INFORMATION

--- a/build.clj
+++ b/build.clj
@@ -63,7 +63,8 @@
                             :tag version
                             :commit current-commit
                             :file jar-file
-                            :content-type "application/java-archive"})
+                            :content-type "application/java-archive"
+                            :draft false})
        (catch ExceptionInfo e
          (assoc (ex-data e) :failure? true))))
 


### PR DESCRIPTION
#### SUMMARY
This change creates a new release everytime
a commit is made to main branch. The mentioning
of updating the changelog is removed with this PR.
