### PR TITLE
Fix tuple schema transaction failing when :db/ident comes last

### DIFF
--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -318,7 +318,7 @@
       (fn [m attr idx]
         (update m attr assoc tuple-attr idx))
       m
-      (-> schema tuple-attr :db/tupleAttrs)))
+      (get-in schema [tuple-attr :db/tupleAttrs])))
    {}
    (:db.type/tuple rschema)))
 

--- a/test/datahike/test/tuples_test.cljc
+++ b/test/datahike/test/tuples_test.cljc
@@ -83,6 +83,28 @@
       (is (d/transact conn [{:reg/course   "BIO-101"
                              :reg/semester "2018-fall"
                              :reg/student  "johndoe@university.edu"}]))
+      (d/release conn)))
+
+  (testing "composite tuple with :db/ident last (issue #754)"
+    (let [conn (connect)
+          reg-schema [{:db/ident       :reg/course
+                       :db/valueType   :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident       :reg/semester
+                       :db/valueType   :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident       :reg/student
+                       :db/valueType   :db.type/string
+                       :db/cardinality :db.cardinality/one}]]
+      (d/transact conn reg-schema)
+      ;; Same schema as above but with :db/ident LAST to test attribute ordering
+      (is (d/transact conn [{:db/valueType   :db.type/tuple
+                             :db/tupleAttrs  [:reg/course :reg/semester :reg/student]
+                             :db/cardinality :db.cardinality/one
+                             :db/ident       :reg/semester+course+student-2}]))
+      (is (d/transact conn [{:reg/course   "MATH-201"
+                             :reg/semester "2019-spring"
+                             :reg/student  "janedoe@university.edu"}]))
       (d/release conn))))
 
 (deftest test-transact-and-query-non-composite


### PR DESCRIPTION
Fixes #754 where tuple attribute schema transactions would fail with ClassCastException when :db/ident was positioned last in the attribute map.

The issue was in attrTuples function (db/utils.cljc:321) which used the threading macro (-> schema tuple-attr :db/tupleAttrs). This expands to (tuple-attr schema), attempting to call the numeric temporary entity ID as a function when :db/ident is processed after other attributes.

Changed to use get-in for safe map lookup instead of threading macro. Added regression test to verify tuple schemas work regardless of attribute ordering.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
