### PR TITLE
Fix CLI: wire up --tx-file, deduplicate transact, fix native test grep

### DIFF
--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -15,7 +15,7 @@ trap "rm -rf $TMPSTORE" EXIT
 ./dthk database-exists edn:$ATTR_REF_CONFIG
 
 # test that warnings etc. get logged to stderr
-LOG_OUTPUT="$(./dthk query '[:find ?e . :where [?e :nonexistent _]]' db:$ATTR_REF_CONFIG 2>&1 >/dev/null | grep ':nonexistent has not been found')"
+LOG_OUTPUT="$(./dthk query '[:find ?e . :where [?e :nonexistent _]]' db:$ATTR_REF_CONFIG 2>&1 >/dev/null | grep ':nonexistent')"
 if [ -z "$LOG_OUTPUT" ]
 then
   echo "Exception: binary did not log to stderr"

--- a/src/datahike/codegen/cli.clj
+++ b/src/datahike/codegen/cli.clj
@@ -54,10 +54,11 @@
      use prefix syntax instead (e.g., asof:timestamp:config.edn)
    - connect: Redundant with conn: prefix syntax
    - db-with: Returns db value that can't be used in subsequent commands
-   - is-filtered: Requires filtered db input, which can't exist in CLI (filter excluded)"
+   - is-filtered: Requires filtered db input, which can't exist in CLI (filter excluded)
+   - transact!: Async variant, redundant with transact in single-shot CLI (also collides on command name)"
   #{'listen 'unlisten 'release 'db 'tempid 'entity-db
     'as-of 'since 'history 'filter
-    'connect 'db-with 'is-filtered})
+    'connect 'db-with 'is-filtered 'transact!})
 
 (defn cli-spec
   "Get merged specification with CLI-specific config."
@@ -390,8 +391,18 @@
         (System/exit 1))
 
       (let [{:keys [args impl]} (cli-spec op-name)
+            ;; Inject --tx-file content at :file-arg position if provided
+            {:keys [file-arg]} (get cli-config op-name)
+            effective-args (if-let [tx-file (:tx-file cli-opts)]
+                             (if file-arg
+                               (let [content (slurp tx-file)]
+                                 (into (vec (take file-arg raw-args))
+                                       (cons content (drop file-arg raw-args))))
+                               (do (println "⚠ --tx-file not supported for command:" cmd-str)
+                                   raw-args))
+                             raw-args)
             ;; Parse arguments (handle prefixes, files, etc.)
-            parsed-args (mapv parse-prefix raw-args)
+            parsed-args (mapv parse-prefix effective-args)
             ;; Validate with malli
             validation (try-arities args parsed-args)]
 


### PR DESCRIPTION
- Wire --tx-file into dispatch-command: reads file content and injects it at the :file-arg position declared in cli-config (position 1 for transact, i.e. the tx-data argument)
- Exclude transact! from CLI (async variant collides with transact on command name and is redundant in single-shot execution)
- Update native-image test grep pattern for new structured logging format from replikativ.logging

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
