### PR TITLE
Refactor db interface

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -168,7 +168,7 @@
   (let [xform (dbi/context-xform context)
         time-pred (dbi/context-time-pred context)]
     (cond
-      
+
       time-pred
       (let [time-xform (temporal-datom-filter datoms time-pred db)]
         (if (dbi/context-historical? context)
@@ -178,9 +178,9 @@
                           (group-by-step (fn [^Datom datom]
                                            [(.-e datom) (.-a datom)])))
                (into [] (dbi/nil-comp (assemble-datoms-xform db) xform)))))
-      
+
       xform (into [] xform datoms)
-      
+
       :else datoms)))
 
 (defn db-transient [db]
@@ -462,9 +462,9 @@
 
   dbi/ISearch
   (-search-context [db]
-    (-> origin-db
-        dbi/-search-context
-        dbi/context-with-history))
+                   (-> origin-db
+                       dbi/-search-context
+                       dbi/context-with-history))
   (-search [db pattern context]
            (dbi/-search origin-db pattern context))
 

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -12,7 +12,7 @@
    [datahike.index :as di]
    [datahike.schema :as ds]
    [datahike.store :as store]
-   [datahike.tools :as tools :refer [raise]]
+   [datahike.tools :as tools :refer [raise group-by-step]]
    [me.tonsky.persistent-sorted-set.arrays :as arrays]
    [medley.core :as m]
    [taoensso.timbre :refer [warn]])
@@ -125,6 +125,64 @@
 
 ;; DB
 
+(defn- date? [d]
+  #?(:cljs (instance? js/Date d)
+     :clj (instance? Date d)))
+
+(defn- as-of-pred [time-point]
+  (if (date? time-point)
+    (fn [^Datom d] (.before ^Date (.-v d) ^Date time-point))
+    (fn [^Datom d] (<= (dd/datom-tx d) time-point))))
+
+(defn- since-pred [time-point]
+  (if (date? time-point)
+    (fn [^Datom d] (.after ^Date (.-v d) ^Date time-point))
+    (fn [^Datom d] (>= (.-tx d) time-point))))
+
+(defn assemble-datoms-xform [db]
+  (mapcat
+   (fn [[[_ a] datoms]]
+     (if (dbu/multival? db a)
+       (->> datoms
+            (sort-by datom-tx)
+            (reduce (fn [current-datoms ^Datom datom]
+                      (if (datom-added datom)
+                        (assoc current-datoms (.-v datom) datom)
+                        (dissoc current-datoms (.-v datom))))
+                    {})
+            vals)
+       (let [last-ea-tx (apply max (map datom-tx datoms))
+             current-ea-datom (first (filter #(and (datom-added %) (= last-ea-tx (datom-tx %)))
+                                             datoms))]
+         (if current-ea-datom
+           [current-ea-datom]
+           []))))))
+
+(defn temporal-datom-filter [datoms pred db]
+  (let [filtered-tx-ids (dbu/filter-txInstant datoms pred db)]
+    (filter (fn [^Datom d]
+              (contains? filtered-tx-ids
+                         (datom-tx d))))))
+
+(defn- post-process-datoms [datoms db context]
+  (let [xform (dbi/context-xform context)
+        time-pred (dbi/context-time-pred context)]
+    (cond
+      
+      time-pred
+      (let [time-xform (temporal-datom-filter datoms time-pred db)]
+        (if (dbi/context-historical? context)
+          (into [] (dbi/nil-comp time-xform xform) datoms)
+          (->> datoms
+               (transduce time-xform
+                          (group-by-step (fn [^Datom datom]
+                                           [(.-e datom) (.-a datom)])))
+               (into [] (dbi/nil-comp (assemble-datoms-xform db) xform)))))
+      
+      xform (into [] xform datoms)
+      
+      :else datoms)))
+
 (defn db-transient [db]
   (-> db
       (update :eavt di/-transient)
@@ -137,64 +195,70 @@
       (update :aevt di/-persistent!)
       (update :avet di/-persistent!)))
 
-(defn contextual-search-fn [{:keys [temporal?]}]
-  (case temporal?
+(defn contextual-search-fn [context]
+  (case (dbi/context-temporal? context)
     true dbs/temporal-search
     false dbs/search-current-indices))
 
 (defn contextual-search [db pattern context]
-  ((contextual-search-fn context) db pattern))
+  (-> ((contextual-search-fn context) db pattern)
+      (post-process-datoms db context)))
 
-(defn contextual-datoms [db index-type cs {:keys [temporal?]}]
-  (case temporal?
-    true (dbu/temporal-datoms db index-type cs)
-    false (di/-slice
-           (get db index-type)
-           (dbu/components->pattern db index-type cs e0 tx0)
-           (dbu/components->pattern db index-type cs emax txmax)
-           index-type)))
+(defn contextual-datoms [db index-type cs context]
+  (-> (case (dbi/context-temporal? context)
+        true (dbu/temporal-datoms db index-type cs)
+        false (di/-slice
+               (get db index-type)
+               (dbu/components->pattern db index-type cs e0 tx0)
+               (dbu/components->pattern db index-type cs emax txmax)
+               index-type))
+      (post-process-datoms db context)))
 
-(defn contextual-seek-datoms [db index-type cs {:keys [temporal?]}]
-  (case temporal?
-    true (dbs/temporal-seek-datoms db index-type cs)
-    false (di/-slice (get db index-type)
-                     (dbu/components->pattern db index-type cs e0 tx0)
-                     (datom emax nil nil txmax)
-                     index-type)))
-
-(defn contextual-rseek-datoms [db index-type cs {:keys [temporal?]}]
-  (case temporal?
-    true (dbs/temporal-rseek-datoms db index-type cs)
-    false (-> (di/-slice (get db index-type)
+(defn contextual-seek-datoms [db index-type cs context]
+  (-> (case (dbi/context-temporal? context)
+        true (dbs/temporal-seek-datoms db index-type cs)
+        false (di/-slice (get db index-type)
                          (dbu/components->pattern db index-type cs e0 tx0)
                          (datom emax nil nil txmax)
-                         index-type)
-              vec
-              rseq)))
+                         index-type))
+      (post-process-datoms db context)))
 
-(defn contextual-index-range [db avet attr start end {:keys [temporal? current-db]}]
-  {:pre [(or (not temporal?) current-db)]}
-  (case temporal?
-    true (dbs/temporal-index-range db current-db attr start end)
-    false (do (when-not (dbu/indexing? db attr)
-                (raise "Attribute"
-                       attr "should be marked as :db/index true" {}))
+(defn contextual-rseek-datoms [db index-type cs context]
+  (-> (case (dbi/context-temporal? context)
+        true (dbs/temporal-rseek-datoms db index-type cs)
+        false (-> (di/-slice (get db index-type)
+                             (dbu/components->pattern db index-type cs e0 tx0)
+                             (datom emax nil nil txmax)
+                             index-type)
+                  vec
+                  rseq))
+      (post-process-datoms db context)))
 
-              (dbu/validate-attr
-               attr (list '-index-range 'db attr start end) db)
-              (di/-slice
-               avet
-               (dbu/resolve-datom db nil attr start nil e0 tx0)
-               (dbu/resolve-datom db nil attr end nil emax txmax)
-               :avet))))
+(defn contextual-index-range [db avet attr start end context]
+  (let [temporal? (dbi/context-temporal? context)
+        current-db (dbi/context-current-db context)]
+    (assert (or (not temporal?) current-db))
+    (-> (case temporal?
+          true (dbs/temporal-index-range db current-db attr start end)
+          false (do (when-not (dbu/indexing? db attr)
+                      (raise "Attribute"
+                             attr "should be marked as :db/index true" {}))
+
+                    (dbu/validate-attr
+                     attr (list '-index-range 'db attr start end) db)
+                    (di/-slice
+                     avet
+                     (dbu/resolve-datom db nil attr start nil e0 tx0)
+                     (dbu/resolve-datom db nil attr end nil emax txmax)
+                     :avet)))
+        (post-process-datoms db context))))
 
 (defn deeper-index-range [origin-db db attr start end context]
   (dbi/-index-range origin-db
                     attr
                     start
                     end
-                    (merge {:current-db db}
-                           context)))
+                    (dbi/context-set-current-db-if-not-set context db)))
 
 (defrecord-updatable DB [schema eavt aevt avet temporal-eavt temporal-aevt temporal-avet max-eid max-tx op-count rschema hash config system-entities ident-ref-map ref-ident-map meta]
   #?@(:cljs
@@ -249,11 +313,7 @@
                 a-ref))
 
   dbi/ISearch
-  (-search-context [db] {;; Don't merge datom operations when true.
-                         :historical? false
-
-                         ;; What index to use.
-                         :temporal? false})
+  (-search-context [db] dbi/base-context)
   (-search [db pattern context]
            (contextual-search db pattern context))
 
@@ -330,29 +390,28 @@
   (-ident-for [db a-ref] (dbi/-ident-for unfiltered-db a-ref))
 
   dbi/ISearch
-  (-search-context [db] (dbi/-search-context unfiltered-db))
+  (-search-context [db] (dbi/context-with-xform-after
+                         (dbi/-search-context unfiltered-db)
+                         (filter (.-pred db))))
   (-search [db pattern context]
-           (filter (.-pred db) (dbi/-search unfiltered-db pattern context)))
+           (dbi/-search unfiltered-db pattern context))
 
   dbi/IIndexAccess
   (-datoms [db index cs context]
-           (filter (.-pred db) (dbi/-datoms unfiltered-db index cs context)))
+           (dbi/-datoms unfiltered-db index cs context))
 
   (-seek-datoms [db index cs context]
-                (filter (.-pred db)
-                        (dbi/-seek-datoms unfiltered-db index cs context)))
+                (dbi/-seek-datoms unfiltered-db index cs context))
 
   (-rseek-datoms [db index cs context]
-                 (filter (.-pred db)
-                         (dbi/-rseek-datoms unfiltered-db index cs context)))
+                 (dbi/-rseek-datoms unfiltered-db index cs context))
 
   (-index-range [db attr start end context]
-                (filter (.-pred db)
-                        (deeper-index-range unfiltered-db
-                                            db
-                                            attr
-                                            start end
-                                            context))))
+                (deeper-index-range unfiltered-db
+                                    db
+                                    attr
+                                    start end
+                                    context)))
 
 ;; HistoricalDB
 
@@ -403,9 +462,9 @@
 
   dbi/ISearch
   (-search-context [db]
-                   (assoc (dbi/-search-context origin-db)
-                          :historical? true
-                          :temporal? true))
+    (-> origin-db
+        dbi/-search-context
+        dbi/context-with-history))
   (-search [db pattern context]
            (dbi/-search origin-db pattern context))
 
@@ -419,48 +478,6 @@
   (-index-range [db attr start end context] (deeper-index-range origin-db db attr start end context)))
 
 ;; AsOfDB
-
-(defn- date? [d]
-  #?(:cljs (instance? js/Date d)
-     :clj (instance? Date d)))
-
-(defn get-current-values [db history-datoms]
-  (->> history-datoms
-       (group-by (fn [^Datom datom] [(.-e datom) (.-a datom)]))
-       (mapcat
-        (fn [[[_ a] datoms]]
-          (if (dbu/multival? db a)
-            (->> datoms
-                 (sort-by datom-tx)
-                 (reduce (fn [current-datoms ^Datom datom]
-                           (if (datom-added datom)
-                             (assoc current-datoms (.-v datom) datom)
-                             (dissoc current-datoms (.-v datom))))
-                         {})
-                 vals)
-            (let [last-ea-tx (apply max (map datom-tx datoms))
-                  current-ea-datom (first (filter #(and (datom-added %) (= last-ea-tx (datom-tx %)))
-                                                  datoms))]
-              (if current-ea-datom
-                [current-ea-datom]
-                [])))))))
-
-(defn filter-as-of-datoms [datoms time-point db {:keys [historical?]}]
-  {:pre [(boolean? historical?)]}
-  (let [as-of-pred (fn [^Datom d]
-                     (if (date? time-point)
-                       (.before ^Date (.-v d) ^Date time-point)
-                       (<= (dd/datom-tx d) time-point)))
-
-        filtered-tx-ids (dbu/filter-txInstant datoms as-of-pred db)
-        filtered-datoms (into []
-                              (filter (fn [^Datom d]
-                                        (contains? filtered-tx-ids
-                                                   (datom-tx d))))
-                              datoms)]
-    (if historical?
-      filtered-datoms
-      (get-current-values db filtered-datoms))))
 
 (defrecord-updatable AsOfDB [origin-db time-point]
   #?@(:cljs
@@ -508,46 +525,24 @@
   (-origin [db] origin-db)
 
   dbi/ISearch
-  (-search-context [db] (assoc (dbi/-search-context origin-db)
-                               :temporal? true))
+  (-search-context [db] (dbi/context-with-temporal-timepred
+                         (dbi/-search-context origin-db)
+                         (as-of-pred time-point)))
   (-search [db pattern context]
-           (-> (dbi/-search origin-db pattern context)
-               (filter-as-of-datoms time-point origin-db context)))
+           (dbi/-search origin-db pattern context))
 
   dbi/IIndexAccess
   (-datoms [db index-type cs context]
-           (-> (dbi/-datoms origin-db index-type cs context)
-               (filter-as-of-datoms time-point origin-db context)))
+           (dbi/-datoms origin-db index-type cs context))
 
   (-seek-datoms [db index-type cs context]
-                (-> (dbi/-seek-datoms origin-db index-type cs context)
-                    (filter-as-of-datoms time-point origin-db context)))
+                (dbi/-seek-datoms origin-db index-type cs context))
 
   (-rseek-datoms [db index-type cs context]
-                 (-> (dbi/-rseek-datoms origin-db index-type cs context)
-                     (filter-as-of-datoms time-point origin-db context)))
+                 (dbi/-rseek-datoms origin-db index-type cs context))
 
   (-index-range [db attr start end context]
-                (-> (deeper-index-range origin-db db attr start end context)
-                    (filter-as-of-datoms time-point origin-db context))))
-
-;; SinceDB
-
-(defn- filter-since [datoms time-point db {:keys [historical?]}]
-  {:pre [(boolean? historical?)]}
-  (let [since-pred (fn [^Datom d]
-                     (if (date? time-point)
-                       (.after ^Date (.-v d) ^Date time-point)
-                       (>= (.-tx d) time-point)))
-        filtered-tx-ids (dbu/filter-txInstant datoms since-pred db)
-        filtered-datoms (into []
-                              (filter (fn [^Datom d]
-                                        (contains? filtered-tx-ids (datom-tx d))))
-                              datoms)]
-
-    (if historical?
-      filtered-datoms
-      (get-current-values db filtered-datoms))))
+                (deeper-index-range origin-db db attr start end context)))
 
 (defrecord-updatable SinceDB [origin-db time-point]
   #?@(:cljs
@@ -595,32 +590,28 @@
   (-origin [db] origin-db)
 
   dbi/ISearch
-  (-search-context [db] (assoc (dbi/-search-context origin-db)
-                               :temporal? true))
+  (-search-context [db] (dbi/context-with-temporal-timepred
+                         (dbi/-search-context origin-db)
+                         (since-pred time-point)))
   (-search [db pattern context]
-           (-> (dbi/-search origin-db pattern context)
-               (filter-since time-point origin-db context)))
+           (dbi/-search origin-db pattern context))
 
   dbi/IIndexAccess
   (dbi/-datoms [db index-type cs context]
-               (-> (dbi/-datoms origin-db index-type cs context)
-                   (filter-since time-point origin-db context)))
+               (dbi/-datoms origin-db index-type cs context))
 
   (dbi/-seek-datoms [db index-type cs context]
-                    (-> (dbi/-seek-datoms origin-db index-type cs context)
-                        (filter-since time-point origin-db context)))
+                    (dbi/-seek-datoms origin-db index-type cs context))
 
   (dbi/-rseek-datoms [db index-type cs context]
-                     (-> (dbi/-rseek-datoms origin-db index-type cs context)
-                         (filter-since time-point origin-db context)))
+                     (dbi/-rseek-datoms origin-db index-type cs context))
 
   (dbi/-index-range [db attr start end context]
-                    (-> (deeper-index-range origin-db
-                                            db
-                                            attr
-                                            start end
-                                            context)
-                        (filter-since time-point origin-db context))))
+                    (deeper-index-range origin-db
+                                        db
+                                        attr
+                                        start end
+                                        context)))
 
 (defn- equiv-db-index [x y]
   (loop [xs (seq x)

--- a/src/datahike/db/interface.cljc
+++ b/src/datahike/db/interface.cljc
@@ -5,7 +5,7 @@
 (defrecord SearchContext [historical temporal timepred xform currentdb])
 
 (def base-context
-  (map->SearchContext 
+  (map->SearchContext
    {:historical false
     :temporal false
     :timepred nil

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -209,6 +209,10 @@
                      (di/-slice index from to index-type)
                      (di/-slice temporal-index from to index-type))))
 
+(def temporal-context (assoc dbi/base-context
+                             :temporal true
+                             :historical false))
+
 (defn filter-txInstant [datoms pred db]
   (let [txInstant (if (:attribute-refs? (dbi/-config db))
                     (dbi/-ref-for db :db/txInstant)
@@ -217,7 +221,7 @@
           (comp
            (map datom-tx)
            (distinct)
-           (mapcat (fn [tx] (dbi/-datoms db :eavt [tx] {:temporal? true :historical? false})))
+           (mapcat (fn [tx] (dbi/-datoms db :eavt [tx] temporal-context)))
            (keep (fn [^Datom d]
                    (when (and (= txInstant (.-a d)) (pred d))
                      (.-e d)))))

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -199,3 +199,13 @@
         (raise "Cannot resolve any more clauses"
                {:clauses clauses})
         (recur resolver context failed-clauses)))))
+
+(defn group-by-step
+  "Create a step function to use with `transduce` for grouping values"
+  [f]
+  (fn
+    ([] (transient {}))
+    ([dst] (persistent! dst))
+    ([dst x]
+     (let [k (f x)]
+       (assoc! dst k (conj (get dst k []) x))))))

--- a/test/datahike/test/tools_test.clj
+++ b/test/datahike/test/tools_test.clj
@@ -41,3 +41,10 @@
                (dt/resolve-clauses add-resolver
                                    {:x 9 :y 10}
                                    [[:w :z :x]]))))
+
+(deftest group-by-step-test
+  (is (= {true [1000 1002 1004 1006 1008]
+          false [1001 1003 1005 1007 1009]}
+         (transduce (map #(+ 1000 %)) 
+                    (dt/group-by-step even?)
+                    (range 10)))))

--- a/test/datahike/test/tools_test.clj
+++ b/test/datahike/test/tools_test.clj
@@ -45,6 +45,6 @@
 (deftest group-by-step-test
   (is (= {true [1000 1002 1004 1006 1008]
           false [1001 1003 1005 1007 1009]}
-         (transduce (map #(+ 1000 %)) 
+         (transduce (map #(+ 1000 %))
                     (dt/group-by-step even?)
                     (range 10)))))


### PR DESCRIPTION
This PR mainly refactors the code in `src/datahike/db.cljc` and `src/datahike/db/interface.cljc` so that datom filtering and evaluation of current datoms from historical ones is moved into the single function `datahike.db/post-process-datoms`. This makes the code easier to reason about and deduplicates some calls. These changes will also make it easier to move forward with the code in the PR https://github.com/replikativ/datahike/pull/674 .

I had to introduce a record `SearchContext` to make it fast enough and resort to Java interop syntax to access fields. Otherwise, it is too slow.

I measured the performance change and this code takes rougly 2% less time in my benchmark which is a small improvement:

```
TARGET                          ABS TIME (s)   REL TIME
Official Datahike                     49.765       100%
Refactor db interface                 48.666        98%
```
