### PR TITLE
Updated import db

### DIFF
--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -3,7 +3,13 @@
             [datahike.constants :as c]
             [datahike.datom :as d]
             [datahike.db :as db]
-            [clj-cbor.core :as cbor]))
+            [clj-cbor.core :as cbor]
+            [clojure.core.async :as async]
+            [clojure.java.io :as io]
+            [taoensso.timbre :as timbre]
+            [clj-cbor.tags.time :as tags.time])
+  (:import [java.util.concurrent LinkedBlockingQueue]
+           [java.sql Timestamp]))
 
 (defn export-db
   "Export the database in a flat-file of datoms at path.
@@ -17,23 +23,117 @@
                           (:attribute-refs? cfg) (remove #(= (d/datom-tx %) c/tx0))
                           true (map seq)))))
 
-(defn update-max-tx
-  "Find bigest tx in datoms and update max-tx of db.
-  Note: the last tx might not be the biggest if the db
-  has been imported before."
-  [db datoms]
-  (assoc db :max-tx (reduce #(max %1 (nth %2 3)) 0 datoms)))
-
 (defn- instance-to-date [v]
   (if (instance? java.time.Instant v) (java.util.Date/from v) v))
 
-(defn import-db
-  "Import a flat-file of datoms at path into your database.
-  Intended as a temporary solution, pending developments in Wanderung."
-  [conn path]
-  (println "Preparing import of" path "in batches of 1000")
-  (let [datoms (->> (cbor/slurp-all path)
-                    (map #(-> (apply d/datom %) (update :v instance-to-date))))]
-    (swap! conn update-max-tx datoms)
-    (print "Importing ")
-    (api/transact conn (vec datoms))))
+(defn- instance-to-double [v]
+  (if (float? v)
+    (double v)
+    v))
+
+(defn process-cbor-file
+  "Reads a CBOR file from `filename` and calls `process-fn` this allows for
+  ingesting a large number of datoms without running out of memory."
+  [filename process-fn stop-fn]
+  (let [codec (cbor/cbor-codec
+               {:read-handlers {0 :x}
+                :write-handlers tags.time/date-read-handlers})]
+    (with-open [in (io/input-stream filename)]
+      (loop []
+        (when-let [data (cbor/decode cbor/default-codec in)]
+          (process-fn data)
+          (recur))))
+    (stop-fn)))
+
+(defn import-db [conn path & opts]
+  (let [star-time (System/currentTimeMillis)
+        filter-schema? (get opts :filter-schema? false)
+        sync? (get opts :sync? true)
+        tx-max (atom 0)
+        datom-count (atom 0)
+        txn-count (atom 0)
+        stop (atom false)
+        processed (atom false)
+        update-tx-max (fn [tx] (reset! tx-max (max @tx-max tx)))
+        q (LinkedBlockingQueue.) ;; thread safe queue for datoms
+        prepare-datom (fn [item]
+                        ;; update as we go so we don't run out of memory
+                        (update-tx-max (nth item 3))
+                        (swap! datom-count inc)
+                        (-> (apply d/datom item)
+                            ;; convert Instant to Date (previously experienced bug)
+                            (update :v instance-to-date)
+                            ;; convert Float to Double (previously reported bug)
+                            (update :v instance-to-double)))
+        add-datom (fn [item]
+                    (let [datom (prepare-datom item)]
+                        ;; skip schema datoms
+                      (if filter-schema?
+                        (when (-> item (nth 1) (str "0000") (subs 0 4) (not= ":db/")) (.put q datom))
+                        (.put q datom))))
+        drain-queue (fn []
+                      (let [acc (java.util.ArrayList.)]
+                          ;; max required otherwise if previous write is slow too many in transaction
+                        (.drainTo q acc 200000)
+                        (vec acc)))]
+      ;; prevent all the datoms that failed from being logged
+    (timbre/merge-config! {:min-level [[#{"datahike.writing"} :fatal] [#{"datahike.writer"} :fatal]]})
+
+    (async/thread
+      (timbre/info "Starting import")
+      (loop []
+        (Thread/sleep 100) ; batch writes for improved performance
+        (let [datoms (drain-queue)]
+          (try
+            (timbre/debug "loading" (count datoms) "datoms")
+            (swap! txn-count + (count datoms))
+            (api/load-entities conn datoms)
+            (catch Exception e
+                ;; we can't print the message as it contains all the datoms
+              (timbre/error "Error loading" (count datoms)))))
+        (when (and (>= @txn-count @datom-count) @processed)
+            ;; stop when we've transacted all datoms
+          (timbre/info "\nImported" @datom-count "datoms in total. \nTime elapsed" (- (System/currentTimeMillis) star-time) "ms")
+          (reset! stop true))
+        (when (not @stop) (recur))))
+
+    (async/thread
+      (process-cbor-file
+       path
+       add-datom
+       (fn []
+         (reset! processed true))))
+
+    (when sync?
+      (loop []
+        (Thread/sleep 100)
+        (timbre/info "remaining" (- @datom-count @txn-count))
+        (when (not @stop) (recur))))
+
+      ;; allow the user to stop or monitor the ingestion thread with this atom
+    (fn []
+      {:complete? @stop
+       :preprocessed? @processed
+       :total-datoms @datom-count
+       :remaining (- @datom-count @txn-count)})))
+
+(comment
+  ;; include
+  ;; [io.replikativ/datahike-jdbc "0.3.49"]
+  ;; [org.xerial/sqlite-jdbc "3.41.2.2"]
+  (require '[stub-server.migrate :as m] :reload)
+  (require '[datahike.api :as d])
+  (require '[clojure.java.io :as io])
+  (require '[datahike-jdbc.core])
+  (def dev-db (str "./temp/sqlite/ingest"))
+  (io/make-parents dev-db)
+  ;; for testing large db's it's best to use sqlite. File store may run out of resources threads or pointers 
+  ;; my test 21 seconds with SQLite with 16M datoms
+  (def cfg      {:store {:backend :jdbc :dbtype "sqlite" :dbname dev-db}
+                 :keep-history? true
+                 :allow-unsafe-config true
+                 :store-cache-size 20000
+                 :search-cache-size 20000})
+  (d/create-database cfg)
+  (def conn (d/connect cfg))
+  (def status (m/import-db conn "prod.backup.cbor" {:sync? true :filter-schema? false})))


### PR DESCRIPTION
#### SUMMARY
The current `import-db` function does not work at scale. It requires a lot of memory and takes very long. 
Restoring our production instance took 2 hours for 16M datoms and required a huge instance. This is not practical. 

This PR changes `import-db` such that one thread reads the serialized data token by token while another loads them into the store. This has changed the restore of 16M datoms from 2 hours to 21 seconds. 

This introduces 3 new options.

```clojure
(defn import-db [conn path & opts] ...)
```

**filter-schema?**:   
ignore schema datoms when importing the db. This is helpful if your schema has evolved over time. 

**load-entities?**:   
uses load-entities instead of transact. This is much faster. It is also more forgiving where intial datoms do not adhere to current schema

**sync?**:  
When set to true old behaviour is preserved, when set to false importing is async in two threads. A status function is return to allow querying of the status

```clojure
=> (status)
{:complete? false
 :preprocessed? true
 :total-datoms 1200000
 :remaining 200000})
```

For backwards compatibility the default mode is synchronous, uses transact, and does not filter the schema. 

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #633`

##### Feature
- [x] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [x] Related issues linked using `fixes #633`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [x] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I would appreciate a second pair of eyes on this. Here's how you can run your own test

```clojure
(comment
  ;; include
  ;; [io.replikativ/datahike-jdbc "0.3.49"]
  ;; [org.xerial/sqlite-jdbc "3.41.2.2"]
  (require '[stub-server.migrate :as m] :reload)
  (require '[datahike.api :as d])
  (require '[clojure.java.io :as io])
  (require '[datahike-jdbc.core])
  (def dev-db (str "./temp/sqlite/ingest"))
  (io/make-parents dev-db)
  ;; for testing large db's it's best to use sqlite. File store may run out of resources threads or pointers 
  ;; my test 21 seconds with SQLite with 16M datoms
  (def cfg      {:store {:backend :jdbc :dbtype "sqlite" :dbname dev-db}
                 :keep-history? true
                 :allow-unsafe-config true
                 :store-cache-size 20000
                 :search-cache-size 20000})
  (d/create-database cfg)
  (def conn (d/connect cfg))
  (def status (m/import-db conn "prod.backup.cbor" {:sync? true :filter-schema? false})))
```

<!--- Paste verbatim command output below, e.g. before and after your change -->


