### PR TITLE
Make datoms function work with system attribute components

### DIFF
--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -148,7 +148,7 @@
 
 (defn attr-has-ref? [db attr]
   (and (not (nil? attr))
-       (not (ds/is-system-keyword? attr))
+       (not (ds/built-in-attribute? attr))
        (:attribute-refs? (dbi/-config db))))
 
 (defn attr-ref-or-ident [db attr]

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -214,5 +214,10 @@
          (= "db" (first (clojure.string/split ns #"\.")))
          false)))
 
+(def built-in-attributes #{:db/ident})
+
+(defn built-in-attribute? [x]
+  (contains? built-in-attributes x))
+
 (defn get-user-schema [{:keys [schema] :as db}]
   (into {} (filter #(not (is-system-keyword? (key %))) schema)))

--- a/test/datahike/test/attribute_refs/datoms_test.cljc
+++ b/test/datahike/test/attribute_refs/datoms_test.cljc
@@ -107,5 +107,4 @@
                  :components [:db/txInstant
                               (:e datom)
                               (:v datom)
-                              (:tx datom)]})))))
-    (def the-datoms (d/datoms @conn {:index :avet}))))
+                              (:tx datom)]})))))))

--- a/test/datahike/test/attribute_refs/datoms_test.cljc
+++ b/test/datahike/test/attribute_refs/datoms_test.cljc
@@ -1,0 +1,111 @@
+(ns datahike.test.attribute-refs.datoms-test
+  (:require
+   #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
+      :clj [clojure.test :as t :refer [is deftest testing]])
+   [datahike.api :as d]
+   [datahike.db :as db :refer [ref-datoms]]
+   [datahike.test.utils :refer [with-connect provide-unique-id
+                                recreate-database]]))
+
+(def cfg
+  {:store {:backend :mem}
+   :keep-history? true
+   :attribute-refs? true
+   :schema-flexibility :write})
+
+(deftest test-datoms-with-components
+  (with-connect [conn (-> cfg
+                          provide-unique-id
+                          recreate-database)]
+    (d/transact conn [{:db/ident :name
+                       :db/cardinality :db.cardinality/one
+                       :db/index true
+                       :db/valueType :db.type/string}
+                      {:db/ident :age
+                       :db/cardinality :db.cardinality/one
+                       :db/valueType :db.type/long}])
+    (d/transact conn [{:name "Alice"
+                       :age 10}])
+    (let [all-datoms (d/datoms @conn {:index :avet :components []})
+          all-tx-inst-datoms (filter (fn [datom]
+                                       (and (= (:e datom)
+                                               (:tx datom))
+                                            (instance? java.util.Date
+                                                       (:v datom))))
+                                     all-datoms)
+          name-datoms (filter (fn [datom] (= "Alice" (:v datom)))
+                              all-datoms)]
+      (is (= 1 (count name-datoms)))
+      (doseq [datom name-datoms]
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [(:a datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [(:a datom)
+                              (:v datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [(:a datom)
+                              (:v datom)
+                              (:e datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [(:a datom)
+                              (:v datom)
+                              (:e datom)
+                              (:tx datom)]}))))
+
+      (is (= 3 (count all-tx-inst-datoms)))
+      (is (= (set all-tx-inst-datoms)
+             (set (d/datoms @conn {:index :avet
+                                   :components [:db/txInstant]}))))
+      (is (= (set all-tx-inst-datoms)
+             (set (d/datoms @conn {:index :aevt
+                                   :components [:db/txInstant]}))))
+      (doseq [datom all-tx-inst-datoms]
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [:db/txInstant
+                              (:v datom)
+                              (:e datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :avet
+                 :components [:db/txInstant
+                              (:v datom)
+                              (:e datom)
+                              (:tx datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :aevt
+                 :components [:db/txInstant
+                              (:e datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :aevt
+                 :components [:db/txInstant
+                              (:e datom)
+                              (:v datom)]})))
+        (is (= [datom]
+               (d/datoms
+                @conn
+                {:index :aevt
+                 :components [:db/txInstant
+                              (:e datom)
+                              (:v datom)
+                              (:tx datom)]})))))
+    (def the-datoms (d/datoms @conn {:index :avet}))))


### PR DESCRIPTION
#### SUMMARY

Corrects the code in `attr-has-ref?` function so that the `datoms` function returns a non-empty result in case a system attribute (such as `:db/txInstant`) is provided as a component when performing the lookup.

Fixes #703 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
