### PR TITLE
Use Timbre's default logging behavior in Babashka pod

### DIFF
--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -5,8 +5,22 @@ set -o pipefail
 
 TMPSTORE=/tmp/dh-test-store
 CONFIG=bb/resources/native-image-tests/testconfig.edn
+ATTR_REF_CONFIG=bb/resources/native-image-tests/testconfig.attr-refs.edn
 
 trap "rm -rf $TMPSTORE" EXIT
+
+./dthk delete-database $ATTR_REF_CONFIG
+./dthk create-database $ATTR_REF_CONFIG
+
+./dthk database-exists $ATTR_REF_CONFIG
+
+# test that warnings etc. get logged to stderr
+LOG_OUTPUT="$(./dthk query '[:find ?e . :where [?e :nonexistent _]]' db:$ATTR_REF_CONFIG 2>&1 >/dev/null | grep ':nonexistent has not been found')"
+if [ -z "$LOG_OUTPUT" ]
+then
+  echo "Exception: binary did not log to stderr"
+  exit 1
+fi
 
 ./dthk delete-database $CONFIG
 ./dthk create-database $CONFIG
@@ -29,7 +43,6 @@ fi
 ./dthk query '[:find (count ?e) . :where [?e :name _]]' history:$CONFIG
 ./dthk query '[:find (count ?e) . :where [?e :name _]]' since:0:$CONFIG
 ./dthk query '[:find (count ?e) . :where [?e :name _]]' asof:0:$CONFIG
-
 
 # other calls
 ./dthk pull db:$CONFIG "[:db/id, :name]" "1"

--- a/bb/resources/native-image-tests/testconfig.attr-refs.edn
+++ b/bb/resources/native-image-tests/testconfig.attr-refs.edn
@@ -1,0 +1,5 @@
+{:store  {:backend :file
+          :path "/tmp/dh-test-store" }
+ :keep-history? true
+ :attribute-refs? true
+ :schema-flexibility :write}

--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -17,7 +17,8 @@
 ;; This file is following https://github.com/clojure/tools.cli
 
 (log/merge-config!
- {:appenders {:println {:doc "Always prints to *err*"
+  {:appenders {:println {:enabled? false}
+               :stderr {:doc "Always prints to *err*"
                         :enabled? true
                         :fn (fn log-to-stderr [{:keys [output_]}]
                               (binding [*out* *err*]

--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -16,13 +16,14 @@
 
 ;; This file is following https://github.com/clojure/tools.cli
 
-(log/merge-config!
-  {:appenders {:println {:enabled? false}
-               :stderr {:doc "Always prints to *err*"
-                        :enabled? true
-                        :fn (fn log-to-stderr [{:keys [output_]}]
-                              (binding [*out* *err*]
-                                (println (force output_))))}}})
+(when-not (= "true" (System/getenv "BABASHKA_POD"))
+  (log/merge-config!
+    {:appenders {:println {:enabled? false} ;; leave a "paper trail"
+                 :stderr {:doc "Always prints to *err*"
+                          :enabled? true
+                          :fn (fn log-to-stderr [{:keys [output_]}]
+                                (binding [*out* *err*]
+                                  (println (force output_))))}}}))
 
 (defn usage [options-summary]
   (->> [datahike-logo


### PR DESCRIPTION
#### SUMMARY

Restores previous logging behavior in Babashka pod.

#### Checks

##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [x] Formatting checked


#### ADDITIONAL INFORMATION

Per your request. Copied from [#699](https://github.com/replikativ/datahike/pull/699/files#diff-4c5ed5ccc6ecc05314605f7866f35665bf20544bd530a257c48e5a6005861849R154)