### PR TITLE
In-memory cljs support.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,9 @@
 
            :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.0"}}}
 
-           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.121"}}}
+           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.132"}
+                               thheller/shadow-cljs {:mvn/version "2.27.2"}
+                               binaryage/devtools   {:mvn/version "1.0.7"}}}
 
            :dev {:extra-paths ["dev" "benchmark/src"]
                  :extra-deps {org.clojure/tools.namespace {:mvn/version "1.4.4"}

--- a/src/datahike/store.cljc
+++ b/src/datahike/store.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc datahike.store
   (:require [clojure.spec.alpha :as s]
-            [konserve.filestore :as fs]
+            [#?(:clj konserve.filestore
+                :cljs konserve.node-filestore) :as fs]
             [konserve.memory :as mem]
             [environ.core :refer [env]]
             [datahike.index :as di]


### PR DESCRIPTION
Addresses #206. First phase is going to be to make Datahike compile with cljs support in-memory. Compared to https://github.com/replikativ/datahike/tree/206-cljs-support this does not require a complete move to core.async yet, but will allow synchronizing indices between clojure and clojurescript peers, e.g. with replikativ. In the second phase we can then port Datahike to support both asynchronous and synchronous execution.