### PR TITLE
fix: bencode and cheshire need to be top level

### DIFF
--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -23,7 +23,7 @@
    (b/javac {:src-dirs java-src-dirs
              :class-dir class-dir
              :basis (basis project-config)
-             :javac-opts ["-source" "8" "-target" "8"
+             :javac-opts ["--release" "8"
                           "-Xlint:deprecation"]})
    (println "Done.")))
 
@@ -51,7 +51,7 @@
   (println "Done." "Saved to" (pom-path project-config)))
 
 (defn jar-path [repo-config {:keys [target-dir jar-pattern] :as project-config}]
-  (str target-dir "/" (render jar-pattern {:project project-config 
+  (str target-dir "/" (render jar-pattern {:project project-config
                                            :repo repo-config
                                            :version-str (version/string repo-config)})))
 

--- a/build.clj
+++ b/build.clj
@@ -1,5 +1,14 @@
 (ns build
-  (:require [clojure.java.shell :refer [sh]]))
+  (:refer-clojure :exclude [compile])
+  (:require [clojure.edn :as edn]
+            [clojure.tools.build.api :as b]))
 
-  (defn bb-trigger [_input]
-    (sh "bb" "jcompile"))
+(defn compile [_]
+  (let [{:build/keys [deps-file class-dir java-src-dirs]}
+        (edn/read-string (slurp "config.edn"))]
+    (print (str "Compiling Java classes saving them to '" class-dir "'..."))
+    (b/javac {:src-dirs java-src-dirs
+              :class-dir class-dir
+              :basis (b/create-basis {:project deps-file})
+              :javac-opts ["--release" "8"]})
+    (println "Done.")))

--- a/build.clj
+++ b/build.clj
@@ -3,12 +3,13 @@
   (:require [clojure.edn :as edn]
             [clojure.tools.build.api :as b]))
 
-(defn compile [_]
-  (let [{:build/keys [deps-file class-dir java-src-dirs]}
-        (edn/read-string (slurp "config.edn"))]
-    (print (str "Compiling Java classes saving them to '" class-dir "'..."))
-    (b/javac {:src-dirs java-src-dirs
-              :class-dir class-dir
-              :basis (b/create-basis {:project deps-file})
-              :javac-opts ["--release" "8"]})
-    (println "Done.")))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+
+(defn compile-java
+  [_]
+  (b/javac {:src-dirs ["java"]
+            :class-dir class-dir
+            :basis basis
+            :javac-opts ["--release" "8"
+                         "-Xlint:deprecation"]}))

--- a/deps.edn
+++ b/deps.edn
@@ -52,7 +52,8 @@
 
            ;; Build
 
-           :build {:ns-default build}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.5"}}
+                   :ns-default build}
 
            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,9 @@
         junit/junit                                 {:mvn/version "4.13.2"}
         medley/medley                               {:mvn/version "1.4.0"}
         metosin/spec-tools                          {:mvn/version "0.10.5"}
-        mvxcvi/clj-cbor                             {:mvn/version "1.1.1"}}
+        mvxcvi/clj-cbor                             {:mvn/version "1.1.1"}
+        nrepl/bencode                               {:mvn/version "1.1.0"}
+        cheshire/cheshire                           {:mvn/version "5.11.0"}}
 
  :paths ["src" "target/classes"]
 
@@ -69,16 +71,12 @@
                          {:git/url "https://github.com/taylorwood/clj.native-image.git"
                           :sha     "7708e7fd4572459c81f6a6b8e44c96f41cdd92d4"}
                          com.cognitect/transit-clj {:mvn/version "1.0.333"}
-                         nrepl/bencode             {:mvn/version "1.1.0"}
                          babashka/pods             {:git/url "https://github.com/babashka/pods"
-                                                    :git/sha "8b717eb001811bc5da5d15d1163565de00b4ffa4"}
-                         cheshire/cheshire         {:mvn/version "5.11.0"}}}
+                                                    :git/sha "8b717eb001811bc5da5d15d1163565de00b4ffa4"}}}
 
            :pod {:extra-deps {com.cognitect/transit-clj {:mvn/version "1.0.333"}
-                              nrepl/bencode             {:mvn/version "1.1.0"}
                               babashka/pods             {:git/url "https://github.com/babashka/pods"
-                                                         :git/sha "8b717eb001811bc5da5d15d1163565de00b4ffa4"}
-                              cheshire/cheshire         {:mvn/version "5.11.0"}}}
+                                                         :git/sha "8b717eb001811bc5da5d15d1163565de00b4ffa4"}}}
 
            ;; Checks
 

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
 
  :deps/prep-lib {:ensure "target/classes"
                  :alias :build
-                 :fn bb-trigger}
+                 :fn compile-java}
 
  :aliases {;; Development
 


### PR DESCRIPTION
I moved the dependencies bencode and cheshire to an alias but since cli- and pod-ns are inside src-directory we have to have them in the top-deps. We need a concept on how to deal with a monorepo and separate the dependencies to keep datahike lean.

I figured we should not use babashka in prep-lib since we can not rely on it being installed in every environment.