### PR TITLE
add resources to http-server-clj src-dirs jvm build configuration

### DIFF
--- a/config.edn
+++ b/config.edn
@@ -19,7 +19,7 @@
                :jar-pattern "{{repo.lib}}-{{version-str}}.jar"
                :lib io.replikativ/datahike}
          :http-server-clj {;; jvm build
-                           :src-dirs      ["src" "http-server"]
+                           :src-dirs      ["src" "http-server" "resources"]
                            :java-src-dirs ["java"]
                            :target-dir    "target-http-server"
                            :class-dir     "target-http-server/classes"


### PR DESCRIPTION
#### SUMMARY
adding `resources` directory to `:src-dirs` [here](https://github.com/replikativ/datahike/blob/4b3a87da8ce79eaa26d680c3bf91a9ed390b0c45/config.edn#L21-L30) since not having `resources/datahike-logo.txt` being packeged into the jar is causing problems while executing it.

fixes #663