### PR TITLE
Fix issue 684: Make it possible to compare values of different types

### DIFF
--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -242,10 +242,21 @@
      :clj
      (.compareTo ^Comparable a1 a2)))
 
+(defn- class-name [x]
+  (let [c (class x)]
+    (.getName ^Class c)))
+
+(defn- safe-compare [a b]
+  (try
+    (compare a b)
+    (catch Exception _e
+      (compare (class-name a)
+               (class-name b)))))
+
 (defn cmp-nil [o1 o2]
   (if (nil? o1) nil
       (if (nil? o2) nil
-          (compare o1 o2))))
+          (safe-compare o1 o2))))
 
 (defn type-hint-datom [x]
   (vary-meta x assoc :tag `Datom))

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -37,6 +37,18 @@
              [3 3 "Ivan"]
              [3 2 "Petr"]}))))
 
+(deftest test-mixed-age-types
+  (let [db (-> (db/empty-db)
+               (d/db-with [{:db/id 1, :name  "Ivan", :age   15}
+                           {:db/id 2, :name  "Petr", :age   "37"}
+                           {:db/id 3, :name  "Ivan", :age   :thirtyseven}
+                           {:db/id 4, :age 15}]))]
+    (is (= (d/q '[:find  ?e ?name
+                  :where
+                  [?e :name ?name]
+                  [?e :age "37"]] db)
+           #{[2 "Petr"]}))))
+
 (deftest test-q-many
   (let [db (-> (db/empty-db {:aka {:db/cardinality :db.cardinality/many}})
                (d/db-with [[:db/add 1 :name "Ivan"]


### PR DESCRIPTION
Fixes #684 

#### SUMMARY

Makes it possible to run queries that require comparing values of different types, such as numbers and strings. The exact order between values of different types is not important, as long as it is consistent and well-defined.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked