### PR TITLE
Fix attribute refs bug when transacting tuple value

### DIFF
--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -591,7 +591,7 @@
 
 (defn check-tuple [db op-vec]
   (let [[_ _ a v] op-vec
-        attr-schema (-> db dbi/-schema a)]
+        attr-schema (-> db dbi/-schema (get a))]
     (cond (:db/tupleType attr-schema)
           (cond (> (count v) 8)
                 (raise "Cannot store more than 8 values for homogeneous tuple: " op-vec

--- a/test/datahike/test/attribute_refs/transact_test.cljc
+++ b/test/datahike/test/attribute_refs/transact_test.cljc
@@ -189,3 +189,17 @@
       (is (= (:age e) 32))
       (is (:had-birthday e)))
     (d/release conn)))
+
+(deftest test-tuples
+  (let [conn (setup-new-connection)]
+    (d/transact conn [#:db{:ident :mapping/attributes,
+                           :valueType :db.type/tuple,
+                           :tupleTypes
+                           [:db.type/keyword :db.type/keyword :db.type/keyword],
+                           :cardinality :db.cardinality/many}])
+    (d/transact conn [{:mapping/attributes [[:mapping :mapped-id :remote-id]]}])
+    (is (= #{[[:mapping :mapped-id :remote-id]]}
+           (d/q '[:find ?v
+                  :where [?e :mapping/attributes ?v]]
+                @conn)))
+    (d/release conn)))


### PR DESCRIPTION
Fixes a bug in the code where the expression `(-> db dbi/-schema a)` fails because `a` is not a keyword and callable as a function as it used to be. The solution is to change this expression to be `(-> db dbi/-schema a)`. 

Fixes #695 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
