### PR TITLE
Replace writer initialization polling with promise-chan signal

### DIFF
--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -212,8 +212,9 @@
                          _ (when-not (:allow-unsafe-config config)
                              (ensure-stored-config-consistency config (:config stored-db)))
                          conn      (conn-from-db (dsi/stored->db (assoc stored-db :config config) store))]
-                     (swap! (:wrapped-atom conn) assoc :writer
-                            (w/create-writer (:writer config) conn))
+                     (let [writer (w/create-writer (:writer config) conn)]
+                       (swap! (:wrapped-atom conn) assoc :writer writer)
+                       (w/signal-writer-ready! writer))
                      (add-connection! conn-id conn)
                      conn))))))
 

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -18,7 +18,7 @@
   (-streaming? [_] "Returns whether the transactor is streaming updates directly into the connection, so it does not need to fetch from store on read."))
 
 (defrecord LocalWriter [thread streaming? transaction-queue-size commit-queue-size
-                        transaction-queue commit-queue]
+                        transaction-queue commit-queue writer-ready-ch]
   PWriter
   (-dispatch! [_ arg-map]
     (let [p (promise-chan)]
@@ -38,7 +38,7 @@
 
 (defn create-thread
   "Creates new transaction thread"
-  [connection write-fn-map transaction-queue-size commit-queue-size commit-wait-time]
+  [connection write-fn-map transaction-queue-size commit-queue-size commit-wait-time writer-ready-ch]
   (let [transaction-queue-buffer    (buffer transaction-queue-size)
         transaction-queue           (chan transaction-queue-buffer)
         commit-queue-buffer         (buffer commit-queue-size)
@@ -49,9 +49,8 @@
       (do
         ;; processing loop
         (go-try S
-         ;; delay processing until the writer we are part of in connection is set
-                (while (not (:writer @(:wrapped-atom connection)))
-                  (<! (timeout 10)))
+         ;; wait until the writer we are part of in connection is set
+                (<! writer-ready-ch)
                 (loop [old @(:wrapped-atom connection)]
                   (if-let [{:keys [op args callback] :as invocation} (<?- transaction-queue)]
                     (do
@@ -150,20 +149,23 @@
   (let [transaction-queue-size (or transaction-queue-size DEFAULT_QUEUE_SIZE)
         commit-queue-size (or commit-queue-size DEFAULT_QUEUE_SIZE)
         commit-wait-time (or commit-wait-time DEFAULT_COMMIT_WAIT_TIME)
+        writer-ready-ch (promise-chan)
         [transaction-queue commit-queue thread]
         (create-thread connection
                        (merge default-write-fn-map
                               write-fn-map)
                        transaction-queue-size
                        commit-queue-size
-                       commit-wait-time)]
+                       commit-wait-time
+                       writer-ready-ch)]
     (map->LocalWriter
      {:transaction-queue transaction-queue
       :transaction-queue-size transaction-queue-size
       :commit-queue commit-queue
       :commit-queue-size commit-queue-size
       :thread thread
-      :streaming? true})))
+      :streaming? true
+      :writer-ready-ch writer-ready-ch})))
 
 ;; Note: :kabel backend is implemented in datahike.kabel.writer
 ;; Require that namespace to register the defmethod
@@ -176,6 +178,13 @@
 
 (defn streaming? [writer]
   (-streaming? writer))
+
+(defn signal-writer-ready!
+  "Signals that the writer has been attached to the connection.
+   Must be called after the writer is set on the connection's wrapped-atom."
+  [writer]
+  (when-let [ch (:writer-ready-ch writer)]
+    (close! ch)))
 
 (defn backend-dispatch [& args]
   (get-in (first args) [:writer :backend] :self))


### PR DESCRIPTION
The writer thread previously polled every 10ms waiting for the writer to be set on the connection:

  (while (not (:writer @(:wrapped-atom connection)))
    (<! (timeout 10)))

This problematic for GraalVM native-image because core.async/timeout uses a daemon thread that can't be captured in the image heap.

Fix: Use a promise-chan that is closed when the writer is attached.
- Add writer-ready-ch to LocalWriter record
- Pass writer-ready-ch to create-thread
- Add signal-writer-ready! function
- Call signal-writer-ready! in connector after setting writer

This eliminates one of three timeout usages in writer.cljc.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
