### PR TITLE
Improve logic for missing idents when calling -ident-for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ kabel
 konserve
 konserve-sync
 persistent-sorted-set
+/.agent-shell/

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -345,10 +345,7 @@
               a-ident))
   (-ident-for [db a-ref]
               (if (:attribute-refs? (.-config db))
-                (let [a-ident (get (.-ref-ident-map db) a-ref)]
-                  (when (nil? a-ident)
-                    (log/warn :datahike/attribute-ref-not-found {:ref a-ref}))
-                  a-ident)
+                (get (.-ref-ident-map db) a-ref)
                 a-ref))
 
   dbi/ISearch
@@ -959,7 +956,7 @@
         counts-map (->> (di/-seq (.-eavt db))
                         (reduce (fn [m ^Datom datom]
                                   (-> m
-                                      (update-count-in [:per-attr-counts (dbi/-ident-for db (.-a datom))])
+                                      (update-count-in [:per-attr-counts (dbi/ident-for db (.-a datom) :error-on-missing)])
                                       (update-count-in [:per-entity-counts (.-e datom)])))
                                 {:per-attr-counts    {}
                                  :per-entity-counts  {}}))
@@ -974,7 +971,7 @@
       (dbi/-keep-history? db)
       (merge {:temporal-count (di/-count (.-temporal-eavt db))
               :temporal-avet-count (->> (di/-seq (.-temporal-eavt db))
-                                        (reduce (fn [m ^Datom datom] (update-count-in m [(dbi/-ident-for db (.-a datom))]))
+                                        (reduce (fn [m ^Datom datom] (update-count-in m [(dbi/ident-for db (.-a datom) :error-on-missing)]))
                                                 {})
                                         sum-indexed-attr-counts)}))))
 

--- a/src/datahike/db/interface.cljc
+++ b/src/datahike/db/interface.cljc
@@ -1,4 +1,5 @@
-(ns datahike.db.interface)
+(ns datahike.db.interface
+  (:require [replikativ.logging :as log]))
 
 ;; Database Protocols
 
@@ -117,3 +118,16 @@
 (defprotocol IHistory
   (-time-point [db])
   (-origin [db]))
+
+(defn ident-for [db a-ref missing-strategy]
+  (or (-ident-for db a-ref)
+      (case missing-strategy
+        :error-on-missing (throw (ex-info "Attribute ref not found"
+                                          {:ref a-ref}))
+        ;; TODO: Occurrences of calls with :warn-on-missing should be
+        ;; considered a code smell and an indication that the logic at
+        ;; the call site is not clear and needs to be improved.
+        :warn-on-missing (do (log/warn :datahike/attribute-ref-not-found
+                                       {:ref a-ref})
+                             nil)
+        :allow-missing nil)))

--- a/src/datahike/db/interface.cljc
+++ b/src/datahike/db/interface.cljc
@@ -124,10 +124,4 @@
       (case missing-strategy
         :error-on-missing (throw (ex-info "Attribute ref not found"
                                           {:ref a-ref}))
-        ;; TODO: Occurrences of calls with :warn-on-missing should be
-        ;; considered a code smell and an indication that the logic at
-        ;; the call site is not clear and needs to be improved.
-        :warn-on-missing (do (log/warn :datahike/attribute-ref-not-found
-                                       {:ref a-ref})
-                             nil)
         :allow-missing nil)))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -32,7 +32,7 @@
     (log/raise "Cannot store nil as a value at " at
                {:error :transact/syntax, :value v, :context at}))
   (let [{:keys [attribute-refs? schema-flexibility]} config
-        a-ident (if (and attribute-refs? (number? a)) (dbi/-ident-for db a) a)
+        a-ident (if (and attribute-refs? (number? a)) (dbi/ident-for db a :error-on-missing) a)
         v-ident (if (and attribute-refs?
                          (contains? (dbi/-system-entities db) a)
                          (not (nil? (ref-ident-map v))))
@@ -91,9 +91,9 @@
         e (.-e datom)
         a (.-a datom)
         v (.-v datom)
-        a-ident (if attribute-refs? (dbi/-ident-for db a) a)
+        a-ident (if attribute-refs? (dbi/ident-for db a :error-on-missing) a)
         v-ident (if (and attribute-refs? (contains? (dbi/-system-entities db) v))
-                  (dbi/-ident-for db v)
+                  (dbi/ident-for db v :error-on-missing)
                   v)]
     (when (and attribute-refs? (contains? (dbi/-system-entities db) e))
       (log/raise "System schema entity cannot be changed"
@@ -159,9 +159,9 @@
         e (.-e datom)
         a (.-a datom)
         v (.-v datom)
-        a-ident (if attribute-refs? (dbi/-ident-for db a) a)
+        a-ident (if attribute-refs? (dbi/ident-for db a :error-on-missing) a)
         v-ident (if (and attribute-refs? (contains? (dbi/-system-entities db) v))
-                  (dbi/-ident-for db v)
+                  (dbi/ident-for db v :error-on-missing)
                   v)]
     (when (and attribute-refs? (contains? (dbi/-system-entities db) e))
       (log/raise "System schema entity cannot be changed"
@@ -212,7 +212,7 @@
 
 (defn- with-datom [db ^Datom datom]
   (validate-datom db datom)
-  (let [{a-ident :ident} (dbu/attr-info db (.-a datom))
+  (let [{a-ident :ident} (dbu/attr-info db (.-a datom) :error-on-missing)
         indexing? (dbu/indexing? db a-ident)
         schema? (or (ds/schema-attr? a-ident) (ds/entity-spec-attr? a-ident)
                     (ds/secondary-index-attr? a-ident))
@@ -251,7 +251,7 @@
         db))))
 
 (defn- with-temporal-datom [db ^Datom datom]
-  (let [{a-ident :ident} (dbu/attr-info db (.-a datom))
+  (let [{a-ident :ident} (dbu/attr-info db (.-a datom) :error-on-missing)
         indexing? (dbu/indexing? db a-ident)
         schema? (ds/schema-attr? a-ident)
         current-datom ^Datom (first (dbi/search db [(.-e datom) (.-a datom) (.-v datom)]))
@@ -299,7 +299,7 @@
 (defn- with-datom-upsert [db ^Datom datom]
   (validate-datom-upsert db datom)
   (let [indexing?     (dbu/indexing? db (.-a datom))
-        {a-ident :ident} (dbu/attr-info db (.-a datom))
+        {a-ident :ident} (dbu/attr-info db (.-a datom) :error-on-missing)
         schema?       (or (ds/schema-attr? a-ident)
                           (ds/secondary-index-attr? a-ident))
         keep-history? (and (dbi/-keep-history? db) (not (dbu/no-history? db a-ident))
@@ -471,8 +471,8 @@
   (let [eid (:db/id entity)
         attribute-refs? (:attribute-refs? (dbi/-config db))
         _ (when (and attribute-refs? (contains? (dbi/-system-entities db) eid))
-            (log/raise "Entity with ID " eid " is a system attribute " (dbi/-ident-for db eid) " and cannot be changed"
-                       {:error :transact/syntax, :eid eid, :attribute (dbi/-ident-for db eid) :context entity}))
+            (log/raise "Entity with ID " eid " is a system attribute " (dbi/ident-for db eid :error-on-missing) " and cannot be changed"
+                       {:error :transact/syntax, :eid eid, :attribute (dbi/ident-for db eid :error-on-missing) :context entity}))
         ensure (:db/ensure entity)
         entities (for [[a-ident vs] entity
                        :when (not (or (= a-ident :db/id) (= a-ident :db/ensure)))
@@ -515,7 +515,7 @@
         tx (or tx (current-tx report))
         db db-after
         e (dbu/entid-strict db e)
-        a-ident (if attribute-refs? (dbi/-ident-for db a) a)
+        a-ident (if attribute-refs? (dbi/ident-for db a :error-on-missing) a)
         v (if (dbu/ref? db a-ident) (dbu/entid-strict db v) v)
         new-datom (datom e a v tx)
         upsert? (not (dbu/multival? db a))]
@@ -702,7 +702,8 @@
     (if-let [e (dbu/entid db e)]
       (let [e-datoms (vec (dbi/search db [e]))
             v-datoms (->> (dbi/-attrs-by db :db.type/ref)
-                          (map (partial dbi/-ident-for db))
+                          ;; TODO: How to best handle nil here?
+                          (map #(dbi/ident-for db % :warn-on-missing))
                           (mapcat (fn [a] (dbi/search db [nil a e])))
                           vec)]
         [(reduce transact-retract-datom report (concat e-datoms v-datoms))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -702,8 +702,14 @@
     (if-let [e (dbu/entid db e)]
       (let [e-datoms (vec (dbi/search db [e]))
             v-datoms (->> (dbi/-attrs-by db :db.type/ref)
-                          ;; TODO: How to best handle nil here?
-                          (map #(dbi/ident-for db % :warn-on-missing))
+                          (map (fn [attr]
+                                 ;; TODO: Consider using
+                                 ;; (or (dbi/-ref-for db attr) attr)
+                                 ;; once warning has been removed from the -ref-for
+                                 ;; implementation in datahike.db.
+                                 (if (dbu/attr-has-ref? db attr)
+                                   (dbi/-ref-for db attr)
+                                   attr)))
                           (mapcat (fn [a] (dbi/search db [nil a e])))
                           vec)]
         [(reduce transact-retract-datom report (concat e-datoms v-datoms))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -522,6 +522,7 @@
     (transact-report report new-datom upsert?)))
 
 (defn- transact-retract-datom
+  ([report] report)
   ([report ^Datom d] (transact-retract-datom report d false))
   ([report ^Datom d keep-tx-id]
    (let [txid (or (and keep-tx-id (datom-tx d)) (current-tx report))]
@@ -701,18 +702,18 @@
   (let [[_ e] op-vec]
     (if-let [e (dbu/entid db e)]
       (let [e-datoms (vec (dbi/search db [e]))
-            v-datoms (->> (dbi/-attrs-by db :db.type/ref)
-                          (map (fn [attr]
-                                 ;; TODO: Consider using
-                                 ;; (or (dbi/-ref-for db attr) attr)
-                                 ;; once warning has been removed from the -ref-for
-                                 ;; implementation in datahike.db.
-                                 (if (dbu/attr-has-ref? db attr)
-                                   (dbi/-ref-for db attr)
-                                   attr)))
-                          (mapcat (fn [a] (dbi/search db [nil a e])))
-                          vec)]
-        [(reduce transact-retract-datom report (concat e-datoms v-datoms))
+            v-datoms (into []
+                           (mapcat (fn [attr]
+                                     ;; TODO: Consider using
+                                     ;; (or (dbi/-ref-for db attr) attr)
+                                     ;; once warning has been removed from
+                                     ;; the -ref-for implementation in datahike.db.
+                                     (let [a (if (dbu/attr-has-ref? db attr)
+                                               (dbi/-ref-for db attr)
+                                               attr)]
+                                       (dbi/search db [nil a e]))))
+                           (dbi/-attrs-by db :db.type/ref))]
+        [(transduce cat transact-retract-datom report [e-datoms v-datoms])
          (retract-components db e-datoms)])
       [report []])))
 

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -17,7 +17,7 @@
           :cljs [^boolean is-attr?]) [db attr property]
   (let [a-ident (if (and (:attribute-refs? (dbi/-config db))
                          (number? attr))
-                  (dbi/-ident-for db attr)
+                  (dbi/ident-for db attr :error-on-missing)
                   attr)]
     (contains? (dbi/-attrs-by db property) a-ident)))
 
@@ -159,12 +159,13 @@
 
 (defn attr-info
   "Returns identifier name and reference value of an attributes. Both values are identical for non-reference databases."
-  [db attr]
-  (if (attr-has-ref? db attr)
-    (if (number? attr)
-      {:ident (dbi/-ident-for db attr) :ref attr}
-      {:ident attr :ref (dbi/-ref-for db attr)})
-    {:ident attr :ref attr}))
+  ([db attr] (attr-info db attr :allow-missing))
+  ([db attr missing-strategy]
+   (if (attr-has-ref? db attr)
+     (if (number? attr)
+       {:ident (dbi/ident-for db attr missing-strategy) :ref attr}
+       {:ident attr :ref (dbi/-ref-for db attr)})
+     {:ident attr :ref attr})))
 
 (defn ident-name? [x]
   (or (keyword? x) (string? x)))
@@ -187,7 +188,7 @@
                  {:error :transact/schema :attribute a-ident :context at}))))
 
 (defn resolve-datom [db e a v t default-e default-tx]
-  (let [{a-ident :ident a-db :ref} (attr-info db a)]
+  (let [{a-ident :ident a-db :ref} (attr-info db a :allow-missing)]
     (when a-ident (validate-attr-ident a-ident (list 'resolve-datom 'db e a v t) db))
     (datom
      (or (entid-some db e) default-e)                       ;; e

--- a/src/datahike/impl/entity.cljc
+++ b/src/datahike/impl/entity.cljc
@@ -197,7 +197,7 @@
   (reduce (fn [acc partition]
             (let [a-db (:a (first partition))
                   a-ident (if (:attribute-refs? (dbi/-config db))
-                            (dbi/-ident-for db a-db)
+                            (dbi/ident-for db a-db :error-on-missing)
                             a-db)]
               (assoc acc a-ident (entity-attr db a-ident partition))))
           {} (partition-by :a datoms)))

--- a/src/datahike/json.cljc
+++ b/src/datahike/json.cljc
@@ -6,6 +6,7 @@
             [datahike.readers :as readers]
             [datahike.connector]
             [datahike.datom :as dd]
+            [datahike.db.interface :as dbi]
             [datahike.schema :as s]
             [jsonista.core :as j]
             [jsonista.tagged :as jt])
@@ -150,7 +151,7 @@
   (if (string? s) (keyword s) s))
 
 (defn ident-for [^datahike.db.DB db a]
-  (if (and (number? a) (some? db)) (.-ident-for db a) a))
+  (if (and (number? a) (some? db)) (dbi/ident-for db a :error-on-missing) a))
 
 (defn cond-xf-val
   [a-ident v {:keys [ref-attrs long-attrs keyword-attrs symbol-attrs] :as valtype-attrs-map} db]

--- a/src/datahike/pull_api.cljc
+++ b/src/datahike/pull_api.cljc
@@ -118,7 +118,7 @@
           (assoc :recursion rec)))))
 
 (defn db-ident-and-id [db x]
-  (let [{:keys [ident ref]} (dbu/attr-info db x)]
+  (let [{:keys [ident ref]} (dbu/attr-info db x :allow-missing)]
     (if (dbu/ident-name? ident)
       {:db/id ref :db/ident ident}
       {:db/id ref})))
@@ -253,7 +253,7 @@
 (defn pull-wildcard-expand
   [db frame frames eid pattern]
   (let [datoms (group-by (fn [d] (if (:attribute-refs? (dbi/-config db))
-                                   (dbi/-ident-for db (.-a ^Datom d))
+                                   (dbi/ident-for db (.-a ^Datom d) :error-on-missing)
                                    (.-a ^Datom d)))
                          (dbi/datoms db :eavt [eid]))
         {:keys [attr recursion]} frame

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -411,7 +411,7 @@
      (when-some [datom (first (dbi/search db [e (translate-for db a)]))]
        (let [a-ident (if (keyword? (:a datom))
                        (:a datom)
-                       (dbi/-ident-for db (:a datom)))]
+                       (dbi/ident-for db (:a datom) :error-on-missing))]
          (reduced [a-ident (:v datom)]))))
    nil
    as))

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -821,7 +821,7 @@
           (let [update-counts (fn [coll] (reduce (fn [m counted] (update m counted #(if % (inc %) 1)))
                                                  {}
                                                  coll))
-                ref-attrs (map #(.-ident-for @conn (.-a %)) db/ref-datoms)
+                ref-attrs (map #(dbi/ident-for @conn (.-a %) :error-on-missing) db/ref-datoms)
                 ref-datom-per-attr-counts (update-counts ref-attrs)
                 indexed? (fn [a] (-> (:db/index (.-rschema @conn))
                                      (contains? a)))]

--- a/test/datahike/test/model/invariant.cljc
+++ b/test/datahike/test/model/invariant.cljc
@@ -32,10 +32,10 @@
   (let [attr-refs? (:attribute-refs? (.-config db))]
     (into #{}
           (comp (filter (if attr-refs?
-                          (comp user-attrs #(dbi/-ident-for db %) :a)
+                          (comp user-attrs #(dbi/ident-for db % :error-on-missing) :a)
                           (comp user-attrs :a)))
                 (map (if attr-refs?
-                       (juxt :e #(dbi/-ident-for db (:a %)) :v)
+                       (juxt :e #(dbi/ident-for db (:a %) :error-on-missing) :v)
                        (juxt :e :a :v))))
           datoms)))
 


### PR DESCRIPTION
#### SUMMARY

Fixes issue #799 

This PR fixes the logic around `datahike.db.interface/-ident-for` such that handling of missing values is more explicit, in the following ways:

* Remove warning of `nil` from `-ident-for` protocol method.
* Add the *function* `ident-for` which accepts a third parameter `missing-strategy` that can be either `:error-on-missing`, `:warn-on-missing` or `:allow-missing`.
* Extend `attr-info` to accept the parameter `missing-strategy` and forward it to `ident-for`.
* Update the calls from `-ident-for` to call `ident-for` with the parameter for the missing strategy. Defensively us `:error-on-missing` whenever possible (as long as unit tests don't break).
* Update the calls of `attr-info` to also specify the `missing-strategy` parameter: Use `:error-on-missing` whenever possible.

As a consequence of these fixes, we get rid of the useless warnings from the pull API as reported in issue #799.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked