### PR TITLE
Fix issue 682: Make history, as-of and since composable with each other

### DIFF
--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -58,13 +58,13 @@
 
 (defmethod datoms PersistentArrayMap
   [db {:keys [index components]}]
-  (dbi/-datoms db index components))
+  (dbi/datoms db index components))
 
 (defmethod datoms Keyword
   [db index & components]
   (if (nil? components)
-    (dbi/-datoms db index [])
-    (dbi/-datoms db index components)))
+    (dbi/datoms db index [])
+    (dbi/datoms db index components)))
 
 (defmulti seek-datoms
   (fn
@@ -75,13 +75,13 @@
 
 (defmethod seek-datoms PersistentArrayMap
   [db {:keys [index components]}]
-  (dbi/-seek-datoms db index components))
+  (dbi/seek-datoms db index components))
 
 (defmethod seek-datoms Keyword
   [db index & components]
   (if (nil? components)
-    (dbi/-seek-datoms db index [])
-    (dbi/-seek-datoms db index components)))
+    (dbi/seek-datoms db index [])
+    (dbi/seek-datoms db index components)))
 
 (defn with
   ([db arg-map]
@@ -125,7 +125,7 @@
     (dt/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 (defn index-range [db {:keys [attrid start end]}]
-  (dbi/-index-range db attrid start end))
+  (dbi/index-range db attrid start end))
 
 (defn schema [db]
   (reduce-kv

--- a/src/datahike/core.cljc
+++ b/src/datahike/core.cljc
@@ -155,31 +155,31 @@
 ; Index lookups
 
 (defn datoms
-  ([db index] {:pre [(dbu/db? db)]} (dbi/-datoms db index []))
-  ([db index c1] {:pre [(dbu/db? db)]} (dbi/-datoms db index [c1]))
-  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/-datoms db index [c1 c2]))
-  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/-datoms db index [c1 c2 c3]))
-  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/-datoms db index [c1 c2 c3 c4])))
+  ([db index] {:pre [(dbu/db? db)]} (dbi/datoms db index []))
+  ([db index c1] {:pre [(dbu/db? db)]} (dbi/datoms db index [c1]))
+  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/datoms db index [c1 c2]))
+  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/datoms db index [c1 c2 c3]))
+  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/datoms db index [c1 c2 c3 c4])))
 
 (defn seek-datoms
-  ([db index] {:pre [(dbu/db? db)]} (dbi/-seek-datoms db index []))
-  ([db index c1] {:pre [(dbu/db? db)]} (dbi/-seek-datoms db index [c1]))
-  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/-seek-datoms db index [c1 c2]))
-  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/-seek-datoms db index [c1 c2 c3]))
-  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/-seek-datoms db index [c1 c2 c3 c4])))
+  ([db index] {:pre [(dbu/db? db)]} (dbi/seek-datoms db index []))
+  ([db index c1] {:pre [(dbu/db? db)]} (dbi/seek-datoms db index [c1]))
+  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/seek-datoms db index [c1 c2]))
+  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/seek-datoms db index [c1 c2 c3]))
+  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/seek-datoms db index [c1 c2 c3 c4])))
 
 (defn rseek-datoms
   "Same as [[seek-datoms]], but goes backwards until the beginning of the index."
-  ([db index] {:pre [(dbu/db? db)]} (dbi/-rseek-datoms db index []))
-  ([db index c1] {:pre [(dbu/db? db)]} (dbi/-rseek-datoms db index [c1]))
-  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/-rseek-datoms db index [c1 c2]))
-  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/-rseek-datoms db index [c1 c2 c3]))
-  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/-rseek-datoms db index [c1 c2 c3 c4])))
+  ([db index] {:pre [(dbu/db? db)]} (dbi/rseek-datoms db index []))
+  ([db index c1] {:pre [(dbu/db? db)]} (dbi/rseek-datoms db index [c1]))
+  ([db index c1 c2] {:pre [(dbu/db? db)]} (dbi/rseek-datoms db index [c1 c2]))
+  ([db index c1 c2 c3] {:pre [(dbu/db? db)]} (dbi/rseek-datoms db index [c1 c2 c3]))
+  ([db index c1 c2 c3 c4] {:pre [(dbu/db? db)]} (dbi/rseek-datoms db index [c1 c2 c3 c4])))
 
 (defn index-range
   [db attr start end]
   {:pre [(dbu/db? db)]}
-  (dbi/-index-range db attr start end))
+  (dbi/index-range db attr start end))
 
 ;; Conn
 

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -137,6 +137,68 @@
       (update :aevt di/-persistent!)
       (update :avet di/-persistent!)))
 
+(defn contextual-search-fn [{:keys [temporal?]}]
+  (case temporal?
+    true dbs/temporal-search
+    false dbs/search-current-indices))
+
+(defn contextual-search [db pattern context]
+  ((contextual-search-fn context) db pattern))
+
+(defn contextual-datoms [db index-type cs {:keys [temporal?]}]
+  (case temporal?
+    true (dbu/temporal-datoms db index-type cs)
+    false (di/-slice
+           (get db index-type)
+           (dbu/components->pattern db index-type cs e0 tx0)
+           (dbu/components->pattern db index-type cs emax txmax)
+           index-type)))
+
+(defn contextual-seek-datoms [db index-type cs {:keys [temporal?]}]
+  (case temporal?
+    true (dbs/temporal-seek-datoms db index-type cs)
+    false (di/-slice (get db index-type)
+                     (dbu/components->pattern db index-type cs e0 tx0)
+                     (datom emax nil nil txmax)
+                     index-type)))
+
+(defn contextual-rseek-datoms [db index-type cs {:keys [temporal?]}]
+  (case temporal?
+    true (dbs/temporal-rseek-datoms db index-type cs)
+    false (-> (di/-slice (get db index-type)
+                         (dbu/components->pattern db index-type cs e0 tx0)
+                         (datom emax nil nil txmax)
+                         index-type)
+              vec
+              rseq)))
+
+(defn contextual-index-range [db avet attr start end {:keys [temporal? current-db]}]
+  {:pre [(or (not temporal?) current-db)]}
+  (case temporal?
+    true (dbs/temporal-index-range db current-db attr start end)
+    false (do (when-not (dbu/indexing? db attr)
+                (raise "Attribute"
+                       attr "should be marked as :db/index true" {}))
+              
+              (dbu/validate-attr
+               attr (list '-index-range 'db attr start end) db)
+              (di/-slice
+               avet
+               (dbu/resolve-datom db nil attr start nil e0 tx0)
+               (dbu/resolve-datom db nil attr end nil emax txmax)
+               :avet))))
+
+(defn deeper-index-range [origin-db db attr start end context]
+  (dbi/-index-range origin-db
+                    attr
+                    start
+                    end
+                    (merge {:current-db db}
+                           context)))
+
+(defmacro todo [x] x)
+
+
 (defrecord-updatable DB [schema eavt aevt avet temporal-eavt temporal-aevt temporal-avet max-eid max-tx op-count rschema hash config system-entities ident-ref-map ref-ident-map meta]
   #?@(:cljs
       [IHash (-hash [db] hash)
@@ -175,70 +237,58 @@
   (-max-eid [db] max-eid)
   (-config [db] config)
   (-ref-for [db a-ident]
-            (if (:attribute-refs? config)
-              (let [ref (get ident-ref-map a-ident)]
-                (when (nil? ref)
-                  (warn (str "Attribute " a-ident " has not been found in database")))
-                ref)
-              a-ident))
+    (if (:attribute-refs? config)
+      (let [ref (get ident-ref-map a-ident)]
+        (when (nil? ref)
+          (warn (str "Attribute " a-ident " has not been found in database")))
+        ref)
+      a-ident))
   (-ident-for [db a-ref]
-              (if (:attribute-refs? config)
-                (let [a-ident (get ref-ident-map a-ref)]
-                  (when (nil? a-ident)
-                    (warn (str "Attribute with reference number " a-ref " has not been found in database")))
-                  a-ident)
-                a-ref))
+    (if (:attribute-refs? config)
+      (let [a-ident (get ref-ident-map a-ref)]
+        (when (nil? a-ident)
+          (warn (str "Attribute with reference number " a-ref " has not been found in database")))
+        a-ident)
+      a-ref))
 
   dbi/ISearch
