### PR TITLE
ci: switch to newer macos runner for intel builds

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             name: macos
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
GitHub just announced the new intel runner for macos builds:
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/