### PR TITLE
fix(query): planner — ctx-nil guard + nested form-args walker

### DIFF
--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3249,11 +3249,36 @@
                                     plan)]
                         (recur ctx' plan' (inc idx)))))))
 
+              ;; Why `(or next-ctx ctx)` instead of `next-ctx`:
+              ;; legacy/filter-by-pred and legacy/bind-by-fn return nil
+              ;; when not all of the clause's argument vars are bound
+              ;; yet — the legacy interpreter's main loop catches this
+              ;; with a "retry-later" pass (see `resolve-clauses` in
+              ;; query.cljc), but the planner here processes ops in a
+              ;; single linear pass. Without the `or`, the next iter
+              ;; sees ctx = nil, every subsequent op reads :consts /
+              ;; :sources / :rels off nil, and any :in-bound function
+              ;; (e.g. a fn passed in as `?my-fn`) fails to resolve via
+              ;; `context-resolve-val` and raises "Unknown function".
+              ;;
+              ;; Falling back to the original ctx is safe: when the
+              ;; clause genuinely couldn't bind anything, the relations
+              ;; stay unchanged and downstream ops see exactly the same
+              ;; state they would have without the (deferred) clause.
+              ;; Repro: any d/q with a fn in :in plus an unrelated
+              ;; predicate / function clause whose arg isn't yet bound
+              ;; from a prior op.
               :predicate
-              (recur (#?(:clj legacy/filter-by-pred :cljs (rel/get-legacy-fn :filter-by-pred)) ctx (:clause op)) plan (inc idx))
+              (let [next-ctx (#?(:clj legacy/filter-by-pred
+                                 :cljs (rel/get-legacy-fn :filter-by-pred))
+                              ctx (:clause op))]
+                (recur (or next-ctx ctx) plan (inc idx)))
 
               :function
-              (recur (#?(:clj legacy/bind-by-fn :cljs (rel/get-legacy-fn :bind-by-fn)) ctx (:clause op)) plan (inc idx))
+              (let [next-ctx (#?(:clj legacy/bind-by-fn
+                                 :cljs (rel/get-legacy-fn :bind-by-fn))
+                              ctx (:clause op))]
+                (recur (or next-ctx ctx) plan (inc idx)))
 
               :or (recur (execute-or op-db op ctx) plan (inc idx))
               :or-join (recur (execute-or-join op-db op ctx) plan (inc idx))

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -372,14 +372,31 @@
                 true (conj (ir/->PEmitTuple 0)))]
     (ir/->PPipeline (vec steps) fused-path use-cursors? (boolean attr-refs?))))
 
+(defn- args-free-vars
+  "Walk an :args list recursively, collecting every free variable that
+   appears anywhere inside. Mirrors `analyze/extract-vars`, which is
+   already the recursive contract for `:vars` on every clause type.
+
+   Why recurse: SQL translators (and any other producer of nested
+   boolean / arithmetic expressions) emit clauses like
+       [(and (= ?x ?p) (some? ?y)) ?out]
+   The :args here are seq forms, not symbols. A flat top-level
+   `(filter free-var?)` returns #{}, so the planner thinks the op has
+   no inputs and orders it before its producers — leaving the legacy
+   bind-by-fn path to fail with nil ctx until the next iteration.
+   The legacy engine is fine with nested expressions because it walks
+   them at runtime via `interpret-form`; the planner just has to
+   recognise the same shape during ordering."
+  [args]
+  (into #{} (mapcat analyze/extract-vars) args))
+
 (defn- op-input-vars
   "Return only the *input* vars of an op — vars it consumes, not vars it produces.
    For :function ops, output vars (bound by the function) are excluded.
    For all other ops, :vars is already the set of input vars."
   [op]
   (if (= :function (:op op))
-    ;; Input vars are the free variables in :args
-    (into #{} (filter analyze/free-var?) (:args op))
+    (args-free-vars (:args op))
     (:vars op)))
 
 (defn post-op-direct-eligible?
@@ -771,7 +788,10 @@
     (if (every? #(contains? bound-vars %) (:vars op)) 0 max-cost)
 
     :function
-    (let [input-vars (into #{} (filter analyze/free-var?) (:args op))]
+    ;; Use args-free-vars (recursive) so nested expressions like
+    ;; (and (= ?x 1) (not ?y)) correctly report ?x and ?y as inputs
+    ;; instead of an empty set. See args-free-vars docstring.
+    (let [input-vars (args-free-vars (:args op))]
       (if (every? #(contains? bound-vars %) input-vars) 1 max-cost))
 
     :external-engine
@@ -783,7 +803,7 @@
           (or (:estimated-card op) 100)
           max-cost))
       ;; Filter/retrieval: check args for free var deps
-      (let [input-vars (into #{} (filter analyze/free-var?) (:args op))]
+      (let [input-vars (args-free-vars (:args op))]
         (if (every? #(contains? bound-vars %) input-vars)
           (or (:estimated-card op) 100)
           max-cost)))


### PR DESCRIPTION
## Summary

Two correctness fixes in the new query planner, both surfaced by `pgwire-datahike`'s Metabase integration testing where SQL translators inject runtime fns through `:in` and emit `:function` clauses with nested seq-form args.

### 1. `fix(query/execute)`: don't replace ctx with nil from legacy delegate

The planner's `:function` and `:predicate` ops delegate to the legacy engine's `bind-by-fn` / `filter-by-pred`. When clause arg vars aren't yet bound, those return `nil` — a "retry-later" signal the legacy main loop catches via `resolve-clauses`.

The planner has no retry pass; it just `(recur next-ctx ...)`. A `nil` return then wipes `:consts` / `:sources` / `:rels` for every subsequent op — so any `:in`-bound fn (e.g. `?pg-format` from a SQL translator that registers a runtime fn against a logic-var symbol) fails with "Unknown function" on the next clause.

Fix: `(recur (or next-ctx ctx) plan (inc idx))` at both delegate sites. Falls back to original ctx when the legacy delegate signals retry; the deferred clause's contribution is no-op for that run, which is what we want.

### 2. `fix(query/plan)`: walk nested form-args when computing :function input vars

`op-cost` / `op-input-vars` extracted `:function` arg vars via a flat top-level walk (`filter free-var? (:args op))`). That misses free vars inside nested seq forms like `[(and (= ?x ?p) (not ?y)) ?out]` — the planner thinks the op has no inputs and orders it before the producer of `?y`.

Fix: a small recursive helper `args-free-vars` that mirrors `extract-vars` from `datahike.query.analyze`, used in both `op-input-vars` and `op-cost` (`:function` and `:external-engine` modes).

With both fixes, the planner reaches the same fixed point as the legacy interpreter on Metabase's describe-fields query. The ctx-nil guard stays as defense-in-depth — `bind-by-fn`'s nil-as-retry contract isn't going away.

## Test plan
- [x] `bb test clj-pss` → 473 tests / 2292 assertions / 0 failures
- [x] Verified end-to-end against pgwire-datahike Metabase sync (planner == legacy on the failing clause)