-  (-search [db pattern]
-           (dbs/search-current-indices db pattern))
+  (-search-context [db] { ;; Don't merge datom operations when true.
+                         :historical? false
+
+                         ;; What index to use.
+                         :temporal? false})
+  (-search [db pattern context]
+    (contextual-search db pattern context))
 
   dbi/IIndexAccess
-  (-datoms [db index-type cs]
-           (di/-slice (get db index-type)
-                      (dbu/components->pattern db index-type cs e0 tx0)
-                      (dbu/components->pattern db index-type cs emax txmax)
-                      index-type))
+  (-datoms [db index-type cs context]
+           (contextual-datoms db index-type cs context))
 
-  (-seek-datoms [db index-type cs]
-                (di/-slice (get db index-type)
-                           (dbu/components->pattern db index-type cs e0 tx0)
-                           (datom emax nil nil txmax)
-                           index-type))
+  (-seek-datoms [db index-type cs context]
+                (contextual-seek-datoms db index-type cs context))
 
-  (-rseek-datoms [db index-type cs]
-                 (-> (di/-slice (get db index-type)
-                                (dbu/components->pattern db index-type cs e0 tx0)
-                                (datom emax nil nil txmax)
-                                index-type)
-                     vec
-                     rseq))
+  (-rseek-datoms [db index-type cs context]
+                 (contextual-rseek-datoms db index-type cs context))
 
-  (-index-range [db attr start end]
-                (when-not (dbu/indexing? db attr)
-                  (raise "Attribute" attr "should be marked as :db/index true" {}))
-                (dbu/validate-attr attr (list '-index-range 'db attr start end) db)
-                (di/-slice avet
-                           (dbu/resolve-datom db nil attr start nil e0 tx0)
-                           (dbu/resolve-datom db nil attr end nil emax txmax)
-                           :avet))
+  (-index-range [db attr start end context]
+                (contextual-index-range db avet attr start end context))
 
   data/EqualityPartition
   (equality-partition [x] :datahike/db)
 
   data/Diff
   (diff-similar [a b]
-                (let [datoms-a (di/-slice (:eavt a) (datom e0 nil nil tx0) (datom emax nil nil txmax) :eavt)
-                      datoms-b (di/-slice (:eavt b) (datom e0 nil nil tx0) (datom emax nil nil txmax) :eavt)]
-                  (dd/diff-sorted datoms-a datoms-b dd/cmp-datoms-eavt-quick))))
+    (let [datoms-a (di/-slice (:eavt a) (datom e0 nil nil tx0) (datom emax nil nil txmax) :eavt)
+          datoms-b (di/-slice (:eavt b) (datom e0 nil nil tx0) (datom emax nil nil txmax) :eavt)]
+      (dd/diff-sorted datoms-a datoms-b dd/cmp-datoms-eavt-quick))))
 
 ;; FilteredDB
 
 (defrecord-updatable FilteredDB [unfiltered-db pred]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
-       ISeqable (-seq [db] (dbi/-datoms db :eavt []))
-       ICounted (-count [db] (count (dbi/-datoms db :eavt [])))
+       ISeqable (-seq [db] (dbi/datoms db :eavt []))
+       ICounted (-count [db] (count (dbi/datoms db :eavt [])))
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on FilteredDB")))
@@ -252,12 +302,12 @@
 
       :clj
       [IPersistentCollection
-       (count [db] (count (dbi/-datoms db :eavt [])))
+       (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on FilteredDB")))
        (empty [db] (throw (UnsupportedOperationException. "empty is not supported on FilteredDB")))
 
-       Seqable (seq [db] (dbi/-datoms db :eavt []))
+       Seqable (seq [db] (dbi/datoms db :eavt []))
 
        clojure.lang.ILookup (valAt [db k] (throw (UnsupportedOperationException. "valAt/2 is not supported on FilteredDB")))
        (valAt [db k nf] (throw (UnsupportedOperationException. "valAt/3 is not supported on FilteredDB")))
@@ -283,29 +333,37 @@
   (-ident-for [db a-ref] (dbi/-ident-for unfiltered-db a-ref))
 
   dbi/ISearch
-  (-search [db pattern]
-           (filter (.-pred db) (dbi/-search unfiltered-db pattern)))
+  (-search-context [db] (dbi/-search-context unfiltered-db))
+  (-search [db pattern context]
+    (filter (.-pred db) (dbi/-search unfiltered-db pattern context)))
 
   dbi/IIndexAccess
-  (-datoms [db index cs]
-           (filter (.-pred db) (dbi/-datoms unfiltered-db index cs)))
+  (-datoms [db index cs context]
+           (filter (.-pred db) (dbi/-datoms unfiltered-db index cs context)))
 
-  (-seek-datoms [db index cs]
-                (filter (.-pred db) (dbi/-seek-datoms unfiltered-db index cs)))
+  (-seek-datoms [db index cs context]
+                (filter (.-pred db)
+                        (dbi/-seek-datoms unfiltered-db index cs context)))
 
-  (-rseek-datoms [db index cs]
-                 (filter (.-pred db) (dbi/-rseek-datoms unfiltered-db index cs)))
+  (-rseek-datoms [db index cs context]
+                 (filter (.-pred db)
+                         (dbi/-rseek-datoms unfiltered-db index cs context)))
 
-  (-index-range [db attr start end]
-                (filter (.-pred db) (dbi/-index-range unfiltered-db attr start end))))
+  (-index-range [db attr start end context]
+                (filter (.-pred db)
+                        (deeper-index-range unfiltered-db
+                                            db
+                                            attr
+                                            start end
+                                            context))))
 
 ;; HistoricalDB
 
 (defrecord-updatable HistoricalDB [origin-db]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
-       ISeqable (-seq [db] (dbi/-datoms db :eavt []))
-       ICounted (-count [db] (count (dbi/-datoms db :eavt [])))
+       ISeqable (-seq [db] (dbi/datoms db :eavt []))
+       ICounted (-count [db] (count (dbi/datoms db :eavt [])))
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on HistoricalDB")))
@@ -318,13 +376,13 @@
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on HistoricalDB")))]
       :clj
       [IPersistentCollection
-       (count [db] (count (dbi/-datoms db :eavt [])))
+       (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on HistoricalDB")))
        (empty [db] (throw (UnsupportedOperationException. "empty is not supported on HistoricalDB")))
 
        Seqable
-       (seq [db] (dbi/-datoms db :eavt []))
+       (seq [db] (dbi/datoms db :eavt []))
 
        Associative
        (assoc [db k v] (throw (UnsupportedOperationException. "assoc is not supported on HistoricalDB")))])
@@ -347,17 +405,21 @@
   (-origin [db] origin-db)
 
   dbi/ISearch
-  (-search [db pattern]
-           (dbs/temporal-search origin-db pattern))
+  (-search-context [db]
+    (assoc (dbi/-search-context origin-db)
+           :historical? true
+           :temporal? true))
+  (-search [db pattern context]
+    (dbi/-search origin-db pattern context))
 
   dbi/IIndexAccess
-  (-datoms [db index-type cs] (dbu/temporal-datoms origin-db index-type cs))
+  (-datoms [db index-type cs context] (dbi/-datoms origin-db index-type cs context))
 
-  (-seek-datoms [db index-type cs] (dbs/temporal-seek-datoms origin-db index-type cs))
+  (-seek-datoms [db index-type cs context] (dbi/-seek-datoms origin-db index-type cs context))
 
-  (-rseek-datoms [db index-type cs] (dbs/temporal-rseek-datoms origin-db index-type cs))
+  (-rseek-datoms [db index-type cs context] (dbi/-seek-datoms origin-db index-type cs context))
 
-  (-index-range [db attr start end] (dbs/temporal-index-range origin-db db attr start end)))
+  (-index-range [db attr start end context] (deeper-index-range origin-db db attr start end context)))
 
 ;; AsOfDB
 
