### PR TITLE
fix(query/planner): not=/== predicates silently dropped when pushed into AVET scan

### DIFF
--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -372,8 +372,13 @@
   (when (seq strict-preds)
     (fn [^Datom d]
       (let [dv (case (int datom-field-idx) 0 (.-e d) 1 (.-a d) 2 (.-v d) 3 (.-tx d))]
-        (every? (fn [{:keys [op const-val]}]
-                  (case op > (> (compare dv const-val) 0) < (< (compare dv const-val) 0) true))
+        (every? (fn [{:keys [op const-val] :as pred}]
+                  (case op
+                    > (> (compare dv const-val) 0)
+                    < (< (compare dv const-val) 0)
+                    not= (not= dv const-val)
+                    (throw (ex-info "Unhandled op in build-strict-filter — every op pushdown-to-bounds writes into :strict-preds must have a case arm here"
+                                    {:op op :pred pred}))))
                 strict-preds)))))
 
 (defn- compute-slice-bounds

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -70,7 +70,12 @@
        =  (-> bounds
               (assoc :from-v const-val)
               (assoc :to-v const-val))
-       bounds))
+       == (-> bounds
+              (assoc :from-v const-val)
+              (assoc :to-v const-val))
+       not= (update bounds :strict-preds (fnil conj []) pred)
+       (throw (ex-info "Unhandled op in pushdown-to-bounds — every op in analyze/range-ops must have a case arm here"
+                       {:op op :pred pred}))))
    {:from-v nil :to-v nil}
    pushdown-preds))
 

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -103,7 +103,20 @@
 
   (testing "Equality predicate"
     (assert-engines-agree @test-db
-                          '[:find ?e ?a :where [?e :age ?a] [(= ?a 37)]])))
+                          '[:find ?e ?a :where [?e :age ?a] [(= ?a 37)]]))
+
+  (testing "not= predicate on AVET-indexed attribute — version 0 excluded"
+    ;; Regression: planner was consuming not= as a pushdown but silently dropping it,
+    ;; causing the predicate to be ignored and all values returned.
+    (let [db (d/db-with (db/empty-db {:version/id {:db/unique :db.unique/identity}})
+                        [{:version/id 0} {:version/id 1} {:version/id 2}])]
+      (assert-engines-agree db '[:find ?v :where [?e :version/id ?v] [(not= ?v 0)]])))
+
+  (testing "== predicate on AVET-indexed attribute — numeric equality"
+    ;; Regression: planner was consuming == as a pushdown but silently dropping it.
+    (let [db (d/db-with (db/empty-db {:version/id {:db/unique :db.unique/identity}})
+                        [{:version/id 0} {:version/id 1} {:version/id 2}])]
+      (assert-engines-agree db '[:find ?v :where [?e :version/id ?v] [(== ?v 1)]]))))
 
 ;; ---------------------------------------------------------------------------
 ;; Phase 2: Value joins (Q5)


### PR DESCRIPTION
## Summary
- Predicates like `(not= ?v 0)` and `(== ?v 1)` referencing the value of a pattern with an AVET-indexed attribute were marked as pushdown candidates and consumed by `plan-pattern-op`, but `pushdown-to-bounds` had no case arm for either op — so the predicate silently vanished and the filter was never applied.
- Fix: `not=` now goes into `:strict-preds` for post-scan filtering; `==` sets exact bounds like `=`. The default case arms in both `pushdown-to-bounds` and `build-strict-filter` now throw, so any future addition to `range-ops` without matching handlers fails loudly instead of silently dropping predicates.
- Reported by Jonas Östlund against `jobtech-taxonomy-api` (`show-versions-without-0` returned version 0 despite `(not= ?version 0)`).

## Test plan
- [x] `DATAHIKE_QUERY_PLANNER=true bb test clj-pss` — 478 tests, 2316 assertions, 0 failures
- [x] Added regression tests in `query_planner_test.clj` covering `not=` and `==` against AVET-indexed attributes (dual-engine equivalence)
- [x] Verified against `utils.mini-db-test` in `jobtech-taxonomy-api` — `not=` no longer drops version 0 (remaining year-off-by-1 failure there is a timezone-dependent bug in their test, also present with planner disabled and with their committed Maven `0.7.1620`)