### PR TITLE
Add backwards compatible `abs`

### DIFF
--- a/src/datahike/query_stats.cljc
+++ b/src/datahike/query_stats.cljc
@@ -7,6 +7,10 @@
      :cljs (let [y (Math/pow 10 precision)]
              (/ (.round js/Math (* y x)) y))))
 
+(defn compatible-abs [n]
+  #?(:clj  (Math/abs n)
+     :cljs (js/Math.abs n)))
+
 (defn get-stats [context]
   {:rels (mapv (fn [rel] {:rows (count (:tuples rel))
                           :bound (set (keys (:attrs rel)))})
@@ -30,7 +34,7 @@
   "Adds summarized row counts, bindings and clause time for convenience"
   [{:keys [branches rels] :as stat}]
   (assoc stat
-         :id (subs (str (abs (hash stat))) 0 6)
+         :id (subs (str (compatible-abs (hash stat))) 0 6)
          :t-branches (reduce #(+ %1 (:t %2)) 0.0 branches)
          :rel-count (count rels)
          :rows (reduce #(+ %1 (:rows %2)) 0 rels)


### PR DESCRIPTION
#### SUMMARY
[#601] introduced the use of `abs` which is only available in Clojure 1.11.x. This is signficant barrier to adoption as most users won't know when `abs` was introduced. 

Solution: Use a local version of `abs` to support older versions of clojure. 

Fixes #626 

#### Checks
<!--- Pick one below and delete the rest -->

##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

