### PR TITLE
fix: remove orchestra from prod

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -14,8 +14,7 @@
         junit/junit                                 {:mvn/version "4.13.2"}
         medley/medley                               {:mvn/version "1.4.0"} 
         metosin/spec-tools                          {:mvn/version "0.10.5"}
-        mvxcvi/clj-cbor                             {:mvn/version "1.1.0"}
-        orchestra/orchestra                         {:mvn/version "2021.01.01-1"}}
+        mvxcvi/clj-cbor                             {:mvn/version "1.1.0"}}
 
  :paths ["src" "target/classes"]
 
@@ -36,12 +35,14 @@
                               org.clojure/tools.cli       {:mvn/version "1.0.206"}
                               incanter/incanter-core      {:mvn/version "1.9.3"}
                               incanter/incanter-charts    {:mvn/version "1.9.3"}
-                              hashp/hashp                 {:mvn/version "0.2.2"}}}
+                              hashp/hashp                 {:mvn/version "0.2.2"} 
+                              orchestra/orchestra         {:mvn/version "2021.01.01-1"}}}
 
            :test {:extra-paths ["test" "bechmark/src" "benchmark/test"]
                   :extra-deps {lambdaisland/kaocha         {:mvn/version "1.71.1119"}
                                lambdaisland/kaocha-cljs    {:mvn/version "1.4.130"}
-                               org.clojure/test.check      {:mvn/version "1.1.1"}}}
+                               org.clojure/test.check      {:mvn/version "1.1.1"}
+                               orchestra/orchestra         {:mvn/version "2021.01.01-1"}}}
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}
 


### PR DESCRIPTION
#### SUMMARY
Moves the orchestra dependency to the test and dev profiles

#### ADDITIONAL INFORMATION
The mere presence of the dependency can have an effect on other libraries as well as has happened in issue #611. 
