### PR TITLE
Fix problem with bump `org.babashka/tools-deps-native` from `0.1.1` to `0.1.2` and `datahike-logo.txt` not being packaged into the jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
 version: 2.1
 
+setup: true
+
 orbs:
-  github-cli: circleci/github-cli@1.0
   tools: replikativ/clj-tools@0
+  continuation: circleci/continuation@0.1.2
 
 jobs:
   setup:
@@ -65,46 +67,20 @@ jobs:
           paths:
             - /home/circleci/.m2
   native-image:
-    machine:
-      image: ubuntu-2004:202010-01
-      resource_class: large
+    executor: tools/clojurecli
     steps:
       - attach_workspace:
           at: /home/circleci
       - run:
-          name: install graalvm
+          name: Generate config
           command: |
-            cd /home/circleci
-            wget https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.0/graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz
-            tar -xzf graalvm-community-jdk-21.0.0_linux-x64_bin.tar.gz
-            export PATH=/home/circleci/graalvm-community-openjdk-21+35.1/bin:$PATH
-            export JAVA_HOME=/home/circleci/graalvm-community-openjdk-21+35.1
-      - run:
-          name: install clojure
-          command: |
-            cd /home/circleci
-            curl -O https://download.clojure.org/install/linux-install-1.11.1.1165.sh
-            chmod +x linux-install-1.11.1.1165.sh
-            ./linux-install-1.11.1.1165.sh --prefix /home/circleci/clojure
-      - run:
-          name: install babashka
-          command: |
-            cd /home/circleci
-            curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
-            chmod +x install
-            ./install --dir /home/circleci/bin
-            export PATH=/home/circleci/bin:$PATH
-      - run:
-          name: build native-image
-          command: |
-            cd /home/circleci/replikativ
-            export PATH=/home/circleci/graalvm-community-openjdk-21+35.1/bin:/home/circleci/clojure/bin:$PATH
-            export JAVA_HOME=/home/circleci/graalvm-community-openjdk-21+35.1
-            bb ni-cli
-      - persist_to_workspace:
-          root: /home/circleci/
+            bb .circleci/scripts/gen_ci.clj > generated_config.yml
+      - continuation/continue:
+          configuration_path: generated_config.yml
+      - save_cache:
+          key: deps-{{ checksum "deps.edn" }}
           paths:
-            - replikativ/dthk
+            - /home/circleci/.m2
   persistent-set-test:
     executor: tools/clojurecli
     steps:

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -26,7 +26,7 @@
    :working_directory "/home/circleci/replikativ"
    :environment {:GRAALVM_VERSION graalvm-version
                  :PATH "/bin:/home/circleci/graalvm/bin:/home/circleci/clojure/bin:/home/circleci/bin"
-                 :JAVA_HOME "/home/circleci/graalvm"}
+                 :JAVA_HOME "/home/circleci/graalvm/bin/java"}
    :steps
    [:checkout
     (run "Install GraalVM"

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -33,8 +33,7 @@
          "cd /home/circleci
   /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz
   /bin/mkdir graalvm
-  /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
-  /bin/ls -lahrt graalvm")
+  /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1")
     (run "Install Clojure"
          "cd /home/circleci
   /bin/curl -sLO https://download.clojure.org/install/linux-install-1.11.1.1165.sh
@@ -47,7 +46,9 @@
   ./install --dir /home/circleci/bin")
     (run "Foo"
          "native-image --version
-  java -version")
+  java -version
+  env
+  /home/circleci/graalvm/bin/java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ
   bb ni-cli")

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -1,0 +1,113 @@
+(ns gen-ci
+  (:require
+   [babashka.tasks :as tasks]
+   [clj-yaml.core :as yaml]
+   [clojure.string :as str]
+   [flatland.ordered.map :refer [ordered-map]]))
+
+(def graalvm-version "21.0.1")
+
+(defn run
+  ([cmd-name cmd]
+   (run cmd-name cmd nil))
+  ([cmd-name cmd no-output-timeout]
+   (let [base {:run {:name    cmd-name
+                     :command cmd}}]
+     (if no-output-timeout
+       (assoc-in base [:run :no_output_timeout] no-output-timeout)
+       base))))
+
+(defn native-image
+  []
+  (ordered-map
+   :machine
+   {:image "ubuntu-2004:202010-01"
+    :resource_class "large"}
+   :working_directory "/home/circleci/replikativ"
+   :environment {:GRAALVM_VERSION graalvm-version
+                 :PATH "/bin:/home/circleci/graalvm/bin:/home/circleci/clojure/bin:/home/circleci/bin"
+                 :JAVA_HOME "/home/circleci/graalvm"}
+   :steps
+   [:checkout
+    (run "Install GraalVM"
+         "cd /home/circleci
+  /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz
+  /bin/mkdir graalvm
+  /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1
+  /bin/ls -lahrt graalvm")
+    (run "Install Clojure"
+         "cd /home/circleci
+  /bin/curl -sLO https://download.clojure.org/install/linux-install-1.11.1.1165.sh
+  /bin/chmod +x linux-install-1.11.1.1165.sh
+  ./linux-install-1.11.1.1165.sh --prefix /home/circleci/clojure")
+    (run "Install Babashka"
+         "cd /home/circleci
+  /bin/curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+  /bin/chmod +x install
+  ./install --dir /home/circleci/bin")
+    (run "Build native image"
+         "cd /home/circleci/replikativ
+  bb ni-cli")
+    (run "Test native image"
+         "cd /home/circleci/replikativ
+  bb test native-image")
+    {:persist_to_workspace
+     {:root "/home/circleci/"
+      :paths ["replikativ/dthk"]}}]))
+
+(defn make-config []
+  (ordered-map
+   :version 2.1
+   :orbs
+   {:tools "replikativ/clj-tools@0"}
+   :commands
+   {:setup-docker-buildx
+    {:steps
+     [{:run
+       {:name "Create multi-platform capable buildx builder"
+        :command
+        "docker run --privileged --rm tonistiigi/binfmt --install all\ndocker buildx create --name ci-builder --use"}}]}}
+   :jobs (ordered-map
+          :linux-amd64 (native-image))
+   :workflows (ordered-map
+               :version 2
+               :native-images
+               {:jobs ["linux-amd64"]})))
+
+(def skip-config
+  {:skip-if-only [#"^doc\/.*"
+                  #"^bb\/.*"
+                  #"^dev\/.*"
+                  #"^examples\/.*"
+                  #"^test\/.*"
+                  #".*.md$"]})
+
+(defn get-changes
+  []
+  (-> (tasks/shell {:out :string} "git diff --name-only HEAD~1")
+      (:out)
+      (str/split-lines)))
+
+(defn irrelevant-change?
+  [change regexes]
+  (some? (some #(re-matches % change) regexes)))
+
+(defn anything-relevant?
+  [change-set regexes]
+  (some? (some #(not (irrelevant-change? % regexes)) change-set)))
+
+(defn main
+  []
+  (let [{:keys [skip-if-only]} skip-config
+        changed-files          (get-changes)]
+    (when (anything-relevant? changed-files skip-if-only)
+      (-> (make-config)
+          (yaml/generate-string :dumper-options {:flow-style :block})
+          println))))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (main))
+
+(comment
+  (def changed-files (get-changes))
+  (anything-relevant? changed-files (:skip-if-only skip-config)))

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -46,7 +46,7 @@
   /bin/chmod +x install
   ./install --dir /home/circleci/bin")
     (run "Foo"
-         "native-image --version)])
+         "native-image --version
   java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -45,6 +45,9 @@
   /bin/curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
   /bin/chmod +x install
   ./install --dir /home/circleci/bin")
+    (run "Foo"
+         "native-image --version)])
+  java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ
   bb ni-cli")

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -21,7 +21,7 @@
   []
   (ordered-map
    :machine
-   {:image "ubuntu-2004:202010-01"
+   {:image "ubuntu-2204:2023.10.1"
     :resource_class "large"}
    :working_directory "/home/circleci/replikativ"
    :environment {:GRAALVM_VERSION graalvm-version
@@ -31,30 +31,34 @@
    [:checkout
     (run "Install GraalVM"
          "cd /home/circleci
-  /bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz
-  /bin/mkdir graalvm
-  /bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1")
+/bin/wget -O graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz
+/bin/mkdir graalvm
+/bin/tar -xzf graalvm.tar.gz --directory graalvm --strip-components 1)]))
+sudo update-alternatives --install /usr/bin/java java /home/circleci/graalvm/bin/java 0)]))
+sudo update-alternatives --install /usr/bin/javac javac /home/circleci/graalvm/bin/javac 0
+sudo update-alternatives --set java /home/circleci/graalvm/bin/java
+sudo update-alternatives --set javac /home/circleci/graalvm/bin/javac")
     (run "Install Clojure"
          "cd /home/circleci
-  /bin/curl -sLO https://download.clojure.org/install/linux-install-1.11.1.1165.sh
-  /bin/chmod +x linux-install-1.11.1.1165.sh
-  ./linux-install-1.11.1.1165.sh --prefix /home/circleci/clojure")
+/bin/curl -sLO https://download.clojure.org/install/linux-install-1.11.1.1165.sh
+/bin/chmod +x linux-install-1.11.1.1165.sh
+./linux-install-1.11.1.1165.sh --prefix /home/circleci/clojure")
     (run "Install Babashka"
          "cd /home/circleci
-  /bin/curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
-  /bin/chmod +x install
-  ./install --dir /home/circleci/bin")
+/bin/curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+/bin/chmod +x install
+./install --dir /home/circleci/bin")
     (run "Foo"
          "native-image --version
-  java -version
-  env
-  /home/circleci/graalvm/bin/java -version")
+java -version
+env
+/home/circleci/graalvm/bin/java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ
-  bb ni-cli")
+bb ni-cli")
     (run "Test native image"
          "cd /home/circleci/replikativ
-  bb test native-image")
+bb test native-image")
     {:persist_to_workspace
      {:root "/home/circleci/"
       :paths ["replikativ/dthk"]}}]))

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -51,11 +51,9 @@
   /home/circleci/graalvm/bin/java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ
-  sudo update-java-alternatives --set $JAVA_HOME
   bb ni-cli")
     (run "Test native image"
          "cd /home/circleci/replikativ
-  sudo update-java-alternatives --set $JAVA_HOME
   bb test native-image")
     {:persist_to_workspace
      {:root "/home/circleci/"

--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -51,9 +51,11 @@
   /home/circleci/graalvm/bin/java -version")
     (run "Build native image"
          "cd /home/circleci/replikativ
+  sudo update-java-alternatives --set $JAVA_HOME
   bb ni-cli")
     (run "Test native image"
          "cd /home/circleci/replikativ
+  sudo update-java-alternatives --set $JAVA_HOME
   bb test native-image")
     {:persist_to_workspace
      {:root "/home/circleci/"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,50 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-monterey-base:latest
+
+task:
+  only_if: $CIRRUS_BRANCH == 'main'
+  env:
+    DTHK_PLATFORM: macos
+    DTHK_ARCH: aarch64
+    INSTALL_DIR: ${HOME}
+    GRAALVM_VERSION: 21.0.1
+    GRAALVM_HOME: ${HOME}/graalvm-community-openjdk-${GRAALVM_VERSION}+12.1/Contents/Home/
+    GITHUB_TOKEN: ENCRYPTED[0ea782cbbd99c2486b0f55b8eefcf91606a0805faaa3f35e55ecb75268b0046b874c856753f528ba689a9cdaa11e47c2]
+  script: |
+    set -euo pipefail
+
+    # install babashka
+    curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install
+    chmod +x install
+    ./install --dir ${HOME}/.local/bin
+    export PATH=${HOME}/.local/bin:$PATH
+
+    # install clojure
+    curl -L -O https://github.com/clojure/brew-install/releases/latest/download/posix-install.sh
+    chmod +x posix-install.sh
+    sudo ./posix-install.sh
+
+    # install graalvm
+    pushd "$INSTALL_DIR" >/dev/null
+    curl -L -O https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/graalvm-community-jdk-${GRAALVM_VERSION}_${DTHK_PLATFORM}-${DTHK_ARCH}_bin.tar.gz
+    sudo xattr -r -d com.apple.quarantine graalvm-community-jdk-${GRAALVM_VERSION}_${DTHK_PLATFORM}-${DTHK_ARCH}_bin.tar.gz
+    tar -xzf graalvm-community-jdk-${GRAALVM_VERSION}_${DTHK_PLATFORM}-${DTHK_ARCH}_bin.tar.gz
+    popd >/dev/null
+
+    # prepare
+    export PATH=${GRAALVM_HOME}/bin:${PATH}
+    export JAVA_HOME=$GRAALVM_HOME
+    sudo /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+    java -version
+
+    # compile
+    bb ni-cli
+
+    # test
+    bb test native-image
+    bb test pod
+
+    # upload artifact
+    bb release native-cli
+  binaries_artifacts:
+    path: "dist/*"

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.8.0"
  :pods {;since babashka 0.8.0, can only be declared in bb.edn
-        org.babashka/tools-deps-native {:version "0.1.1"}
-        clj-kondo/clj-kondo {:version "2023.07.13"}}
+        org.babashka/tools-deps-native {:version "0.1.2"}
+        clj-kondo/clj-kondo {:version "2023.10.20"}}
  :deps {datahike/bb {:local/root "bb"}}
  :tasks {:requires [[babashka.fs :as fs]
                     [clojure.edn :as edn]

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:min-bb-version "0.8.0"
  :pods {;since babashka 0.8.0, can only be declared in bb.edn
-        org.babashka/tools-deps-native {:version "0.1.2"}
+        org.babashka/tools-deps-native {:version "0.1.1"}
         clj-kondo/clj-kondo {:version "2023.10.20"}}
  :deps {datahike/bb {:local/root "bb"}}
  :tasks {:requires [[babashka.fs :as fs]

--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -86,7 +86,7 @@
       (p/shell (str graalvm-dir "/bin/native-image")
                "-jar" native-jar
                "-cp" class-path
-               (str "-H:Name=" project-name)
+               (str "-o " project-name)
                "--shared"
                "-H:+ReportExceptionStackTraces"
                "-J-Dclojure.spec.skip-macros=true"

--- a/config.edn
+++ b/config.edn
@@ -19,7 +19,7 @@
                :jar-pattern "{{repo.lib}}-{{version-str}}.jar"
                :lib timokramer/datahike}
          :http-server-clj {;; jvm build
-                           :src-dirs      ["src" "http-server"]
+                           :src-dirs      ["src" "http-server" "resources"]
                            :java-src-dirs ["java"]
                            :target-dir    "target-http-server"
                            :class-dir     "target-http-server/classes"

--- a/config.edn
+++ b/config.edn
@@ -1,13 +1,13 @@
-{:org "replikativ"
+{:org "timokramer"
  :lib "datahike"
  :version {:major 0
            :minor 6}
- :git-url "git@github.com:replikativ/datahike.git"
+ :git-url "git@github.com:timokramer/datahike.git"
 
  :pom-template "./bb/resources/template/pom.xml"
- :scm {:connection "scm:git:git@github.com:replikativ/datahike.git"
-       :developerConnection "scm:git:git@github.com:replikativ/datahike.git"
-       :url "https://github.com/replikativ/datahike"}
+ :scm {:connection "scm:git:git@github.com:timokramer/datahike.git"
+       :developerConnection "scm:git:git@github.com:timokramer/datahike.git"
+       :url "https://github.com/timokramer/datahike"}
 
  :build {:clj {;; jvm build
                :src-dirs ["src"]
@@ -17,7 +17,7 @@
                :class-dir "target/classes"
                :deps-file "deps.edn"
                :jar-pattern "{{repo.lib}}-{{version-str}}.jar"
-               :lib io.replikativ/datahike}
+               :lib timokramer/datahike}
          :http-server-clj {;; jvm build
                            :src-dirs      ["src" "http-server"]
                            :java-src-dirs ["java"]
@@ -27,7 +27,7 @@
                            :jar-pattern   "{{repo.lib}}-http-server-{{version-str}}.jar"
                            :aliases       [:http-server]
                            :main          datahike.http.server
-                           :lib           io.replikativ/datahike-http-server}
+                           :lib           timokramer/datahike-http-server}
          :native {;; jvm build
                   :src-dirs ["src" "libdatahike/src"]
                   :java-src-dirs ["java"]

--- a/deps.edn
+++ b/deps.edn
@@ -87,7 +87,7 @@
                                     "--initialize-at-build-time"
                                     "--no-fallback"
                                     "-J-Xmx4g"
-                                    "-H:Name=dthk"]
+                                    "-o dthk"]
                         :jvm-opts  ["-Dclojure.compiler.direct-linking=true"]
                         :extra-deps
                         {clj.native-image/clj.native-image


### PR DESCRIPTION
#### SUMMARY
Downgrading `org.babashka/tools-deps-native` from `0.1.2` to `0.1.1` since it is causing problems with jar creation for `datahike.http.server`.
Also adding `resources` directory to `:src-dirs` [here](https://github.com/replikativ/datahike/blob/4b3a87da8ce79eaa26d680c3bf91a9ed390b0c45/config.edn#L21-L30) since not having `resources/datahike-logo.txt` being packeged into the jar is causing problems while executing it.

fixes #663

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #663`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked


#### ADDITIONAL INFORMATION
I am not sure if any integration tests addition are needed.
No design changes necessary.