@@ -386,23 +448,28 @@
                 [current-ea-datom]
                 [])))))))
 
-(defn filter-as-of-datoms [datoms time-point db]
+(defn filter-as-of-datoms [datoms time-point db {:keys [historical?]}]
+  {:pre [(boolean? historical?)]}
   (let [as-of-pred (fn [^Datom d]
                      (if (date? time-point)
                        (.before ^Date (.-v d) ^Date time-point)
                        (<= (dd/datom-tx d) time-point)))
 
         filtered-tx-ids (dbu/filter-txInstant datoms as-of-pred db)
-        filtered-datoms (->> datoms
-                             (filter (fn [^Datom d] (contains? filtered-tx-ids (datom-tx d))))
-                             (get-current-values db))]
-    filtered-datoms))
+        filtered-datoms (into []
+                              (filter (fn [^Datom d]
+                                        (contains? filtered-tx-ids
+                                                   (datom-tx d))))
+                              datoms)]
+    (if historical?
+      filtered-datoms
+      (get-current-values db filtered-datoms))))
 
 (defrecord-updatable AsOfDB [origin-db time-point]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
-       ISeqable (-seq [db] (dbi/-datoms db :eavt []))
-       ICounted (-count [db] (count (dbi/-datoms db :eavt [])))
+       ISeqable (-seq [db] (dbi/datoms db :eavt []))
+       ICounted (-count [db] (count (dbi/datoms db :eavt [])))
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on AsOfDB")))
@@ -415,13 +482,13 @@
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on AsOfDB")))]
       :clj
       [IPersistentCollection
-       (count [db] (count (dbi/-datoms db :eavt [])))
+       (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on AsOfDB")))
        (empty [db] (throw (UnsupportedOperationException. "empty is not supported on AsOfDB")))
 
        Seqable
-       (seq [db] (dbi/-datoms db :eavt []))
+       (seq [db] (dbi/datoms db :eavt []))
 
        Associative
        (assoc [db k v] (throw (UnsupportedOperationException. "assoc is not supported on AsOfDB")))])
@@ -444,44 +511,52 @@
   (-origin [db] origin-db)
 
   dbi/ISearch
-  (-search [db pattern]
-           (-> (dbs/temporal-search origin-db pattern)
-               (filter-as-of-datoms time-point origin-db)))
+  (-search-context [db] (assoc (dbi/-search-context origin-db)
+                               :temporal? true))
+  (-search [db pattern context]
+    (-> (dbi/-search origin-db pattern context)
+        (filter-as-of-datoms time-point origin-db context)))
 
   dbi/IIndexAccess
-  (-datoms [db index-type cs]
-           (-> (dbu/temporal-datoms origin-db index-type cs)
-               (filter-as-of-datoms time-point origin-db)))
+  (-datoms [db index-type cs context]
+           (-> (dbi/-datoms origin-db index-type cs context)
+               (filter-as-of-datoms time-point origin-db context)))
 
-  (-seek-datoms [db index-type cs]
-                (-> (dbs/temporal-seek-datoms origin-db index-type cs)
-                    (filter-as-of-datoms time-point origin-db)))
+  (-seek-datoms [db index-type cs context]
+                (-> (dbi/-seek-datoms origin-db index-type cs context)
+                    (filter-as-of-datoms time-point origin-db context)))
 
-  (-rseek-datoms [db index-type cs]
-                 (-> (dbs/temporal-rseek-datoms origin-db index-type cs)
-                     (filter-as-of-datoms time-point origin-db)))
+  (-rseek-datoms [db index-type cs context]
+                 (-> (dbi/-rseek-datoms origin-db index-type cs context)
+                     (filter-as-of-datoms time-point origin-db context)))
 
-  (-index-range [db attr start end]
-                (-> (dbs/temporal-index-range origin-db db attr start end)
-                    (filter-as-of-datoms time-point origin-db))))
+  (-index-range [db attr start end context]
+                (-> (deeper-index-range origin-db db attr start end context)
+                    (filter-as-of-datoms time-point origin-db context))))
 
 ;; SinceDB
 
-(defn- filter-since [datoms time-point db]
+(defn- filter-since [datoms time-point db {:keys [historical?]}]
+  {:pre [(boolean? historical?)]}
   (let [since-pred (fn [^Datom d]
                      (if (date? time-point)
                        (.after ^Date (.-v d) ^Date time-point)
                        (>= (.-tx d) time-point)))
-        filtered-tx-ids (dbu/filter-txInstant datoms since-pred db)]
-    (->> datoms
-         (filter datom-added)
-         (filter (fn [^Datom d] (contains? filtered-tx-ids (datom-tx d)))))))
+        filtered-tx-ids (dbu/filter-txInstant datoms since-pred db)
+        filtered-datoms (into []
+                              (filter (fn [^Datom d]
+                                        (contains? filtered-tx-ids (datom-tx d))))
+                              datoms)]
+    
+    (if historical?
+      filtered-datoms
+      (get-current-values db filtered-datoms))))
 
 (defrecord-updatable SinceDB [origin-db time-point]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
-       ISeqable (-seq [db] (dbi/-datoms db :eavt []))
-       ICounted (-count [db] (count (dbi/-datoms db :eavt [])))
+       ISeqable (-seq [db] (dbi/datoms db :eavt []))
+       ICounted (-count [db] (count (dbi/datoms db :eavt [])))
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on SinceDB")))
@@ -494,13 +569,13 @@
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on SinceDB")))]
       :clj
       [IPersistentCollection
-       (count [db] (count (dbi/-datoms db :eavt [])))
+       (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on SinceDB")))
        (empty [db] (throw (UnsupportedOperationException. "empty is not supported on SinceDB")))
 
        Seqable
-       (seq [db] (dbi/-datoms db :eavt []))
+       (seq [db] (dbi/datoms db :eavt []))
 
        Associative
        (assoc [db k v] (throw (UnsupportedOperationException. "assoc is not supported on SinceDB")))])
@@ -523,26 +598,32 @@
   (-origin [db] origin-db)
 
   dbi/ISearch
-  (-search [db pattern]
-           (-> (dbs/temporal-search origin-db pattern)
-               (filter-since time-point origin-db)))
+  (-search-context [db] (assoc (dbi/-search-context origin-db)
+                               :temporal? true))
+  (-search [db pattern context]
+    (-> (dbi/-search origin-db pattern context)
+        (filter-since time-point origin-db context)))
 
   dbi/IIndexAccess
-  (dbi/-datoms [db index-type cs]
-               (-> (dbu/temporal-datoms origin-db index-type cs)
-                   (filter-since time-point origin-db)))
+  (dbi/-datoms [db index-type cs context]
+               (-> (dbi/-datoms origin-db index-type cs context)
+                   (filter-since time-point origin-db context)))
 
-  (dbi/-seek-datoms [db index-type cs]
-                    (-> (dbs/temporal-seek-datoms origin-db index-type cs)
-                        (filter-since time-point origin-db)))
+  (dbi/-seek-datoms [db index-type cs context]
+                    (-> (dbi/-seek-datoms origin-db index-type cs context)
+                        (filter-since time-point origin-db context)))
 
-  (dbi/-rseek-datoms [db index-type cs]
-                     (-> (dbs/temporal-rseek-datoms origin-db index-type cs)
-                         (filter-since time-point origin-db)))
+  (dbi/-rseek-datoms [db index-type cs context]
+                     (-> (dbi/-rseek-datoms origin-db index-type cs context)
+                         (filter-since time-point origin-db context)))
 
-  (dbi/-index-range [db attr start end]
-                    (-> (dbs/temporal-index-range origin-db db attr start end)
-                        (filter-since time-point origin-db))))
+  (dbi/-index-range [db attr start end context]
+                    (-> (deeper-index-range origin-db
+                                            db
+                                            attr
+                                            start end
+                                            context)
+                        (filter-since time-point origin-db context))))
 
 (defn- equiv-db-index [x y]
   (loop [xs (seq x)
@@ -556,7 +637,7 @@
   (and (or (instance? DB other) (instance? FilteredDB other))
        (or (not (instance? DB other)) (= (hash db) (hash other)))
        (= (dbi/-schema db) (dbi/-schema other))
-       (equiv-db-index (dbi/-datoms db :eavt []) (dbi/-datoms other :eavt []))))
+       (equiv-db-index (dbi/datoms db :eavt []) (dbi/datoms other :eavt []))))
 
 #?(:cljs
    (defn pr-db [db w opts]

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -196,9 +196,6 @@
                     (merge {:current-db db}
                            context)))
 
