### PR TITLE
fix(cljs): use JS arrays in execute-pattern-scan for CLJS compatibility

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -333,9 +333,9 @@
         l2 (alength idxs2)
         res (da/make-array (+ l1 l2))]
     (dotimes [i l1]
-      (aset res i (#?(:cljs da/aget :clj get) t1 (aget idxs1 i)))) ;; FIXME aget
+      (aset res i (get t1 (aget idxs1 i))))
     (dotimes [i l2]
-      (aset res (+ l1 i) (#?(:cljs da/aget :clj get) t2 (aget idxs2 i)))) ;; FIXME aget
+      (aset res (+ l1 i) (get t2 (aget idxs2 i))))
     res))
 
 (defn sum-rel [a b]
@@ -358,7 +358,7 @@
                       (fn [acc tuple-b]
                         (let [tuple' (da/make-array tlen)]
                           (doseq [[idx-b idx-a] idxb->idxa]
-                            (aset tuple' idx-a (#?(:cljs da/aget :clj get) tuple-b idx-b)))
+                            (aset tuple' idx-a (get tuple-b idx-b)))
                           (conj! acc tuple')))
                       (transient (vec tuples-a))
                       tuples-b))]
@@ -670,14 +670,14 @@
   (let [idx (attrs attr)]
     (if (contains? rel/*lookup-attrs* attr)
       (fn [tuple]
-        (let [eid (#?(:cljs da/aget :clj get) tuple idx)]
+        (let [eid (get tuple idx)]
           (cond
             (number? eid) eid                               ;; quick path to avoid fn call
             (sequential? eid) (dbu/entid rel/*implicit-source* eid)
             (da/array? eid) (dbu/entid rel/*implicit-source* eid)
             :else eid)))
       (fn [tuple]
-        (#?(:cljs da/aget :clj get) tuple idx)))))
+        (get tuple idx)))))
 
 (defn tuple-key-fn [getters]
   (if (== (count getters) 1)
@@ -856,7 +856,7 @@
     replacement
     (when-some [rel (rel-with-attr context sym)]
       (when-some [tuple (first (:tuples rel))]
-        (#?(:cljs da/aget :clj get) tuple ((:attrs rel) sym))))))
+        (get tuple ((:attrs rel) sym))))))
 
 (defn- rel-contains-attrs? [rel attrs]
   (some #(contains? (:attrs rel) %) attrs))
@@ -885,7 +885,7 @@
       ;; TODO raise if not all args are bound
       (dotimes [i len]
         (when-some [tuple-idx (aget tuples-args i)]
-          (let [v (#?(:cljs da/aget :clj get) tuple tuple-idx)]
+          (let [v (get tuple tuple-idx)]
             (da/aset static-args i v))))
       (apply f static-args))))
 
@@ -2047,7 +2047,7 @@
                     (let [res (aclone t1)]
                       (dotimes [i len]
                         (when-some [idx (aget copy-map i)]
-                          (aset res i (#?(:cljs da/aget :clj get) t2 idx))))
+                          (aset res i (get t2 idx))))
                       res))
                   (next rels)
                   symbols))))

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -416,7 +416,14 @@
                            (if strict-filter (filter strict-filter) identity)
                            (map (fn [^Datom d]
                                   (check-cancel! cancel)
-                                  [(.-e d) (.-a d) (.-v d) (.-tx d) true])))
+                                  #?(:clj  [(.-e d) (.-a d) (.-v d) (.-tx d) true]
+                                     :cljs (let [t (make-array 5)]
+                                             (aset t 0 (.-e d))
+                                             (aset t 1 (.-a d))
+                                             (aset t 2 (.-v d))
+                                             (aset t 3 (.-tx d))
+                                             (aset t 4 true)
+                                             t)))))
                      datoms)]
     (rel/->Relation var-map tuples)))
 

--- a/src/datahike/query/relation.cljc
+++ b/src/datahike/query/relation.cljc
@@ -57,14 +57,14 @@
   (let [idx (attrs attr)]
     (if (contains? *lookup-attrs* attr)
       (fn [tuple]
-        (let [eid (#?(:cljs da/aget :clj get) tuple idx)]
+        (let [eid (get tuple idx)]
           (cond
             (number? eid) eid                               ;; quick path to avoid fn call
             (sequential? eid) (dbu/entid *implicit-source* eid)
             (da/array? eid) (dbu/entid *implicit-source* eid)
             :else eid)))
       (fn [tuple]
-        (#?(:cljs da/aget :clj get) tuple idx)))))
+        (get tuple idx)))))
 
 (defn tuple-key-fn [getters]
   (if (== (count getters) 1)
@@ -92,9 +92,9 @@
         l2 (alength idxs2)
         res (da/make-array (+ l1 l2))]
     (dotimes [i l1]
-      (aset res i (#?(:cljs da/aget :clj get) t1 (aget idxs1 i)))) ;; FIXME aget
+      (aset res i (get t1 (aget idxs1 i))))
     (dotimes [i l2]
-      (aset res (+ l1 i) (#?(:cljs da/aget :clj get) t2 (aget idxs2 i)))) ;; FIXME aget
+      (aset res (+ l1 i) (get t2 (aget idxs2 i))))
     res))
 
 ;; ---------------------------------------------------------------------------
@@ -162,7 +162,7 @@
                       (fn [acc tuple-b]
                         (let [tuple' (da/make-array tlen)]
                           (doseq [[idx-b idx-a] idxb->idxa]
-                            (aset tuple' idx-a (#?(:cljs da/aget :clj get) tuple-b idx-b)))
+                            (aset tuple' idx-a (get tuple-b idx-b)))
                           (conj! acc tuple')))
                       (transient (vec tuples-a))
                       tuples-b))]

--- a/test/datahike/test/async.cljc
+++ b/test/datahike/test/async.cljc
@@ -1,0 +1,78 @@
+(ns datahike.test.async
+  "Cross-platform `deftest-async`.
+
+   The body is wrapped in a `clojure.core.async/go` block on both
+   platforms, so `<!` works inside the body uniformly. The outer
+   wait-for-completion mechanism is platform-specific:
+
+     - CLJ:  `<!!` on the go-block's result channel.
+     - CLJS: `cljs.test/async done#` + `(done#)` after the body.
+
+   Test author writes a single body using `<!` to take from
+   channel-returning APIs (`d/transact!`, `d/connect` on CLJS, the
+   `setup-db` helpers in `datahike.test.utils`, etc.). Works on CLJ
+   even though some of those APIs are nominally synchronous, because
+   wrapping a synchronous value in `(go ...)` produces a channel that
+   yields the value, and `<!` of that channel returns the value.
+
+   Usage:
+
+       (require '[datahike.test.async :refer [deftest-async]
+                  :refer-macros [deftest-async]])
+       (require '[clojure.core.async :as a :refer [go <!]
+                  :refer-macros [go]])
+
+       (deftest-async basic-roundtrip
+         (let [conn (<! (utils/setup-db {:store {:backend :memory}}))]
+           (<! (d/transact! conn [{:db/id -1 :name \"Ivan\"}]))
+           (is (= 1 (count (d/q '[:find ?e :where [?e :name _]] @conn))))
+           (<! (utils/teardown-db conn))))
+
+   This is the test-suite analogue of konserve.utils/async+sync, but
+   simpler: tests don't need a runtime sync/async toggle, only a
+   compile-time platform dispatch."
+  #?(:clj  (:require [clojure.test]
+                     [clojure.core.async])
+     :cljs (:require [cljs.test]
+                     [clojure.core.async]))
+  #?(:cljs (:require-macros [datahike.test.async])))
+
+(defn- cljs-env? [env] (some? (:ns env)))
+
+(defmacro deftest-async
+  "Like `clojure.test/deftest` but wraps the body in a `go` block.
+   On CLJ blocks the test thread until the go-block completes via
+   `<!!`; on CLJS uses `cljs.test/async` + a `done` callback so it
+   integrates with cljs.test's async runner.
+
+   Inside the body, `<!` (from `clojure.core.async`) works uniformly
+   on both platforms. Use it for any expression that may return a
+   channel; for synchronous CLJ expressions a `(go x)` wrapper
+   harmlessly turns `x` into a single-value channel that `<!` resolves
+   immediately."
+  [name & body]
+  (if (cljs-env? &env)
+    `(cljs.test/deftest ~name
+       (cljs.test/async done#
+                        (clojure.core.async/go
+                          (try
+                            ~@body
+                            (catch :default e#
+                              (cljs.test/is false (str "deftest-async error: "
+                                                       (or (.-message e#) e#)
+                                                       "\n"
+                                                       (.-stack e#))))
+                            (finally (done#))))))
+    `(clojure.test/deftest ~name
+       (clojure.core.async/<!!
+        (clojure.core.async/go
+          (try
+            ~@body
+            (catch Throwable e#
+              (clojure.test/is false
+                               (str "deftest-async error: "
+                                    (.getMessage e#)
+                                    "\n"
+                                    (clojure.string/join
+                                     "\n"
+                                     (map str (.getStackTrace e#))))))))))))

--- a/test/datahike/test/cljs_pattern_scan_test.cljc
+++ b/test/datahike/test/cljs_pattern_scan_test.cljc
@@ -1,0 +1,126 @@
+(ns datahike.test.cljs-pattern-scan-test
+  "Regression tests for the CLJS bug fixed by this PR.
+
+   In CLJS, `execute-pattern-scan` previously materialized each datom
+   as a Clojure vector `[(.-e d) (.-a d) (.-v d) (.-tx d) true]`. The
+   downstream join machinery in `query.cljc` / `query/relation.cljc`
+   read tuple elements via `da/aget`, which on CLJS expands to
+   `(arr[i])`. PersistentVectors don't expose elements as
+   integer-indexed JS properties, so every tuple access returned nil.
+
+   Symptom: multi-clause queries such as
+       [:find [?var ...] :where [?a ...] [?b ?join ?a]]
+   would join on nil keys (cross-product), and FindColl extracts
+   would return `[nil]` instead of the expected results.
+
+   The fix has two parts:
+     1) execute-pattern-scan now produces JS arrays on CLJS.
+     2) tuple access sites use `get` (works uniformly on JS arrays,
+        Object[], and PersistentVectors) instead of `da/aget`.
+
+   On CLJ this code path was masked by `*force-legacy* = true` (the
+   new planner is opt-in via DATAHIKE_QUERY_PLANNER); on CLJS the new
+   planner is the default."
+  (:require
+   #?(:clj  [clojure.test :as t :refer [is]]
+      :cljs [cljs.test :as t :refer-macros [is]])
+   [clojure.core.async :as a :refer [<!]]
+   [datahike.api :as d]
+   [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
+
+(defn- mem-cfg []
+  {:store {:backend :memory
+           :id #?(:clj (java.util.UUID/randomUUID)
+                  :cljs (random-uuid))}
+   :keep-history? false
+   :schema-flexibility :read})
+
+(defn- setup [cfg]
+  (a/go
+    #?(:clj  (do (d/create-database cfg)
+                 (d/connect cfg))
+       :cljs (do (<! (d/create-database cfg))
+                 (<! (d/connect cfg {:sync? false}))))))
+
+(defn- teardown [conn cfg]
+  (a/go
+    #?(:clj  (do (d/release conn)
+                 (d/delete-database cfg))
+       :cljs (do (d/release conn)
+                 (<! (d/delete-database cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; The failing query from the PR description:
+;;   [:find [?var ...] :where [?a ...] [?b ?join ?a]]
+;; Before the fix, FindColl returns [nil] on CLJS.
+
+(deftest-async multi-clause-find-coll
+  (let [cfg  (mem-cfg)
+        conn (<! (setup cfg))]
+    ;; A handful of entities with two attributes; the query joins
+    ;; on a value that's also an attribute name elsewhere.
+    (<! (d/transact! conn [{:db/id -1 :a 1 :b 10}
+                           {:db/id -2 :a 2 :b 20}
+                           {:db/id -3 :a 3 :b 30}]))
+    (let [;; Simplest multi-clause FindColl: project entity ids whose
+          ;; :a value matches some entity's :b. Triggers hash-join
+          ;; over scan-produced tuples.
+          result (d/q '[:find [?e ...]
+                        :where
+                        [?e :a ?v]
+                        [_ :b ?v]]
+                      @conn)]
+      ;; Pre-fix on CLJS: result was [nil] (single nil from
+      ;; cross-product fed through nil-extracting join).
+      ;; Post-fix: the query has no matches (no :b value equals
+      ;; any :a value in this dataset) → result is empty.
+      (is (not (= [nil] result))
+          (str "Multi-clause FindColl must not return [nil]; got: "
+               (pr-str result))))
+    (<! (teardown conn cfg))))
+
+;; ---------------------------------------------------------------------------
+;; A positive case: matched join. Pre-fix: produced [nil] (or wrong
+;; cardinality) due to nil tuple keys. Post-fix: returns the matched
+;; entity ids.
+
+(deftest-async two-clause-join-finds-matches
+  (let [cfg  (mem-cfg)
+        conn (<! (setup cfg))]
+    (<! (d/transact! conn [{:db/id -1 :name "Alice" :friend "Bob"}
+                           {:db/id -2 :name "Bob"   :friend "Carol"}
+                           {:db/id -3 :name "Carol" :friend "Dave"}]))
+    (let [;; Find names of entities someone is a friend of.
+          result (set (d/q '[:find [?name ...]
+                             :where
+                             [?e :friend ?fname]
+                             [?f :name ?fname]
+                             [?f :name ?name]]
+                           @conn))]
+      (is (= #{"Bob" "Carol"} result)
+          (str "Expected {Bob, Carol}; got: " (pr-str result))))
+    (<! (teardown conn cfg))))
+
+;; ---------------------------------------------------------------------------
+;; Single-clause FindColl as a control: this path doesn't exercise
+;; hash-join, so it should pass even before the fix. Acts as a
+;; sanity check that the test infrastructure itself is correct.
+
+(deftest-async single-clause-find-coll-works
+  (let [cfg  (mem-cfg)
+        conn (<! (setup cfg))]
+    (<! (d/transact! conn [{:db/id -1 :name "Ivan"}
+                           {:db/id -2 :name "Petr"}]))
+    (let [result (set (d/q '[:find [?name ...]
+                             :where [_ :name ?name]]
+                           @conn))]
+      (is (= #{"Ivan" "Petr"} result)))
+    (<! (teardown conn cfg))))
+
+(comment
+  ;; CLJ REPL:
+  (require 'datahike.test.cljs-pattern-scan-test :reload)
+  (clojure.test/run-tests 'datahike.test.cljs-pattern-scan-test)
+  ;; CLJS REPL (after `npx shadow-cljs watch cljs-tests`):
+  ;; (cljs.test/run-tests 'datahike.test.cljs-pattern-scan-test)
+  )

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -5,7 +5,17 @@
             [konserve.core :as k]
             [konserve.node-filestore] ;; Register :file backend for Node.js
             [cljs.core.async :refer [go <!] :include-macros true]
-            [cljs.nodejs :as nodejs]))
+            [cljs.nodejs :as nodejs]
+            ;; Sibling test namespaces — included so `bb node-cljs-test`
+            ;; covers them too.
+            [datahike.test.cljs-pattern-scan-test]))
+
+;; Hook cljs.test's end-of-run callback so the Node process exits with
+;; status 0 only when all tests pass. The previous setup always exited
+;; 0 (via a fixed `(.exit js/process 0)` inside the last deftest's
+;; finally-clause), which silently masked failing tests in CI.
+(defmethod t/report [::t/default :end-run-tests] [m]
+  (.exit js/process (if (t/successful? m) 0 1)))
 
 (def fs (nodejs/require "fs"))
 (def path (nodejs/require "path"))
@@ -338,10 +348,8 @@
              (catch js/Error e
                (is false (str "Error in online-gc-multi-branch-safety-test: " (.-message e))))
              (finally
-               (done)
-               (js/process.nextTick
-                (fn []
-                  (.exit js/process 0))))))))
+               (done))))))
 
 (defn -main []
-  (t/run-tests 'datahike.test.nodejs-test))
+  (t/run-tests 'datahike.test.nodejs-test
+               'datahike.test.cljs-pattern-scan-test))


### PR DESCRIPTION
In CLJS, `getter-fn` and `join-tuples` in `relation.cljc` use `da/aget` (native JS `arr[idx]`) to access tuple elements. This works on JS arrays but returns nil on Clojure PersistentVectors.

`execute-pattern-scan` was creating tuples as Clojure vectors `[(.-e d) (.-a d) ...]` in both CLJ and CLJS. In CLJS this produces PersistentVectors, causing `da/aget` to return nil for all tuple accesses during `hash-join`. All tuples then hash to the same nil key producing a cross-product join, and `join-tuples` fills result tuples with nil values.

Fix: use `make-array` + `aset` to produce native JS arrays in CLJS. Clojure path unchanged (still uses vector literal).

This fixes `[:find [?var ...] :where [?a ...] [?b ?join ?a]]` style multi-clause FindColl queries returning `[nil]` instead of results.

#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Documentation added
- [ ] Architecture Decision Record added 
- [ ] Formatting checked


#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
