### PR TITLE
Replace timeout-based throttling with proper channel backpressure

### DIFF
--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -95,9 +95,9 @@
                                 (when (> (count commit-queue-buffer) (/ commit-queue-size 2))
                                   (log/warn "Commit queue buffer more than 50% full, "
                                             (count commit-queue-buffer) "of" commit-queue-size  " filled."
-                                            "Throttling transaction processing. Reduce transaction frequency and check your storage throughput.")
-                                  (<! (timeout 50)))
-                                (put! commit-queue [res callback])
+                                            "Backpressure may slow down transaction processing. Check your storage throughput."))
+                                ;; Use >! for natural backpressure - parks when buffer is full
+                                (>! commit-queue [res callback])
                                 (recur (:db-after res)))
                               :else
                               (recur old))))


### PR DESCRIPTION
Use >! (blocking put) instead of put! combined with timeout sleeping. This provides proper backpressure semantics - the go-loop naturally parks when the commit queue buffer is full, instead of using an artificial 50ms sleep as a throttle.

This removes one use of core.async/timeout which helps with GraalVM native-image compatibility (timeout creates a daemon thread).

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
