### PR TITLE
Fix upsert-eid to support composite-tuples

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752950548,
+        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      lib = nixpkgs.lib;
+      allSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      pkgsFor = lib.genAttrs allSystems (system: import nixpkgs { inherit system; config.allowUnfree = true; });
+      overEachSystem = f: lib.genAttrs allSystems (system: f { inherit system; pkgs = pkgsFor.${system}; });
+    in {
+      formatter = overEachSystem ({ system, pkgs }: pkgs.nixfmt-rcf-style);
+      devShells = overEachSystem ({ system, pkgs }: {
+        default = pkgs.mkShellNoCC {
+          packages = [
+            pkgs.clojure
+            pkgs.babashka
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fixes https://github.com/replikativ/datahike/issues/739

Allowing composite tuples to upsert correctly.

I've also added a `flake.nix` for nix convenience, but happy to remove if unwanted.


#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`
- [x] Formatting checked

#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
