### PR TITLE
Make sure that the datoms of history are distinct

### DIFF
--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -204,10 +204,15 @@
 
 (defn distinct-datoms [db current-datoms history-datoms]
   (if  (dbi/-keep-history? db)
-    (concat (filter #(or (no-history? db (:a %))
-                         (multival? db (:a %)))
-                    current-datoms)
-            history-datoms)
+    (let [current-datoms (filterv (fn [datom]
+                                    (let [a (:a datom)]
+                                      (or (no-history? db a)
+                                          (multival? db a))))
+                                  current-datoms)
+          current-datom-set (set current-datoms)]
+      (into current-datoms
+            (remove current-datom-set)
+            history-datoms))
     current-datoms))
 
 (defn temporal-datoms [db index-type cs]

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -874,3 +874,18 @@
 
 (deftest test-metrics-attr-refs
   (test-metrics (assoc metrics-base-cfg :attribute-refs? true)))
+
+(deftest test-no-history-datoms-in-empty-db
+  (testing "When attribute-refs? is false, there are no initial datoms"
+    (utils/with-connect [conn (-> {:store {:backend :mem
+                                           :id "hashing"}
+                                   :keep-history? true
+                                   :schema-flexibility :write}
+                                  utils/provide-unique-id
+                                  utils/recreate-database)]
+      (is (-> @conn
+              d/history
+              (d/datoms {:index :aevt
+                         :components []
+                         :limit -1})
+              empty?)))))


### PR DESCRIPTION
#### SUMMARY
Make sure that datoms returned from the history of a database are distinct.

Fixes #705 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
