### PR TITLE
Break out schema and cache. Move gc to public API.

### DIFF
--- a/java/src/datahike/java/Datahike.java
+++ b/java/src/datahike/java/Datahike.java
@@ -50,6 +50,7 @@ public class Datahike {
     private static final IFn schemaFn = Clojure.var("datahike.api", "schema");
     private static final IFn reverseSchemaFn = Clojure.var("datahike.api", "reverse-schema");
     private static final IFn metricsFn = Clojure.var("datahike.api", "metrics");
+    private static final IFn gcStorageFn = Clojure.var("datahike.api", "gc-storage");
 
     /**
      * Forbids instances creation.
@@ -364,5 +365,24 @@ public class Datahike {
      */
     public static APersistentMap metrics(Object db) {
         return (APersistentMap)metricsFn.invoke(db);
+    }
+
+    /**
+     * Perform garbage collection on the database
+     *
+     * @param db a database
+     */
+    public static Object gcStorage(Object db) {
+        return gcStorageFn.invoke(db);
+    }
+
+    /**
+     * Perform garbage collection on the database
+     *
+     * @param db a database
+     * @param removeBefore a date
+     */
+    public static Object gcStorage(Object db, Date removeBefore) {
+        return gcStorageFn.invoke(db, removeBefore);
     }
 }

--- a/java/src/datahike/java/DatahikeTest.java
+++ b/java/src/datahike/java/DatahikeTest.java
@@ -251,6 +251,15 @@ public class DatahikeTest {
         assertTrue(res.size() == 3);
     }
 
+    /* TODO: This requires a durable backend */
+    // @Test
+    // public void gcStorage() {
+    //     APersistentMap config = config();
+    //     Datahike.createDatabase(config);
+    //     Object conn = Datahike.connect(config);
+    //     Set<UUID> res = (Set<UUID>)deref(Datahike.gcStorage(conn));
+    //     assertTrue(res.size() == 0);
+    // }
 
     /**
      * Called by Datahike's Clojure tests and runs the above Junit tests.

--- a/libdatahike/src/datahike/impl/LibDatahike.java
+++ b/libdatahike/src/datahike/impl/LibDatahike.java
@@ -282,11 +282,12 @@ public final class LibDatahike {
     @CEntryPoint(name = "gc_storage")
     public static void gc_storage(@CEntryPoint.IsolateThreadContext long isolateId,
                                  @CConst CCharPointer db_config,
+                                 long before_tx_unix_time_ms,
                                  @CConst CCharPointer output_format,
                                  @CConst OutputReader output_reader) {
         try {
             Object db = Datahike.connect(readConfig(db_config));
-            output_reader.call(toOutput(output_format, Datahike.gcStorage(db)));
+            output_reader.call(toOutput(output_format, Datahike.gcStorage(db, new Date(before_tx_unix_time_ms))));
         } catch (Exception e) {
             output_reader.call(toException(e));
         }

--- a/libdatahike/src/datahike/impl/LibDatahike.java
+++ b/libdatahike/src/datahike/impl/LibDatahike.java
@@ -279,6 +279,19 @@ public final class LibDatahike {
         }
     }
 
+    @CEntryPoint(name = "gc_storage")
+    public static void gc_storage(@CEntryPoint.IsolateThreadContext long isolateId,
+                                 @CConst CCharPointer db_config,
+                                 @CConst CCharPointer output_format,
+                                 @CConst OutputReader output_reader) {
+        try {
+            Object db = Datahike.connect(readConfig(db_config));
+            output_reader.call(toOutput(output_format, Datahike.gcStorage(db)));
+        } catch (Exception e) {
+            output_reader.call(toException(e));
+        }
+    }
+
     // seekdatoms not supported yet because we would always realize the iterator until the end
 
     // release we do not expose connection objects yet, but create them internally on the fly

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -857,7 +857,7 @@ Returns the key under which this listener is registered. See also [[unlisten]]."
     gc-storage
     {:args             (s/alt :with-date (s/cat :conn spec/SConnection :remove-before spec/time-point?)
                               :no-date (s/cat :conn spec/SConnection))
-     :ret              seq? #_(s/set? @%)
+     :ret              set?
      :doc "Invokes garbage collection on the store of connection by whitelisting currently known branches.
 All db snapshots on these branches before remove-before date will also be
 erased (defaults to beginning of time [no erasure]). The branch heads will
@@ -867,4 +867,5 @@ always be retained. Return the set of removed blobs from the store."
      :referentially-transparent? false}})
 
 (comment
-  (map (fn [[k v]] [k (:impl v)]) api-specification))
+  (map (fn [[k v]] [k (:impl v)]) api-specification)
+  )

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -865,7 +865,3 @@ always be retained. Return the set of removed blobs from the store."
      :impl datahike.writer/gc-storage!
      :supports-remote? true
      :referentially-transparent? false}})
-
-(comment
-  (map (fn [[k v]] [k (:impl v)]) api-specification)
-  )

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -857,7 +857,7 @@ Returns the key under which this listener is registered. See also [[unlisten]]."
     gc-storage
     {:args             (s/alt :with-date (s/cat :conn spec/SConnection :remove-before spec/time-point?)
                               :no-date (s/cat :conn spec/SConnection))
-     :ret              any? #_(s/set? @%)
+     :ret              seq? #_(s/set? @%)
      :doc "Invokes garbage collection on the store of connection by whitelisting currently known branches.
 All db snapshots on these branches before remove-before date will also be
 erased (defaults to beginning of time [no erasure]). The branch heads will

--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -257,4 +257,8 @@
 
         :metrics
         (let [out (d/metrics (load-input (first arguments)))]
+          (report (:format options) out))
+
+        :gc-storage
+        (let [out (d/gc-storage (load-input (first arguments)) (load-input (second arguments)))]
           (report (:format options) out))))))

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -9,6 +9,11 @@
             [datahike.index :as di])
   (:import [java.net URI]))
 
+;; global
+(def ^:dynamic *schema-meta-cache-size* (or (env :schema-meta-cache-size) 1024))
+(def ^:dynamic *schema-write-cache-max-db-count* (or (env :schema-write-cache-size) 1024))
+
+;; per database
 (def ^:dynamic *default-index* :datahike.index/persistent-set)
 (def ^:dynamic *default-schema-flexibility* :write)
 (def ^:dynamic *default-keep-history?* true)

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -10,8 +10,8 @@
   (:import [java.net URI]))
 
 ;; global
-(def ^:dynamic *schema-meta-cache-size* (or (env :schema-meta-cache-size) 1024))
-(def ^:dynamic *schema-write-cache-max-db-count* (or (env :schema-write-cache-size) 1024))
+(def ^:dynamic *schema-meta-cache-size* (env :schema-meta-cache-size 1024))
+(def ^:dynamic *schema-write-cache-max-db-count* (env :schema-write-cache-size 1024))
 
 ;; per database
 (def ^:dynamic *default-index* :datahike.index/persistent-set)

--- a/src/datahike/experimental/versioning.cljc
+++ b/src/datahike/experimental/versioning.cljc
@@ -78,7 +78,7 @@
     (when-not (branches branch)
       (dt/raise "Branch does not exist." {:type :branch-does-not-exist
                                           :branch branch}))
-    #_(delete-connection! [(store-identity (get-in @conn [:config :store])) branch])
+    (delete-connection! [(store-identity (get-in @conn [:config :store])) branch])
     (k/update store :branches #(disj % branch) {:sync? true})))
 
 (defn force-branch!

--- a/src/datahike/experimental/versioning.cljc
+++ b/src/datahike/experimental/versioning.cljc
@@ -78,7 +78,7 @@
     (when-not (branches branch)
       (dt/raise "Branch does not exist." {:type :branch-does-not-exist
                                           :branch branch}))
-    (delete-connection! [(store-identity (get-in @conn [:config :store])) branch])
+    #_(delete-connection! [(store-identity (get-in @conn [:config :store])) branch])
     (k/update store :branches #(disj % branch) {:sync? true})))
 
 (defn force-branch!
@@ -94,11 +94,12 @@
   (parent-check parents)
   (let [store (:store db)
         cid (create-commit-id db)
-        db (db->stored (-> db
-                           (assoc-in [:config :branch] branch)
-                           (assoc-in [:meta :datahike/parents] parents)
-                           (assoc-in [:meta :datahike/commit-id] cid))
-                       true)]
+        [_schema-meta-op db] (db->stored (-> db
+                                             (assoc-in [:config :branch] branch)
+                                             (assoc-in [:meta :datahike/parents] parents)
+                                             (assoc-in [:meta :datahike/commit-id] cid))
+                                         true
+                                         true)]
     (flush-pending-writes store true)
     (k/update store :branches #(conj % branch) {:sync? true})
     (k/assoc store cid db {:sync? true})

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -58,12 +58,12 @@
                  {:keys [config store]} db
                  _ (sc/clear-write-cache (:store config)) ; Clear the schema write cache for this store
                  branches (<? S (k/get store :branches))
-                 _ (debug  "retaining branches" branches)
+                 _ (trace  "retaining branches" branches)
                  reachable (->> branches
                                 (map #(reachable-in-branch store % remove-before config))
                                 async/merge
                                 (<<? S)
                                 (apply set/union))
                  reachable (conj reachable :branches)]
-             (debug  "gc reached: " reachable)
+             (trace  "gc reached: " reachable)
              (<? S (sweep! store reachable now))))))

--- a/src/datahike/schema_cache.cljc
+++ b/src/datahike/schema_cache.cljc
@@ -1,0 +1,41 @@
+(ns datahike.schema-cache
+  (:require [clojure.core.cache.wrapped :as cw]
+            [datahike.config :as dc]
+            [datahike.store :as ds]))
+
+;; Shared schema read cache across all stores
+(def schema-meta-cache (cw/lru-cache-factory {} :threshold dc/*schema-meta-cache-size*))
+
+;; LRU cache of LRU caches for write operations, one per store
+(def schema-write-caches
+  (cw/lru-cache-factory {} :threshold dc/*schema-write-cache-max-db-count*))
+
+(defn get-or-create-write-cache [store-config]
+  (let [store-id (ds/store-identity store-config)]
+    (if (cw/has? schema-write-caches store-id)
+      (cw/lookup schema-write-caches store-id)
+      (let [new-cache (cw/lru-cache-factory {} :threshold dc/*schema-meta-cache-size*)]
+        (cw/miss schema-write-caches store-id new-cache)
+        new-cache))))
+
+(defn cache-has? [schema-meta-key]
+  (cw/has? schema-meta-cache schema-meta-key))
+
+(defn cache-lookup [schema-meta-key]
+  (cw/lookup schema-meta-cache schema-meta-key))
+
+(defn cache-miss [schema-meta-key schema-meta]
+  (cw/miss schema-meta-cache schema-meta-key schema-meta))
+
+(defn write-cache-has? [store-config schema-meta-key]
+  (let [write-cache (get-or-create-write-cache store-config)]
+    (cw/has? write-cache schema-meta-key)))
+
+(defn add-to-write-cache [store-config schema-meta-key]
+  (let [write-cache (get-or-create-write-cache store-config)]
+    (cw/miss write-cache schema-meta-key true)))
+
+(defn clear-write-cache [store-config]
+  (let [store-id (ds/store-identity store-config)]
+    (cw/evict schema-write-caches store-id)))
+

--- a/src/datahike/schema_cache.cljc
+++ b/src/datahike/schema_cache.cljc
@@ -10,7 +10,7 @@
 (def schema-write-caches
   (cw/lru-cache-factory {} :threshold dc/*schema-write-cache-max-db-count*))
 
-(defn get-or-create-write-cache [store-config]
+(defn- get-or-create-write-cache [store-config]
   (let [store-id (ds/store-identity store-config)]
     (if (cw/has? schema-write-caches store-id)
       (cw/lookup schema-write-caches store-id)

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -6,8 +6,7 @@
             [datahike.gc :as gc]
             [datahike.tools :as dt :refer [throwable-promise get-time-ms]]
             [clojure.core.async :refer [chan close! promise-chan put! go go-loop <! >! poll! buffer timeout]])
-  (:import [clojure.lang ExceptionInfo]
-           [clojure.core.async.impl.channels ManyToManyChannel]))
+  (:import [clojure.core.async.impl.channels ManyToManyChannel]))
 
 (defn chan? [x]
   (instance? ManyToManyChannel x))
@@ -59,10 +58,9 @@
                         (log/warn "Transaction queue buffer more than 90% full, "
                                   (count transaction-queue-buffer) "of" transaction-queue-size  " filled."
                                   "Reduce transaction frequency."))
-                      (let [old (if-not (= (:max-tx old) (:max-tx @(:wrapped-atom connection)))
-                                  (do
-                                    (log/warn "DEPRECATED. Connection was changed outside of writer.")
-                                    (assoc old :max-tx (:max-tx @(:wrapped-atom connection))))
+                      (let [;; TODO remove this after import is ported to writer API
+                            old (if-not (= (:max-tx old) (:max-tx @(:wrapped-atom connection)))
+                                  (assoc old :max-tx (:max-tx @(:wrapped-atom connection)))
                                   old)
 
                             op-fn (write-fn-map op)

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -255,6 +255,7 @@
           active-conns (filter (fn [[store-id _branch]]
                                  (= store-id config-store-id))
                                (keys @*connections*))]
+      (sc/clear-write-cache (:store config))
       (doseq [conn active-conns]
         (log/warn "Deleting database without releasing all connections first: " conn "."
                   "All connections will be released now, but this cannot be ensured for remote readers.")

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -8,20 +8,20 @@
             [datahike.tools :as dt]
             [datahike.core :as core]
             [datahike.config :as dc]
+            [datahike.schema-cache :as sc]
             [konserve.core :as k]
             [taoensso.timbre :as log]
             [hasch.core :refer [uuid]]
             [superv.async :refer [go-try- <?-]]
             [clojure.core.async :refer [poll!]]
-            [konserve.utils :refer [async+sync *default-sync-translation*]]
-            [taoensso.timbre :as t]))
+            [konserve.utils :refer [async+sync *default-sync-translation*]]))
 
 ;; mapping to storage
 
 (defn stored-db? [obj]
   ;; TODO use proper schema to match?
-  (let [keys-to-check [:eavt-key :aevt-key :avet-key :schema :rschema
-                       :system-entities :ident-ref-map :ref-ident-map :config
+  (let [keys-to-check [:eavt-key :aevt-key :avet-key ;:schema :rschema
+                       ;:system-entities :ident-ref-map :ref-ident-map :config
                        :max-tx :max-eid :op-count :hash :meta]]
     (= (count (select-keys obj keys-to-check))
        (count keys-to-check))))
@@ -48,7 +48,7 @@
 
 (defn db->stored
   "Maps memory db to storage layout and flushes dirty indices."
-  [db flush?]
+  [db flush? sync?]
   (when-not (dbu/db? db)
     (dt/raise "Argument is not a database."
               {:type     :argument-is-not-a-db
@@ -56,28 +56,36 @@
   (let [{:keys [eavt aevt avet temporal-eavt temporal-aevt temporal-avet
                 schema rschema system-entities ident-ref-map ref-ident-map config
                 max-tx max-eid op-count hash meta store]} db
+        schema-meta {:schema schema
+                     :rschema rschema
+                     :system-entities system-entities
+                     :ident-ref-map ident-ref-map
+                     :ref-ident-map ref-ident-map}
+        schema-meta-key (uuid schema-meta)
         backend                                           (di/konserve-backend (:index config) store)
         not-in-memory?                                    (not= :mem (-> config :store :backend))
-        flush! (and flush? not-in-memory?)]
-    (merge
-     {:schema          schema
-      :rschema         rschema
-      :system-entities system-entities
-      :ident-ref-map   ident-ref-map
-      :ref-ident-map   ref-ident-map
-      :config          config
-      :meta            meta
-      :hash            hash
-      :max-tx          max-tx
-      :max-eid         max-eid
-      :op-count        op-count
-      :eavt-key        (cond-> eavt flush! (di/-flush backend))
-      :aevt-key        (cond-> aevt flush! (di/-flush backend))
-      :avet-key        (cond-> avet flush! (di/-flush backend))}
-     (when (:keep-history? config)
-       {:temporal-eavt-key (cond-> temporal-eavt flush! (di/-flush backend))
-        :temporal-aevt-key (cond-> temporal-aevt flush! (di/-flush backend))
-        :temporal-avet-key (cond-> temporal-avet flush! (di/-flush backend))}))))
+        flush! (and flush? not-in-memory?)
+        schema-meta-op (when-not (sc/write-cache-has? (:store config) schema-meta-key)
+                         (sc/add-to-write-cache (:store config) schema-meta-key)
+                         (k/assoc store schema-meta-key schema-meta {:sync? sync?}))]
+    (when-not (sc/cache-has? schema-meta-key)
+      (sc/cache-miss schema-meta-key schema-meta))
+    [schema-meta-op
+     (merge
+      {:schema-meta-key  schema-meta-key
+       :config          config
+       :meta            meta
+       :hash            hash
+       :max-tx          max-tx
+       :max-eid         max-eid
+       :op-count        op-count
+       :eavt-key        (cond-> eavt flush! (di/-flush backend))
+       :aevt-key        (cond-> aevt flush! (di/-flush backend))
+       :avet-key        (cond-> avet flush! (di/-flush backend))}
+      (when (:keep-history? config)
+        {:temporal-eavt-key (cond-> temporal-eavt flush! (di/-flush backend))
+         :temporal-aevt-key (cond-> temporal-aevt flush! (di/-flush backend))
+         :temporal-avet-key (cond-> temporal-avet flush! (di/-flush backend))}))]))
 
 (defn stored->db
   "Constructs in-memory db instance from stored map value."
@@ -85,28 +93,35 @@
   (let [{:keys [eavt-key aevt-key avet-key
                 temporal-eavt-key temporal-aevt-key temporal-avet-key
                 schema rschema system-entities ref-ident-map ident-ref-map
-                config max-tx max-eid op-count hash meta]
+                config max-tx max-eid op-count hash meta schema-meta-key]
          :or   {op-count 0}} stored-db
-        empty              (db/empty-db nil config store)]
-    (assoc empty
-           :max-tx max-tx
-           :max-eid max-eid
-           :config config
-           :meta meta
-           :schema schema
-           :hash hash
-           :op-count op-count
-           :eavt eavt-key
-           :aevt aevt-key
-           :avet avet-key
-           :temporal-eavt temporal-eavt-key
-           :temporal-aevt temporal-aevt-key
-           :temporal-avet temporal-avet-key
-           :rschema rschema
-           :system-entities system-entities
-           :ident-ref-map ident-ref-map
-           :ref-ident-map ref-ident-map
-           :store store)))
+        schema-meta (or (sc/cache-lookup schema-meta-key)
+                        ;; not in store in case we load an old db where the schema meta data was inline
+                        (when-let [schema-meta (k/get store schema-meta-key nil {:sync? true})]
+                          (sc/cache-miss schema-meta-key schema-meta)
+                          schema-meta))
+        empty       (db/empty-db nil config store)]
+    (merge
+     (assoc empty
+            :max-tx max-tx
+            :max-eid max-eid
+            :config config
+            :meta meta
+            :schema schema
+            :hash hash
+            :op-count op-count
+            :eavt eavt-key
+            :aevt aevt-key
+            :avet avet-key
+            :temporal-eavt temporal-eavt-key
+            :temporal-aevt temporal-aevt-key
+            :temporal-avet temporal-avet-key
+            :rschema rschema
+            :system-entities system-entities
+            :ident-ref-map ident-ref-map
+            :ref-ident-map ref-ident-map
+            :store store)
+     schema-meta)))
 
 (defn branch-heads-as-commits [store parents]
   (set (doall (for [p parents]
@@ -140,10 +155,12 @@
                       db            (-> db
                                         (assoc-in [:meta :datahike/commit-id] cid)
                                         (assoc-in [:meta :datahike/parents] parents))
-                      db-to-store   (db->stored db true)
+                      [schema-meta-op db-to-store]   (db->stored db true sync?)
                       _             (<?- (flush-pending-writes store sync?))
                       commit-log-op (k/assoc store cid db-to-store {:sync? sync?})
                       branch-op     (k/assoc store (:branch config) db-to-store {:sync? sync?})]
+                      ;; now wait for all the writes to complete
+                  (when (and schema-meta-op (not sync?)) (<?- schema-meta-op))
                   (<?- commit-log-op)
                   (<?- branch-op)
                   db)))))
@@ -202,15 +219,17 @@
           backend (di/konserve-backend (:index config) store)
           cid (create-commit-id db)
           meta (assoc meta :datahike/commit-id cid)
-          db-to-store (merge {:schema          schema
-                              :max-tx          max-tx
+          schema-meta {:schema schema
+                       :rschema rschema
+                       :system-entities system-entities
+                       :ident-ref-map ident-ref-map
+                       :ref-ident-map ref-ident-map}
+          schema-meta-key (uuid schema-meta)
+          db-to-store (merge {:max-tx          max-tx
                               :max-eid         max-eid
                               :op-count        op-count
                               :hash            hash
-                              :rschema         rschema
-                              :system-entities system-entities
-                              :ident-ref-map   ident-ref-map
-                              :ref-ident-map   ref-ident-map
+                              :schema-meta-key schema-meta-key
                               :config          (update config :initial-tx (comp not empty?))
                               :meta            meta
                               :eavt-key        (di/-flush eavt backend)
@@ -220,6 +239,9 @@
                                {:temporal-eavt-key (di/-flush temporal-eavt backend)
                                 :temporal-aevt-key (di/-flush temporal-aevt backend)
                                 :temporal-avet-key (di/-flush temporal-avet backend)}))]
+      (k/assoc store schema-meta-key schema-meta {:sync? true})
+      (when-not (sc/cache-has? schema-meta-key)
+        (sc/cache-miss schema-meta-key schema-meta))
       (flush-pending-writes store true)
       (k/assoc store :branches #{:db} {:sync? true})
       (k/assoc store cid db-to-store {:sync? true})
@@ -263,7 +285,7 @@
    (-database-exists? config)))
 
 (defn transact! [old {:keys [tx-data tx-meta]}]
-  (log/debug "Transacting" (count tx-data) " objects with meta: " tx-meta)
+  (log/debug "Transacting" (count tx-data) "objects with meta:" tx-meta)
   (log/trace "Transaction data" tx-data)
   (complete-db-update old (core/with old tx-data tx-meta)))
 

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -239,7 +239,9 @@
                                {:temporal-eavt-key (di/-flush temporal-eavt backend)
                                 :temporal-aevt-key (di/-flush temporal-aevt backend)
                                 :temporal-avet-key (di/-flush temporal-avet backend)}))]
+      ;;we just created the first data base in this store, so the write cache is empty
       (k/assoc store schema-meta-key schema-meta {:sync? true})
+      (sc/add-to-write-cache (:store config) schema-meta-key)
       (when-not (sc/cache-has? schema-meta-key)
         (sc/cache-miss schema-meta-key schema-meta))
       (flush-pending-writes store true)

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -20,8 +20,7 @@
 
 (defn stored-db? [obj]
   ;; TODO use proper schema to match?
-  (let [keys-to-check [:eavt-key :aevt-key :avet-key ;:schema :rschema
-                       ;:system-entities :ident-ref-map :ref-ident-map :config
+  (let [keys-to-check [:eavt-key :aevt-key :avet-key :config
                        :max-tx :max-eid :op-count :hash :meta]]
     (= (count (select-keys obj keys-to-check))
        (count keys-to-check))))
@@ -288,8 +287,8 @@
    (-database-exists? config)))
 
 (defn transact! [old {:keys [tx-data tx-meta]}]
-  (log/debug "Transacting" (count tx-data) "objects with meta:" tx-meta)
-  (log/trace "Transaction data" tx-data)
+  (log/debug "Transacting" (count tx-data) "objects")
+  (log/trace "Transaction data" tx-data  "with meta:" tx-meta)
   (complete-db-update old (core/with old tx-data tx-meta)))
 
 (defn load-entities [old entities]


### PR DESCRIPTION
Fixes #715. So far the schema has been stored inline in the db record that is written after each transaction commit. The problem with this is that it bloats the storage size and slows down commits when the schema size increases. We now break out the schema meta data separately and only write it when the schema changes. A downside of breaking out data and storing it separately is that it requires an additional write operation to the underlying store, the write cache reduces the overhead of this and we do it in parallel, nonetheless we might also want to break out the `config` since it is probably constant, and that would require another cache and write operation. So we should be mindful with the overheads involved. For the schema this definitely makes sense, since its size is not bounded, while the config stays constant in size (so far). This PR also coordinates this cache with the garbage collector, which is now properly routed through the writer (invalidating its write cache) and also exposed with a Datomic compatible API call.