### PR TITLE
Fix issue 680: correctly pull attributes

### DIFF
--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -28,6 +28,10 @@
           :cljs [^boolean ref?]) [db attr]
   (is-attr? db attr :db.type/ref))
 
+(defn #?@(:clj [^Boolean system-attrib-ref?]
+          :cljs [^boolean system-attrib-ref?]) [db attr]
+  (is-attr? db attr :db/systemAttribRef))
+
 (defn #?@(:clj [^Boolean component?]
           :cljs [^boolean component?]) [db attr]
   (is-attr? db attr :db/isComponent))
@@ -152,8 +156,11 @@
       {:ident attr :ref (dbi/-ref-for db attr)})
     {:ident attr :ref attr}))
 
+(defn ident-name? [x]
+  (or (keyword? x) (string? x)))
+
 (defn validate-attr-ident [a-ident at db]
-  (when-not (or (keyword? a-ident) (string? a-ident))
+  (when-not (ident-name? a-ident)
     (raise "Bad entity attribute " a-ident " at " at ", expected keyword or string"
            {:error :transact/syntax, :attribute a-ident, :context at}))
   (when (and (= :write (:schema-flexibility (dbi/-config db)))
@@ -234,6 +241,11 @@
     :db.cardinality/many [:db.cardinality/many]
     :db.type/ref [:db.type/ref :db/index]
     :db.type/tuple [:db.type/tuple]
+
+    :db.type/valueType [:db/systemAttribRef]
+    :db.type/cardinality [:db/systemAttribRef]
+    :db.type/unique [:db/systemAttribRef]
+    
     (if (= k :db/ident)
       [:db/ident]
       (when (true? v)

--- a/src/datahike/pull_api.cljc
+++ b/src/datahike/pull_api.cljc
@@ -118,6 +118,12 @@
           (subpattern-frame eids multi? attr-key)
           (assoc :recursion rec)))))
 
+(defn db-ident-and-id [db x]
+  (let [{:keys [ident ref]} (dbu/attr-info db x)]
+    (if (dbu/ident-name? ident)
+      {:db/id ref :db/ident ident}
+      {:db/id ref})))
+
 (defn pull-attr-datoms
   "Processes datoms found to requested pattern for given attribute, i.e.
    - limits the result set to specified or default limit,
@@ -136,11 +142,13 @@
                  limit (into [] (take limit))))]
     (if found
       (let [ref?       (dbu/ref? db attr)
+            system-attrib-ref? (dbu/system-attrib-ref? db attr)
             component? (and ref? (dbu/component? db attr))
             multi?     (if forward? (dbu/multival? db attr)
                            (not component?))
             datom-val  (if forward? (fn [d] (.-v ^Datom d))
                            (fn [d] (.-e ^Datom d)))]
+
         (cond
           (contains? opts :subpattern)
           (->> (subpattern-frame (:subpattern opts)
@@ -160,8 +168,9 @@
                (conj frames parent))
 
           :else
-          (let [as-value  (cond->> datom-val
-                            ref? (comp #(hash-map :db/id %)))
+          (let [as-value  (if (or ref? system-attrib-ref?)
+                            #(db-ident-and-id db (datom-val %))
+                            datom-val)
                 single?   (not multi?)]
             (->> (cond-> (into [] (map as-value) found)
                    single? first)

--- a/test/datahike/test/attribute_refs/query_pull_test.cljc
+++ b/test/datahike/test/attribute_refs/query_pull_test.cljc
@@ -129,3 +129,28 @@
                         :where [?ref :age ?a]
                         [(>= ?a 18)]]
                       db [[:name "Ivan"] [:name "Oleg"] [:name "Petr"]]))))))
+
+(deftest test-pull-attribute
+  (testing "Pull an attribute"
+    (let [db (d/db-with ref-db [{:db/ident :attribute-to-use
+                                 :db/cardinality :db.cardinality/one
+                                 :db/valueType :db.type/keyword}])
+          result (d/q '[:find (pull ?attr [*])
+                        :in $ ?attr-name
+                        :where
+                        [?attr :db/ident ?attr-name]]
+                      db :attribute-to-use)
+          [[x]] result
+          ids [(:db/id x)
+               (-> x :db/valueType :db/id)
+               (-> x :db/cardinality :db/id)]]
+      (is (= 1 (count result)))
+      (is (= 1 (count (first result))))
+      (is (= #{:db/id :db/ident :db/valueType :db/cardinality} (set (keys x))))
+      (is (number? (:db/id x)))
+      (is (= :attribute-to-use (:db/ident x)))
+      (is (= :db.type/keyword (-> x :db/valueType :db/ident)))
+      (is (= :db.cardinality/one (-> x :db/cardinality :db/ident)))
+      (is (every? number? ids))
+      (is (= (count (set ids))
+             (count ids))))))


### PR DESCRIPTION
#### SUMMARY

Fixes #680 

This PR fixes a bug related to pulling attributes. See the issue description and the unit test.

In short, if we run the following query

```clj
(let [db (d/db-with ref-db [{:db/ident :attribute-to-use
                                 :db/cardinality :db.cardinality/one
                                 :db/valueType :db.type/keyword}])
          result (d/q '[:find (pull ?attr [*])
                        :in $ ?attr-name
                        :where
                        [?attr :db/ident ?attr-name]]
                      db :attribute-to-use)
```

the code in this PR makes sure that we get the **correct result** of 

```clj
[[#:db{:id 62,
       :ident :attribute-to-use,
       :valueType #:db{:id 23, :ident :db.type/keyword},
       :cardinality #:db{:id 11, :ident :db.cardinality/one}}]]
```

instead of the **incorrect result** of

```clj
[[#:db{:id 62,
       :ident :attribute-to-use,
       :valueType 23,
       :cardinality 11}]]
```




#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked
