### PR TITLE
cljs compilation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ dhi
 dhi.build_artifacts.txt
 trace.edn
 tmp.edn
+.shadow-cljs

--- a/bb/resources/native-image-tests/run-bb-pod-tests.clj
+++ b/bb/resources/native-image-tests/run-bb-pod-tests.clj
@@ -85,6 +85,7 @@
                     [?e :age ?a]]
                   (d/db conn)))))
     (let [timestamp (Date.)]
+      (Thread/sleep 1)
       (d/transact conn {:tx-data [{:db/id 3 :age 25}]})
       (d/transact conn [{:name "FOO"  :age "BAR"}])
       (testing "pull"

--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -58,12 +58,17 @@
 (defn specs []
   (kaocha "--focus" "specs" "--plugin" "kaocha.plugin/orchestra"))
 
+(defn cljs-compile-test []
+  (p/shell "clj -M:cljs -m shadow.cljs.devtools.cli compile :comptest")
+  (p/shell "node target/out/comptest.js"))
+
 (defn all [config]
   (kaocha "--skip" "specs")
   (specs)
   (back-compat config)
   (native-image)
-  (bb-pod))
+  (bb-pod)
+  (cljs-compile-test))
 
 (defn -main [config & args]
   (if (seq args)
@@ -72,5 +77,6 @@
       "bb-pod" (bb-pod)
       "back-compat" (back-compat config)
       "specs" (specs)
+      "cljs" (cljs-compile-test)
       (apply kaocha "--focus" args))
     (all config)))

--- a/deps.edn
+++ b/deps.edn
@@ -20,9 +20,7 @@
         mvxcvi/clj-cbor                             {:mvn/version "1.1.1"}
         org.babashka/http-client                    {:mvn/version "0.3.11"}
         metosin/jsonista                            {:mvn/version "0.3.7"}
-        pkpkpk/cljs-cache                           {:git/url "https://github.com/pkpkpk/cljs-cache"
-                                                     :git/tag "datahike-fix"
-                                                     :git/sha "a0e7298fb90daadbf4dcf12ae996396e68cb1f3e"}}
+        com.github.pkpkpk/cljs-cache                {:mvn/version "1.0.21"}}
 
  :paths ["src" "target/classes" "resources"]
 

--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,11 @@
         io.replikativ/hitchhiker-tree               {:mvn/version "0.2.222"
                                                      :exclusions [org.clojure/clojurescript]}
         io.replikativ/konserve                      {:mvn/version "0.7.319"
-                                                     :exclusions [org.clojure/clojurescript]}
+                                                     :exclusions [org.clojure/clojurescript
+                                                                  org.clojars.mmb90/cljs-cache]}
         io.replikativ/superv.async                  {:mvn/version "0.3.48"
                                                      :exclusions [org.clojure/clojurescript]}
-        io.replikativ/datalog-parser                {:mvn/version "0.2.29"}
+        io.replikativ/datalog-parser                {:mvn/version "0.2.30"}
         io.replikativ/zufall                        {:mvn/version "0.2.9"}
         persistent-sorted-set/persistent-sorted-set {:mvn/version "0.3.0"}
         environ/environ                             {:mvn/version "1.2.0"}
@@ -18,7 +19,10 @@
         metosin/spec-tools                          {:mvn/version "0.10.6"}
         mvxcvi/clj-cbor                             {:mvn/version "1.1.1"}
         org.babashka/http-client                    {:mvn/version "0.3.11"}
-        metosin/jsonista                            {:mvn/version "0.3.7"}}
+        metosin/jsonista                            {:mvn/version "0.3.7"}
+        pkpkpk/cljs-cache                           {:git/url "https://github.com/pkpkpk/cljs-cache"
+                                                     :git/tag "datahike-fix"
+                                                     :git/sha "a0e7298fb90daadbf4dcf12ae996396e68cb1f3e"}}
 
  :paths ["src" "target/classes" "resources"]
 
@@ -32,7 +36,9 @@
 
            :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.0"}}}
 
