### PR TITLE
Fix reflection in call to alength

### DIFF
--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -205,7 +205,7 @@
         _ (arrays/asort arr (index-type->cmp-quick index-type false))
         ^PersistentSortedSet pset (psset/from-sorted-array (index-type->cmp-quick index-type false)
                                                            arr
-                                                           (alength arr)
+                                                           (arrays/alength arr)
                                                            {:branching-factor DEFAULT_BRANCHING_FACTOR})]
     (set! (.-_storage pset) (:storage store))
     (with-meta pset


### PR DESCRIPTION
#### SUMMARY
Fix reflection warnings in order to speed up execution.

#### Checks

I have run the tests (bb test clj-pss), and our performance test suite without seeing any performance gains in that (https://gitlab.com/arbetsformedlingen/taxonomy-dev/backend/experimental/datahike-benchmark)

##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ x ] Formatting checked

#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
