### PR TITLE
always log to STDERR from datahike.cli

### DIFF
--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -16,6 +16,13 @@
 
 ;; This file is following https://github.com/clojure/tools.cli
 
+(log/merge-config!
+  {:appenders {:println {:doc "Always prints to *err*"
+                         :enabled? true
+                         :fn (fn log-to-stderr [{:keys [output_]}]
+                               (binding [*out* *err*]
+                                 (println (force output_))))}}})
+
 (defn usage [options-summary]
   (->> [datahike-logo
         "This is the Datahike command line interface."


### PR DESCRIPTION
#### SUMMARY

Fixes #694 

This is an alternative proposal to #699 

#### Checks

##### Bugfix
- [x] Related issues linked using `fixes #number`
- [ ] Integration tests added - **happy to add to `run-native-image-tests` if we agree this is a good path forward**
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

#### ADDITIONAL INFORMATION

While #699 solves the proximate issue, I think that always logging to stderr is actually _more_ flexible.

For one thing, logging to stderr is more Unix-y. That's a good thing because it's fewer knobs to turn in the CLI itself. To log to a file you can just use standard redirection:

```sh
dthk query '[:find ...]' 2>/path/to/log/file
```

Also, requiring a logfile precludes the possibility of logging to stderr (or stdout for that matter), which you might want to do. One big advantage of doing so is capturing the output via `clojure.java.shell/sh`:

```clj
(let [{:keys [out err]} (sh "/path/to/dthk" "query" "[:find ...]")
  (when err (log/warn (str "Datahike error: " err))
  ,,,)
```

This is what I intend to do [in Bread's CGI binary](https://github.com/breadsystems/bread-cms/blob/feature/cgi/plugins/datahike/systems/bread/alpha/plugin/datahike_cli.cljc#L27). With stderr logging, I can detect when `dthk` complains about something, and bubble that up as a warning from Bread's code. Without it, I would need to add another knob in Bread to configure a separate Datahike logfile (so it can call `dthk --log-file ...` with the correct path), and it would still be up to users to watch said logfile themselves.