### PR TITLE
Query stats

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,9 @@
                               incanter/incanter-core      {:mvn/version "1.9.3"}
                               incanter/incanter-charts    {:mvn/version "1.9.3"}
                               hashp/hashp {:mvn/version "0.2.2"}}
-                 :main-opts ["-e" "(require 'hashp.core)"]}
+                ; :main-opts ["-e" "(require 'hashp.core)"]
+                 
+                 }
 
            :test {:extra-paths ["test"]
                   :extra-deps {lambdaisland/kaocha         {:mvn/version "1.70.1086"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,5 +1,6 @@
 (ns user
-  (:require [datahike.api :as d]))
+  (:require [datahike.api :as d]
+            [hashp.core]))
 
 (comment
 
@@ -18,7 +19,7 @@
   (def cfg {:store              {:backend :mem :id "sandbox"}
             :keep-history?      true
             :schema-flexibility :write
-            :middleware         {:query ['datahike.middleware.query/timed]}
+            ;:middleware         {:query ['datahike.middleware.query/timed]}
             :attribute-refs?    true})
 
   (def conn (do
@@ -44,7 +45,7 @@
                      :age     45
                      :sibling [[:name "Alice"] [:name "Bob"]]}])
 
-  (d/q '[:find ?e ?a ?v ?t
+  (d/query-stats '[:find ?e ?a ?v ?t
          :in $ ?a
          :where
          [?e :name ?v ?t]

--- a/src/datahike/api.cljc
+++ b/src/datahike/api.cljc
@@ -262,6 +262,10 @@
              Query passed as map needs vectors as values. Query can not be passed as list. The 1-arity function takes a map with the arguments :query and :args and optionally the additional keys :offset and :limit."}
   q dq/q)
 
+(def ^{:arglists '([query & args] [arg-map])
+       :doc "Executes a datalog query and returns the result as well as some execution details."}
+  query-stats dq/query-stats)
+
 (defmulti datoms {:arglists '([db arg-map] [db index & components])
                   :doc "Index lookup. Returns a sequence of datoms (lazy iterator over actual DB index) which components
                         (e, a, v) match passed arguments. Datoms are sorted in index sort order. Possible `index` values

--- a/src/datahike/middleware/query.cljc
+++ b/src/datahike/middleware/query.cljc
@@ -1,14 +1,14 @@
 (ns datahike.middleware.query
-  (:require [clojure.pprint :as pprint]))
+  (:require [clojure.pprint :as pprint]
+            [datahike.tools :as dt]))
 
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn timed-query [query-handler]
   (fn [query & inputs]
-    (let [start (. System (nanoTime))
-          result (apply query-handler query inputs)
-          t (/ (double (- (. System (nanoTime)) start)) 1000000.0)]
+    (let [{:keys [t res]} (dt/timed #(apply query-handler query inputs))]
       (println "Query time:")
       (pprint/pprint {:t      t
                       :q      (update query :args str)
                       :inputs (str inputs)})
-      result)))
-
+      res)))

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -123,3 +123,14 @@
        (reduce merge-entry (or a {}) (seq b)))))
   ([a b & more]
    (reduce deep-merge (or a {}) (cons b more))))
+
+(defn timed [f] 
+  (let [now #?(:clj #(. System (nanoTime))
+               :cljs #(* 1000 (. (js/Date.) (getTime))))
+        start (now)
+        result (f)
+        end (now)
+        t (/ (double (- end start))
+             1000000.0)]
+    {:res result
+     :t t}))


### PR DESCRIPTION
New function `query-stats` returns details like tuple counts and time during execution steps of the query engine.
