### PR TITLE
Optimize queries to be 20 times faster

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -1390,7 +1390,6 @@ more expanded patterns but only more specific patterns."
       true                                          (-post-process qfind)
       qreturnmaps                                   (convert-to-return-maps qreturnmaps)
       stats?                                        (#(-> context-out
-                                                          (update :settings dissoc :relprod-strategy) ;; <-- Don't return non-serializable data.
-                                                          (dissoc :rels :sources)
+                                                          (dissoc :rels :sources :settings)
                                                           (assoc :ret %
                                                                  :query query))))))

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -88,7 +88,9 @@
 
 ;; Utilities
 
-(defn distinct-tuples [tuples]
+(defn distinct-tuples
+  "Remove duplicates just like `distinct` but with the difference that it only works on values on which `vec` can be applied and two different objects are considered equal if and only if their results after `vec` has been applied are equal. This means that two different Java arrays are considered equal if and only if their elements are equal."
+  [tuples]
   (first (reduce (fn [[dst seen] tuple]
                    (let [key (vec tuple)]
                      (if (seen key)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -1390,6 +1390,7 @@ more expanded patterns but only more specific patterns."
       true                                          (-post-process qfind)
       qreturnmaps                                   (convert-to-return-maps qreturnmaps)
       stats?                                        (#(-> context-out
+                                                          (update :settings dissoc :relprod-strategy) ;; <-- Don't return non-serializable data.
                                                           (dissoc :rels :sources)
                                                           (assoc :ret %
                                                                  :query query))))))

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -1429,7 +1429,7 @@ than doing no expansion at all."
   (->> (-collect context symbols)
        (map vec)))
 
-(def default-settings {:relprod-strategy select-all})
+(def default-settings {:relprod-strategy expand-once})
 
 (defn raw-q [{:keys [query args offset limit stats? settings] :as _query-map}]
   (let [settings (merge default-settings settings)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -944,7 +944,7 @@
   ([source pattern] (resolve-pattern-lookup-refs source pattern nil))
   ([source pattern error-code]
    (if (dbu/db? source)
-     (dt/with-elements-of pattern
+     (dt/with-destructured-vector pattern
        e (resolve-pattern-lookup-entity-id source e error-code)
        a (if (and (:attribute-refs? (dbi/-config source)) (keyword? a))
            (dbi/-ref-for source a)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -1385,7 +1385,7 @@ than doing no expansion at all."
   (->> (-collect context symbols)
        (map vec)))
 
-(def default-settings {:relprod-strategy relprod-select-simple})
+(def default-settings {:relprod-strategy relprod-select-all})
 
 (defn raw-q [{:keys [query args offset limit stats? settings] :as _query-map}]
   (let [settings (merge default-settings settings)

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -152,7 +152,7 @@
   #?(:clj (.getHostAddress (InetAddress/getLocalHost))
      :cljs (raise "Not supported yet." {:type :hostname-not-supported-yet})))
 
-(def datahike-logo (slurp "resources/datahike-logo.txt"))
+(def datahike-logo (slurp (io/resource "datahike-logo.txt")))
 
 (defmacro with-elements-of [v & var-expr-pairs]
   {:pre [(even? (count var-expr-pairs))]}

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -154,7 +154,7 @@
 
 (def datahike-logo (slurp (io/resource "datahike-logo.txt")))
 
-(defmacro with-elements-of [v & var-expr-pairs]
+(defmacro with-destructured-vector [v & var-expr-pairs]
   {:pre [(even? (count var-expr-pairs))]}
   (let [pairs (partition 2 var-expr-pairs)
         vars (mapv first pairs)

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -882,9 +882,9 @@
   ;; it checks that the result of a simple query is
   ;; correct no matter the choice of strategy.
   (doseq [inner-strategy [identity
-                          dq/relprod-select-simple
-                          dq/relprod-select-all
-                          dq/relprod-expand-once]]
+                          dq/select-simple
+                          dq/select-all
+                          dq/expand-once]]
     (let [strategy-was-called (atom false)
           strategy (fn [relprod]
                      (reset! strategy-was-called true)

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -888,16 +888,7 @@
     (let [strategy-was-called (atom false)
           strategy (fn [relprod]
                      (reset! strategy-was-called true)
-                     (inner-strategy relprod))
-          cfg {:store {:backend :mem
-                       :id "q"}
-               :initial-tx [[:db/add -1 :name "Ivan"]
-                            [:db/add -1 :likes "fries"]
-                            [:db/add -1 :likes "pizza"]
-                            [:db/add -1 :friend 296]]
-               :keep-history? false
-               :schema-flexibility :read}
-          _conn (utils/setup-db cfg)]
+                     (inner-strategy relprod))]
       (is (= #{["fries"] ["candy"] ["pie"] ["pizza"]}
              (d/q {:query '[:find ?value :where [_ :likes ?value]]
                    :settings {:relprod-strategy strategy}

--- a/test/datahike/test/lookup_refs_test.cljc
+++ b/test/datahike/test/lookup_refs_test.cljc
@@ -234,23 +234,6 @@
                 db [1 2 3 "A"])
            #{[2]}))
 
-    (is (= (d/q '[:find ?e
-                  :in $ [?e ...]
-                  :where [?e :friend 3]]
-                db ["A"])
-           #{}))
-
-    ;; Because the previous test with `[?e ...]` being `["A"]` passes,
-    ;; wouldn't it be consistent if this test with `?e` being `"A"`
-    ;; passes too? This is currently not the case. A first step
-    ;; to make it work would be to remove the branch in `resolve-in`
-    ;; where the `:consts` is accumulated.
-    #_(is (= (d/q '[:find ?e
-                    :in $ ?e
-                    :where [?e :friend 3]]
-                  db "A")
-             #{}))
-
     (let [db2 (d/db-with (db/empty-db schema)
                          [{:db/id 3 :name "Ivan" :id 3}
                           {:db/id 1 :name "Petr" :id 1}

--- a/test/datahike/test/lookup_refs_test.cljc
+++ b/test/datahike/test/lookup_refs_test.cljc
@@ -241,12 +241,15 @@
            #{}))
 
     ;; Because the previous test with `[?e ...]` being `["A"]` passes,
-    ;; this test must pass too.
+    ;; wouldn't it be consistent if this test with `?e` being `"A"`
+    ;; passes too? This is currently not the case. A first step
+    ;; to make it work would be to remove the branch in `resolve-in`
+    ;; where the `:consts` is accumulated.
     #_(is (= (d/q '[:find ?e
-                  :in $ ?e
-                  :where [?e :friend 3]]
-                db "A")
-           #{}))
+                    :in $ ?e
+                    :where [?e :friend 3]]
+                  db "A")
+             #{}))
 
     (let [db2 (d/db-with (db/empty-db schema)
                          [{:db/id 3 :name "Ivan" :id 3}

--- a/test/datahike/test/lookup_refs_test.cljc
+++ b/test/datahike/test/lookup_refs_test.cljc
@@ -228,20 +228,25 @@
            #{[[:name "Ivan"] [:name "Petr"]]
              [[:name "Petr"] [:name "Oleg"]]}))
 
-      ;;;;;;; What should happen in this case?
-      ;;;;;;; ... and what should happen if we wrap "A" in a  collection
-      ;;;;;;;     with one element? Maybe it should not throw an error.
-    #_(is (= (d/q '[:find ?e
-                    :in $ ?e
-                    :where [?e :friend 3]]
-                  db "A")
-             #{}))
-
     (is (= (d/q '[:find ?e
                   :in $ [?e ...]
                   :where [?e :friend 3]]
                 db [1 2 3 "A"])
            #{[2]}))
+
+    (is (= (d/q '[:find ?e
+                  :in $ [?e ...]
+                  :where [?e :friend 3]]
+                db ["A"])
+           #{}))
+
+    ;; Because the previous test with `[?e ...]` being `["A"]` passes,
+    ;; this test must pass too.
+    #_(is (= (d/q '[:find ?e
+                  :in $ ?e
+                  :where [?e :friend 3]]
+                db "A")
+           #{}))
 
     (let [db2 (d/db-with (db/empty-db schema)
                          [{:db/id 3 :name "Ivan" :id 3}

--- a/test/datahike/test/lookup_refs_test.cljc
+++ b/test/datahike/test/lookup_refs_test.cljc
@@ -228,6 +228,15 @@
            #{[[:name "Ivan"] [:name "Petr"]]
              [[:name "Petr"] [:name "Oleg"]]}))
 
+      ;;;;;;; What should happen in this case?
+      ;;;;;;; ... and what should happen if we wrap "A" in a  collection
+      ;;;;;;;     with one element? Maybe it should not throw an error.
+    #_(is (= (d/q '[:find ?e
+                    :in $ ?e
+                    :where [?e :friend 3]]
+                  db "A")
+             #{}))
+
     (is (= (d/q '[:find ?e
                   :in $ [?e ...]
                   :where [?e :friend 3]]

--- a/test/datahike/test/query_stats_test.cljc
+++ b/test/datahike/test/query_stats_test.cljc
@@ -26,12 +26,13 @@
 (use-fixtures :once (partial with-db config (into test-schema test-data)))
 
 (defn unify-stats [stats]
-  (cw/postwalk
-   #(cond
-      (and (map? %) (contains? % :t))                  (assoc % :t :measurement)
-      (and (symbol? %) (re-find #"__auto__" (name %))) (symbol (str/replace (name %) #"__auto__\d*" "_tmp"))
-      :else                                            %)
-   stats))
+  (dissoc (cw/postwalk
+           #(cond
+              (and (map? %) (contains? % :t))                  (assoc % :t :measurement)
+              (and (symbol? %) (re-find #"__auto__" (name %))) (symbol (str/replace (name %) #"__auto__\d*" "_tmp"))
+              :else                                            %)
+           stats)
+          :settings))
 
 (deftest test-not
   (is (= {:consts {}

--- a/test/datahike/test/query_stats_test.cljc
+++ b/test/datahike/test/query_stats_test.cljc
@@ -26,13 +26,12 @@
 (use-fixtures :once (partial with-db config (into test-schema test-data)))
 
 (defn unify-stats [stats]
-  (dissoc (cw/postwalk
-           #(cond
-              (and (map? %) (contains? % :t))                  (assoc % :t :measurement)
-              (and (symbol? %) (re-find #"__auto__" (name %))) (symbol (str/replace (name %) #"__auto__\d*" "_tmp"))
-              :else                                            %)
-           stats)
-          :settings))
+  (cw/postwalk
+   #(cond
+      (and (map? %) (contains? % :t))                  (assoc % :t :measurement)
+      (and (symbol? %) (re-find #"__auto__" (name %))) (symbol (str/replace (name %) #"__auto__\d*" "_tmp"))
+      :else                                            %)
+   stats))
 
 (deftest test-not
   (is (= {:consts {}

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -540,8 +540,8 @@
         relprod (dq/init-relprod rel-data xy-vars)
         relprod-x (dq/relprod-select-keys relprod #{['?x]})
         relprod-xy (dq/relprod-select-keys relprod #{['?x] ['?y]})
-        relprod-xy2 (dq/relprod-select-all relprod)
-        relprod-y (dq/relprod-select-simple relprod)
+        relprod-xy2 (dq/select-all relprod)
+        relprod-y (dq/select-simple relprod)
         prodks (comp set keys :attrs :product)]
     (is (= #{} (dq/relprod-vars relprod-x)))
     (is (= #{'?x} (dq/relprod-vars relprod-x :include)))

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -538,8 +538,8 @@
         xy-vars ['?x '?y]
         rel-data (dq/expansion-rel-data rels xy-vars)
         relprod (dq/init-relprod rel-data xy-vars)
-        relprod-x (dq/relprod-select-keys relprod ['?x])
-        relprod-xy (dq/relprod-select-keys relprod ['?x] ['?y])
+        relprod-x (dq/relprod-select-keys relprod #{['?x]})
+        relprod-xy (dq/relprod-select-keys relprod #{['?x] ['?y]})
         relprod-xy2 (dq/relprod-select-all relprod)
         relprod-y (dq/relprod-select-simple relprod)
         prodks (comp set keys :attrs :product)]
@@ -550,12 +550,10 @@
     (is (= 2 (count rel-data)))
     (is (= [{:rel x
              :tuple-count 4
-             :vars ['?x]
-             :key ['?x]}
+             :vars ['?x]}
             {:rel y
              :tuple-count 1
-             :vars ['?y]
-             :key ['?y]}]
+             :vars ['?y]}]
            rel-data))
     (is (sequential? (:exclude relprod)))
     (is (= 2 (count (:exclude relprod))))

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -511,6 +511,14 @@
 
 (deftest test-distinct-tuples
   (is (= [[3 4]] (dq/distinct-tuples [[3 4]])))
+  (let [arrays [(object-array [:a]) (object-array [:a])]
+        result (dq/distinct-tuples arrays)
+        object-array-type (type (object-array []))]
+    (is (every? #(= object-array-type (type %)) result))
+    (is (= [[:a]] (map vec result)))
+
+    ;; This is just to highlight the difference w.r.t. `distinct`:
+    (is (= [[:a] [:a]] (map vec (distinct arrays)))))
   (is (= [[3 4]] (dq/distinct-tuples [[3 4] [3 4]])))
   (is (= [[3 4]] (dq/distinct-tuples [[3 4]
                                       (long-array [3 4])])))

--- a/test/datahike/test/strategy_test.clj
+++ b/test/datahike/test/strategy_test.clj
@@ -1,0 +1,285 @@
+(ns datahike.test.strategy-test
+  (:require [clojure.test :refer [is deftest testing]]
+            [datahike.test.utils :as utils]
+            [datahike.api :as d]
+            [datahike.query :as dq]))
+
+(defn concept-id [index]
+  (let [s (format "%010d" index)]
+    (str (subs s 0 4) "_" (subs s 4 7) "_" (subs s 7 10))))
+
+(defn concept-id-generator []
+  (let [counter (atom 0)]
+    #(concept-id (swap! counter inc))))
+
+(defn temp-id [x]
+  (str "tmp-" x))
+
+(defn relation-id [cid0 rel cid1]
+  (str cid0 ":" rel ":" cid1))
+
+(defn make-tree [id-gen type-count-pairs]
+  (loop [[tos & stack] [[nil type-count-pairs]]
+         tx-data []
+         counter 0
+         concept-map {}]
+    (if (nil? tos)
+      {:tx-data tx-data
+       :concept-map concept-map}
+      (let [[parent-id [[this-type child-count] & remaining-pairs]] tos
+            concept-id (id-gen)
+            tid (temp-id concept-id)
+            edge-tid (format "edge-tmp-%d" counter)]
+        (recur (into stack
+                     (when (seq remaining-pairs)
+                       (repeat child-count [concept-id remaining-pairs])))
+               (into tx-data
+                     cat
+                     [[[:db/add tid :concept/id concept-id]
+                       [:db/add tid :concept/type this-type]]
+                      (when parent-id
+                        [[:db/add edge-tid :relation/id
+                          (relation-id concept-id "broader" parent-id)]
+                         [:db/add edge-tid :relation/concept-1
+                          tid]
+                         [:db/add edge-tid :relation/type "broader"]
+                         [:db/add edge-tid :relation/concept-2
+                          (temp-id parent-id)]])])
+               (inc counter)
+               (assoc concept-map concept-id {:parent-id parent-id
+                                              :type this-type
+                                              :id concept-id}))))))
+(def schema [ ;; Concepts
+             #:db{:ident :concept/id,
+                  :valueType :db.type/string,
+                  :cardinality :db.cardinality/one,
+                  :doc "Unique identifier for concepts",
+                  :unique :db.unique/identity}
+             #:db{:ident :concept/type,
+                  :valueType :db.type/string,
+                  :cardinality :db.cardinality/one,
+                  :doc "The concepts main type"}
+
+             ;; Relations
+             #:db{:ident :relation/id,
+                  :valueType :db.type/string,
+                  :cardinality :db.cardinality/one,
+                  :doc "Unique identifier for relations",
+                  :unique :db.unique/identity}
+             #:db{:ident :relation/type,
+                  :valueType :db.type/string,
+                  :cardinality :db.cardinality/one,
+                  :doc "the type of relationship"}
+             #:db{:ident :relation/concept-1,
+                  :valueType :db.type/ref,
+                  :cardinality :db.cardinality/one,
+                  :doc "The entity ID of the first concept in a relation"}
+             #:db{:ident :relation/concept-2,
+                  :valueType :db.type/ref,
+                  :cardinality :db.cardinality/one,
+                  :doc "The entity ID of the second concept in a relation"}])
+
+(defn initialize-test-db0 []
+  (let [conn (utils/setup-db {:store {:backend :mem}
+                              :schema-flexibility :write
+                              :attribute-refs? false
+                              :keep-history? true})]
+    (d/transact conn {:tx-data schema})
+    conn))
+
+(def rules '[[(-forward-edge ?from-concept ?type ?to-concept ?relation)
+              [(ground
+                ["broader"
+                 "related"
+                 "possible-combination"
+                 "unlikely-combination"
+                 "substitutability"
+                 "broad-match"
+                 "exact-match"
+                 "close-match"])
+               [?type ...]]
+              [?relation :relation/concept-1 ?from-concept]
+              [?relation :relation/type ?type]
+              [?relation :relation/concept-2 ?to-concept]]
+             [(-reverse-edge ?from-concept ?type ?to-concept ?relation)
+              [(ground
+                {"narrower" "broader",
+                 "related" "related",
+                 "possible-combination" "possible-combination",
+                 "unlikely-combination" "unlikely-combination",
+                 "substituted-by" "substitutability",
+                 "narrow-match" "broad-match",
+                 "exact-match" "exact-match",
+                 "close-match" "close-match"})
+               [[?type ?reverse-type]]]
+              [?relation :relation/concept-2 ?from-concept]
+              [?relation :relation/type ?reverse-type]
+              [?relation :relation/concept-1 ?to-concept]]
+             [(edge ?from-concept ?type ?to-concept ?relation)
+              (or
+               (-forward-edge ?from-concept ?type ?to-concept ?relation)
+               (-reverse-edge ?from-concept ?type ?to-concept ?relation))]])
+
+(defn evaluate-strategy-times [f]
+  (into {}
+        (map (fn [[k strategy]] [k (let [start (System/nanoTime)
+                                         result (f strategy)
+                                         end (System/nanoTime)]
+                                     {:result result
+                                      :elapsed-ns (- end start)})]))
+        [[:identity identity]
+         [:select-simple dq/relprod-select-simple]
+         [:select-all dq/relprod-select-all]
+         [:expand-once dq/relprod-expand-once]]))
+
+(defn print-strategy-times [result-map]
+  (doseq [[k v] (sort-by (comp :elapsed-ns val) result-map)]
+    (println (format "%16s: %.6f" (name k) (* 1.0e-9 (:elapsed-ns v))))))
+
+(defn faster-strategy? [strategy-times key-a key-b]
+  (< (get-in strategy-times [key-a :elapsed-ns])
+     (get-in strategy-times [key-b :elapsed-ns])))
+
+(def related-query '{:find [?from-id ?id],
+                     :keys [from_id id],
+                     :in [$ % [?from-id ...] ?relation-type],
+                     :where
+                     [[?c :concept/id ?from-id]
+                      (edge ?c ?relation-type ?related-c ?r)
+                      [?related-c :concept/id ?id]]})
+
+(deftest synthetic-ssyk-tree-test
+  (let [conn (initialize-test-db0)
+        cgen (concept-id-generator)
+        ssyk-data (make-tree cgen
+                             [["ssyk-level-1" 8]
+                              ["ssyk-level-2" 8]
+                              ["ssyk-level-3" 32]
+                              ["ssyk-level-4" 2]
+                              ["occupation-name" 0]])
+        ssyk-concept-map (:concept-map ssyk-data)
+        _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
+        concepts-per-type (update-vals (group-by (comp :type val) ssyk-concept-map)
+                                       (fn [kv-pairs]
+                                         (mapv first kv-pairs)))
+        ;;ssyk-level-2-ids (concepts-per-type "ssyk-level-2")
+        ssyk-level-3-ids (concepts-per-type "ssyk-level-3")
+        expected-result-fn (fn [concept-ids]
+                             (into #{}
+                                   (map (fn [cid]
+                                          {:from_id cid
+                                           :id (get-in ssyk-concept-map
+                                                       [cid :parent-id])}))
+                                   concept-ids))]
+    (def the-concepts-per-type concepts-per-type)
+    (doseq [[k v] (sort-by val (update-vals concepts-per-type count))]
+      (println k v))
+    (is (seq ssyk-level-3-ids))
+
+    (testing "That the strategies select-simple, select-all and expand-once are more efficient than identiy"
+      (let [input-concept-id (first ssyk-level-3-ids)
+            _ (is (string? input-concept-id))
+            result-map (evaluate-strategy-times
+                        (fn [strategy]
+                          (d/q {:query related-query
+                                :settings {:relprod-strategy strategy}
+                                :args [(d/db conn)
+                                       rules
+                                       #{input-concept-id}
+                                       "broader"]})))]
+        (doseq [[_ {:keys [result]}] result-map]
+          (is (= (expected-result-fn [input-concept-id])
+                 (set result))))
+        (println "Query related to 1 concept:")
+        (print-strategy-times result-map)
+        (is (faster-strategy? result-map :select-simple :identity))
+        (is (faster-strategy? result-map :select-all :identity))
+        (is (faster-strategy? result-map :expand-once :identity))))
+    (testing "Test that the strategies select-all and expand-once are more efficient in case we have more than one input id"
+      (let [input-ids (set (take 2 ssyk-level-3-ids))
+            result-map (evaluate-strategy-times
+                        (fn [strategy]
+                          (d/q {:query related-query
+                                :settings {:relprod-strategy strategy}
+                                :args [(d/db conn)
+                                       rules
+                                       input-ids
+                                       "broader"]})))]
+        (doseq [[_ {:keys [result]}] result-map]
+          (is (= (expected-result-fn input-ids)
+                 (set result))))
+        (println "Query related to 2 concepts:")
+        (print-strategy-times result-map)
+        (is (faster-strategy? result-map :select-all :identity))
+        (is (faster-strategy? result-map :expand-once :identity))
+
+        ;; Because we have more than one input id the select-simple strategy will
+        ;; not be able to do as many substitutions. Therefore, it will perform worse than
+        ;; select-all and expand-once. But it may still be faster than identity, although
+        ;; the difference is no longer as remarkable.
+        (is (faster-strategy? result-map :select-all :select-simple))
+        (is (faster-strategy? result-map :expand-once :select-simple))))
+    
+    (testing "Find all edges between ssyk-level-2 concepts and ssyk-level-3 concepts. The strategy expand-once seems about twice as fast as select-all"
+      (let [result-map (evaluate-strategy-times
+                        (fn [strategy]
+                          (d/q {:query ' {:find [?parent-id ?child-id]
+                                          :keys [parent_id child_id]
+                                          :in [$ %],
+                                          :where
+                                          [[?pc :concept/type "ssyk-level-2"]
+                                           [?cc :concept/type "ssyk-level-3"]
+                                           (edge ?cc "broader" ?pc ?r)
+                                           [?pc :concept/id ?parent-id]
+                                           [?cc :concept/id ?child-id]]}
+                                :settings {:relprod-strategy strategy}
+                                :args [(d/db conn)
+                                       rules]})))]
+        (doseq [[_k v] result-map]
+          (is (= 64 (count (:result v)))))
+        (println "Find all edges between concept types:")
+        (print-strategy-times result-map)
+        (is (faster-strategy? result-map :expand-once :select-all))))
+
+
+    (testing "Find all edges between ssyk-level-2 concepts and ssyk-level-3 concepts and let the edge type be a parameter. Why is expand-once better than select-all?"
+      (let [result-map (evaluate-strategy-times
+                        (fn [strategy]
+                          (d/q {:query ' {:find [?parent-id ?child-id]
+                                          :keys [parent_id child_id]
+                                          :in [$ % [?relation-type ...]],
+                                          :where
+                                          [[?pc :concept/type "ssyk-level-2"]
+                                           [?cc :concept/type "ssyk-level-3"]
+                                           (edge ?cc ?relation-type ?pc ?r)
+                                           [?pc :concept/id ?parent-id]
+                                           [?cc :concept/id ?child-id]]}
+                                :settings {:relprod-strategy strategy}
+                                :args [(d/db conn)
+                                       rules
+                                       #{"broader" "narrower" "related" "close-match"}]})))]
+        (doseq [[_k v] result-map]
+          (is (= 64 (count (:result v)))))
+        (println "Find all edges between concept types with the edge type being parameterized:")
+        (print-strategy-times result-map)
+        (is (faster-strategy? result-map :expand-once :select-all))))
+
+    (testing "WIP: why is expand-once so fast???"
+      (let [result-map (evaluate-strategy-times
+        (fn [strategy]
+          (d/q {:query ' {:find [?parent-id ?child-id]
+                          :keys [parent_id child_id]
+                          :in [$ %
+                               [?parent-id ...]
+                               [?child-id ...]],
+                          :where
+                          [[?pc :concept/id ?parent-id]
+                           [?cc :concept/id ?child-id]
+                           (edge ?cc "broader" ?pc ?r)]}
+                :settings {:relprod-strategy strategy}
+                :args [(d/db conn)
+                       rules
+                       (take 2 (the-concepts-per-type "ssyk-level-3"))
+                       (take 2 (the-concepts-per-type "ssyk-level-4"))]})))]
+        (println "Find all edges between a few small sets of concept types")
+        (print-strategy-times result-map)))))

--- a/test/datahike/test/strategy_test.clj
+++ b/test/datahike/test/strategy_test.clj
@@ -29,6 +29,7 @@
       (let [[parent-id [[this-type child-count] & remaining-pairs]] tos
             concept-id (id-gen)
             tid (temp-id concept-id)
+            parent-tid (temp-id parent-id)
             edge-tid (format "edge-tmp-%d" counter)]
         (recur (into stack
                      (when (seq remaining-pairs)
@@ -38,17 +39,22 @@
                      [[[:db/add tid :concept/id concept-id]
                        [:db/add tid :concept/type this-type]]
                       (when parent-id
-                        [[:db/add edge-tid :relation/id
+                        [[:db/add tid :concept/broader parent-tid]
+
+                         [:db/add edge-tid :relation/id
                           (relation-id concept-id "broader" parent-id)]
                          [:db/add edge-tid :relation/concept-1
                           tid]
                          [:db/add edge-tid :relation/type "broader"]
                          [:db/add edge-tid :relation/concept-2
-                          (temp-id parent-id)]])])
+                          parent-tid]])])
                (inc counter)
-               (assoc concept-map concept-id {:parent-id parent-id
-                                              :type this-type
-                                              :id concept-id}))))))
+               (cond-> concept-map
+                 true (update concept-id
+                              merge {:parent-id parent-id
+                                     :type this-type
+                                     :id concept-id})
+                 parent-id (update-in [parent-id :child-ids] #(conj (or % []) concept-id))))))))
 (def schema [ ;; Concepts
              #:db{:ident :concept/id,
                   :valueType :db.type/string,
@@ -59,7 +65,11 @@
                   :valueType :db.type/string,
                   :cardinality :db.cardinality/one,
                   :doc "The concepts main type"}
-
+             #:db {:ident :concept/broader
+                   :valueType :db.type/ref
+                   :cardinality :db.cardinality/one
+                   :doc "A broader concept. NOTE: This relation is just used instead of using entities with :relation/type='broader' because it better highlights performance differences in some cases."}
+             
              ;; Relations
              #:db{:ident :relation/id,
                   :valueType :db.type/string,
@@ -148,6 +158,16 @@
                       (edge ?c ?relation-type ?related-c ?r)
                       [?related-c :concept/id ?id]]})
 
+(defn group-concepts-by-type [concept-map]
+  (let [groups (update-vals (group-by (comp :type val)
+                                      concept-map)
+                            (fn [kv-pairs]
+                              (mapv first kv-pairs)))]
+    (doseq [[k v] (sort-by val (update-vals groups count))]
+      (println k v))    
+    (println "Total count:" (count concept-map))
+    groups))
+
 (deftest synthetic-ssyk-tree-test
   (let [conn (initialize-test-db0)
         cgen (concept-id-generator)
@@ -159,10 +179,7 @@
                               ["occupation-name" 0]])
         ssyk-concept-map (:concept-map ssyk-data)
         _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
-        concepts-per-type (update-vals (group-by (comp :type val) ssyk-concept-map)
-                                       (fn [kv-pairs]
-                                         (mapv first kv-pairs)))
-        ;;ssyk-level-2-ids (concepts-per-type "ssyk-level-2")
+        concepts-per-type (group-concepts-by-type ssyk-concept-map)
         ssyk-level-3-ids (concepts-per-type "ssyk-level-3")
         expected-result-fn (fn [concept-ids]
                              (into #{}
@@ -171,11 +188,6 @@
                                            :id (get-in ssyk-concept-map
                                                        [cid :parent-id])}))
                                    concept-ids))]
-    (def the-concepts-per-type concepts-per-type)
-    (doseq [[k v] (sort-by val (update-vals concepts-per-type count))]
-      (println k v))
-    (is (seq ssyk-level-3-ids))
-
     (testing "That the strategies select-simple, select-all and expand-once are more efficient than identiy"
       (let [input-concept-id (first ssyk-level-3-ids)
             _ (is (string? input-concept-id))
@@ -218,9 +230,59 @@
         ;; select-all and expand-once. But it may still be faster than identity, although
         ;; the difference is no longer as remarkable.
         (is (faster-strategy? result-map :select-all :select-simple))
-        (is (faster-strategy? result-map :expand-once :select-simple))))
-    
-    (testing "Find all edges between ssyk-level-2 concepts and ssyk-level-3 concepts. The strategy expand-once seems about twice as fast as select-all"
+        (is (faster-strategy? result-map :expand-once :select-simple))))))
+
+(deftest synthetic-ssyk-tree-test2
+  (let [conn (initialize-test-db0)
+        cgen (concept-id-generator)
+        ssyk-data (make-tree cgen
+                             [["ssyk-level-1" 10]
+                              ["ssyk-level-2" 400]
+                              ["ssyk-level-3" 0]])
+        ssyk-concept-map (:concept-map ssyk-data)
+        _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
+        concepts-per-type (group-concepts-by-type ssyk-concept-map)]
+    (def the-concept-map ssyk-concept-map)
+    (testing "The select-all strategy is expected to perform best because of a small number of possible combinations"
+      (let [parent-ids (take 2 (concepts-per-type "ssyk-level-2"))
+            child-ids (take 3 (get-in ssyk-concept-map [(first parent-ids) :child-ids]))
+            _ (is (= 2 (count parent-ids)))
+            _ (is (= 3 (count child-ids)))
+            result-map (evaluate-strategy-times
+                        (fn [strategy]
+                          (d/q {:query ' {:find [?parent-id ?child-id]
+                                          :keys [parent_id child_id]
+                                          :in [$
+                                               [?parent-id ...]
+                                               [?child-id ...]],
+                                          :where
+                                          [[?pc :concept/id ?parent-id]
+                                           [?cc :concept/id ?child-id]
+                                           [?cc :concept/broader ?pc]]}
+                                :settings {:relprod-strategy strategy}
+                                :args [(d/db conn)
+                                       parent-ids
+                                       child-ids]})))]
+        (println "Find all edges between a few small sets of concept types")
+        (print-strategy-times result-map)
+        (doseq [[_k v] result-map]
+          (is (= 3 (count (:result v)))))
+        (is (faster-strategy? result-map :select-all :expand-once))
+        (is (faster-strategy? result-map :expand-once :select-simple))
+        (is (faster-strategy? result-map :expand-once :identity))))))
+
+(deftest synthetic-ssyk-tree-test3
+  (let [conn (initialize-test-db0)
+        cgen (concept-id-generator)
+        ssyk-data (make-tree cgen
+                             [["ssyk-level-1" 200]
+                              ["ssyk-level-2" 1]
+                              ["ssyk-level-3" 0]])
+        ssyk-concept-map (:concept-map ssyk-data)
+        _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
+        _concepts-per-type (group-concepts-by-type ssyk-concept-map)
+        ]
+    (testing "The select-all strategy will perform poorly because of a large number of possible combinations"
       (let [result-map (evaluate-strategy-times
                         (fn [strategy]
                           (d/q {:query ' {:find [?parent-id ?child-id]
@@ -229,57 +291,13 @@
                                           :where
                                           [[?pc :concept/type "ssyk-level-2"]
                                            [?cc :concept/type "ssyk-level-3"]
-                                           (edge ?cc "broader" ?pc ?r)
+                                           [?cc :concept/broader ?pc]
                                            [?pc :concept/id ?parent-id]
                                            [?cc :concept/id ?child-id]]}
                                 :settings {:relprod-strategy strategy}
-                                :args [(d/db conn)
-                                       rules]})))]
+                                :args [(d/db conn)]})))]
         (doseq [[_k v] result-map]
-          (is (= 64 (count (:result v)))))
+          (is (= 200 (count (:result v)))))
         (println "Find all edges between concept types:")
         (print-strategy-times result-map)
-        (is (faster-strategy? result-map :expand-once :select-all))))
-
-
-    (testing "Find all edges between ssyk-level-2 concepts and ssyk-level-3 concepts and let the edge type be a parameter. Why is expand-once better than select-all?"
-      (let [result-map (evaluate-strategy-times
-                        (fn [strategy]
-                          (d/q {:query ' {:find [?parent-id ?child-id]
-                                          :keys [parent_id child_id]
-                                          :in [$ % [?relation-type ...]],
-                                          :where
-                                          [[?pc :concept/type "ssyk-level-2"]
-                                           [?cc :concept/type "ssyk-level-3"]
-                                           (edge ?cc ?relation-type ?pc ?r)
-                                           [?pc :concept/id ?parent-id]
-                                           [?cc :concept/id ?child-id]]}
-                                :settings {:relprod-strategy strategy}
-                                :args [(d/db conn)
-                                       rules
-                                       #{"broader" "narrower" "related" "close-match"}]})))]
-        (doseq [[_k v] result-map]
-          (is (= 64 (count (:result v)))))
-        (println "Find all edges between concept types with the edge type being parameterized:")
-        (print-strategy-times result-map)
-        (is (faster-strategy? result-map :expand-once :select-all))))
-
-    (testing "WIP: why is expand-once so fast???"
-      (let [result-map (evaluate-strategy-times
-        (fn [strategy]
-          (d/q {:query ' {:find [?parent-id ?child-id]
-                          :keys [parent_id child_id]
-                          :in [$ %
-                               [?parent-id ...]
-                               [?child-id ...]],
-                          :where
-                          [[?pc :concept/id ?parent-id]
-                           [?cc :concept/id ?child-id]
-                           (edge ?cc "broader" ?pc ?r)]}
-                :settings {:relprod-strategy strategy}
-                :args [(d/db conn)
-                       rules
-                       (take 2 (the-concepts-per-type "ssyk-level-3"))
-                       (take 2 (the-concepts-per-type "ssyk-level-4"))]})))]
-        (println "Find all edges between a few small sets of concept types")
-        (print-strategy-times result-map)))))
+        (is (faster-strategy? result-map :expand-once :select-all))))))

--- a/test/datahike/test/strategy_test.clj
+++ b/test/datahike/test/strategy_test.clj
@@ -2,23 +2,17 @@
   (:require [clojure.test :refer [is deftest testing]]
             [datahike.test.utils :as utils]
             [datahike.api :as d]
+            [taoensso.timbre :as log]
             [datahike.query :as dq]))
 
 (defn concept-id [index]
   (let [s (format "%010d" index)]
     (str (subs s 0 4) "_" (subs s 4 7) "_" (subs s 7 10))))
 
-(defn concept-id-generator []
-  (let [counter (atom 0)]
-    #(concept-id (swap! counter inc))))
-
 (defn temp-id [x]
   (str "tmp-" x))
 
-(defn relation-id [cid0 rel cid1]
-  (str cid0 ":" rel ":" cid1))
-
-(defn make-tree [id-gen type-count-pairs]
+(defn make-tree [type-count-pairs]
   (loop [[tos & stack] [[nil type-count-pairs]]
          tx-data []
          counter 0
@@ -27,10 +21,9 @@
       {:tx-data tx-data
        :concept-map concept-map}
       (let [[parent-id [[this-type child-count] & remaining-pairs]] tos
-            concept-id (id-gen)
+            concept-id (concept-id counter)
             tid (temp-id concept-id)
-            parent-tid (temp-id parent-id)
-            edge-tid (format "edge-tmp-%d" counter)]
+            parent-tid (temp-id parent-id)]
         (recur (into stack
                      (when (seq remaining-pairs)
                        (repeat child-count [concept-id remaining-pairs])))
@@ -39,15 +32,7 @@
                      [[[:db/add tid :concept/id concept-id]
                        [:db/add tid :concept/type this-type]]
                       (when parent-id
-                        [[:db/add tid :concept/broader parent-tid]
-
-                         [:db/add edge-tid :relation/id
-                          (relation-id concept-id "broader" parent-id)]
-                         [:db/add edge-tid :relation/concept-1
-                          tid]
-                         [:db/add edge-tid :relation/type "broader"]
-                         [:db/add edge-tid :relation/concept-2
-                          parent-tid]])])
+                        [[:db/add tid :concept/broader parent-tid]])])
                (inc counter)
                (cond-> concept-map
                  true (update concept-id
@@ -68,26 +53,7 @@
              #:db {:ident :concept/broader
                    :valueType :db.type/ref
                    :cardinality :db.cardinality/one
-                   :doc "A broader concept. NOTE: This relation is just used instead of using entities with :relation/type='broader' because it better highlights performance differences in some cases."}
-             
-             ;; Relations
-             #:db{:ident :relation/id,
-                  :valueType :db.type/string,
-                  :cardinality :db.cardinality/one,
-                  :doc "Unique identifier for relations",
-                  :unique :db.unique/identity}
-             #:db{:ident :relation/type,
-                  :valueType :db.type/string,
-                  :cardinality :db.cardinality/one,
-                  :doc "the type of relationship"}
-             #:db{:ident :relation/concept-1,
-                  :valueType :db.type/ref,
-                  :cardinality :db.cardinality/one,
-                  :doc "The entity ID of the first concept in a relation"}
-             #:db{:ident :relation/concept-2,
-                  :valueType :db.type/ref,
-                  :cardinality :db.cardinality/one,
-                  :doc "The entity ID of the second concept in a relation"}])
+                   :doc "A broader concept. NOTE: This the JobTech Taxonomy, every relation between two concepts has an entity with attributes :relation/concept-1, :relation-concept-2 and :relation/type."}])
 
 (defn initialize-test-db0 []
   (let [conn (utils/setup-db {:store {:backend :mem}
@@ -96,39 +62,6 @@
                               :keep-history? true})]
     (d/transact conn {:tx-data schema})
     conn))
-
-(def rules '[[(-forward-edge ?from-concept ?type ?to-concept ?relation)
-              [(ground
-                ["broader"
-                 "related"
-                 "possible-combination"
-                 "unlikely-combination"
-                 "substitutability"
-                 "broad-match"
-                 "exact-match"
-                 "close-match"])
-               [?type ...]]
-              [?relation :relation/concept-1 ?from-concept]
-              [?relation :relation/type ?type]
-              [?relation :relation/concept-2 ?to-concept]]
-             [(-reverse-edge ?from-concept ?type ?to-concept ?relation)
-              [(ground
-                {"narrower" "broader",
-                 "related" "related",
-                 "possible-combination" "possible-combination",
-                 "unlikely-combination" "unlikely-combination",
-                 "substituted-by" "substitutability",
-                 "narrow-match" "broad-match",
-                 "exact-match" "exact-match",
-                 "close-match" "close-match"})
-               [[?type ?reverse-type]]]
-              [?relation :relation/concept-2 ?from-concept]
-              [?relation :relation/type ?reverse-type]
-              [?relation :relation/concept-1 ?to-concept]]
-             [(edge ?from-concept ?type ?to-concept ?relation)
-              (or
-               (-forward-edge ?from-concept ?type ?to-concept ?relation)
-               (-reverse-edge ?from-concept ?type ?to-concept ?relation))]])
 
 (defn evaluate-strategy-times [f]
   (into {}
@@ -144,19 +77,11 @@
 
 (defn print-strategy-times [result-map]
   (doseq [[k v] (sort-by (comp :elapsed-ns val) result-map)]
-    (println (format "%16s: %.6f" (name k) (* 1.0e-9 (:elapsed-ns v))))))
+    (log/info (format "%16s: %.6f" (name k) (* 1.0e-9 (:elapsed-ns v))))))
 
 (defn faster-strategy? [strategy-times key-a key-b]
   (< (get-in strategy-times [key-a :elapsed-ns])
      (get-in strategy-times [key-b :elapsed-ns])))
-
-(def related-query '{:find [?from-id ?id],
-                     :keys [from_id id],
-                     :in [$ % [?from-id ...] ?relation-type],
-                     :where
-                     [[?c :concept/id ?from-id]
-                      (edge ?c ?relation-type ?related-c ?r)
-                      [?related-c :concept/id ?id]]})
 
 (defn group-concepts-by-type [concept-map]
   (let [groups (update-vals (group-by (comp :type val)
@@ -165,14 +90,12 @@
                               (mapv first kv-pairs)))]
     (doseq [[k v] (sort-by val (update-vals groups count))]
       (println k v))    
-    (println "Total count:" (count concept-map))
+    (log/info "Total count:" (count concept-map))
     groups))
 
 (deftest synthetic-ssyk-tree-test
   (let [conn (initialize-test-db0)
-        cgen (concept-id-generator)
-        ssyk-data (make-tree cgen
-                             [["ssyk-level-1" 8]
+        ssyk-data (make-tree [["ssyk-level-1" 8]
                               ["ssyk-level-2" 8]
                               ["ssyk-level-3" 32]
                               ["ssyk-level-4" 2]
@@ -187,7 +110,15 @@
                                           {:from_id cid
                                            :id (get-in ssyk-concept-map
                                                        [cid :parent-id])}))
-                                   concept-ids))]
+                                   concept-ids))
+
+        related-query '{:find [?from-id ?id],
+                        :keys [from_id id],
+                        :in [$ [?from-id ...]],
+                        :where
+                        [[?c :concept/id ?from-id]
+                         [?c :concept/broader ?related-c]
+                         [?related-c :concept/id ?id]]}]
     (testing "That the strategies select-simple, select-all and expand-once are more efficient than identiy"
       (let [input-concept-id (first ssyk-level-3-ids)
             _ (is (string? input-concept-id))
@@ -196,13 +127,14 @@
                           (d/q {:query related-query
                                 :settings {:relprod-strategy strategy}
                                 :args [(d/db conn)
-                                       rules
+                                       ;rules
                                        #{input-concept-id}
-                                       "broader"]})))]
+                                       ;"broader"
+                                       ]})))]
         (doseq [[_ {:keys [result]}] result-map]
           (is (= (expected-result-fn [input-concept-id])
                  (set result))))
-        (println "Query related to 1 concept:")
+        (log/info "Query related to 1 concept:")
         (print-strategy-times result-map)
         (is (faster-strategy? result-map :select-simple :identity))
         (is (faster-strategy? result-map :select-all :identity))
@@ -214,35 +146,27 @@
                           (d/q {:query related-query
                                 :settings {:relprod-strategy strategy}
                                 :args [(d/db conn)
-                                       rules
-                                       input-ids
-                                       "broader"]})))]
+                                       input-ids]})))]
         (doseq [[_ {:keys [result]}] result-map]
           (is (= (expected-result-fn input-ids)
                  (set result))))
-        (println "Query related to 2 concepts:")
+        (log/info "Query related to 2 concepts:")
         (print-strategy-times result-map)
         (is (faster-strategy? result-map :select-all :identity))
         (is (faster-strategy? result-map :expand-once :identity))
 
-        ;; Because we have more than one input id the select-simple strategy will
-        ;; not be able to do as many substitutions. Therefore, it will perform worse than
-        ;; select-all and expand-once. But it may still be faster than identity, although
-        ;; the difference is no longer as remarkable.
+        ;; Because we have more than one input id, select-simple no longer performs that well.
         (is (faster-strategy? result-map :select-all :select-simple))
         (is (faster-strategy? result-map :expand-once :select-simple))))))
 
 (deftest synthetic-ssyk-tree-test2
   (let [conn (initialize-test-db0)
-        cgen (concept-id-generator)
-        ssyk-data (make-tree cgen
-                             [["ssyk-level-1" 10]
-                              ["ssyk-level-2" 400]
+        ssyk-data (make-tree [["ssyk-level-1" 4]
+                              ["ssyk-level-2" 2000]
                               ["ssyk-level-3" 0]])
         ssyk-concept-map (:concept-map ssyk-data)
         _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
         concepts-per-type (group-concepts-by-type ssyk-concept-map)]
-    (def the-concept-map ssyk-concept-map)
     (testing "The select-all strategy is expected to perform best because of a small number of possible combinations"
       (let [parent-ids (take 2 (concepts-per-type "ssyk-level-2"))
             child-ids (take 3 (get-in ssyk-concept-map [(first parent-ids) :child-ids]))
@@ -263,7 +187,7 @@
                                 :args [(d/db conn)
                                        parent-ids
                                        child-ids]})))]
-        (println "Find all edges between a few small sets of concept types")
+        (log/info "Find all edges between a few small sets of concept types")
         (print-strategy-times result-map)
         (doseq [[_k v] result-map]
           (is (= 3 (count (:result v)))))
@@ -273,9 +197,7 @@
 
 (deftest synthetic-ssyk-tree-test3
   (let [conn (initialize-test-db0)
-        cgen (concept-id-generator)
-        ssyk-data (make-tree cgen
-                             [["ssyk-level-1" 200]
+        ssyk-data (make-tree [["ssyk-level-1" 200]
                               ["ssyk-level-2" 1]
                               ["ssyk-level-3" 0]])
         ssyk-concept-map (:concept-map ssyk-data)
@@ -298,6 +220,6 @@
                                 :args [(d/db conn)]})))]
         (doseq [[_k v] result-map]
           (is (= 200 (count (:result v)))))
-        (println "Find all edges between concept types:")
+        (log/info "Find all edges between concept types:")
         (print-strategy-times result-map)
         (is (faster-strategy? result-map :expand-once :select-all))))))

--- a/test/datahike/test/strategy_test.clj
+++ b/test/datahike/test/strategy_test.clj
@@ -87,9 +87,9 @@
                                      {:result result
                                       :elapsed-ns (- end start)})]))
         [[:identity identity]
-         [:select-simple dq/relprod-select-simple]
-         [:select-all dq/relprod-select-all]
-         [:expand-once dq/relprod-expand-once]]))
+         [:select-simple dq/select-simple]
+         [:select-all dq/select-all]
+         [:expand-once dq/expand-once]]))
 
 (defn print-strategy-times [result-map]
   (doseq [[k v] (sort-by (comp :elapsed-ns val) result-map)]

--- a/test/datahike/test/strategy_test.clj
+++ b/test/datahike/test/strategy_test.clj
@@ -12,18 +12,34 @@
 (defn temp-id [x]
   (str "tmp-" x))
 
-(defn make-tree [type-count-pairs]
-  (loop [[tos & stack] [[nil type-count-pairs]]
+(defn make-forest
+  "This function constructs tx-data for a forest of concepts in a terminology, 
+  for example a labor market terminology of occupations. The edges in the
+  forest point toward the root and are labeled `:concept/broader` because the
+  closer to the root we get, the broader the concept is. For instance, we could
+  have a concept for the occupation name 'Software Engineer' and an edge from 
+  that concept pointing at a broader concept 'Occuptions in Computer Science'.
+
+  This function takes as input a concatenated list of pairs of `m` and `t`
+  on the form `[m1 t1 m2 t2 ... mN tN]` that specifies how many sub nodes
+  should be generated at each level from the root and the type. For example,
+  `[5 'ssyk-level-1' 3 'ssyk-level-2']` means that we will construct 5 trees
+  of root node type 'ssyk-level-1' and each one of them will have 3 children
+  of node type 'ssyk-level-2'."
+  [[root-count & tree-spec]]
+  {:pre [(number? root-count)]}
+  (loop [[tos & stack] (repeat root-count [nil tree-spec])
          tx-data []
          counter 0
          concept-map {}]
     (if (nil? tos)
       {:tx-data tx-data
        :concept-map concept-map}
-      (let [[parent-id [[this-type child-count] & remaining-pairs]] tos
+      (let [[parent-id [this-type child-count & remaining-pairs]] tos
             concept-id (concept-id counter)
             tid (temp-id concept-id)
             parent-tid (temp-id parent-id)]
+        (assert (or (nil? parent-id) (string? parent-id)))
         (recur (into stack
                      (when (seq remaining-pairs)
                        (repeat child-count [concept-id remaining-pairs])))
@@ -40,8 +56,8 @@
                                      :type this-type
                                      :id concept-id})
                  parent-id (update-in [parent-id :child-ids] #(conj (or % []) concept-id))))))))
-(def schema [ ;; Concepts
-             #:db{:ident :concept/id,
+
+(def schema [#:db{:ident :concept/id,
                   :valueType :db.type/string,
                   :cardinality :db.cardinality/one,
                   :doc "Unique identifier for concepts",
@@ -89,87 +105,117 @@
                             (fn [kv-pairs]
                               (mapv first kv-pairs)))]
     (doseq [[k v] (sort-by val (update-vals groups count))]
-      (println k v))    
+      (log/info k v))    
     (log/info "Total count:" (count concept-map))
     groups))
 
+
 (deftest synthetic-ssyk-tree-test
-  (let [conn (initialize-test-db0)
-        ssyk-data (make-tree [["ssyk-level-1" 8]
-                              ["ssyk-level-2" 8]
-                              ["ssyk-level-3" 32]
-                              ["ssyk-level-4" 2]
-                              ["occupation-name" 0]])
-        ssyk-concept-map (:concept-map ssyk-data)
-        _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
-        concepts-per-type (group-concepts-by-type ssyk-concept-map)
-        ssyk-level-3-ids (concepts-per-type "ssyk-level-3")
-        expected-result-fn (fn [concept-ids]
-                             (into #{}
-                                   (map (fn [cid]
-                                          {:from_id cid
-                                           :id (get-in ssyk-concept-map
-                                                       [cid :parent-id])}))
-                                   concept-ids))
 
-        related-query '{:find [?from-id ?id],
-                        :keys [from_id id],
-                        :in [$ [?from-id ...]],
-                        :where
-                        [[?c :concept/id ?from-id]
-                         [?c :concept/broader ?related-c]
-                         [?related-c :concept/id ?id]]}]
-    (testing "That the strategies select-simple, select-all and expand-once are more efficient than identiy"
-      (let [input-concept-id (first ssyk-level-3-ids)
-            _ (is (string? input-concept-id))
-            result-map (evaluate-strategy-times
-                        (fn [strategy]
-                          (d/q {:query related-query
-                                :settings {:relprod-strategy strategy}
-                                :args [(d/db conn)
-                                       ;rules
-                                       #{input-concept-id}
-                                       ;"broader"
-                                       ]})))]
-        (doseq [[_ {:keys [result]}] result-map]
-          (is (= (expected-result-fn [input-concept-id])
-                 (set result))))
-        (log/info "Query related to 1 concept:")
-        (print-strategy-times result-map)
-        (is (faster-strategy? result-map :select-simple :identity))
-        (is (faster-strategy? result-map :select-all :identity))
-        (is (faster-strategy? result-map :expand-once :identity))))
-    (testing "Test that the strategies select-all and expand-once are more efficient in case we have more than one input id"
-      (let [input-ids (set (take 2 ssyk-level-3-ids))
-            result-map (evaluate-strategy-times
-                        (fn [strategy]
-                          (d/q {:query related-query
-                                :settings {:relprod-strategy strategy}
-                                :args [(d/db conn)
-                                       input-ids]})))]
-        (doseq [[_ {:keys [result]}] result-map]
-          (is (= (expected-result-fn input-ids)
-                 (set result))))
-        (log/info "Query related to 2 concepts:")
-        (print-strategy-times result-map)
-        (is (faster-strategy? result-map :select-all :identity))
-        (is (faster-strategy? result-map :expand-once :identity))
+  "In this test we construct a labor market taxonomy of occupations. Given
+some concept ids, we look up broader concepts. The queries in this test will
+include clauses with up to two unknown variables.
 
-        ;; Because we have more than one input id, select-simple no longer performs that well.
-        (is (faster-strategy? result-map :select-all :select-simple))
-        (is (faster-strategy? result-map :expand-once :select-simple))))))
+We perform two queries. In the first query, we only provide one input id and
+look up concepts broader than that id. Here, we expect all strategies except
+identity to perform well because there will always be some substitutions to be made.
+
+In the second query, we provide two input ids. This means that the select-simple
+strategy will not perform the substitution that it performed in the first case where
+we only had one one input id. Therefore, it will perform about as bad as identity."
+  
+  (testing "Given some concepts, query concepts that are broader."
+    (let [conn (initialize-test-db0)
+          ssyk-data (make-forest
+                     [3 "ssyk-level-1"
+                      5 "ssyk-level-2"
+                      30 "ssyk-level-3"
+                      5 "ssyk-level-4"
+                      2 "occupation-name"])
+          ssyk-concept-map (:concept-map ssyk-data)
+          _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
+          concepts-per-type (group-concepts-by-type ssyk-concept-map)
+          ssyk-level-3-ids (concepts-per-type "ssyk-level-3")
+          expected-result-fn (fn [concept-ids]
+                               (into #{}
+                                     (map (fn [cid]
+                                            {:from_id cid
+                                             :id (get-in ssyk-concept-map
+                                                         [cid :parent-id])}))
+                                     concept-ids))
+
+          related-query '{:find [?from-id ?id],
+                          :keys [from_id id],
+                          :in [$ [?from-id ...]],
+                          :where
+                          [[?c :concept/id ?from-id]
+                           [?c :concept/broader ?related-c]
+                           [?related-c :concept/id ?id]]}]
+      (testing "Query for 1 input concept id."
+        (let [input-concept-id (first ssyk-level-3-ids)
+              _ (is (string? input-concept-id))
+              result-map (evaluate-strategy-times
+                          (fn [strategy]
+                            (d/q {:query related-query
+                                  :settings {:relprod-strategy strategy}
+                                  :args [(d/db conn) #{input-concept-id}]})))]
+          (doseq [[_ {:keys [result]}] result-map]
+            (is (= (expected-result-fn [input-concept-id])
+                   (set result))))
+          (log/info "Query related to 1 concept:")
+          (print-strategy-times result-map)
+          (is (faster-strategy? result-map :select-simple :identity))
+          (is (faster-strategy? result-map :select-all :identity))
+          (is (faster-strategy? result-map :expand-once :identity))))
+      (testing "Query for 2 input ids."
+        (let [input-ids (set (take 2 ssyk-level-3-ids))
+              result-map (evaluate-strategy-times
+                          (fn [strategy]
+                            (d/q {:query related-query
+                                  :settings {:relprod-strategy strategy}
+                                  :args [(d/db conn) input-ids]})))]
+          (doseq [[_ {:keys [result]}] result-map]
+            (is (= (expected-result-fn input-ids)
+                   (set result))))
+          (log/info "Query related to 2 concepts:")
+          (print-strategy-times result-map)
+          (is (faster-strategy? result-map :select-all :identity))
+          (is (faster-strategy? result-map :expand-once :identity))
+
+          ;; Because we have more than one input id, select-simple no longer performs that well.
+          (is (faster-strategy? result-map :select-all :select-simple))
+          (is (faster-strategy? result-map :expand-once :select-simple)))))))
 
 (deftest synthetic-ssyk-tree-test2
+
+  "This test is designed for the select-all strategy to perform well. We construct a 
+forest of four trees with each tree having 2000 subnodes each. We then pick the ids
+of two of the root nodes of the trees and the ids from three of the children of one 
+trees. Then we we query for all (parent,child) pairs.
+
+The select-all strategy is going to expand the `[?cc :concept/broader ?pc]` to the 
+6 = 2*3 combinations of the possible parent child pairs and consequently make six
+queries to the database backend. Each such query will return either one or zero rows.
+
+The expand-once strategy will only substitude the `?pc` variable in the 
+`[?cc :concept/broader ?pc]` pattern because `?pc` has the smallest number of
+possible bindings, that is two. So it will make two database lookups. Each one of 
+those lookups will result in 2000 rows returned from the database backend and most 
+of those rows will be discarded. So it will be slower.
+
+Finally, the select-simple and identity strategies will both run the query
+`[?cc :concept/broader ?pc]` without any substitutions which will return 8000 rows
+to be filtered."
+  
   (let [conn (initialize-test-db0)
-        ssyk-data (make-tree [["ssyk-level-1" 4]
-                              ["ssyk-level-2" 2000]
-                              ["ssyk-level-3" 0]])
+        ssyk-data (make-forest [4 "ssyk-level-1" 2000 "ssyk-level-2"])
         ssyk-concept-map (:concept-map ssyk-data)
         _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
         concepts-per-type (group-concepts-by-type ssyk-concept-map)]
-    (testing "The select-all strategy is expected to perform best because of a small number of possible combinations"
-      (let [parent-ids (take 2 (concepts-per-type "ssyk-level-2"))
-            child-ids (take 3 (get-in ssyk-concept-map [(first parent-ids) :child-ids]))
+    (testing "Query (parent,child) pairs from a *small* set of possible combinations in a labour market taxonomy."
+      (let [parent-ids (take 2 (concepts-per-type "ssyk-level-1"))
+            parent-id (first parent-ids)
+            child-ids (take 3 (get-in ssyk-concept-map [parent-id :child-ids]))
             _ (is (= 2 (count parent-ids)))
             _ (is (= 3 (count child-ids)))
             result-map (evaluate-strategy-times
@@ -186,40 +232,58 @@
                                 :settings {:relprod-strategy strategy}
                                 :args [(d/db conn)
                                        parent-ids
-                                       child-ids]})))]
+                                       child-ids]})))
+            expected-result (into #{}
+                                  (map (fn [child-id] {:parent_id parent-id :child_id child-id}))
+                                  child-ids)]
+        (is (= 3 (count expected-result)))
         (log/info "Find all edges between a few small sets of concept types")
         (print-strategy-times result-map)
         (doseq [[_k v] result-map]
-          (is (= 3 (count (:result v)))))
+          (is (-> v :result set (= expected-result))))
         (is (faster-strategy? result-map :select-all :expand-once))
         (is (faster-strategy? result-map :expand-once :select-simple))
         (is (faster-strategy? result-map :expand-once :identity))))))
 
 (deftest synthetic-ssyk-tree-test3
+
+  "This test is designed to show a case where select-all performs bad. We construct
+a labor market taxonomy of 200 trees where each root node has one child. Then
+we query all (parent, child) pairs.
+
+When the select-all strategy encounters the `[?cc :concept/broader ?pc]` pattern,
+it will perform 40000 = 200*200 substitutions for all possible combinations of 
+`?cc` and `?pc`. Out of those 40000 combinations, only 200 will be valid. That means
+39800 database backend queries that return nothing. All the other strategies, even 
+identity, perform better than that."
+  
   (let [conn (initialize-test-db0)
-        ssyk-data (make-tree [["ssyk-level-1" 200]
-                              ["ssyk-level-2" 1]
-                              ["ssyk-level-3" 0]])
+        ssyk-data (make-forest [200 "ssyk-level-1" 1 "ssyk-level-2"])
         ssyk-concept-map (:concept-map ssyk-data)
         _ (d/transact conn {:tx-data (:tx-data ssyk-data)})
-        _concepts-per-type (group-concepts-by-type ssyk-concept-map)
-        ]
-    (testing "The select-all strategy will perform poorly because of a large number of possible combinations"
+        _concepts-per-type (group-concepts-by-type ssyk-concept-map)]
+    (testing "Query (parent,child) pairs from a *large* set of possible combinations in a labour market taxonomy."
       (let [result-map (evaluate-strategy-times
                         (fn [strategy]
                           (d/q {:query ' {:find [?parent-id ?child-id]
                                           :keys [parent_id child_id]
                                           :in [$ %],
                                           :where
-                                          [[?pc :concept/type "ssyk-level-2"]
-                                           [?cc :concept/type "ssyk-level-3"]
+                                          [[?pc :concept/type "ssyk-level-1"]
+                                           [?cc :concept/type "ssyk-level-2"]
                                            [?cc :concept/broader ?pc]
                                            [?pc :concept/id ?parent-id]
                                            [?cc :concept/id ?child-id]]}
                                 :settings {:relprod-strategy strategy}
-                                :args [(d/db conn)]})))]
+                                :args [(d/db conn)]})))
+            expected-result (into #{}
+                                  (keep (fn [[child-id {:keys [parent-id]}]]
+                                          (when parent-id
+                                            {:child_id child-id :parent_id parent-id})))
+                                  ssyk-concept-map)]
+        (is (= 200 (count expected-result)))
         (doseq [[_k v] result-map]
-          (is (= 200 (count (:result v)))))
+          (is (-> v :result set (= expected-result))))
         (log/info "Find all edges between concept types:")
         (print-strategy-times result-map)
         (is (faster-strategy? result-map :expand-once :select-all))))))

--- a/test/datahike/test/tools_test.clj
+++ b/test/datahike/test/tools_test.clj
@@ -1,0 +1,22 @@
+(ns datahike.test.tools-test
+  (:require [datahike.tools :as dt]
+            [clojure.test :refer :all]))
+
+(deftest test-with-elements-of
+  (is (= [11 19]
+         (dt/with-elements-of [10 20]
+           a (inc a)
+           b (dec b))))
+  (is (= [11]
+         (dt/with-elements-of [10]
+           a (inc a)
+           b (+ a b))))
+  (is (= [300 40]
+         (dt/with-elements-of [10 30]
+           a (* a b)
+           b (+ a b))))
+  (is (= [100 400]
+         (dt/with-elements-of [10 20]
+           a (* a a)
+           b (* b b)
+           c (throw (ex-info "This element should not be evaluated" {}))))))

--- a/test/datahike/test/tools_test.clj
+++ b/test/datahike/test/tools_test.clj
@@ -2,21 +2,21 @@
   (:require [datahike.tools :as dt]
             [clojure.test :refer :all]))
 
-(deftest test-with-elements-of
+(deftest test-with-destructured-vector
   (is (= [11 19]
-         (dt/with-elements-of [10 20]
+         (dt/with-destructured-vector [10 20]
            a (inc a)
            b (dec b))))
   (is (= [11]
-         (dt/with-elements-of [10]
+         (dt/with-destructured-vector [10]
            a (inc a)
            b (+ a b))))
   (is (= [300 40]
-         (dt/with-elements-of [10 30]
+         (dt/with-destructured-vector [10 30]
            a (* a b)
            b (+ a b))))
   (is (= [100 400]
-         (dt/with-elements-of [10 20]
+         (dt/with-destructured-vector [10 20]
            a (* a a)
            b (* b b)
            c (throw (ex-info "This element should not be evaluated" {}))))))


### PR DESCRIPTION
#### SUMMARY

***Background:*** We noticed that Datahike queries take a lot of time. Using the [clj-async-profiler][100] revelealed that Datahike queries with clauses that have multiple unknown variables, e.g. `[?c :concept/id ?from-id]` take a lot of time because they result in calls to the `datahike.db.interface.IDB/-search` protocol methods where the database backend is asked to find all matches for those variables. However, often it is possible to substitute a variable for a set of known possible values. For instance if we know that `?c` can only be either `119`, `120` or `121`, the pattern `[?c :concept/id ?from-id]` can be replaced by `[119 :concept/id ?from-id]`, `[120 :concept/id ?from-id]` and `[121 :concept/id ?from-id]`.

***Proposed improvement:*** Change the `datahike.query` engine so that it attempts to substitute variables in patterns to make the patterns more specific. This is done by introducing the function `expand-constrained-patterns`. Exactly how the substitution should be performed is determined by a *relprod strategy* in located in the `context` map at `(-> context :settings :relprod-strategy)`. I tried out a few different strategies:

* `identity` (`no-strategy`): Don't perform any substitutions
* `select-simple`: Only perform substitutions that result in no or one pattern.
* `select-all`: Perform all possible substitutions
* `expand-once`: This performs all substitutions of `select-simple` *and one more substitution* (if possible) that results in more patterns.

I ran a set of 135 test requests against our API and noticed that the best strategy `expand-once` is about *20 times faster* than not trying to substitute any variables (`no-strategy`).

![total_time_plot](https://github.com/replikativ/datahike/assets/5850088/27c821e5-6a54-4d64-ab71-b9342703c86c)

The strategies are implemented as the functions `clojure.core/identity`, `relprod-select-simple`, `relprod-select-all` and `relprod-expand-once` and can be passed by including the strategy at the path `[:settings :relprod-strategy]` in the query.

[100]: https://github.com/clojure-goes-fast/clj-async-profiler