### PR TITLE
I/624/prep lib is broken

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,5 @@
+(ns build
+  (:require [clojure.java.shell :refer [sh]]))
+
+  (defn bb-trigger [_input]
+    (sh "bb" "jcompile"))

--- a/deps.edn
+++ b/deps.edn
@@ -18,8 +18,8 @@
  :paths ["src" "target/classes"]
 
  :deps/prep-lib {:ensure "target/classes"
-                 :alias :build
-                 :fn jcompile}
+                 :alias :prep-lib-build
+                 :fn bb-trigger}
 
  :aliases {;; Development
 
@@ -49,7 +49,7 @@
                   :main-opts ["-m" "cljfmt.main" "fix"]}
 
            ;; Build
-
+           :prep-lib-build {:ns-dfault build}
            :build {:replace-paths []
                    :replace-deps {datahike.bb {:local/root "bb"}}
                    :ns-default tools.build}

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,7 @@
  :paths ["src" "target/classes"]
 
  :deps/prep-lib {:ensure "target/classes"
-                 :alias :prep-lib-build
+                 :alias :build
                  :fn bb-trigger}
 
  :aliases {;; Development
@@ -49,10 +49,8 @@
                   :main-opts ["-m" "cljfmt.main" "fix"]}
 
            ;; Build
-           :prep-lib-build {:ns-dfault build}
-           :build {:replace-paths []
-                   :replace-deps {datahike.bb {:local/root "bb"}}
-                   :ns-default tools.build}
+
+           :build {:ns-default build}
 
            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}}
 


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds a trigger for the babashka build system and now `clj -X:deps prep` should work for at library using datahike.

#### Checks
##### Bugfix
Fixes #624 
