### PR TITLE
refactor(query/execute): drop redundant ctx-nil guard from planner

### DIFF
--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3249,36 +3249,17 @@
                                     plan)]
                         (recur ctx' plan' (inc idx)))))))
 
-              ;; Why `(or next-ctx ctx)` instead of `next-ctx`:
-              ;; legacy/filter-by-pred and legacy/bind-by-fn return nil
-              ;; when not all of the clause's argument vars are bound
-              ;; yet — the legacy interpreter's main loop catches this
-              ;; with a "retry-later" pass (see `resolve-clauses` in
-              ;; query.cljc), but the planner here processes ops in a
-              ;; single linear pass. Without the `or`, the next iter
-              ;; sees ctx = nil, every subsequent op reads :consts /
-              ;; :sources / :rels off nil, and any :in-bound function
-              ;; (e.g. a fn passed in as `?my-fn`) fails to resolve via
-              ;; `context-resolve-val` and raises "Unknown function".
-              ;;
-              ;; Falling back to the original ctx is safe: when the
-              ;; clause genuinely couldn't bind anything, the relations
-              ;; stay unchanged and downstream ops see exactly the same
-              ;; state they would have without the (deferred) clause.
-              ;; Repro: any d/q with a fn in :in plus an unrelated
-              ;; predicate / function clause whose arg isn't yet bound
-              ;; from a prior op.
               :predicate
-              (let [next-ctx (#?(:clj legacy/filter-by-pred
-                                 :cljs (rel/get-legacy-fn :filter-by-pred))
-                              ctx (:clause op))]
-                (recur (or next-ctx ctx) plan (inc idx)))
+              (recur (#?(:clj legacy/filter-by-pred
+                         :cljs (rel/get-legacy-fn :filter-by-pred))
+                      ctx (:clause op))
+                     plan (inc idx))
 
               :function
-              (let [next-ctx (#?(:clj legacy/bind-by-fn
-                                 :cljs (rel/get-legacy-fn :bind-by-fn))
-                              ctx (:clause op))]
-                (recur (or next-ctx ctx) plan (inc idx)))
+              (recur (#?(:clj legacy/bind-by-fn
+                         :cljs (rel/get-legacy-fn :bind-by-fn))
+                      ctx (:clause op))
+                     plan (inc idx))
 
               :or (recur (execute-or op-db op ctx) plan (inc idx))
               :or-join (recur (execute-or-join op-db op ctx) plan (inc idx))


### PR DESCRIPTION
Follow-up to #814.

## Summary

Drops the `(or next-ctx ctx)` guard around `legacy/filter-by-pred` and `legacy/bind-by-fn` in the planner's `:predicate` and `:function` op dispatch. That guard was the band-aid we found first — it defended against the legacy fns' nil-as-retry-later return clobbering the planner's context.

It's now structurally unreachable: #814's `args-free-vars` deep walk in `op-input-vars` / `op-cost` already gates dispatch on every free var (top-level OR nested) being bound. `bind-by-fn`'s only nil-return path is `(every? symbols-with-values attrs)` where `attrs = (filter symbol? args)` — a flat top-level subset of what the planner's deep walk gates on. Deep ⊇ flat, so when the planner says "all bound", the legacy fn proceeds without returning nil.

So the guard was masking a now-impossible case. Crashing loudly on an unexpected nil is better diagnostic feedback than silently falling through with a stale ctx.

The deep-walk fix in `plan.cljc` stays — that's the real root-cause patch.

## Test plan
- [x] `bb test clj-pss` → 473 tests / 2292 assertions / 0 failures