### PR TITLE
fix: invalidate query cache for attrs in pull patterns

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -2217,6 +2217,36 @@
           ;; Unknown shape — skip
           :else (recur rest-clauses attrs))))))
 
+(defn- extract-find-pull-attr-deps
+  "Extract the set of attributes referenced in pull patterns within :find.
+   Returns a set of keywords, or :all for wildcard pulls or unresolvable patterns."
+  [find-clause]
+  (let [find-elements (dpip/find-elements find-clause)]
+    (reduce
+     (fn [attrs el]
+       (if (= attrs :all)
+         (reduced :all)
+         (if (instance? Pull el)
+           (let [pattern (:pattern el)]
+             (if-not (sequential? pattern)
+                ;; Pattern is a variable bound via :in — cannot determine attrs
+               (reduced :all)
+               (let [spec (dpp/parse-pull pattern)]
+                 (if (:wildcard? spec)
+                   (reduced :all)
+                   (into attrs (keys (:attrs spec)))))))
+           attrs)))
+     #{}
+     find-elements)))
+
+(defn- merge-attr-deps
+  "Merge two attr-dep sets. :all dominates."
+  [a b]
+  (cond
+    (= a :all) :all
+    (= b :all) :all
+    :else (into a b)))
+
 (defn- result-cache-get
   "Look up a cached query result for the given DB."
   [db cache-key]
@@ -3237,7 +3267,10 @@
             (if entry
               (:result entry)
               (let [result (uncached)
-                    attr-deps (extract-query-attr-deps (:where query))]
+                    where-deps (extract-query-attr-deps (:where query))
+                    find-deps  (extract-find-pull-attr-deps
+                                (:qfind (memoized-parse-query query)))
+                    attr-deps  (merge-attr-deps where-deps find-deps)]
                 (result-cache-put! db cache-key result attr-deps)
                 result))))))))
 

--- a/test/datahike/test/attribute_refs/query_pull_test.cljc
+++ b/test/datahike/test/attribute_refs/query_pull_test.cljc
@@ -154,3 +154,33 @@
       (is (every? number? ids))
       (is (= (count (set ids))
              (count ids))))))
+
+(deftest test-pull-retract-cache-invalidation
+  (testing "Retracting an attr only referenced in pull invalidates the cache"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :schema-flexibility :write
+               :attribute-refs? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)]
+      (try
+        (d/transact conn [{:db/ident :c/id
+                           :db/valueType :db.type/string
+                           :db/unique :db.unique/identity
+                           :db/cardinality :db.cardinality/one}
+                          {:db/ident :c/labels
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/many}])
+        (d/transact conn [{:c/id "t1" :c/labels ["a" "b"]}])
+        ;; Populate cache — :c/labels only in pull, not in :where
+        (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Retract one label
+        (let [tx (d/transact conn [[:db/retract [:c/id "t1"] :c/labels "a"]])]
+          (is (= ["b"]
+                 (:c/labels (first (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                                          :where [?c :c/id]]
+                                        (:db-after tx)))))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))

--- a/test/datahike/test/query_cache_test.cljc
+++ b/test/datahike/test/query_cache_test.cljc
@@ -1,0 +1,130 @@
+(ns datahike.test.query-cache-test
+  (:require
+   #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
+      :clj  [clojure.test :as t :refer [is deftest testing]])
+   [datahike.api :as d]))
+
+(defn- with-temp-db
+  "Create a temp in-memory db with schema, run f with the connection, then clean up."
+  [schema-txs f]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :attribute-refs? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    (try
+      (d/transact conn schema-txs)
+      (f conn)
+      (finally
+        (d/release conn)
+        (d/delete-database cfg)))))
+
+(def ^:private label-schema
+  [{:db/ident :c/id
+    :db/valueType :db.type/string
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :c/labels
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/many}
+   {:db/ident :c/note
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(deftest test-pull-only-attr-retract-invalidates-cache
+  (testing "Core bug: retract on attr only in pull pattern must invalidate cache"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/labels ["a" "b"]}])
+        ;; Populate cache
+        (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Retract one label
+        (let [tx (d/transact conn [[:db/retract [:c/id "t1"] :c/labels "a"]])]
+          (is (= ["b"]
+                 (:c/labels (first (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                                          :where [?c :c/id]]
+                                        (:db-after tx)))))))))))
+
+(deftest test-pull-only-attr-assert-invalidates-cache
+  (testing "Adding a value to an attr only in pull pattern must show in results"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/labels ["a"]}])
+        ;; Populate cache
+        (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Add a label
+        (let [tx (d/transact conn [{:c/id "t1" :c/labels ["b"]}])]
+          (is (= #{"a" "b"}
+                 (set (:c/labels (first (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                                               :where [?c :c/id]]
+                                             (:db-after tx))))))))))))
+
+(deftest test-pull-only-attr-update-cardinality-one
+  (testing "Updating a cardinality-one attr only in pull must show new value"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/note "old"}])
+        ;; Populate cache
+        (d/q '[:find [(pull ?c [:c/id :c/note]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Update note
+        (let [tx (d/transact conn [{:c/id "t1" :c/note "new"}])]
+          (is (= "new"
+                 (:c/note (first (d/q '[:find [(pull ?c [:c/id :c/note]) ...]
+                                        :where [?c :c/id]]
+                                      (:db-after tx)))))))))))
+
+(deftest test-wildcard-pull-invalidates-on-any-change
+  (testing "Wildcard pull [*] must invalidate when any attr changes"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/note "old"}])
+        ;; Populate cache with wildcard pull
+        (d/q '[:find [(pull ?c [*]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Update note
+        (let [tx (d/transact conn [{:c/id "t1" :c/note "new"}])]
+          (is (= "new"
+                 (:c/note (first (d/q '[:find [(pull ?c [*]) ...]
+                                        :where [?c :c/id]]
+                                      (:db-after tx)))))))))))
+
+(deftest test-variable-pull-pattern-invalidates-on-any-change
+  (testing "Variable pull pattern bound via :in must invalidate conservatively"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/note "old"}])
+        ;; Populate cache with variable pattern
+        (d/q '[:find [(pull ?c ?pattern) ...]
+               :in $ ?pattern
+               :where [?c :c/id]]
+             @conn [:c/id :c/note])
+        ;; Update note
+        (let [tx (d/transact conn [{:c/id "t1" :c/note "new"}])]
+          (is (= "new"
+                 (:c/note (first (d/q '[:find [(pull ?c ?pattern) ...]
+                                        :in $ ?pattern
+                                        :where [?c :c/id]]
+                                      (:db-after tx) [:c/id :c/note]))))))))))
+
+(deftest test-where-attr-change-still-invalidates
+  (testing "Changes to attrs in :where clauses still invalidate correctly"
+    (with-temp-db label-schema
+      (fn [conn]
+        (d/transact conn [{:c/id "t1" :c/labels ["a" "b"]}
+                          {:c/id "t2" :c/labels ["x"]}])
+        ;; Query with :c/id in both :where and pull
+        (is (= 2 (count (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                               :where [?c :c/id]]
+                             @conn))))
+        ;; Retract an entity's :c/id — affects :where clause
+        (let [tx (d/transact conn [[:db/retract [:c/id "t2"] :c/id "t2"]])]
+          (is (= 1 (count (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                                 :where [?c :c/id]]
+                               (:db-after tx))))))))))

--- a/test/datahike/test/query_pull_test.cljc
+++ b/test/datahike/test/query_pull_test.cljc
@@ -145,3 +145,33 @@
                      db [[:name "Ivan"] [:name "Oleg"] [:name "Petr"]]))
            #{[[:name "Petr"] 44 {:db/id 1 :name "Petr"}]
              [[:name "Ivan"] 25 {:db/id 2 :name "Ivan"}]}))))
+
+(deftest test-pull-retract-cache-invalidation
+  (testing "Retracting an attr only referenced in pull invalidates the cache"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :schema-flexibility :write
+               :attribute-refs? false}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)]
+      (try
+        (d/transact conn [{:db/ident :c/id
+                           :db/valueType :db.type/string
+                           :db/unique :db.unique/identity
+                           :db/cardinality :db.cardinality/one}
+                          {:db/ident :c/labels
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/many}])
+        (d/transact conn [{:c/id "t1" :c/labels ["a" "b"]}])
+        ;; Populate cache — :c/labels only in pull, not in :where
+        (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+               :where [?c :c/id]]
+             @conn)
+        ;; Retract one label
+        (let [tx (d/transact conn [[:db/retract [:c/id "t1"] :c/labels "a"]])]
+          (is (= ["b"]
+                 (:c/labels (first (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
+                                          :where [?c :c/id]]
+                                        (:db-after tx)))))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))


### PR DESCRIPTION
## Summary

Fixes #808 — the query result cache returned stale data when attributes were only referenced in `(pull ...)` expressions in `:find`, not in `:where` clauses.

**Root cause:** `extract-query-attr-deps` (used to build cache invalidation keys) only examined `:where` clauses. For a query like:

```clojure
[:find [(pull ?c [:c/id :c/labels]) ...] :where [?c :c/id]]
```

the cache tracked `#{:c/id}` as dependencies but ignored `:c/labels` from the pull pattern. When `:c/labels` was retracted, `propagate-query-cache` saw no overlap with the cached deps and kept the stale entry.

**Fix:** Added `extract-find-pull-attr-deps` which walks `:find` elements, collects attributes from `Pull` patterns, and merges them with the `:where`-derived deps before caching. Wildcard (`[*]`) and variable pull patterns (bound via `:in`) conservatively produce `:all` deps to ensure correctness.

The change is localized to the dep-collection step in `raw-q` — the invalidation logic in `propagate-query-cache` is unchanged.

## Changes

- `src/datahike/query.cljc` — `extract-find-pull-attr-deps`, `merge-attr-deps`, updated `raw-q`
- `test/datahike/test/query_pull_test.cljc` — retract-through-pull cache invalidation test
- `test/datahike/test/attribute_refs/query_pull_test.cljc` — same for attribute-refs mode
- `test/datahike/test/query_cache_test.cljc` — 6 dedicated cache invalidation tests covering retract, assert, cardinality-one update, wildcard pull, variable pull pattern, and :where-attr regression guard

## Test plan

- [x] Exact reproduction from #808 now returns `["b"]` instead of `["a" "b"]`
- [x] All 21 existing `query-pull-test` tests pass (both regular and attribute-refs)
- [x] All 6 new `query-cache-test` tests pass