### PR TITLE
Fix issue 678: Make it possible to store :db/id as a keyword value

### DIFF
--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -378,9 +378,12 @@
                      (assoc v (dbu/reverse-ref a-ident) eid)
                      (if reverse?
                        [:db/add v straight-a eid]
-                       [:db/add eid straight-a (if (and attribute-refs? (ds/is-system-keyword? v)) ;; translation of system enums
-                                                 (dbi/-ref-for db v)
-                                                 v)])))]
+                       [:db/add eid straight-a
+                        (if (and attribute-refs?
+                                 (dbu/is-attr? db straight-a-ident :db/systemAttribRef)
+                                 (ds/is-system-keyword? v)) ;; translation of system enums
+                          (dbi/-ref-for db v)
+                          v)])))]
     (if ensure
       (let [{:keys [:db.entity/attrs :db.entity/preds]} (-> db :schema ensure)]
         (if (empty? attrs)

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -234,6 +234,11 @@
     :db.cardinality/many [:db.cardinality/many]
     :db.type/ref [:db.type/ref :db/index]
     :db.type/tuple [:db.type/tuple]
+
+    :db.type/valueType [:db/systemAttribRef]
+    :db.type/cardinality [:db/systemAttribRef]
+    :db.type/unique [:db/systemAttribRef]
+    
     (if (= k :db/ident)
       [:db/ident]
       (when (true? v)

--- a/test/datahike/test/attribute_refs/differences_test.cljc
+++ b/test/datahike/test/attribute_refs/differences_test.cljc
@@ -216,6 +216,24 @@
                #{:name}))
         (d/release conn)))))
 
+(deftest test-store-db-id-as-keyword
+  (doseq [cfg (init-cfgs)]
+    (testing "Do not resolve enums in keyword DB"
+      (let [conn (setup-db cfg)]
+        (d/transact conn [{:db/ident :attribute-to-use
+                           :db/cardinality :db.cardinality/one
+                           :db/valueType :db.type/keyword}])
+        (d/transact conn [{:attribute-to-use :the-location}
+                          {:attribute-to-use :db/id}])
+        (is (= #{[:the-location]
+                 [:db/id]}
+               (d/q '[:find ?v
+                      :in $ ?a
+                      :where
+                      [_ :attribute-to-use ?v]]
+                    @conn)))
+        (d/release conn)))))
+
 (deftest test-indexing
   (let [[no-ref-cfg ref-cfg] (init-cfgs)
         schema [{:db/ident :name


### PR DESCRIPTION
#### SUMMARY

Fixes #678 

The code in this PR makes it possible to run the following transactions against an empty database with attribute-refs turned on:

```clj
        (d/transact conn [{:db/ident :attribute-to-use
                           :db/cardinality :db.cardinality/one
                           :db/valueType :db.type/keyword}])
        (d/transact conn [{:attribute-to-use :the-location}
                          {:attribute-to-use :db/id}])
```
Currently, in the main branch, this is not possible and results in an exception being thrown. The fundamental issue is that a part of the code in `transact.cljc` tries to convert keywords that are system keywords to their database ids. It tries to do this mapping *no matter the value type of the attribute of the datom being transacted*. For example, if the value type is a keyword that just happens to have the same name as a system attribute, it will still attempt to map, which is wrong. And this specifically fails for `:db/id` which is not an attribute in the database but is a system keyword. The line that fixes this issue is `(dbu/is-attr? db straight-a-ident :db/systemAttribRef)` in `transaction.cljc` which will make sure that we only attempt this mapping to database ids if the value type of the attribute is a type that makes sense to map.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked