### PR TITLE
Update datalog-parser dependency: Support pull patterns being sets

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
                                                      :exclusions [org.clojure/clojurescript]}
         io.replikativ/superv.async                  {:mvn/version "0.3.46"
                                                      :exclusions [org.clojure/clojurescript]}
-        io.replikativ/datalog-parser                {:mvn/version "0.2.28"}
+        io.replikativ/datalog-parser                {:mvn/version "0.2.29"}
         io.replikativ/zufall                        {:mvn/version "0.2.9"}
         persistent-sorted-set/persistent-sorted-set {:mvn/version "0.3.0"}
         environ/environ                             {:mvn/version "1.2.0"}

--- a/test/datahike/test/query_pull_test.cljc
+++ b/test/datahike/test/query_pull_test.cljc
@@ -27,6 +27,9 @@
 
     '[?e ?a (pull ?e [:name])]
     #{[2 25 {:name "Ivan"}] [1 44 {:name "Petr"}]}
+    
+    '[?e ?a (pull ?e #{:name})]
+    #{[2 25 {:name "Ivan"}] [1 44 {:name "Petr"}]}
 
     '[?e (pull ?e [:name]) ?a]
     #{[2 {:name "Ivan"} 25] [1 {:name "Petr"} 44]}))
@@ -39,6 +42,9 @@
                                        test-db pattern))
                              res)
     '[(pull ?e ?pattern)] [:name]
+    #{[{:name "Ivan"}] [{:name "Petr"}]}
+    
+    '[(pull ?e ?pattern)] #{:name}
     #{[{:name "Ivan"}] [{:name "Petr"}]}
 
     '[?e ?a ?pattern (pull ?e ?pattern)] [:name]
@@ -83,6 +89,10 @@
                 :where [?e :age 25]]
               test-db)
          {:name "Ivan"}))
+  (is (= (d/q '[:find (pull ?e #{:name}) .
+                :where [?e :age 25]]
+              test-db)
+         {:name "Ivan"}))
 
   (is (= (set (d/q '[:find [(pull ?e [:name]) ...]
                      :where [?e :age ?a]]
@@ -99,6 +109,11 @@
                 :in $ ?p
                 :where [(ground 2) ?e]]
               test-db [:name])
+         {:name "Ivan"}))
+  (is (= (d/q '[:find (pull ?e ?p) .
+                :in $ ?p
+                :where [(ground 2) ?e]]
+              test-db #{:name})
          {:name "Ivan"}))
   (is (= (d/q '[:find (pull ?e p) .
                 :in $ p

--- a/test/datahike/test/query_pull_test.cljc
+++ b/test/datahike/test/query_pull_test.cljc
@@ -27,7 +27,7 @@
 
     '[?e ?a (pull ?e [:name])]
     #{[2 25 {:name "Ivan"}] [1 44 {:name "Petr"}]}
-    
+
     '[?e ?a (pull ?e #{:name})]
     #{[2 25 {:name "Ivan"}] [1 44 {:name "Petr"}]}
 
@@ -43,7 +43,7 @@
                              res)
     '[(pull ?e ?pattern)] [:name]
     #{[{:name "Ivan"}] [{:name "Petr"}]}
-    
+
     '[(pull ?e ?pattern)] #{:name}
     #{[{:name "Ivan"}] [{:name "Petr"}]}
 


### PR DESCRIPTION
#### SUMMARY

Fixes #686 

Update the datalog parser dependency to version `0.2.29` to allow pull patterns to be *sets*, so that we can write queries like this one:

```clj
(d/q '[:find (pull ?e #{:name}) .
      :where [?e :age 25]]
     test-db)
```

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked