### PR TITLE
Fix ClassCastException when deleting branches

### DIFF
--- a/src/datahike/experimental/versioning.cljc
+++ b/src/datahike/experimental/versioning.cljc
@@ -66,7 +66,7 @@
                       {:type :from-branch-does-not-point-to-existing-branch-or-commit
                        :from from})))
     (k/assoc store new-branch (assoc-in db [:config :branch] new-branch) {:sync? true})
-    (k/update store :branches #(conj % new-branch) {:sync? true})))
+    (k/update store :branches #(conj (set %) new-branch) {:sync? true})))
 
 (defn delete-branch!
   "Removes this branch from set of known branches. The branch will still be
@@ -81,7 +81,7 @@
       (dt/raise "Branch does not exist." {:type :branch-does-not-exist
                                           :branch branch}))
     (delete-connection! [(store-identity (get-in @conn [:config :store])) branch])
-    (k/update store :branches #(disj % branch) {:sync? true})))
+    (k/update store :branches #(disj (set %) branch) {:sync? true})))
 
 (defn force-branch!
   "Force the branch to point to the provided db value. Branch will be created if
@@ -107,7 +107,7 @@
         pending-kvs (get-and-clear-pending-kvs! store)]
 
     ;; Update the set of known branches
-    (k/update store :branches #(conj % branch) {:sync? true})
+    (k/update store :branches #(conj (set %) branch) {:sync? true})
 
     ;; Write all data synchronously
     (if (multi-key-capable? store)


### PR DESCRIPTION
Defensively convert :branches to set before set operations (disj/conj). When :branches is deserialized from storage, it may come back as a list instead of a set, causing ClassCastException in delete-branch! when calling disj.

This fix ensures type safety by converting to set before all operations:
- branch! (line 69): conj on set
- delete-branch! (line 84): disj on set
- force-branch! (line 110): conj on set

Fixes issue with Postgres backend in tiered storage where disj was attempted on PersistentList instead of IPersistentSet.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
