### PR TITLE
docs: fix cljdoc src-kabel

### DIFF
--- a/src-kabel/datahike/kabel/connector.cljc
+++ b/src-kabel/datahike/kabel/connector.cljc
@@ -1,4 +1,4 @@
-(ns datahike.kabel.connector
+(ns ^:no-doc datahike.kabel.connector
   "Client-side connection for remote Datahike databases via KabelWriter.
 
    This namespace provides the internal connection logic for :kabel writer backends.

--- a/src-kabel/datahike/kabel/fressian_handlers.cljc
+++ b/src-kabel/datahike/kabel/fressian_handlers.cljc
@@ -1,4 +1,4 @@
-(ns datahike.kabel.fressian-handlers
+(ns ^:no-doc datahike.kabel.fressian-handlers
   "Fressian handlers for Datahike types over kabel.
 
    Provides read/write handlers for:

--- a/src-kabel/datahike/kabel/handlers.cljc
+++ b/src-kabel/datahike/kabel/handlers.cljc
@@ -1,4 +1,4 @@
-(ns datahike.kabel.handlers
+(ns ^:no-doc datahike.kabel.handlers
   "Server-side handlers for remote datahike operations via kabel.
 
    This namespace provides GLOBAL handlers that are registered with distributed-scope

--- a/src-kabel/datahike/kabel/tx_broadcast.cljc
+++ b/src-kabel/datahike/kabel/tx_broadcast.cljc
@@ -1,4 +1,4 @@
-(ns datahike.kabel.tx-broadcast
+(ns ^:no-doc datahike.kabel.tx-broadcast
   "Tx-report broadcasting via kabel.pubsub.
 
    This namespace provides functions for:

--- a/src-kabel/datahike/kabel/writer.cljc
+++ b/src-kabel/datahike/kabel/writer.cljc
@@ -1,4 +1,4 @@
-(ns datahike.kabel.writer
+(ns ^:no-doc datahike.kabel.writer
   "KabelWriter for remote transactions via kabel/distributed-scope.
 
    The KabelWriter sends transactions to a remote peer that owns the database,


### PR DESCRIPTION
#### SUMMARY
cljdoc did not build api docs because it failed analyzing src-kabel namespaces. this fixes it with no-doc metadata on ns.