### PR TITLE
fix: failing python tests

### DIFF
--- a/.circleci/scripts/gen_ci.clj
+++ b/.circleci/scripts/gen_ci.clj
@@ -82,8 +82,6 @@ bb test bb-pod")
       (run "Test libdatahike"
            "cd /home/circleci/replikativ
 bb test libdatahike")
-      (run "Install Python dependencies"
-           "pip install --user pytest")
       (run "Test Python bindings"
            "cd /home/circleci/replikativ
 bb test python")

--- a/bb/resources/native-image-tests/run-python-tests
+++ b/bb/resources/native-image-tests/run-python-tests
@@ -6,9 +6,19 @@ set -o nounset
 
 echo "Setting up Python test environment..."
 
-# Set library paths so Python can find libdatahike.so
-export LD_LIBRARY_PATH=./libdatahike/target
-export DYLD_LIBRARY_PATH=./libdatahike/target
+# Set library paths so Python can find libdatahike.so (absolute, for use after cd)
+LIB_DIR="$(pwd)/libdatahike/target"
+export LD_LIBRARY_PATH="${LIB_DIR}"
+export DYLD_LIBRARY_PATH="${LIB_DIR}"
+if [ -f "${LIB_DIR}/libdatahike.so" ]; then
+  export LIBDATAHIKE_PATH="${LIB_DIR}/libdatahike.so"
+elif [ -f "${LIB_DIR}/libdatahike.dylib" ]; then
+  export LIBDATAHIKE_PATH="${LIB_DIR}/libdatahike.dylib"
+fi
+
+# Generate Python bindings (pydatahike/src/datahike/generated.py is gitignored)
+echo "Generating Python bindings..."
+bb codegen-python
 
 # Install the pydatahike package with dev extras (pulls in cbor2, pytest, etc.)
 echo "Installing pydatahike and test dependencies..."

--- a/bb/resources/native-image-tests/run-python-tests
+++ b/bb/resources/native-image-tests/run-python-tests
@@ -10,13 +10,13 @@ echo "Setting up Python test environment..."
 export LD_LIBRARY_PATH=./libdatahike/target
 export DYLD_LIBRARY_PATH=./libdatahike/target
 
-# Install pytest (use pip3 explicitly to avoid Python 2.7)
-echo "Installing pytest..."
-pip3 install --user pytest
+# Install the pydatahike package with dev extras (pulls in cbor2, pytest, etc.)
+echo "Installing pydatahike and test dependencies..."
+cd pydatahike
+pip3 install --user -e ".[dev]"
 
 # Run Python tests using python3 -m pytest to avoid PATH issues
 echo "Running Python tests..."
-cd pydatahike
 python3 -m pytest -v tests/
 
 echo "Python tests completed successfully!"


### PR DESCRIPTION
#### SUMMARY
This fix simplifies the python setup for running the python tests and resolves the dependencies like pytest and cbor automatically once specified in pydatahike/pyproject.toml.