-(defmacro todo [x] x)
-
-
 (defrecord-updatable DB [schema eavt aevt avet temporal-eavt temporal-aevt temporal-avet max-eid max-tx op-count rschema hash config system-entities ident-ref-map ref-ident-map meta]
   #?@(:cljs
       [IHash (-hash [db] hash)

--- a/src/datahike/db/interface.cljc
+++ b/src/datahike/db/interface.cljc
@@ -3,13 +3,29 @@
 ;; Database Protocols
 
 (defprotocol ISearch
-  (-search [data pattern]))
+  (-search-context [data])
+  (-search [data pattern context]))
+
+(defn search [data pattern]
+  (-search data pattern (-search-context data)))
 
 (defprotocol IIndexAccess
-  (-datoms [db index components])
-  (-seek-datoms [db index components])
-  (-rseek-datoms [db index components])
-  (-index-range [db attr start end]))
+  (-datoms [db index components context])
+  (-seek-datoms [db index components context])
+  (-rseek-datoms [db index components context])
+  (-index-range [db attr start end context]))
+
+(defn datoms [db index components]
+  (-datoms db index components (-search-context db)))
+
+(defn seek-datoms [db index components]
+  (-seek-datoms db index components (-search-context db)))
+
+(defn rseek-datoms [db index components]
+  (-rseek-datoms db index components (-search-context db)))
+
+(defn index-range [db attr start end]
+  (-index-range db attr start end (-search-context db)))
 
 (defprotocol IDB
   (-schema [db])
@@ -18,7 +34,7 @@
   (-attrs-by [db property])
   (-max-tx [db])
   (-max-eid [db])
-  (-temporal-index? [db])                                   ;;deprecated
+  (-temporal-index? [db]) ;;deprecated
   (-keep-history? [db])
   (-config [db])
   (-ref-for [db a-ident])

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -117,12 +117,12 @@
          (nil? value)
          nil
          :else
-         (-> (dbi/-datoms db :avet eid) first :e)))
+         (-> (dbi/datoms db :avet eid) first :e)))
 
-     #?@(:cljs [(array? eid) (recur db (array-seq eid))])
+     #?@(:cljs [(array? eid) (recur db (array-seq eid) error-code)])
 
      (keyword? eid)
-     (-> (dbi/-datoms db :avet [:db/ident eid]) first :e)
+     (-> (dbi/datoms db :avet [:db/ident eid]) first :e)
 
      :else
      (or error-code
@@ -210,7 +210,7 @@
           (comp
            (map datom-tx)
            (distinct)
-           (mapcat (fn [tx] (temporal-datoms db :eavt [tx])))
+           (mapcat (fn [tx] (dbi/-datoms db :eavt [tx] {:temporal? true :historical? false})))
            (keep (fn [^Datom d]
                    (when (and (= txInstant (.-a d)) (pred d))
                      (.-e d)))))

--- a/src/datahike/impl/entity.cljc
+++ b/src/datahike/impl/entity.cljc
@@ -32,7 +32,7 @@
   "Translate reverse attribute recording to database and find datoms"
   [db eid a-ident not-found]
   (let [a-db (if (:attribute-refs? (dbi/-config db)) (dbi/-ref-for db a-ident) a-ident)]
-    (if-let [datoms (not-empty (dbi/-search db [nil a-db eid]))]
+    (if-let [datoms (not-empty (dbi/search db [nil a-db eid]))]
       (if (dbu/component? db a-ident)
         (entity db (:e (first datoms)))
         (reduce #(conj %1 (entity db (:e %2))) #{} datoms))
@@ -176,7 +176,7 @@
            (if-let [a-db (if (:attribute-refs? (dbi/-config (.-db this)))
                            (dbi/-ref-for (.-db this) a-ident)
                            a-ident)]
-             (if-some [datoms (not-empty (dbi/-search (.-db this) [(.-eid this) a-db]))]
+             (if-some [datoms (not-empty (dbi/search (.-db this) [(.-eid this) a-db]))]
                (let [value (entity-attr (.-db this) a-ident datoms)]
                  (vreset! (.-cache this) (assoc @(.-cache this) a-ident value))
                  value)
@@ -205,7 +205,7 @@
 (defn touch [^Entity e]
   {:pre [(entity? e)]}
   (when-not @(.-touched e)
-    (when-let [datoms (not-empty (dbi/-search (.-db e) [(.-eid e)]))]
+    (when-let [datoms (not-empty (dbi/search (.-db e) [(.-eid e)]))]
       (vreset! (.-cache e) (->> datoms
                                 (datoms->cache (.-db e))
                                 (touch-components (.-db e))))

--- a/src/datahike/pull_api.cljc
+++ b/src/datahike/pull_api.cljc
@@ -177,7 +177,7 @@
   [db spec eid frames]
   (let [[attr-key opts] spec]
     (if (= :db/id attr-key)
-      (if (not-empty (dbi/-datoms db :eavt [eid]))
+      (if (not-empty (dbi/datoms db :eavt [eid]))
         (conj (rest frames)
               (update (first frames) :kvps assoc! :db/id eid))
         frames)
@@ -190,8 +190,8 @@
             results  (if (nil? a)
                        []
                        (if forward?
-                         (dbi/-datoms db :eavt [eid a])
-                         (dbi/-datoms db :avet [a eid])))]
+                         (dbi/datoms db :eavt [eid a])
+                         (dbi/datoms db :avet [a eid])))]
         (pull-attr-datoms db attr-key attr eid forward?
                           results opts frames)))))
 
@@ -247,7 +247,7 @@
   (let [datoms (group-by (fn [d] (if (:attribute-refs? (dbi/-config db))
                                    (dbi/-ident-for db (.-a ^Datom d))
                                    (.-a ^Datom d)))
-                         (dbi/-datoms db :eavt [eid]))
+                         (dbi/datoms db :eavt [eid]))
         {:keys [attr recursion]} frame
         rec (cond-> recursion
               (some? attr) (push-recursion attr eid))]

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -245,7 +245,7 @@
   [db e a else-val]
   (when (nil? else-val)
     (dt/raise "get-else: nil default value is not supported" {:error :query/where}))
-  (if-some [datom (first (dbi/-search db [e (translate-for db a)]))]
+  (if-some [datom (first (dbi/search db [e (translate-for db a)]))]
     (:v datom)
     else-val))
 
@@ -253,7 +253,7 @@
   [db e & as]
   (reduce
    (fn [_ a]
-     (when-some [datom (first (dbi/-search db [e (translate-for db a)]))]
+     (when-some [datom (first (dbi/search db [e (translate-for db a)]))]
        (let [a-ident (if (keyword? (:a datom))
                        (:a datom)
                        (dbi/-ident-for db (:a datom)))]
@@ -604,9 +604,9 @@
         search-pattern (mapv #(if (symbol? %) nil %) pattern)
         datoms  (if (first search-pattern)
                   (if-let [eid (dbu/entid db (first search-pattern))]
-                    (dbi/-search db (assoc search-pattern 0 eid))
+                    (dbi/search db (assoc search-pattern 0 eid))
                     [])
-                  (dbi/-search db search-pattern))
+                  (dbi/search db search-pattern))
         idx->const (reduce-kv (fn [m k v]
                                 (if-let [c (k (:consts context))]
                                   (if (= c (get (first datoms) v)) ;; All datoms have the same format and the same value at position v


### PR DESCRIPTION
#### SUMMARY

Fixes #682 

Makes it possible to compose `history`, `as-of` and `since` in arbitrary ways, e.g. `(-> @conn history (as-of tx-id) (since tx-id2))`.

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked
