### PR TITLE
Fix as-of and since so that they include and exclude time-point respectively

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -129,15 +129,20 @@
   #?(:cljs (instance? js/Date d)
      :clj (instance? Date d)))
 
-(defn- as-of-pred [time-point]
+(defn- date<= [^Date a ^Date b]
+  (not (.before b a)))
+
+(defn- as-of-pred
+  "Create an as-of predicate, *including* the time-point"
+  [time-point]
   (if (date? time-point)
-    (fn [^Datom d] (.before ^Date (.-v d) ^Date time-point))
+    (fn [^Datom d] (date<= (.-v d) time-point))
     (fn [^Datom d] (<= (dd/datom-tx d) time-point))))
 
-(defn- since-pred [time-point]
-  (if (date? time-point)
-    (fn [^Datom d] (.after ^Date (.-v d) ^Date time-point))
-    (fn [^Datom d] (>= (.-tx d) time-point))))
+(defn- since-pred
+  "Create a since predicate, *excluding* the time-point. The opposite of `as-of-pred`."
+  [time-point]
+  (complement (as-of-pred time-point)))
 
 (defn assemble-datoms-xform [db]
   (mapcat

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -345,6 +345,8 @@
 
     (def date (java.util.Date.))
 
+    (Thread/sleep 100)
+    
     (d/transact conn {:tx-data [{:db/id [:name "Alice"] :age 35}]})
 
     (is (= #{["Alice" 25] ["Bob" 30]}

--- a/test/datahike/test/attribute_refs/db_test.cljc
+++ b/test/datahike/test/attribute_refs/db_test.cljc
@@ -22,7 +22,7 @@
 
 (deftest test-partial-db
   (let [conn (setup-db ref-cfg)
-        _tx0 (d/transact conn name-schema)
+        tx0 (-> (d/transact conn name-schema) :db-after :max-tx)
         tx1 (-> (d/transact conn [{:name "Peter"}]) :db-after :max-tx)
         tx2 (-> (d/transact conn [{:name "Maria"}]) :db-after :max-tx)]
     (testing "AsOfDB"
@@ -35,8 +35,8 @@
     (testing "SinceDB"
       (is (= #{["Maria"] ["Peter"]}
              (d/q '[:find ?v :where [?e :name ?v]]
-                  (d/since @conn tx1))))
+                  (d/since @conn tx0))))
       (is (= #{["Maria"]}
              (d/q '[:find  ?v :where [?e :name ?v]]
-                  (d/since @conn tx2)))))
+                  (d/since @conn tx1)))))
     (d/release conn)))

--- a/test/datahike/test/time_variance_test.cljc
+++ b/test/datahike/test/time_variance_test.cljc
@@ -74,7 +74,7 @@
         #{[30] [25]}
         (d/q '[:find ?a :in $ ?e :where [?e :age ?a]] (d/history @conn) [:name "Alice"])))
     (testing "historical values after with retraction"
-      (let [;;tx-id1 (:max-tx @conn)
+      (let [tx-id1 (:max-tx @conn)
             _ (d/transact conn [[:db/retractEntity [:name "Alice"]]])
             tx-id2 (:max-tx @conn)]
         (is (thrown-with-msg? Throwable #"Nothing found for entity id"
@@ -90,7 +90,7 @@
                  (d/q '[:find ?a :in $ ?e :where [?e :age ?a]]
                       db
                       [:name "Alice"]))))
-        (doseq [db (vary-db-ops @conn d/history #(d/since % tx-id2))]
+        (doseq [db (vary-db-ops @conn d/history #(d/since % tx-id1))]
           (is (= #{[30]}
                  (d/q '[:find ?a :in $ ?e :where [?e :age ?a]]
                       db
@@ -199,7 +199,7 @@
         first-date (now)
         ;; sleep to make sure that transact thread has newer timestamp
         _ (sleep 10)
-        tx-id 536870914
+        tx-id 536870913
         query '[:find ?a :where [?e :age ?a]]]
     (testing "empty after first insertion"
       (is (= #{}
@@ -212,7 +212,7 @@
         (is (= #{[new-age]}
                (d/q query (d/since @conn tx-id))))))
     (testing "print DB"
-      (is (= "#datahike/SinceDB {:origin #datahike/DB {:store-id [[:mem \"test.datahike.io\" \"test-since-db\"] :db] :commit-id :REPLACED :max-tx 536870914 :max-eid 4} :time-point 536870914}"
+      (is (= "#datahike/SinceDB {:origin #datahike/DB {:store-id [[:mem \"test.datahike.io\" \"test-since-db\"] :db] :commit-id :REPLACED :max-tx 536870914 :max-eid 4} :time-point 536870913}"
              (replace-commit-id (pr-str (d/since @conn tx-id))))))
     (d/release conn)))
 


### PR DESCRIPTION
#### SUMMARY

Implement `as-of` and `since` so that they work just like in Datomic.

* Implement `as-of` so that it *includes* time-point
* Implement `since` so that it *excludes* time-point

Fixes #712 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked