### PR TITLE
Optimize the persistent set comparator

### DIFF
--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -247,6 +247,9 @@
       (if (nil? o2) nil
           (compare o1 o2))))
 
+(defn type-hint-datom [x]
+  (vary-meta x assoc :tag `Datom))
+
 (defn cmp-val [val]
   (case val
     :e (fn [^Datom d1 ^Datom d2] (#?(:clj Long/compare :cljs -) (.-e d1) (.-e d2)))
@@ -254,6 +257,14 @@
     :v (fn [^Datom d1 ^Datom d2] (cmp-nil (.-v d1) (.-v d2)))
     :tx (fn [^Datom d1 ^Datom d2] (#?(:clj Long/compare :cljs -) (datom-tx d1) (datom-tx d2)))
     :added (fn [^Datom d1 ^Datom d2] (#?(:clj Boolean/compare :cljs -) (datom-added d1) (datom-added d2)))))
+
+(defn cmp-val-expr [val d1 d2]
+  (case val
+    :e `(#?(:clj Long/compare :cljs -) (.-e ~d1) (.-e ~d2))
+    :a `(cmp-nil (.-a ~d1) (.-a ~d2))
+    :v `(cmp-nil (.-v ~d1) (.-v ~d2))
+    :tx `(#?(:clj Long/compare :cljs -) (datom-tx ~d1) (datom-tx ~d2))
+    :added `(#?(:clj Boolean/compare :cljs -) (datom-added ~d1) (datom-added ~d2))))
 
 (defn cmp-datoms-eavt-quick [^Datom d1, ^Datom d2]
   (combine-cmp

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -14,19 +14,7 @@
   #?(:clj (:import [datahike.datom Datom]
                    [org.fressian.handlers WriteHandler ReadHandler]
                    [me.tonsky.persistent_sorted_set PersistentSortedSet IStorage Leaf Branch ANode Settings]
-                   [java.util UUID List])))
-
-(defn index-type->cmp
-  ([index-type] (index-type->cmp index-type true))
-  ([index-type current?] (if current?
-                           (case index-type
-                             :aevt dd/cmp-datoms-aevt
-                             :avet dd/cmp-datoms-avet
-                             dd/cmp-datoms-eavt)
-                           (case index-type
-                             :aevt dd/cmp-temporal-datoms-aevt
-                             :avet dd/cmp-temporal-datoms-avet
-                             dd/cmp-temporal-datoms-eavt))))
+                   [java.util List])))
 
 (defn index-type->cmp-quick
   ([index-type] (index-type->cmp-quick index-type true))
@@ -40,30 +28,106 @@
                              :avet dd/cmp-temporal-datoms-avet-quick
                              dd/cmp-temporal-datoms-eavt-quick))))
 
-(defn multi-cmp [cmps d1 d2]
-  (reduce (fn [old cmp] (let [res (cmp d1 d2)]
-                          (if (nil? res)
-                            (reduced old)
-                            (if (not= 0 res)
-                              (reduced res)
-                              old))))
-          0
-          cmps))
-
 (def index-type->kwseq
   {:eavt [:e :a :v :tx :added]
    :aevt [:a :e :v :tx :added]
    :avet [:a :v :e :tx :added]})
 
-(defn index-type->slice-cmp [index-type from to]
-  (let [cmps (->> (index-type index-type->kwseq)
-                  (take-while #(not (and (nil? (% from))
-                                         (nil? (% to)))))
-                  (mapv dd/cmp-val))]
-    (partial multi-cmp cmps)))
+(defn slice-from-to-tree
+  "This function generates code for deciding which datom elements that need to be compared based on which elements in the slice bounds are nil, as well as the index. Once all datom elements have been considered, `leaf-fn` is called with a vector containing the keywords of the actual elements to compare."
+  [from-sym to-sym index-spec acc leaf-fn]
+  (if (empty? index-spec)
 
-(defn slice [pset from to index-type]
-  (psset/slice pset from to (index-type->slice-cmp index-type from to)))
+    ;; When there is nothing left to compare,
+    ;; return the correct comparator.
+    (leaf-fn acc)
+    
+    (let [[findex & index-spec] index-spec]
+      `(if (and (nil? (~findex ~from-sym))
+                (nil? (~findex ~to-sym)))
+
+         ;; Whenever both slice bounds are nil, there is nothing more to compare
+         ;; and we know what comparator to return.
+         ~(leaf-fn acc)
+
+         ;; Otherwise, if at least one slie bound is non-nil, we need a comparator for
+         ;; the remaining datom elements.
+         ~(slice-from-to-tree from-sym to-sym index-spec (conj acc findex) leaf-fn)))))
+
+(defn cmp-for-kwseq-sub
+  "This function generates the actual body of the comparator"
+  [old datom0 datom1 kwseq]
+  (let [result (gensym)]
+    (if (empty? kwseq)
+      0
+      (let [[k & kwseq] kwseq]
+        `(let [;; Compare the datoms at the element with key `k`
+               ~result ~(dd/cmp-val-expr k datom0 datom1)]
+           (cond
+             ;; If it is nil, typically return 0 (`old` is logically always bound to 0)
+             (nil? ~result) ~old
+
+             ;; If it is zero, we need to proceed with the next datom element to compare.
+             (zero? ~result) ~(cmp-for-kwseq-sub old datom0 datom1 kwseq)
+
+             ;; If it is non-zero, it means that this is the result of the comparison.
+             :else ~result))))))
+
+(defn cmp-for-kwseq
+  "Given a sequence of keywords for datom elements to compare, generate the code for a function that performs the comparison."
+  [kwseq]
+  (let [datom0 (dd/type-hint-datom (gensym))
+        datom1 (dd/type-hint-datom (gensym))]
+    `(fn [~datom0 ~datom1] ~(cmp-for-kwseq-sub 0 datom0 datom1 kwseq))))
+
+(defmacro generate-slice-comparator-constructor []
+  (let [index-sym (gensym)
+        from-sym (gensym)
+        to-sym (gensym)
+
+        ;; List keyword sequences referring to datom elements for
+        ;; all combinations of indexes and leftmost slices of the
+        ;; corresponding datom elements.
+        all-kwseqs (set (for [[_ kwseq] index-type->kwseq
+                              limit (range 6)]
+                          (vec (take limit kwseq))))
+        kwseq-sym-map (zipmap all-kwseqs (repeatedly gensym))]
+    `(let [;; Pre-build comparators for every sequence
+           ;; of keywords referring to datom elements.
+           ;; A comparator is a function taking two datoms
+           ;; as arguments.
+           ~@(mapcat (fn [[kwseq sym]]
+                       [sym (cmp-for-kwseq kwseq)])
+                     kwseq-sym-map)]
+
+
+       ;; This is the function generated by this macro
+       ;; and it is called by the `-slice` method.
+       (fn [~index-sym ~from-sym ~to-sym]
+
+         ;; First branch based on which index to use ...
+         (case ~index-sym
+           ~@(mapcat
+              (fn [[index-key index-spec]]
+                [index-key
+
+                 ;; ... then branch based on what elements
+                 ;; are non-nil in the slice bound datoms ...
+                 (slice-from-to-tree
+                  from-sym to-sym
+                  index-spec
+                  []
+
+                  (fn [acc]
+                    {:post [(symbol? %)]}
+
+                    ;; ... and eventually return a precomputed comparator
+                    ;; that will be used by `psset/slice`. The generated
+                    ;; code is the symbol that is bound to a comparator.
+                    (get kwseq-sym-map acc)))])
+              index-type->kwseq))))))
+
+(def slice-comparator-constructor (generate-slice-comparator-constructor))
 
 (defn remove-datom [pset ^Datom datom index-type]
   (psset/disj pset datom (index-type->cmp-quick index-type false)))
@@ -114,7 +178,7 @@
 (extend-type PersistentSortedSet
   IIndex
   (-slice [^PersistentSortedSet pset from to index-type]
-    (slice pset from to index-type))
+    (psset/slice pset from to (slice-comparator-constructor index-type from to)))
   (-all [pset]
     (identity pset))
   (-seq [^PersistentSortedSet pset]

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -56,7 +56,7 @@
 
 (defn cmp-for-kwseq-sub
   "This function generates the actual body of the comparator"
-  [old datom0 datom1 kwseq]
+  [datom0 datom1 kwseq]
   (let [result (gensym)]
     (if (empty? kwseq)
       0
@@ -65,10 +65,10 @@
                ~result ~(dd/cmp-val-expr k datom0 datom1)]
            (cond
              ;; If it is nil, typically return 0 (`old` is logically always bound to 0)
-             (nil? ~result) ~old
+             (nil? ~result) 0
 
              ;; If it is zero, we need to proceed with the next datom element to compare.
-             (zero? ~result) ~(cmp-for-kwseq-sub old datom0 datom1 kwseq)
+             (zero? ~result) ~(cmp-for-kwseq-sub datom0 datom1 kwseq)
 
              ;; If it is non-zero, it means that this is the result of the comparison.
              :else ~result))))))
@@ -78,7 +78,7 @@
   [kwseq]
   (let [datom0 (dd/type-hint-datom (gensym))
         datom1 (dd/type-hint-datom (gensym))]
-    `(fn [~datom0 ~datom1] ~(cmp-for-kwseq-sub 0 datom0 datom1 kwseq))))
+    `(fn [~datom0 ~datom1] ~(cmp-for-kwseq-sub datom0 datom1 kwseq))))
 
 (defmacro generate-slice-comparator-constructor []
   (let [index-sym (gensym)

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -64,7 +64,7 @@
         `(let [;; Compare the datoms at the element with key `k`
                ~result ~(dd/cmp-val-expr k datom0 datom1)]
            (cond
-             ;; If it is nil, typically return 0 (`old` is logically always bound to 0)
+             ;; If it is nil, typically return 0
              (nil? ~result) 0
 
              ;; If it is zero, we need to proceed with the next datom element to compare.


### PR DESCRIPTION
This PR rewrites the slice comparator for the persistent set index backend to be much faster. It accomplishes that by doing most of the work at macro expansion time to generate an inlined implementation of the comparator. Here are the absolute and relative times measured using [this benchmark](https://gitlab.com/arbetsformedlingen/taxonomy-dev/backend/experimental/datahike-benchmark/).

```
TARGET              ABS TIME (s)   REL TIME
Some other db              4.797         6%
Official Datahike         75.648       100%
Datahike pset cmp         53.027        70%
```

This PR is the line "Datahike pset cmp". We see that it takes about 30% less time to run the benchmark using the code in this PR compared to the code in the main branch.