-           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.121"}}}
+           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.132"}
+                               thheller/shadow-cljs {:mvn/version "2.28.20"}}
+                  :extra-paths ["test"]}
 
            :dev {:extra-paths ["dev" "benchmark/src"]
                  :extra-deps {org.clojure/tools.namespace {:mvn/version "1.4.4"}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,9 @@
+{:deps true
+ :src-paths ["src" "test"]
+ :builds {:comptest
+          {:target :node-script
+           :output-to "target/out/comptest.js"
+           :main datahike.cljs-compilation-test/-main
+           :compiler-options {:infer-externs true
+                              :warnings {:fn-deprecated false
+                                         :protocol-multiple-impls false}}}}}

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -857,7 +857,7 @@ Returns the key under which this listener is registered. See also [[unlisten]]."
     gc-storage
     {:args             (s/alt :with-date (s/cat :conn spec/SConnection :remove-before spec/time-point?)
                               :no-date (s/cat :conn spec/SConnection))
-     :ret              set?
+     :ret              any?
      :doc "Invokes garbage collection on the store of connection by whitelisting currently known branches.
 All db snapshots on these branches before remove-before date will also be
 erased (defaults to beginning of time [no erasure]). The branch heads will

--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -1,8 +1,10 @@
 (ns ^:no-doc datahike.datom
+  #?(:cljs (:require-macros [datahike.datom :refer [combine-cmp]]))
   (:require  [clojure.walk]
              [clojure.data]
+             [datahike.constants :refer [tx0]]
              [datahike.tools :refer [combine-hashes]]
-             [datahike.constants :refer [tx0]]))
+             #?(:cljs [goog.array :as garray])))
 
 (declare hash-datom equiv-datom seq-datom nth-datom assoc-datom val-at-datom)
 
@@ -147,7 +149,8 @@
     :v (datom (.-e d) (.-a d) v (datom-tx d) (datom-added d))
     :tx (datom (.-e d) (.-a d) (.-v d) v (datom-added d))
     :added (datom (.-e d) (.-a d) (.-v d) (datom-tx d) v)
-    (throw (IllegalArgumentException. (str "invalid key for #datahike/Datom: " k)))))
+    (throw (#?(:clj IllegalArgumentException. :cljs js/Error.)
+            (str "invalid key for #datahike/Datom: " k)))))
 
 ;; printing and reading
 ;; #datomic/DB {:schema <map>, :datoms <vector of [e a v tx]>}
@@ -243,13 +246,13 @@
      (.compareTo ^Comparable a1 a2)))
 
 (defn- class-name [x]
-  (let [c (class x)]
-    (.getName ^Class c)))
+  #?(:clj (.getName (class x))
+     :cljs (type x)))
 
 (defn- safe-compare [a b]
   (try
     (compare a b)
-    (catch Exception _e
+    (catch #?(:clj Exception :cljs js/Error) _e
       (compare (class-name a)
                (class-name b)))))
 

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -18,7 +18,7 @@
    [taoensso.timbre :refer [warn]])
   #?(:cljs (:require-macros [datahike.db :refer [defrecord-updatable]]
                             [datahike.datom :refer [combine-cmp datom]]
-                            [datahike.tools :refer [case-tree raise]]))
+                            [datahike.tools :refer [raise]]))
   (:refer-clojure :exclude [seqable?])
   #?(:clj (:import [clojure.lang AMapEntry ITransientCollection IEditableCollection IPersistentCollection Seqable
                     IHashEq Associative IKeywordLookup ILookup]
@@ -109,9 +109,7 @@
 
 #?(:clj
    (defn- make-record-updatable-cljs [name fields & impls]
-     `(do
-        (defrecord ~name ~fields)
-        (extend-type ~name ~@impls))))
+     `(defrecord ~name ~fields ~@impls)))
 
 #?(:clj
    (defmacro defrecord-updatable [name fields & impls]
@@ -360,12 +358,12 @@
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on FilteredDB")))
-       IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on FilteredDB")))
 
        ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on FilteredDB")))
                         ([_ _ _] (throw (js/Error. "-lookup is not supported on FilteredDB"))))
 
-       IAssociative (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on FilteredDB")))
+       IAssociative
+       (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on FilteredDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on FilteredDB")))]
 
       :clj
@@ -436,12 +434,12 @@
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on HistoricalDB")))
-       IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on HistoricalDB")))
 
        ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on HistoricalDB")))
                         ([_ _ _] (throw (js/Error. "-lookup is not supported on HistoricalDB"))))
 
-       IAssociative (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on HistoricalDB")))
+       IAssociative
+       (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on HistoricalDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on HistoricalDB")))]
       :clj
       [IPersistentCollection
@@ -502,12 +500,12 @@
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on AsOfDB")))
-       IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on AsOfDB")))
 
        ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on AsOfDB")))
                         ([_ _ _] (throw (js/Error. "-lookup is not supported on AsOfDB"))))
 
-       IAssociative (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on AsOfDB")))
+       IAssociative
+       (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on AsOfDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on AsOfDB")))]
       :clj
       [IPersistentCollection
@@ -569,12 +567,12 @@
        IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on SinceDB")))
-       IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on SinceDB")))
 
        ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on SinceDB")))
                         ([_ _ _] (throw (js/Error. "-lookup is not supported on SinceDB"))))
 
-       IAssociative (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on SinceDB")))
+       IAssociative
+       (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on SinceDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on SinceDB")))]
       :clj
       [IPersistentCollection
@@ -871,9 +869,6 @@
          {:temporal-eavt eavt
           :temporal-aevt aevt
           :temporal-avet avet}))))))
-
-(defn get-max-tx [eavt]
-  (transduce (map (fn [^Datom d] (datom-tx d))) max tx0 (di/-all eavt)))
 
 (defn ^DB init-db
   ([datoms] (init-db datoms nil nil nil))

--- a/src/datahike/db/search.cljc
+++ b/src/datahike/db/search.cljc
@@ -1,6 +1,8 @@
 (ns datahike.db.search
+  #?(:cljs (:require-macros [datahike.db.search :refer [lookup-strategy]]))
   (:require
-   [clojure.core.cache.wrapped :as cw]
+   #?(:clj [clojure.core.cache.wrapped :as cw]
+      :cljs [cljs.cache.wrapped :as cw])
    [datahike.array :refer [a=]]
    [datahike.constants :refer [e0 tx0 emax txmax]]
    [datahike.datom :refer [datom datom-tx datom-added type-hint-datom]]

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -7,7 +7,7 @@
             [superv.async :refer [<? S go-try <<?]]
             [clojure.core.async  :as async]
             [datahike.schema-cache :as sc])
-  (:import [java.util Date]))
+  #?(:clj (:import [java.util Date])))
 
 ;; meta-data does not get passed in macros
 (defn get-time [d]
@@ -50,10 +50,10 @@
   All db snapshots on these branches before remove-before date will also be
   erased (defaults to beginning of time [no erasure]). The branch heads will
   always be retained."
-  ([db] (gc-storage! db (Date. 0)))
+  ([db] (gc-storage! db (#?(:clj Date. :cljs js/Date.) 0)))
   ([db remove-before]
    (go-try S
-           (let [now (Date.)
+           (let [now #?(:clj (Date.) :cljs (js/Date.))
                  _ (debug "starting gc" now)
                  {:keys [config store]} db
                  _ (sc/clear-write-cache (:store config)) ; Clear the schema write cache for this store

--- a/src/datahike/impl/entity.cljc
+++ b/src/datahike/impl/entity.cljc
@@ -4,7 +4,7 @@
             [datahike.db :as db]
             [datahike.db.interface :as dbi]
             [datahike.db.utils :as dbu])
-  (:import [datahike.java IEntity]))
+  #?(:clj (:import [datahike.java IEntity])))
 
 (declare entity ->Entity equiv-entity lookup-entity touch)
 
@@ -46,7 +46,7 @@
    (defn- js-seq [e]
      (touch e)
      (for [[a v] @(.-cache e)]
-       (if (db/multival? (.-db e) a)
+       (if (dbu/multival? (.-db e) a)
          [a (multival->js v)]
          [a v]))))
 
@@ -60,7 +60,7 @@
 
        ;; js/map interface
        (keys [this]
-             (es6-iterator (c/keys this)))
+             (es6-iterator (cljs.core/keys this)))
        (entries [this]
                 (es6-entries-iterator (js-seq this)))
        (values [this]
@@ -83,7 +83,7 @@
                   (.call f use-as-this v a this)))
 
        ;; js fallbacks
-       (key_set   [this] (to-array (c/keys this)))
+       (key_set   [this] (to-array (cljs.core/keys this)))
        (entry_set [this] (to-array (map to-array (js-seq this))))
        (value_set [this] (to-array (map second (js-seq this))))
 

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -1,7 +1,8 @@
 (ns ^:no-doc datahike.index
+  (:refer-clojure :exclude [-persistent! -flush -count -seq])
   (:require [datahike.index.interface :as di]
             [datahike.index.persistent-set]
-            [datahike.index.hitchhiker-tree]))
+            #?(:clj [datahike.index.hitchhiker-tree])))
 
 ;; Aliases for protocol functions
 

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -1,5 +1,6 @@
 (ns datahike.index.interface
-  "All the functions in this namespace must be implemented for each index type")
+  "All the functions in this namespace must be implemented for each index type"
+  #?(:cljs (:refer-clojure :exclude [-seq -count -persistent! -flush])))
 
 (defprotocol IIndex
   (-all [index] "Returns a sequence of all datoms in the index")

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -1,8 +1,11 @@
 (ns ^:no-doc datahike.index.persistent-set
+  #?(:cljs (:require-macros [datahike.index.persistent-set :refer [generate-slice-comparator-constructor]]))
   (:require [me.tonsky.persistent-sorted-set :as psset]
             [me.tonsky.persistent-sorted-set.arrays :as arrays]
-            [clojure.core.cache :as cache]
-            [clojure.core.cache.wrapped :as wrapped]
+            #?@(:clj  [[clojure.core.cache :as cache]
+                       [clojure.core.cache.wrapped :as wrapped]]
+                :cljs [[cljs.cache :as cache]
+                       [cljs.cache.wrapped :as wrapped]])
             [datahike.datom :as dd :refer [index-type->cmp-quick]]
             [datahike.constants :refer [tx0 txmax]]
             [datahike.index.interface :as di :refer [IIndex]]
@@ -162,7 +165,7 @@
     (psset/walk-addresses pset (fn [address] (swap! addresses conj address)))
     @addresses))
 
-(extend-type PersistentSortedSet
+(extend-type #?(:clj PersistentSortedSet :cljs psset/BTSet)
   IIndex
   (-slice [^PersistentSortedSet pset from to index-type]
     (psset/slice pset from to (slice-comparator-constructor index-type from to)))
@@ -268,10 +271,11 @@
 
 ;; temporary import from psset until public
 (defn- map->settings ^Settings [m]
-  (Settings.
-   (int (or (:branching-factor m) 0))
-   nil ;; weak ref default
-   ))
+  #?(:cljs m
+     :clj (Settings.
+           (int (or (:branching-factor m) 0))
+           nil                                             ;; weak ref default
+           )))
 
 (defmethod di/add-konserve-handlers :datahike.index/persistent-set [config store]
   ;; deal with circular reference between storage and store

--- a/src/datahike/integration_test.cljc
+++ b/src/datahike/integration_test.cljc
@@ -1,8 +1,7 @@
 (ns ^:no-doc datahike.integration-test
   "This namespace is the minimum test a Datahike backend needs to pass for compatibility assessment."
-  (:require [datahike.api :as d]
-            #?(:clj [clojure.test :refer :all]
-               :cljs [cljs.test :refer :all :include-macros true])))
+  (:require [clojure.test :refer [is]]
+            [datahike.api :as d]))
 
 (defn integration-test-fixture [config]
   (d/delete-database config)

--- a/src/datahike/lru.cljc
+++ b/src/datahike/lru.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc datahike.lru
-  (:require [clojure.core.cache :refer [defcache CacheProtocol]]
-            clojure.data.priority-map))
+  (:require [#?(:clj clojure.core.cache :cljs cljs.cache) :refer [defcache CacheProtocol]]
+            #?(:clj clojure.data.priority-map
+               :cljs tailrecursion.priority-map)))
 
 (declare assoc-lru cleanup-lru)
 
@@ -119,7 +120,8 @@
            this))
   (seed [_ base]
         (LRUDatomCache. base
-                        (into (clojure.data.priority-map/priority-map)
+                        (into #?(:clj (clojure.data.priority-map/priority-map)
+                                 :cljs (tailrecursion.priority-map/priority-map))
                               (map #(vector % 0)
                                    (keys base)))
                         (into {}
@@ -140,4 +142,5 @@
   [base & {threshold :threshold :or {threshold 32}}]
   {:pre [(number? threshold) (< 0 threshold)
          (map? base)]}
-  (atom (clojure.core.cache/seed (LRUDatomCache. {} (clojure.data.priority-map/priority-map) {} 0 0 threshold) base)))
+  #?(:clj (atom (clojure.core.cache/seed (LRUDatomCache. {} (clojure.data.priority-map/priority-map) {} 0 0 threshold) base))
+     :cljs (atom (cljs.cache/seed (LRUDatomCache. {} (tailrecursion.priority-map/priority-map) {} 0 0 threshold) base))))

--- a/src/datahike/middleware/utils.cljc
+++ b/src/datahike/middleware/utils.cljc
@@ -3,10 +3,13 @@
 (defn apply-middlewares
   "Combines a list of middleware functions into one."
   [middlewares handler]
-  (reduce
-   (fn [acc f-sym]
-     (if-let [f (resolve f-sym)]
-       (f acc)
-       (throw (ex-info "Invalid middleware.😱" {:fn f-sym}))))
-   handler
-   middlewares))
+  #?(:cljs (throw (ex-info "middleware resolution is not supported in cljs at this time" {:middlewares middlewares
+                                                                                          :handler handler}))
+     :clj
+     (reduce
+      (fn [acc f-sym]
+        (if-let [f (resolve f-sym)]
+          (f acc)
+          (throw (ex-info "Invalid middleware.😱" {:fn f-sym}))))
+      handler
+      middlewares)))

--- a/src/datahike/pull_api.cljc
+++ b/src/datahike/pull_api.cljc
@@ -2,8 +2,7 @@
   (:require
    [datahike.db.utils :as dbu]
    [datahike.db.interface :as dbi]
-   [datalog.parser.pull :as dpp])
-  #?@(:cljs [datalog.parser.pull :refer [PullSpec]])
+   [datalog.parser.pull :as dpp #?@(:cljs [:refer [PullSpec]])])
   #?(:clj
      (:import
       [datahike.datom Datom]

--- a/src/datahike/query_stats.cljc
+++ b/src/datahike/query_stats.cljc
@@ -2,8 +2,8 @@
   (:require [clojure.set :as set]
             [datahike.tools :as dt]))
 
-(defn round [^long precision ^java.math.BigDecimal x]
-  #?(:clj (with-precision precision x)
+(defn round [precision x]
+  #?(:clj (with-precision ^long precision ^java.math.BigDecimal x)
      :cljs (let [y (Math/pow 10 precision)]
              (/ (.round js/Math (* y x)) y))))
 

--- a/src/datahike/readers.cljc
+++ b/src/datahike/readers.cljc
@@ -2,6 +2,7 @@
   (:require [datahike.connections :refer [get-connection *connections*]]
             [datahike.writing :as dw]
             [datahike.datom :refer [datom] :as dd]
+            #?(:cljs [datahike.db :refer [HistoricalDB AsOfDB SinceDB]])
             [datahike.impl.entity :as de]
             [datahike.core :refer [init-db] :as dc]
             [datahike.tools :refer [raise]]

--- a/src/datahike/schema_cache.cljc
+++ b/src/datahike/schema_cache.cljc
@@ -1,5 +1,6 @@
 (ns datahike.schema-cache
-  (:require [clojure.core.cache.wrapped :as cw]
+  (:require #?(:clj [clojure.core.cache.wrapped :as cw]
+               :cljs [cljs.cache.wrapped :as cw])
             [datahike.config :as dc]
             [datahike.store :as ds]))
 

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -1,4 +1,5 @@
 (ns ^:no-doc datahike.tools
+  #?(:cljs (:require-macros [datahike.tools :refer [raise]]))
   (:require
    [superv.async :refer [throw-if-exception-]]
    [clojure.core.async.impl.protocols :as async-impl]
@@ -68,8 +69,7 @@
   (let [msgs (butlast fragments)
         data (last fragments)]
     (list `(log/log! :error :p ~fragments ~{:?line (:line (meta &form))})
-          `(throw #?(:clj  (ex-info (str ~@(map (fn [m#] (if (string? m#) m# (list 'pr-str m#))) msgs)) ~data)
-                     :cljs (error (str ~@(map (fn [m#] (if (string? m#) m# (list 'pr-str m#))) msgs)) ~data))))))
+          `(throw (ex-info (str ~@(map (fn [m#] (if (string? m#) m# (list 'pr-str m#))) msgs)) ~data)))))
 
 ;; adapted from https://clojure.atlassian.net/browse/CLJ-2766
 #?(:clj
@@ -128,8 +128,8 @@
    :konserve/version konserve-version
    :hitchhiker.tree/version hitchhiker-tree-version
    :persistent.set/version persistent-set-version
-   :datahike/id (UUID/randomUUID)
-   :datahike/created-at (Date.)})
+   :datahike/id #?(:clj (UUID/randomUUID) :cljs (random-uuid))
+   :datahike/created-at #?(:clj (Date.) :cljs (js/Date.))})
 
 (defn deep-merge
   "Recursively merges maps together. If all the maps supplied have nested maps
@@ -169,9 +169,9 @@
 
 (defn get-hostname []
   #?(:clj (.getHostAddress (InetAddress/getLocalHost))
-     :cljs (raise "Not supported yet." {:type :hostname-not-supported-yet})))
+     :cljs "" #_(raise "Not supported." {:type :hostname-not-supported})))
 
-(def datahike-logo (slurp (io/resource "datahike-logo.txt")))
+#?(:clj (def datahike-logo (slurp (io/resource "datahike-logo.txt"))))
 
 (defmacro with-destructured-vector [v & var-expr-pairs]
   {:pre [(even? (count var-expr-pairs))]}

--- a/test/datahike/cljs_compilation_test.cljs
+++ b/test/datahike/cljs_compilation_test.cljs
@@ -1,0 +1,45 @@
+(ns datahike.cljs-compilation-test
+  (:require [clojure.test :refer [deftest is] :as t]
+            [datahike.api :as d]
+            datahike.api.impl
+            datahike.api.specification
+            datahike.array
+            datahike.config
+            datahike.connector
+            datahike.connections
+            datahike.constants
+            datahike.core
+            datahike.datom
+            datahike.db
+            datahike.db.interface
+            datahike.db.search
+            datahike.db.transaction
+            datahike.db.utils
+            datahike.gc
+            datahike.impl.entity
+            datahike.index
+            datahike.index.interface
+            datahike.index.persistent-set
+            datahike.index.utils
+            datahike.integration-test
+            datahike.lru
+            datahike.middleware.utils
+            datahike.pull-api
+            datahike.query
+            datahike.readers
+            datahike.schema
+            datahike.schema-cache
+            datahike.spec
+            datahike.store
+            datahike.transit
+            datahike.tools
+            datahike.writing
+            datahike.writer))
+
+(deftest sanity-test
+  (is (fn? d/q)))
+
+;clj -M:cljs -m shadow.cljs.devtools.cli compile :comptest && node target/out/comptest.js
+(defn -main []
+  (let [summary (clojure.test/run-tests)]
+    (js/process.exit (if (t/successful? summary) 0 1))))


### PR DESCRIPTION
#### SUMMARY
incremental fix for #206. restores clojurescript compilation of `datahike.api`, but not full functionality.

#### Checks
##### Bugfix
- [X] Related issues linked using `fixes #number`
- [X] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [X] Formatting checked

#### ADDITIONAL INFORMATION

+ mostly superficial fixes
+ datahike.api now unrolls a top-level do form in sorted-order, instead of side-effecting evals. the sorted-order is important to cljs
+ there is a node test that tests the core namespaces compile and load ok
+ there is weird subtle behavior difference wrt vanilla & shadow cljs in the way they handle macros that is relevant to konserve, so shadow is preferred at this time
