### PR TITLE
fix: return :all attr deps when query has variable in attribute position

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -2189,10 +2189,13 @@
           (let [f (first clause)
                 src? (and (symbol? f) (clojure.string/starts-with? (name f) "$"))
                 a (if src? (nth clause 2 nil) (second clause))]
-            (recur rest-clauses
-                   (if (and (some? a) (not (symbol? a)))
-                     (conj attrs a)
-                     attrs)))
+            (if (symbol? a)
+              ;; Variable in attribute position — query touches all attributes
+              :all
+              (recur rest-clauses
+                     (if (some? a)
+                       (conj attrs a)
+                       attrs))))
 
           ;; Predicate/function clause [(> ?a 50)] — deps come from binding
           ;; pattern clauses, safe to skip.


### PR DESCRIPTION
Queries with a variable in the attribute position of a data pattern (e.g. [?e ?a ?v]) scan all attributes but extract-query-attr-deps was silently skipping the symbol, tagging the cached result with an incomplete dependency set. This made such entries immune to cache invalidation, potentially serving stale results after transactions.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
