### PR TITLE
Fix issue 676: make bind-by-fn require all attrs to have values

### DIFF
--- a/test/datahike/test/query_fns_test.cljc
+++ b/test/datahike/test/query_fns_test.cljc
@@ -31,6 +31,11 @@
              (d/q '[:find ?e ?age ?height
                     :where [?e :age ?age]
                     [(get-else $ ?e :height 300) ?height]] db)))
+      (is (= #{[1 15 300] [2 22 240] [3 37 300] [4 22 300]}
+             (d/q '[:find ?e ?age ?height
+                    :where
+                    [(get-else $ ?e :height 300) ?height]
+                    [?e :age ?age]] db)))
 
       (is (thrown-with-msg? ExceptionInfo #"get-else: nil default value is not supported"
                             (d/q '[:find ?e ?height

--- a/test/datahike/test/tools_test.clj
+++ b/test/datahike/test/tools_test.clj
@@ -20,3 +20,24 @@
            a (* a a)
            b (* b b)
            c (throw (ex-info "This element should not be evaluated" {}))))))
+(defn add-resolver [context [result-var a b]]
+  (when (and (contains? context a)
+             (contains? context b))
+    (assoc context result-var (+ (context a)
+                                 (context b)))))
+
+(deftest resolve-clauses-test
+  (is (= {:x 9 :y 10 :z 19 :w 28}
+         (dt/resolve-clauses add-resolver
+                             {:x 9 :y 10}
+                             [[:w :z :x]
+                              [:z :x :y]])))
+  (is (= {:x 9 :y 10 :z 19 :w 28}
+         (dt/resolve-clauses add-resolver
+                             {:x 9 :y 10}
+                             [[:z :x :y]
+                              [:w :z :x]])))
+  (is (thrown? Exception
+               (dt/resolve-clauses add-resolver
+                                   {:x 9 :y 10}
+                                   [[:w :z :x]]))))


### PR DESCRIPTION
#### SUMMARY
Fixes #676 using the following changes:

* Rewrite `datahike.query/bind-by-fn` to return nil if not all symbols in the function call can be bound to values.
* Add function `datahike.tools/resolve-clauses`.
* Replace all occurrences in of `(reduce -resolve-clause ...)`  by `(dt/resolve-clauses ...)` to handle the `nil` returned by `datahike.query/bind-by-fn`.
* Add unit test that demonstrates that the bug has been fixed.

*Discussion about the solution to issue 676:*
The code in `bind-by-fn` is currently written in such a way that it assumes all symbols in the function call to be known in the context when the clause is evaluated but there are not checks to ensure that this is actually the case. Maybe there is a way to make it possible for symbols to be unknown but that would probably require a substantial rewrite of `bind-by-fn`. An easier way to address this problem is to make `bind-by-fn` return `nil`, instead of the new context, if not all symbols are known. However, this `nil` will consequently be returned by `-resolve-clause` and needs to be handled. We handle that `nil` by replacing all occurences of `(reduce -resolve-clause ...)` by `(dt/resolve-clauses ...)` to handle the nil and retry failed clauses in subsequent iterations.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked