### PR TITLE
Update on documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,36 @@
 <a href="https://clojurians.slack.com/archives/CB7GJAN0L"><img src="https://badgen.net/badge/-/slack?icon=slack&label"/></a>
 <a href="https://clojars.org/io.replikativ/datahike"> <img src="https://img.shields.io/clojars/v/io.replikativ/datahike.svg" /></a>
 <a href="https://circleci.com/gh/replikativ/datahike"><img src="https://circleci.com/gh/replikativ/datahike.svg?style=shield"/></a>
-<a href="https://github.com/replikativ/datahike/tree/main"><img src="https://img.shields.io/github/last-commit/replikativ/datahike/main"/></a>
+<a href="https://cljdoc.org/d/io.replikativ/datahike"><img src="https://badgen.net/badge/cljdoc/datahike/blue"/></a>
 </p>
 
-[Datahike](https://datahike.io) is a durable [Datalog](https://en.wikipedia.org/wiki/Datalog) database
-powered by an efficient Datalog query engine. This project started as a port of
-[DataScript](https://github.com/tonsky/DataScript) to the
-[hitchhiker-tree](https://github.com/datacrypt-project/hitchhiker-tree). All
-DataScript tests are passing, but we are still working on the internals. Having
-said this we consider Datahike usable for medium sized projects, since DataScript is
-very mature and deployed in many applications and the hitchhiker-tree
-implementation is heavily tested through generative testing. We are
-building on the two projects and the storage backends for the hitchhiker-tree
-through [konserve](https://github.com/replikativ/konserve). We would like to
-hear experience reports and are happy if you join us.
+[Datahike](https://datahike.io) is a git-like, read-scalable, distributed
+[Datalog](https://en.wikipedia.org/wiki/Datalog) database powered by an
+efficient Datalog query engine. It expands the *copy-on-write* memory semantics
+of Clojure to a globally joinable index space, Datahike databases can be joined
+remotely without any coordination, only access to the underlying store is needed
+and database snapshots can be hold onto by readers between queries. This removes
+the necessity of any glue code to bring different data sources together.
+Compared to SQL Datahike allows invocation of any Clojure (JVM) function as part
+of its queries. Datahike has competitive performance to Datomic and can handle
+databases with many millions of entities consisting of billions of Datoms. It is
+used in multiple production setups for years and has not experienced any data
+losses to our knowledge. Datahike has a [Java
+API](./java/src/datahike/java/Datahike.java), can be natively compiled and used
+from the [command line](./doc/cli.md) and a [babashka pod](./doc/bb-pod.md). Its
+ClojureScript port is work in progress. The goal is to make it easy to bring the
+Datalog query engine in whatever runtime environments that need access to your
+data.
 
-You can find [API documentation on cljdoc](https://cljdoc.org/d/io.replikativ/datahike) and articles on Datahike on our company's [blog page](https://lambdaforge.io/articles).
+Besides the integrated file store different underlying durable stores are supported by Datahike:
 
-[![cljdoc](https://badgen.net/badge/cljdoc/datahike/blue)](https://cljdoc.org/d/io.replikativ/datahike)
+- [S3](https://github.com/replikativ/datahike-s3)
+- [DynamoDB](https://github.com/replikativ/datahike-dynamodb)
+- [JDBC](https://github.com/replikativ/datahike-jdbc)
+- [Redis](https://github.com/replikativ/datahike-redis)
+- [Google Cloud Storage](https://github.com/The-Literal-Company/datahike-gcs)
 
-We presented Datahike also at meetups,for example at:
+We presented Datahike also at meetups, for example at:
 
 - [2021 Bay Area Clojure meetup](https://www.youtube.com/watch?v=GG-S-xrDS5M)
 - [2019 scicloj online meetup](https://www.youtube.com/watch?v=Hjo4TEV81sQ).
@@ -38,10 +48,6 @@ We presented Datahike also at meetups,for example at:
 Add to your dependencies:
 
 [![Clojars Project](http://clojars.org/io.replikativ/datahike/latest-version.svg)](http://clojars.org/io.replikativ/datahike)
-
-We provide a small stable API for the JVM at the moment, but the on-disk schema
-is not fixed yet. We will provide a migration guide until we have reached a
-stable on-disk schema. _Take a look at the ChangeLog before upgrading_.
 
 ```clojure
 (require '[datahike.api :as d])
@@ -108,18 +114,20 @@ stable on-disk schema. _Take a look at the ChangeLog before upgrading_.
 ```
 
 The API namespace provides compatibility to a subset of Datomic functionality
-and should work as a drop-in replacement on the JVM. The rest of Datahike will
-be ported to core.async to coordinate IO in a platform-neutral manner.
+and should work as a drop-in replacement on the JVM.
 
 Refer to the docs for more information:
 
+- [babashka pod](./doc/bb-pod.md)
 - [backend development](./doc/backend-development.md)
 - [benchmarking](./doc/benchmarking.md)
-- [garbage collection](./doc/gc.md)
+- [cli](./doc/cli.md)
 - [contributing to Datahike](./doc/contributing.md)
 - [configuration](./doc/config.md)
 - [differences to Datomic](./doc/datomic_differences.md)
+- [distribution](./doc/distribution.md)
 - [entity spec](./doc/entity_spec.md)
+- [garbage collection](./doc/gc.md)
 - [logging and error handling](./doc/logging_and_error_handling.md)
 - [schema flexibility](./doc/schema.md)
 - [time variance](./doc/time_variance.md)
@@ -248,6 +256,6 @@ feature, please let us know.
 
 ## License
 
-Copyright © 2014–2023 Konrad Kühne, Christian Weilbach, Chrislain Razafimahefa, Timo Kramer, Judith Massa, Nikita Prokopov, Ryan Sundberg
+Copyright © 2014–2025 Konrad Kühne, Christian Weilbach, Chrislain Razafimahefa, Timo Kramer, Judith Massa, Nikita Prokopov, Ryan Sundberg
 
 Licensed under Eclipse Public License (see [LICENSE](LICENSE)).

--- a/config.edn
+++ b/config.edn
@@ -1,7 +1,7 @@
 {:org "replikativ"
  :lib "datahike"
- :version {:major 0
-           :minor 6}
+ :version {:major 1
+           :minor 0}
  :git-url "git@github.com:replikativ/datahike.git"
 
  :pom-template "./bb/resources/template/pom.xml"


### PR DESCRIPTION
Finally update all the documentation and make sure it reflects the current state of datahike. Also move to the first major release and commit to the current storage format as stable enough to retain backwards compatibility.