### PR TITLE
Improve error message for IndexedDB backend usage (#763)

### DIFF
--- a/bb/resources/native-image-tests/run-bb-pod-tests.clj
+++ b/bb/resources/native-image-tests/run-bb-pod-tests.clj
@@ -11,7 +11,7 @@
 (def config {:keep-history? true,
              :search-cache-size 10000,
              :index :datahike.index/persistent-set,
-             :store {:id "inexpensive-red-fox", :backend :mem :scope "test.datahike.io"},
+             :store {:id #uuid "550e8400-e29b-41d4-a716-446655440763", :backend :memory :scope "test.datahike.io"},
              :store-cache-size 1000,
              :attribute-refs? false,
              :writer {:backend :self},
@@ -29,7 +29,7 @@
     (is (= {:keep-history? true
             :search-cache-size 10000
             :index :datahike.index/persistent-set
-            :store {:id "inexpensive-red-fox", :backend :mem :scope "test.datahike.io"}
+            :store {:id #uuid "550e8400-e29b-41d4-a716-446655440763", :backend :memory :scope "test.datahike.io"}
             :store-cache-size 1000
             :attribute-refs? false
             :writer {:backend :self}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.11.1"}
         org.replikativ/hasch                        {:mvn/version "0.3.96"
                                                      :exclusions [org.clojure/clojurescript]}
-        org.replikativ/konserve                     {:mvn/version "0.9.342"
+        org.replikativ/konserve                     {:mvn/version "0.9.343"
                                                      :exclusions [org.clojure/clojurescript
                                                                   org.clojars.mmb90/cljs-cache]
                                                      }

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -11,6 +11,7 @@
                     ["Garbage Collection" {:file "doc/gc.md"}]
                     ["Norms (Database Migrations)" {:file "doc/norms.md"}]]
                    ["Platform Support" {}
+                    ["ClojureScript Support" {:file "doc/cljs-support.md"}]
                     ["JavaScript API" {:file "doc/javascript-api.md"}]
                     ["Babashka Pod" {:file "doc/bb-pod.md"}]
                     ["Command Line Interface" {:file "doc/cli.md"}]


### PR DESCRIPTION
Users trying to use :indexeddb directly get a cryptic assertion error from konserve. This change catches the issue early in load-config and provides a clear error message explaining:
- Why IndexedDB can't be used directly (sync query engine vs async API)
- How to fix it (use TieredStore with memory frontend)
- Link to documentation

Also adds ClojureScript Support docs to cljdoc.edn so they appear on cljdoc.org.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
