### PR TITLE
Remove special treatment of :db/ident attribute

### DIFF
--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -148,7 +148,6 @@
 
 (defn attr-has-ref? [db attr]
   (and (not (nil? attr))
-       (not (ds/built-in-attribute? attr))
        (:attribute-refs? (dbi/-config db))))
 
 (defn attr-ref-or-ident [db attr]

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -214,10 +214,5 @@
          (= "db" (first (clojure.string/split ns #"\.")))
          false)))
 
-(def built-in-attributes #{:db/ident})
-
-(defn built-in-attribute? [x]
-  (contains? built-in-attributes x))
-
 (defn get-user-schema [{:keys [schema] :as db}]
   (into {} (filter #(not (is-system-keyword? (key %))) schema)))

--- a/test/datahike/test/attribute_refs/differences_test.cljc
+++ b/test/datahike/test/attribute_refs/differences_test.cljc
@@ -310,14 +310,38 @@
       (d/release conn)))
 
   (testing "Keyword transaction in reference DB"
-    (let [[no-ref-cfg ref-cfg] (init-cfgs)
-          conn (setup-db ref-cfg)
-          next-eid (inc (:max-eid @conn))]
-      (is (thrown-with-msg? Throwable
-                            (re-pattern (str "Bad entity attribute :db/ident"
-                                             " at \\[:db/add " next-eid " :db/ident :name\\],"
-                                             " expected reference number"))
-                            (d/transact conn [[:db/add next-eid :db/ident :name]])))
+    (doseq [cfg (init-cfgs)
+            :let [attribute-refs? (:attribute-refs? cfg)
+                  conn (setup-db cfg)
+                  next-eid (inc (:max-eid @conn))
+                  init-datoms (d/datoms
+                               @conn
+                               {:index :aevt
+                                :components [:db/ident]})]]
+      (is (= (boolean (seq init-datoms))
+             (boolean attribute-refs?)))
+      (is (some? (d/transact
+                  conn
+                  [[:db/add next-eid :db/ident :name]])))
+      (let [datoms (d/datoms @conn
+                             {:index :aevt
+                              :components [:db/ident]})]
+        (is (= (inc (count init-datoms))
+               (count datoms)))
+        (is (some (fn [[_ a v]]
+                    (and (= v :name)
+                         (or attribute-refs?
+                             (= a :db/ident))))
+                  datoms)))
+      (let [[ident-name-datom :as ident-name-datoms]
+            (d/datoms @conn
+                      {:index :avet
+                       :components [:db/ident
+                                    :name]})]
+        (is (= 1 (count ident-name-datoms)))
+        (is (= :name (:v ident-name-datom)))
+        (is (or attribute-refs?
+                (= :db/ident (:a ident-name-datom)))))
       (d/release conn))))
 
 (deftest test-transact-data-with-reference-attr


### PR DESCRIPTION
#### SUMMARY

I removed the special treatment of `:db/ident` in one place of the code. This addresses issue #710 and also makes it possible to transact datoms with `:db/ident` attribute even if database is of type `:attribute-refs?`.

Fixes #710 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked