### PR TITLE
fix(query/planner): jobtech-surfaced correctness fixes + central op-required-vars

### DIFF
--- a/src/datahike/query/estimate.cljc
+++ b/src/datahike/query/estimate.cljc
@@ -245,17 +245,22 @@
      - Neither bound: existing estimate-pattern result.
 
    When `bound-var-cards` is empty, returns the same value as the 3-arity
-   `estimate-pattern`."
+   `estimate-pattern`. Defensive: if a caller still passes a plain set
+   instead of a map (legacy interface), entries are treated as bound with
+   unknown cardinality — fall back to 3-arity behavior for those vars."
   [db pattern-info schema-info bound-var-cards]
-  (let [base (estimate-pattern db pattern-info schema-info)]
+  (let [base (estimate-pattern db pattern-info schema-info)
+        ;; Tolerate both map (var → card) and set (legacy) forms.
+        card-of (fn [m k]
+                  (when (contains? m k)
+                    (let [v (get m k)]
+                      (when (number? v) (long v)))))]
     (if (or (empty? bound-var-cards) (nil? base))
       base
       (let [{:keys [e v]} pattern-info
             free-var? analyze/free-var?
-            e-card (when (and (free-var? e) (contains? bound-var-cards e))
-                     (long (get bound-var-cards e)))
-            v-card (when (and (free-var? v) (contains? bound-var-cards v))
-                     (long (get bound-var-cards v)))]
+            e-card (when (free-var? e) (card-of bound-var-cards e))
+            v-card (when (free-var? v) (card-of bound-var-cards v))]
         (cond
           ;; No bound free vars in this pattern — base estimate stands.
           (and (nil? e-card) (nil? v-card))

--- a/src/datahike/query/estimate.cljc
+++ b/src/datahike/query/estimate.cljc
@@ -161,6 +161,133 @@
     (estimate-pattern-counted db pattern-info schema-info)
     (estimate-pattern-heuristic db pattern-info schema-info)))
 
+;; ---------------------------------------------------------------------------
+;; Distinct-value sampling for fan-out estimation
+;;
+;; When a pattern's value position is a free var that's bound from upstream,
+;; the effective per-call cardinality is the AVERAGE matches per value, not
+;; the total attribute count. We approximate this as
+;;     attr-total-count / distinct-value-count
+;; sampling distinct values from the AVET / AEVT slice.
+
+(defn- sample-distinct-v-count
+  "Estimate the number of distinct values for a ground attribute.
+   For unique attrs, returns attr-count (1:1). For others, samples up to
+   `sample-size` datoms from AVET (preferred) or AEVT and counts distinct vals,
+   extrapolating against the total slice count.
+   Returns a positive long, or nil if estimation isn't possible."
+  [db pattern-info schema-info]
+  (let [{:keys [a]} pattern-info
+        ground? (fn [x] (and (some? x) (not (symbol? x))))]
+    (when (ground? a)
+      (let [resolved-a (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
+                         (dbi/-ref-for db a)
+                         a)
+            attr-count (di/-count-slice (:aevt db)
+                                        (datom e0 resolved-a nil tx0)
+                                        (datom emax resolved-a nil txmax)
+                                        cmp-attr-only)]
+        (cond
+          (zero? attr-count) 1
+          (:unique? schema-info) attr-count
+          :else
+          (let [;; Prefer AVET (already sorted by value) — distinct values appear in runs
+                index-key (if (:indexed? schema-info) :avet :aevt)
+                index (get db index-key)]
+            (if (or (not index) (<= attr-count sample-size))
+              ;; Small enough to count exactly via the full slice
+              (let [datoms (di/-slice (or index (:aevt db))
+                                      (datom e0 resolved-a nil tx0)
+                                      (datom emax resolved-a nil txmax)
+                                      (or index-key :aevt))]
+                (max 1 (count (into #{} (map (fn [^datahike.datom.Datom d] (.-v d))) datoms))))
+              ;; Sample first N datoms; count distinct, extrapolate.
+              (let [datoms (into [] (take sample-size)
+                                 (di/-slice index
+                                            (datom e0 resolved-a nil tx0)
+                                            (datom emax resolved-a nil txmax)
+                                            index-key))
+                    n-sampled (count datoms)
+                    n-distinct (count (into #{} (map (fn [^datahike.datom.Datom d] (.-v d))) datoms))]
+                (if (zero? n-sampled)
+                  attr-count
+                  (max 1 (long (* attr-count
+                                  (/ (double n-distinct) (double n-sampled))))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Bound-aware pattern cardinality estimation
+;;
+;; A free-var position whose var is bound from upstream context is effectively
+;; a probe constraint, not a free position: at execution time the lookup is
+;; per-bound-value, not a full attribute scan. The CARDINALITY OF THE BOUND VAR
+;; is the deciding factor:
+;;   - Bound var with N values × per-value fan-out = effective scan size
+;;   - Free var → attr-total-count (the existing estimator's answer)
+;;
+;; `bound-var-cards` is a {var-symbol → cardinality-upper-bound} map. Vars not
+;; in the map are treated as free.
+
+(defn estimate-pattern-with-bindings
+  "Estimate cardinality for a pattern clause, factoring in upstream-bound
+   free variables. `bound-var-cards` maps each bound var symbol to its known
+   cardinality upper bound (output rel size of the producing op). Vars not in
+   the map are treated as free (pre-existing behavior).
+
+   Semantics:
+     - Both e and v positions bound (or one bound + the other ground):
+         min(bound-card, base) — at most this many matches across all probes.
+     - Only e bound (free or ground v):
+         For card-one: e-card (each entity has at most 1 match for this attr).
+         For card-many: e-card × (attr-total / max-eid) approximation.
+     - Only v bound (free e), attr indexed:
+         v-card × (attr-total / distinct-v) — per-value fan-out from AVET.
+     - Only v bound, attr not indexed: v-card × small-factor (capped by base).
+     - Neither bound: existing estimate-pattern result.
+
+   When `bound-var-cards` is empty, returns the same value as the 3-arity
+   `estimate-pattern`."
+  [db pattern-info schema-info bound-var-cards]
+  (let [base (estimate-pattern db pattern-info schema-info)]
+    (if (or (empty? bound-var-cards) (nil? base))
+      base
+      (let [{:keys [e v]} pattern-info
+            free-var? analyze/free-var?
+            e-card (when (and (free-var? e) (contains? bound-var-cards e))
+                     (long (get bound-var-cards e)))
+            v-card (when (and (free-var? v) (contains? bound-var-cards v))
+                     (long (get bound-var-cards v)))]
+        (cond
+          ;; No bound free vars in this pattern — base estimate stands.
+          (and (nil? e-card) (nil? v-card))
+          base
+
+          ;; Both bound — point lookup; matches ≤ min(both cards, base).
+          (and e-card v-card)
+          (max 1 (long (min e-card v-card (or base 1))))
+
+          ;; Entity bound: per-entity probes.
+          e-card
+          (if (:card-one? schema-info)
+            ;; Each bound entity contributes at most 1 datom for this attr.
+            (max 1 (long (min e-card base)))
+            ;; Cardinality-many: rough per-entity fan-out.
+            (let [max-eid (max 1 (long (dbi/-max-eid db)))
+                  fan-out (max 1 (long (/ base max-eid)))]
+              (max 1 (long (min base (* e-card fan-out))))))
+
+          ;; Value bound: per-value probes via AVET (or non-indexed fallback).
+          v-card
+          (if (:indexed? schema-info)
+            (let [distinct-v (or (sample-distinct-v-count db pattern-info schema-info)
+                                 (max 1 (long (/ base 10))))
+                  per-v (max 1 (long (/ base (max 1 distinct-v))))]
+              (max 1 (long (min base (* v-card per-v)))))
+            ;; Non-indexed attr: lacking AVET, use a softer reduction.
+            ;; The existing legacy/temporal path will scan AEVT, so we still
+            ;; pay attribute-count cost; cap at attr-count to avoid false
+            ;; over-estimates of selectivity.
+            (max 1 (long (min base (* v-card 10))))))))))
+
 (defn estimate-predicate-selectivity-heuristic
   "Heuristic selectivity estimate for a predicate operator.
    Used as fallback when sampling is not possible."

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -1175,6 +1175,12 @@
         temporal-tx-filter (aget ^objects temporal-ctx 13)
         scan-added-val (aget ^objects temporal-ctx 14)
         origin-db (aget ^objects temporal-ctx 15)
+        ;; Optional merge arrays (added for get-else on temporal DBs).
+        ;; Nil-safe so callers built before this slot was added still work.
+        ^objects merge-optional (when (> (alength ^objects temporal-ctx) 16)
+                                  (aget ^objects temporal-ctx 16))
+        ^objects merge-defaults (when (> (alength ^objects temporal-ctx) 17)
+                                  (aget ^objects temporal-ctx 17))
         ^objects merge-datoms merge-datoms
         ^ints find-source find-source
         ^objects const-vals const-vals]
@@ -1252,9 +1258,16 @@
                                          found? (and d (temporal-merge-datom-match? d eid ra vg? vgv check-v? check-tx? scan-d temporal-tx-filter added-filter))]
                                      (if anti?
                                        (when (not found?) (process-merges (inc mi)))
-                                       (when found?
-                                         (aset merge-datoms mi d)
-                                         (process-merges (inc mi)))))
+                                       (cond
+                                         found?
+                                         (do (aset merge-datoms mi d)
+                                             (process-merges (inc mi)))
+                                         ;; Optional merge (get-else): emit synthetic
+                                         ;; default-valued datom on miss.
+                                         (and merge-optional (aget merge-optional mi))
+                                         (do (aset merge-datoms mi
+                                                   (datom eid ra (aget merge-defaults mi) tx0))
+                                             (process-merges (inc mi))))))
                                  ;; Temporal card-one: for as-of/since, try direct lookupGE
                                  ;; on current EAVT (avoids lazy-seq merge overhead per entity).
                                    (if (and (not= temporal-type :historical) temporal-tx-filter)
@@ -1278,8 +1291,19 @@
                                                  (if anti? nil
                                                      (do (aset merge-datoms mi td)
                                                          (process-merges (inc mi))))
-                                                 (when anti? (process-merges (inc mi)))))
-                                             (when anti? (process-merges (inc mi)))))))
+                                                 (cond
+                                                   anti? (process-merges (inc mi))
+                                                   ;; Optional merge: emit default on miss
+                                                   (and merge-optional (aget merge-optional mi))
+                                                   (do (aset merge-datoms mi
+                                                             (datom eid ra (aget merge-defaults mi) tx0))
+                                                       (process-merges (inc mi))))))
+                                             (cond
+                                               anti? (process-merges (inc mi))
+                                               (and merge-optional (aget merge-optional mi))
+                                               (do (aset merge-datoms mi
+                                                         (datom eid ra (aget merge-defaults mi) tx0))
+                                                   (process-merges (inc mi))))))))
                                    ;; Historical: full temporal-merge-slice (needs all versions)
                                      (let [from-d (datom eid ra (when vg? vgv) tx0)
                                            to-d (datom eid ra (when vg? vgv) txmax)
@@ -1289,11 +1313,16 @@
                                        (if anti?
                                          (when (not-any? (fn [^Datom d] (temporal-merge-datom-match? d eid ra vg? vgv check-v? check-tx? scan-d temporal-tx-filter added-filter)) mslice)
                                            (process-merges (inc mi)))
-                                         (when-let [^Datom d (some (fn [^Datom d]
-                                                                     (when (temporal-merge-datom-match? d eid ra vg? vgv check-v? check-tx? scan-d temporal-tx-filter added-filter) d))
-                                                                   mslice)]
-                                           (aset merge-datoms mi d)
-                                           (process-merges (inc mi)))))))))))]
+                                         (if-let [^Datom d (some (fn [^Datom d]
+                                                                   (when (temporal-merge-datom-match? d eid ra vg? vgv check-v? check-tx? scan-d temporal-tx-filter added-filter) d))
+                                                                 mslice)]
+                                           (do (aset merge-datoms mi d)
+                                               (process-merges (inc mi)))
+                                           ;; Optional merge: emit default when no version matched
+                                           (when (and merge-optional (aget merge-optional mi))
+                                             (aset merge-datoms mi
+                                                   (datom eid ra (aget merge-defaults mi) tx0))
+                                             (process-merges (inc mi))))))))))))]
                    (process-merges 0)))))))
        :cljs
        (doseq [scan-d slice
@@ -1334,8 +1363,14 @@
                                    found? (and d (temporal-merge-datom-match? d eid ra vg? vgv check-v? check-tx? scan-d temporal-tx-filter added-filter))]
                                (if anti?
                                  (when (not found?) (process-merges (inc mi)))
-                                 (when found?
-                                   (aset merge-datoms mi d) (process-merges (inc mi)))))))))]
+                                 (cond
+                                   found?
+                                   (do (aset merge-datoms mi d) (process-merges (inc mi)))
+                                   ;; Optional merge: emit synthetic default datom on miss
+                                   (and merge-optional (aget merge-optional mi))
+                                   (do (aset merge-datoms mi
+                                             (datom eid ra (aget merge-defaults mi) tx0))
+                                       (process-merges (inc mi))))))))))]
                (process-merges 0))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1515,7 +1550,8 @@
                                                merge-temporal-only merge-cursor-cache
                                                temporal-eavt-pss temporal-cursors
                                                temporal-type temporal-tx-filter
-                                               scan-added-val origin-db])
+                                               scan-added-val origin-db
+                                               merge-optional merge-defaults])
                                 cancel))
 
       ;; Non-temporal dispatch via fused-path keyword

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3238,16 +3238,33 @@
                 ;; Temporal/non-standard DB — fall back to per-clause legacy lookup.
                 ;; lookup-batch-search takes [source context orig-pattern resolved-pattern];
                 ;; passing clause twice is intentional (no resolution needed in fallback).
+                ;;
+                ;; Optional merges (LOptionalScan from get-else) require left-outer
+                ;; semantics with a default-on-miss. lookup-batch-search is inner-join,
+                ;; so we route optional merges through bind-by-fn (which evaluates
+                ;; -get-else per row, mirroring the legacy engine).
                 (let [scan-clause (:clause (:scan-op op))
-                      merge-clauses (mapv :clause
-                                          (remove :anti? (:merge-ops op)))
-                      anti-clauses (mapv :clause
-                                         (filter :anti? (:merge-ops op)))
-                      all-clauses (into [scan-clause] merge-clauses)
+                      all-merge-ops (:merge-ops op)
+                      regular-merge-clauses (mapv :clause
+                                                  (filter (fn [m] (not (or (:anti? m) (:optional? m))))
+                                                          all-merge-ops))
+                      optional-merge-ops (filterv :optional? all-merge-ops)
+                      anti-clauses (mapv :clause (filter :anti? all-merge-ops))
+                      all-clauses (into [scan-clause] regular-merge-clauses)
                       ctx' (binding [rel/*implicit-source* op-db]
                              (reduce (fn [c clause]
                                        (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search)) op-db c clause clause))
                                      ctx all-clauses))
+                      ;; Optional merges via per-row bind-by-fn(get-else). Synthetic
+                      ;; clause is [e-var attr bind-var] (attr already resolved to eid
+                      ;; in :attribute-refs? mode by logical.cljc).
+                      ctx' (binding [rel/*implicit-source* op-db]
+                             (reduce (fn [c opt-merge]
+                                       (let [[e-var attr bind-var] (:clause opt-merge)
+                                             default-val (:default-value opt-merge)
+                                             fn-clause [(list 'get-else '$ e-var attr default-val) bind-var]]
+                                         (#?(:clj legacy/bind-by-fn :cljs (rel/get-legacy-fn :bind-by-fn)) c fn-clause)))
+                                     ctx' optional-merge-ops))
                       ;; Apply anti-merges: look up each anti clause and subtract its matches
                       ctx' (binding [rel/*implicit-source* op-db]
                              (reduce (fn [c anti-clause]
@@ -3276,8 +3293,20 @@
                   ;; Temporal/non-standard DB — use legacy lookup with search context.
                   ;; lookup-batch-search takes [source context orig-pattern resolved-pattern];
                   ;; passing clause twice — no resolution needed in fallback.
+                  ;; If this op is a standalone LOptionalScan-derived pattern-scan
+                  ;; (get-else where the entity isn't shared with another scan in
+                  ;; the same scope, e.g. `?e` only appears inside OR branches),
+                  ;; the legacy lookup-batch-search would inner-join and drop
+                  ;; entities lacking the attribute. Route through bind-by-fn for
+                  ;; left-outer-with-default semantics, matching the legacy
+                  ;; engine's behavior for [(get-else …) ?v].
                   (let [ctx' (binding [rel/*implicit-source* op-db]
-                               (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search)) op-db ctx (:clause op) (:clause op)))]
+                               (if (:optional? op)
+                                 (let [[e-var attr bind-var] (:clause op)
+                                       default-val (:default-value op)
+                                       fn-clause [(list 'get-else '$ e-var attr default-val) bind-var]]
+                                   (#?(:clj legacy/bind-by-fn :cljs (rel/get-legacy-fn :bind-by-fn)) ctx fn-clause))
+                                 (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search)) op-db ctx (:clause op) (:clause op))))]
                     (recur ctx' plan (inc idx)))
                 ;; DB source — use fused scan or single pattern scan
                   (let [;; Check if next ops form an ad-hoc fusable group

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3300,7 +3300,28 @@
                                                         (reduce rel/hash-join (:rels neg-ctx)))
                                              result (if neg-join (rel/subtract-rel join-rel neg-join) join-rel)]
                                          (assoc c :rels [result])))
-                                     ctx' anti-clauses))]
+                                     ctx' anti-clauses))
+                      ;; Apply pushed-down predicates as post-filters. The
+                      ;; planner records each push-down predicate's original
+                      ;; clause in the scan-op's :pushdown-preds list and adds
+                      ;; the clause to the plan's :consumed-preds set, so the
+                      ;; clause-level predicate isn't emitted as its own
+                      ;; :predicate op. The fused PSS scan path applies these
+                      ;; via slice bounds + strict-filter inside
+                      ;; execute-fused-scan-rel; the temporal fallback uses
+                      ;; lookup-batch-search which doesn't honor :pushdown-preds,
+                      ;; so without a post-filter the predicate is silently
+                      ;; dropped — surfaced in jobtech daynotes tests as rows
+                      ;; matching ?inst < ?from-version that should have been
+                      ;; filtered out.
+                      pushdown-pred-clauses
+                      (concat (mapv :pred-clause (:pushdown-preds (:scan-op op)))
+                              (mapcat #(mapv :pred-clause (:pushdown-preds %)) all-merge-ops))
+                      ctx' (binding [rel/*implicit-source* op-db]
+                             (reduce (fn [c pred-clause]
+                                       (#?(:clj legacy/filter-by-pred :cljs (rel/get-legacy-fn :filter-by-pred))
+                                        c pred-clause))
+                                     ctx' (filter some? pushdown-pred-clauses)))]
                   (recur ctx' plan (inc idx))))
 
               ;; Single pattern scan

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3244,17 +3244,42 @@
                 ;; so we route optional merges through bind-by-fn (which evaluates
                 ;; -get-else per row, mirroring the legacy engine).
                 (let [scan-clause (:clause (:scan-op op))
+                      scan-evar (first scan-clause)
                       all-merge-ops (:merge-ops op)
                       regular-merge-clauses (mapv :clause
                                                   (filter (fn [m] (not (or (:anti? m) (:optional? m))))
                                                           all-merge-ops))
                       optional-merge-ops (filterv :optional? all-merge-ops)
                       anti-clauses (mapv :clause (filter :anti? all-merge-ops))
-                      all-clauses (into [scan-clause] regular-merge-clauses)
+                      ;; Run scan with full ctx so upstream constants/constraints
+                      ;; (e.g. const-bound safe-vars, lookup-refs in v) feed into
+                      ;; the scan's substitution.
+                      ctx-after-scan (binding [rel/*implicit-source* op-db]
+                                       (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search))
+                                        op-db ctx scan-clause scan-clause))
+                      ;; For each merge clause, trim ctx to rels connected to the
+                      ;; scan entity-var. Independent upstream rels (no shared var
+                      ;; with scan-derived rels) would otherwise cause
+                      ;; lookup-batch-search to substitute the cartesian of all
+                      ;; bound rels — a blowup when upstream and scan-rel are
+                      ;; both large but disjoint. After lookup we re-add the
+                      ;; aside rels; collapse-rels hash-joins on shared vars
+                      ;; (e.g. the merge-introduced v-var) — semantically
+                      ;; equivalent to cartesian-then-filter, but avoids the
+                      ;; quadratic substitution.
+                      contains-scan-evar? (fn [r] (contains? (set (keys (:attrs r))) scan-evar))
                       ctx' (binding [rel/*implicit-source* op-db]
                              (reduce (fn [c clause]
-                                       (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search)) op-db c clause clause))
-                                     ctx all-clauses))
+                                       (let [{scan-rels true other-rels false}
+                                             (group-by contains-scan-evar? (:rels c))
+                                             trimmed-ctx (assoc c :rels (vec scan-rels))
+                                             after-merge (#?(:clj legacy/lookup-batch-search :cljs (rel/get-legacy-fn :lookup-batch-search))
+                                                          op-db trimmed-ctx clause clause)
+                                             final-rels (reduce rel/collapse-rels
+                                                                (:rels after-merge)
+                                                                (or other-rels []))]
+                                         (assoc c :rels final-rels)))
+                                     ctx-after-scan regular-merge-clauses))
                       ;; Optional merges via per-row bind-by-fn(get-else). Synthetic
                       ;; clause is [e-var attr bind-var] (attr already resolved to eid
                       ;; in :attribute-refs? mode by logical.cljc).

--- a/src/datahike/query/logical.cljc
+++ b/src/datahike/query/logical.cljc
@@ -100,10 +100,23 @@
                                (mapcat analyze/extract-vars)
                                where-clauses)
 
-         ;; Walk classified clauses → accumulate IR node collections
+         ;; Walk classified clauses → accumulate IR node collections.
+         ;; Each created LP node is tagged via metadata with `:source-idx` —
+         ;; the position of its originating clause in the user's source order.
+         ;; lower.cljc uses this to compute each node's bound-var-cards from
+         ;; outputs of PRECEDING source-order nodes only, so a rule call's
+         ;; planning bvc doesn't include outputs of later patterns that
+         ;; consume the rule's outputs (the directional over-binding that
+         ;; otherwise makes the rule body pick wrong scans). Source order is
+         ;; a sound heuristic: it's the order Datalog programmers write
+         ;; clauses to encode dependencies, and the engine's later
+         ;; `order-plan-ops` is free to reorder execution without affecting
+         ;; correctness — it only affects estimate accuracy.
+         tag-src (fn [node idx]
+                   (vary-meta node assoc :source-idx idx))
          {:keys [scans filters binds nots or-nodes rule-nodes passthrough-nodes and-nodes]}
          (reduce
-          (fn [acc ci]
+          (fn [acc [idx ci]]
             (let [is-rule? (rule-call? ci rules)
                   lookup-mode (when is-rule?
                                 (:rule-lookup-mode (meta (:clause ci))))]
@@ -114,26 +127,29 @@
                 (let [rule-vars (into #{} (filter analyze/free-var?) (rest (:clause ci)))
                       mode (or lookup-mode :main)]
                   (update acc :rule-nodes conj
-                          (ir/->LRuleLookup (:clause ci) (:e ci)
-                                            (vec (rest (:clause ci))) mode rule-vars)))
+                          (tag-src (ir/->LRuleLookup (:clause ci) (:e ci)
+                                                     (vec (rest (:clause ci))) mode rule-vars)
+                                   idx)))
 
                 ;; Normal rule call — opaque node for lowering to expand
                 is-rule?
                 (let [rule-vars (into #{} (filter analyze/free-var?) (rest (:clause ci)))]
                   (update acc :rule-nodes conj
-                          (ir/->LRuleCall (:clause ci) (:e ci)
-                                          (vec (rest (:clause ci))) rule-vars)))
+                          (tag-src (ir/->LRuleCall (:clause ci) (:e ci)
+                                                   (vec (rest (:clause ci))) rule-vars)
+                                   idx)))
 
                 :else
                 (case (:type ci)
                   ;; Data pattern → LScan
                   :pattern
-                  (update acc :scans conj (make-scan ci nil))
+                  (update acc :scans conj (tag-src (make-scan ci nil) idx))
 
                   ;; Predicate → LFilter
                   :predicate
                   (update acc :filters conj
-                          (ir/->LFilter (:clause ci) (:fn-sym ci) (:args ci) (:vars ci)))
+                          (tag-src (ir/->LFilter (:clause ci) (:fn-sym ci) (:args ci) (:vars ci))
+                                   idx))
 
                   ;; Function binding → LBind (or LOptionalScan for get-else)
                   :function
@@ -171,36 +187,40 @@
                                            (analyze/free-var? e-var))
                                       (conj e-var))]
                       (update acc :scans conj
-                              (ir/->LOptionalScan
-                               [e-var attr bind-var]  ;; synthetic clause
-                               scan-vars
-                               e-var attr bind-var nil ;; e a v tx
-                               nil                     ;; source
-                               default-val             ;; default value
-                               bind-var)))             ;; binding var
+                              (tag-src (ir/->LOptionalScan
+                                        [e-var attr bind-var]  ;; synthetic clause
+                                        scan-vars
+                                        e-var attr bind-var nil ;; e a v tx
+                                        nil                     ;; source
+                                        default-val             ;; default value
+                                        bind-var)               ;; binding var
+                                       idx)))
                     ;; Regular function → LBind
                     (update acc :binds conj
-                            (ir/->LBind (:clause ci) (:fn-sym ci) (:args ci)
-                                        (:binding ci) (:vars ci))))
+                            (tag-src (ir/->LBind (:clause ci) (:fn-sym ci) (:args ci)
+                                                 (:binding ci) (:vars ci))
+                                     idx)))
 
                   ;; NOT → collect for anti-merge folding
                   :not
-                  (update acc :nots conj {:ci ci :type :not :source nil})
+                  (update acc :nots conj {:ci ci :type :not :source nil :source-idx idx})
 
                   ;; NOT-JOIN → always stays separate (has explicit join vars)
                   :not-join
-                  (update acc :nots conj {:ci ci :type :not-join :source nil})
+                  (update acc :nots conj {:ci ci :type :not-join :source nil :source-idx idx})
 
                   ;; OR → LUnion (branches built by lowering)
                   :or
                   (update acc :or-nodes conj
-                          (ir/->LUnion (:clause ci) nil (:vars ci) nil :or))
+                          (tag-src (ir/->LUnion (:clause ci) nil (:vars ci) nil :or)
+                                   idx))
 
                   ;; OR-JOIN → LUnion with join vars
                   :or-join
                   (update acc :or-nodes conj
-                          (ir/->LUnion (:clause ci) nil (:vars ci)
-                                       (set (:join-vars ci)) :or-join))
+                          (tag-src (ir/->LUnion (:clause ci) nil (:vars ci)
+                                                (set (:join-vars ci)) :or-join)
+                                   idx))
 
                   ;; AND → flatten: build sub-plan (which does its own entity
                   ;; grouping) and merge resulting nodes into parent as-is
@@ -217,23 +237,26 @@
                         inner-ci (analyze/classify-clause inner)]
                     (case (:type inner-ci)
                       :pattern
-                      (update acc :scans conj (make-scan inner-ci source-sym))
+                      (update acc :scans conj (tag-src (make-scan inner-ci source-sym) idx))
 
                       ;; Source-prefixed NOT/OR → LPassthrough (lowering delegates)
                       (:not :not-join :or :or-join)
                       (update acc :passthrough-nodes conj
-                              (ir/->LPassthrough (:clause ci) :source-prefix (:vars ci)))
+                              (tag-src (ir/->LPassthrough (:clause ci) :source-prefix (:vars ci))
+                                       idx))
 
                       ;; Other source-prefix → passthrough
                       (update acc :passthrough-nodes conj
-                              (ir/->LPassthrough (:clause ci) :source-prefix (:vars ci)))))
+                              (tag-src (ir/->LPassthrough (:clause ci) :source-prefix (:vars ci))
+                                       idx))))
 
                   ;; Unknown → passthrough
                   (update acc :passthrough-nodes conj
-                          (ir/->LPassthrough (:clause ci) (:type ci) (:vars ci)))))))
+                          (tag-src (ir/->LPassthrough (:clause ci) (:type ci) (:vars ci))
+                                   idx))))))
           {:scans [] :filters [] :binds [] :nots [] :or-nodes []
            :rule-nodes [] :passthrough-nodes [] :and-nodes []}
-          classified)
+          (map-indexed vector classified))
 
          ;; ---------------------------------------------------------------
          ;; Group scans by entity variable
@@ -259,22 +282,32 @@
                                             (map (comp :clause :ci :not-entry) entries)))
                                   foldable-nots)
 
-         ;; Build entity join nodes from scan groups
+         ;; Build entity join nodes from scan groups. An LEntityJoin folds
+         ;; multiple scans on the same entity-var into a single node — the
+         ;; node's source-idx is the MIN of its component scans' indices,
+         ;; so it inherits the position of the earliest scan in user
+         ;; source order. Standalone scans pass through their tag from
+         ;; build above.
          entity-nodes
          (mapv
           (fn [[[e-var source] group-scans]]
             (let [anti-entries (get foldable-nots [e-var source])
                   anti-scans (mapv :anti-scan anti-entries)
                   all-vars (into (into #{} (mapcat :vars) group-scans)
-                                 (mapcat :vars) anti-scans)]
+                                 (mapcat :vars) anti-scans)
+                  min-idx (apply min Long/MAX_VALUE
+                                 (keep #(:source-idx (meta %)) group-scans))]
               (if (and (= 1 (count group-scans)) (empty? anti-scans))
                 ;; Single scan, no anti-merges → standalone LScan
                 (first group-scans)
                 ;; Multi-scan group → LEntityJoin
-                (ir/->LEntityJoin e-var (vec group-scans) anti-scans all-vars source))))
+                (vary-meta (ir/->LEntityJoin e-var (vec group-scans) anti-scans all-vars source)
+                           assoc :source-idx min-idx))))
           scan-groups)
 
-         ;; Remaining NOTs (not folded into entity groups)
+         ;; Remaining NOTs (not folded into entity groups). Each LAntiJoin
+         ;; inherits the source-idx from the not-entry (recorded during the
+         ;; classified walk above).
          remaining-nots
          (into []
                (comp
@@ -284,10 +317,11 @@
                          ;; Already an IR node from AND flattening
                          ir-node
                          ;; Build LAntiJoin from clause-info
-                         (let [{:keys [ci type]} not-entry]
-                           (ir/->LAntiJoin (:clause ci) (:sub-clauses ci) (:vars ci)
-                                           (when (= type :not-join) (set (:join-vars ci)))
-                                           type))))))
+                         (let [{:keys [ci type source-idx]} not-entry]
+                           (cond-> (ir/->LAntiJoin (:clause ci) (:sub-clauses ci) (:vars ci)
+                                                   (when (= type :not-join) (set (:join-vars ci)))
+                                                   type)
+                             source-idx (vary-meta assoc :source-idx source-idx)))))))
                nots)
 
          ;; Assemble all nodes (UNORDERED — ordering is physical)

--- a/src/datahike/query/logical.cljc
+++ b/src/datahike/query/logical.cljc
@@ -295,14 +295,24 @@
                   anti-scans (mapv :anti-scan anti-entries)
                   all-vars (into (into #{} (mapcat :vars) group-scans)
                                  (mapcat :vars) anti-scans)
-                  min-idx (apply min Long/MAX_VALUE
-                                 (keep #(:source-idx (meta %)) group-scans))]
+                  min-idx (let [idxs (keep #(:source-idx (meta %)) group-scans)]
+                            (if (seq idxs)
+                              (apply min idxs)
+                              ;; Sentinel: scans without :source-idx (e.g.
+                              ;; from AND-flattening sub-plans) keep their
+                              ;; existing meta — the LEntityJoin then has
+                              ;; no source-idx and lower.cljc treats it as
+                              ;; "process last" via the JS-portable
+                              ;; max-source-idx fallback there.
+                              nil))]
               (if (and (= 1 (count group-scans)) (empty? anti-scans))
                 ;; Single scan, no anti-merges → standalone LScan
                 (first group-scans)
-                ;; Multi-scan group → LEntityJoin
-                (vary-meta (ir/->LEntityJoin e-var (vec group-scans) anti-scans all-vars source)
-                           assoc :source-idx min-idx))))
+                ;; Multi-scan group → LEntityJoin (only tag if we have a
+                ;; concrete index; an absent tag is handled by lower.cljc's
+                ;; default-to-end fallback)
+                (cond-> (ir/->LEntityJoin e-var (vec group-scans) anti-scans all-vars source)
+                  min-idx (vary-meta assoc :source-idx min-idx)))))
           scan-groups)
 
          ;; Remaining NOTs (not folded into entity groups). Each LAntiJoin

--- a/src/datahike/query/logical.cljc
+++ b/src/datahike/query/logical.cljc
@@ -11,7 +11,8 @@
    are made here — those belong in the lowering pass (lower.cljc)."
   (:require
    [datahike.query.analyze :as analyze]
-   [datahike.query.ir :as ir]))
+   [datahike.query.ir :as ir]
+   [datahike.db.interface :as dbi]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -145,9 +146,24 @@
                     ;; Recognize get-else as an optional scan:
                     ;; [(get-else $ ?e :attr default) ?v]
                     ;; args = ($ ?e :attr default), binding = ?v
+                    ;;
+                    ;; In :attribute-refs? mode every other data-pattern clause
+                    ;; has its keyword attribute resolved to the attribute eid by
+                    ;; resolve-pattern-lookup-refs before the planner sees it.
+                    ;; The function form [(get-else $ ?e :attr default) ?v] is
+                    ;; classified as :function, so its inner attr keyword is
+                    ;; never visited by that resolution pass — we must resolve
+                    ;; it here, otherwise the synthetic [?e attr ?v] clause
+                    ;; carries a keyword while merge-clauses around it carry
+                    ;; eids, and the index lookup returns 0 datoms (datoms are
+                    ;; stored with eid attributes in this mode).
                     (let [args (:args ci)
                           e-var (second args)
-                          attr (nth args 2)
+                          raw-attr (nth args 2)
+                          attr (if (and (keyword? raw-attr)
+                                        (:attribute-refs? (dbi/-config db)))
+                                 (dbi/-ref-for db raw-attr)
+                                 raw-attr)
                           default-val (nth args 3)
                           bind-var (:binding ci)
                           scan-vars (cond-> #{bind-var}

--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -15,6 +15,8 @@
    consumed by execute.cljc."
   (:require
    [clojure.set]
+   [datahike.db.interface :as dbi]
+   [datahike.index.interface :as di]
    [datahike.query.analyze :as analyze]
    [datahike.query.estimate :as estimate]
    [datahike.query.ir :as ir]
@@ -136,6 +138,68 @@
 ;; plan/build-pipeline, plan/structurally-fusable?
 
 ;; ---------------------------------------------------------------------------
+;; Per-node output cardinality estimates for outer bound-var-cards propagation
+;;
+;; To make scan-vs-merge selection inside a rule body / OR branch / entity-group
+;; aware of how constrained an upstream-bound var actually is, we estimate per-LP-
+;; node output-var cardinalities BEFORE lowering, then for each node N feed the
+;; UNION of OTHER nodes' estimates as `bound-var-cards` into N's lowering. This
+;; replaces the prior "vars are either bound or free" model with "vars are
+;; either bound with-known-cardinality or free", so estimate-pattern-with-bindings
+;; can produce differentiated estimates instead of returning the attribute-total
+;; for every pattern with the same attribute.
+
+(defn- estimate-node-output-cards
+  "Estimate output cardinality per free-var for an LP node, without lowering it.
+   Returns {var-symbol → long} or nil if the estimate isn't useful.
+
+   Currently handles pure data-pattern nodes (LScan, LOptionalScan) where the
+   estimate is direct and cheap. Other node types return nil — their downstream
+   propagation falls back to the existing all-vars-treated-as-free behavior.
+   Extensions for LEntityJoin / LRuleCall / LUnion can be added in follow-ups
+   as we measure their planning impact."
+  [node db]
+  (cond
+    (ir/scan? node)
+    (let [ci (scan->classified node)
+          si (analyze/pattern-schema-info db ci)
+          est (or (estimate/estimate-pattern db ci si)
+                  (di/-count (:eavt db)))
+          free-output-vars (filter analyze/free-var? (:vars ci))]
+      (when (seq free-output-vars)
+        (zipmap free-output-vars (repeat (long est)))))
+
+    :else nil))
+
+(defn- bound-var-cards-for-node
+  "Compute the bound-var-cards map to pass when lowering `node`: the merge of
+   every OTHER node's output-card estimate plus the static initial bound-vars
+   (treated as known but with unknown cardinality — placeholder card 1 since
+   :in-bound vars are typically singletons in practice and a placeholder is
+   safer than omitting them entirely).
+
+   When duplicate vars appear across multiple producers, take the MIN — the
+   tightest known bound."
+  [node node->cards initial-bound-vars]
+  (let [merged (reduce-kv (fn [acc other-node other-cards]
+                            (if (or (identical? other-node node) (nil? other-cards))
+                              acc
+                              (reduce-kv (fn [acc' v c]
+                                           (let [prev (get acc' v)]
+                                             (assoc acc' v (if prev (min prev c) c))))
+                                         acc
+                                         other-cards)))
+                          {}
+                          node->cards)]
+    ;; Add initial :in-bound vars with placeholder cardinality.
+    ;; Existing call sites that pass a Set still work via estimate-pattern-with-bindings'
+    ;; defensive lookup, but going forward callers within the planner should pass
+    ;; this enriched map.
+    (reduce (fn [m v] (if (contains? m v) m (assoc m v 1)))
+            merged
+            (seq initial-bound-vars))))
+
+;; ---------------------------------------------------------------------------
 ;; Entity group construction from LEntityJoin
 
 (defn- lower-entity-join
@@ -231,55 +295,61 @@
         ;; Step 2: Lower each node to physical op(s)
         total-entities (estimate/estimate-total-entities db)
 
+        ;; Pre-compute per-node output-cards estimates, then derive each node's
+        ;; bound-var-cards from the OTHER nodes' estimates.
+        node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db) nodes))
+        node->bound-cards (zipmap nodes (map #(bound-var-cards-for-node % node->output-cards bound-vars) nodes))
+
         {:keys [ops actual-consumed not-ops]}
         (reduce
          (fn [acc node]
-           (cond
-             ;; LEntityJoin → entity-group op
-             (instance? datahike.query.ir.LEntityJoin node)
-             (let [{:keys [op consumed]}
-                   (lower-entity-join node db pushdowns (:actual-consumed acc)
-                                      bound-vars total-entities)]
-               (-> acc
-                   (update :ops conj op)
-                   (update :actual-consumed into consumed)))
+           (let [bvc (get node->bound-cards node bound-vars)]
+             (cond
+               ;; LEntityJoin → entity-group op
+               (instance? datahike.query.ir.LEntityJoin node)
+               (let [{:keys [op consumed]}
+                     (lower-entity-join node db pushdowns (:actual-consumed acc)
+                                        bvc total-entities)]
+                 (-> acc
+                     (update :ops conj op)
+                     (update :actual-consumed into consumed)))
 
-             ;; Standalone LScan or LOptionalScan → pattern-scan op
-             (ir/scan? node)
-             (let [{:keys [op consumed]}
-                   (lower-standalone-scan node db pushdowns (:actual-consumed acc)
-                                          bound-vars)]
-               (-> acc
-                   (update :ops conj op)
-                   (update :actual-consumed into consumed)))
+               ;; Standalone LScan or LOptionalScan → pattern-scan op
+               (ir/scan? node)
+               (let [{:keys [op consumed]}
+                     (lower-standalone-scan node db pushdowns (:actual-consumed acc)
+                                            bvc)]
+                 (-> acc
+                     (update :ops conj op)
+                     (update :actual-consumed into consumed)))
 
-             ;; LFilter → deferred predicate (may be consumed by pushdown)
-             (instance? datahike.query.ir.LFilter node)
-             (update acc :ops conj [:maybe-pred (filter->classified node)])
+               ;; LFilter → deferred predicate (may be consumed by pushdown)
+               (instance? datahike.query.ir.LFilter node)
+               (update acc :ops conj [:maybe-pred (filter->classified node)])
 
-             ;; LBind → function op
-             (instance? datahike.query.ir.LBind node)
-             (update acc :ops conj (plan/plan-function-op (bind->classified node) db))
+               ;; LBind → function op
+               (instance? datahike.query.ir.LBind node)
+               (update acc :ops conj (plan/plan-function-op (bind->classified node) db))
 
-             ;; LAntiJoin → NOT/NOT-JOIN op (delegate to plan.cljc)
-             (instance? datahike.query.ir.LAntiJoin node)
-             (let [ci (anti-join->classified node)
-                   join-vars? (= :not-join (.-type ^datahike.query.ir.LAntiJoin node))
-                   op (plan/plan-not-op db ci all-clause-vars rules join-vars?)]
-               (if join-vars?
-                 (update acc :ops conj op)
-                 (update acc :not-ops conj op)))
+               ;; LAntiJoin → NOT/NOT-JOIN op (delegate to plan.cljc)
+               (instance? datahike.query.ir.LAntiJoin node)
+               (let [ci (anti-join->classified node)
+                     join-vars? (= :not-join (.-type ^datahike.query.ir.LAntiJoin node))
+                     op (plan/plan-not-op db ci all-clause-vars rules join-vars?)]
+                 (if join-vars?
+                   (update acc :ops conj op)
+                   (update acc :not-ops conj op)))
 
-             ;; LUnion → OR/OR-JOIN op (delegate to plan.cljc)
-             (instance? datahike.query.ir.LUnion node)
-             (let [ci (union->classified node)
-                   join-vars? (= :or-join (.-type ^datahike.query.ir.LUnion node))]
-               (update acc :ops conj (plan/plan-or-op db ci all-clause-vars rules join-vars?)))
+               ;; LUnion → OR/OR-JOIN op (delegate to plan.cljc)
+               (instance? datahike.query.ir.LUnion node)
+               (let [ci (union->classified node)
+                     join-vars? (= :or-join (.-type ^datahike.query.ir.LUnion node))]
+                 (update acc :ops conj (plan/plan-or-op db ci bvc rules join-vars?)))
 
-             ;; LRuleCall → delegate to plan/plan-rule-op
-             (instance? datahike.query.ir.LRuleCall node)
-             (let [ci (rule-call->classified node)]
-               (update acc :ops conj (plan/plan-rule-op db ci all-clause-vars rules scc-info)))
+               ;; LRuleCall → delegate to plan/plan-rule-op
+               (instance? datahike.query.ir.LRuleCall node)
+               (let [ci (rule-call->classified node)]
+                 (update acc :ops conj (plan/plan-rule-op db ci bvc rules scc-info)))
 
              ;; LRuleLookup → rule lookup op
              (instance? datahike.query.ir.LRuleLookup node)
@@ -311,10 +381,10 @@
                  ;; Regular passthrough
                  (update acc :ops conj (plan/plan-passthrough-op ci))))
 
-             ;; Anything else → passthrough
-             :else
-             (update acc :ops conj (plan/plan-passthrough-op
-                                    {:clause nil :type :unknown :vars #{}}))))
+               ;; Anything else → passthrough
+               :else
+               (update acc :ops conj (plan/plan-passthrough-op
+                                      {:clause nil :type :unknown :vars #{}})))))
          {:ops [] :actual-consumed #{} :not-ops []}
          nodes)
 

--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -295,15 +295,57 @@
         ;; Step 2: Lower each node to physical op(s)
         total-entities (estimate/estimate-total-entities db)
 
-        ;; Pre-compute per-node output-cards estimates, then derive each node's
-        ;; bound-var-cards from the OTHER nodes' estimates.
+        ;; Per-node output-card estimates + initial bound-vars (Map form).
+        ;; SOURCE-ORDER directional bvc: each node's bound-var-cards is the
+        ;; union of `initial-bvc` and outputs of every node with a STRICTLY
+        ;; LOWER `:source-idx` (set by build-logical-plan). This avoids the
+        ;; over-binding bug where build-logical-plan groups all
+        ;; entity-nodes BEFORE rule-nodes, causing the lower.cljc reduce
+        ;; to add later-in-source patterns' outputs to the rule call's
+        ;; bvc — making the rule body's planner treat consumed-by-later
+        ;; vars (e.g. ?related-c in the edge query) as upstream-bound
+        ;; probe constraints. Source order is sound (Datalog is set
+        ;; semantics; correctness doesn't depend on bvc accuracy — only
+        ;; estimate quality and downstream scan choice). Datalog
+        ;; programmers conventionally write clauses in dependency order,
+        ;; so source-idx is a reasonable proxy for "what's bound entering
+        ;; this clause." The execution path itself is reordered later by
+        ;; order-plan-ops based on actual cost, independent of this.
         node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db) nodes))
-        node->bound-cards (zipmap nodes (map #(bound-var-cards-for-node % node->output-cards bound-vars) nodes))
+        node->src-idx (into {} (map (fn [n] [n (or (:source-idx (meta n))
+                                                    Long/MAX_VALUE)])) nodes)
+        initial-bvc (cond (map? bound-vars) bound-vars
+                          :else (zipmap (or bound-vars #{}) (repeat 1)))
+        merge-cards (fn [acc-map outs]
+                      (reduce-kv
+                       (fn [m v c]
+                         (let [cur (get m v)]
+                           (cond
+                             (and (number? cur) (number? c)) (assoc m v (long (min cur c)))
+                             (number? c) (assoc m v c)
+                             :else m)))
+                       acc-map outs))
+        ;; Pre-compute bvc per node from PRECEDING source-idx nodes' outputs.
+        node->bvc (into {}
+                        (map (fn [n]
+                               (let [my-idx (node->src-idx n)
+                                     prior (filter (fn [other]
+                                                     (let [oi (node->src-idx other)]
+                                                       (and (not (identical? other n))
+                                                            (< oi my-idx))))
+                                                   nodes)
+                                     bvc (reduce (fn [acc o]
+                                                   (if-let [outs (node->output-cards o)]
+                                                     (merge-cards acc outs)
+                                                     acc))
+                                                 initial-bvc prior)]
+                                 [n bvc])))
+                        nodes)
 
         {:keys [ops actual-consumed not-ops]}
         (reduce
          (fn [acc node]
-           (let [bvc (get node->bound-cards node bound-vars)]
+           (let [bvc (get node->bvc node initial-bvc)]
              (cond
                ;; LEntityJoin → entity-group op
                (instance? datahike.query.ir.LEntityJoin node)

--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -318,7 +318,7 @@
         ;; this portable across both the JVM and the Node target.
         max-src-idx #?(:clj Long/MAX_VALUE :cljs (.-MAX_SAFE_INTEGER js/Number))
         node->src-idx (into {} (map (fn [n] [n (or (:source-idx (meta n))
-                                                    max-src-idx)])) nodes)
+                                                   max-src-idx)])) nodes)
         initial-bvc (cond (map? bound-vars) bound-vars
                           :else (zipmap (or bound-vars #{}) (repeat 1)))
         merge-cards (fn [acc-map outs]
@@ -399,34 +399,34 @@
                  (update acc :ops conj (plan/plan-rule-op db ci bvc rules scc-info)))
 
              ;; LRuleLookup → rule lookup op
-             (instance? datahike.query.ir.LRuleLookup node)
-             (let [ci (rule-lookup->classified node)]
-               (update acc :ops conj
-                       (plan/plan-rule-lookup-op ci (.-mode ^datahike.query.ir.LRuleLookup node))))
+               (instance? datahike.query.ir.LRuleLookup node)
+               (let [ci (rule-lookup->classified node)]
+                 (update acc :ops conj
+                         (plan/plan-rule-lookup-op ci (.-mode ^datahike.query.ir.LRuleLookup node))))
 
              ;; LPassthrough → passthrough op
-             (instance? datahike.query.ir.LPassthrough node)
-             (let [ci (passthrough->classified node)
-                   ptype (.-type ^datahike.query.ir.LPassthrough node)]
-               (if (= :source-prefix ptype)
+               (instance? datahike.query.ir.LPassthrough node)
+               (let [ci (passthrough->classified node)
+                     ptype (.-type ^datahike.query.ir.LPassthrough node)]
+                 (if (= :source-prefix ptype)
                  ;; Source-prefix passthrough: re-classify inner clause and delegate
-                 (let [clause (.-clause ^datahike.query.ir.LPassthrough node)
-                       source-sym (first clause)
-                       inner-clause (vec (rest clause))
-                       inner-ci (analyze/classify-clause inner-clause)
-                       inner-ci (assoc inner-ci :source source-sym)]
-                   (case (:type inner-ci)
-                     :not (let [op (plan/plan-not-op db inner-ci all-clause-vars rules)]
-                            (update acc :ops conj (assoc op :source source-sym)))
-                     :not-join (let [op (plan/plan-not-op db inner-ci all-clause-vars rules true)]
-                                 (update acc :ops conj (assoc op :source source-sym)))
-                     :or (update acc :ops conj
-                                 (assoc (plan/plan-or-op db inner-ci all-clause-vars rules) :source source-sym))
-                     :or-join (update acc :ops conj
-                                      (assoc (plan/plan-or-op db inner-ci all-clause-vars rules true) :source source-sym))
-                     (update acc :ops conj (plan/plan-passthrough-op ci))))
+                   (let [clause (.-clause ^datahike.query.ir.LPassthrough node)
+                         source-sym (first clause)
+                         inner-clause (vec (rest clause))
+                         inner-ci (analyze/classify-clause inner-clause)
+                         inner-ci (assoc inner-ci :source source-sym)]
+                     (case (:type inner-ci)
+                       :not (let [op (plan/plan-not-op db inner-ci all-clause-vars rules)]
+                              (update acc :ops conj (assoc op :source source-sym)))
+                       :not-join (let [op (plan/plan-not-op db inner-ci all-clause-vars rules true)]
+                                   (update acc :ops conj (assoc op :source source-sym)))
+                       :or (update acc :ops conj
+                                   (assoc (plan/plan-or-op db inner-ci all-clause-vars rules) :source source-sym))
+                       :or-join (update acc :ops conj
+                                        (assoc (plan/plan-or-op db inner-ci all-clause-vars rules true) :source source-sym))
+                       (update acc :ops conj (plan/plan-passthrough-op ci))))
                  ;; Regular passthrough
-                 (update acc :ops conj (plan/plan-passthrough-op ci))))
+                   (update acc :ops conj (plan/plan-passthrough-op ci))))
 
                ;; Anything else → passthrough
                :else

--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -312,8 +312,13 @@
         ;; this clause." The execution path itself is reordered later by
         ;; order-plan-ops based on actual cost, independent of this.
         node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db) nodes))
+        ;; Nodes without :source-idx (AND-flattened sub-plans, etc.) are
+        ;; treated as "comes last" via a sentinel beyond any real index.
+        ;; #?(:clj Long/MAX_VALUE :cljs js/Number.MAX_SAFE_INTEGER) keeps
+        ;; this portable across both the JVM and the Node target.
+        max-src-idx #?(:clj Long/MAX_VALUE :cljs (.-MAX_SAFE_INTEGER js/Number))
         node->src-idx (into {} (map (fn [n] [n (or (:source-idx (meta n))
-                                                    Long/MAX_VALUE)])) nodes)
+                                                    max-src-idx)])) nodes)
         initial-bvc (cond (map? bound-vars) bound-vars
                           :else (zipmap (or bound-vars #{}) (repeat 1)))
         merge-cards (fn [acc-map outs]

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -109,14 +109,26 @@
         has-avet? (boolean (:avet db))
         index (select-index pattern-info schema-info has-avet? (seq pushdown-preds))
         effective-preds (if (= :avet index) pushdown-preds [])
-        base-est (or (estimate/estimate-pattern-with-bindings
-                      db pattern-info schema-info (or bound-var-cards {}))
+        ;; Base estimate (unconstrained by upstream bindings) — preserves the
+        ;; existing assemble-entity-group pass-rate semantics (pass-rate is
+        ;; merge-est / total-entities, which assumes merge-est is the full
+        ;; attribute count, not a bound-aware filtered count).
+        base-est (or (estimate/estimate-pattern db pattern-info schema-info)
                      (di/-count (:eavt db)))
         ;; Build a partial scan-op for sampling context
         scan-ctx {:clause (:clause pattern-info) :index index}
         est (if (seq effective-preds)
               (estimate/estimate-pushdown-range base-est effective-preds db scan-ctx)
               base-est)
+        ;; Bound-aware estimate — used for scan-vs-merge selection inside an
+        ;; entity-group (and other op-ordering decisions that should reflect
+        ;; upstream constraints). Defaults to the base estimate when
+        ;; bound-var-cards is empty.
+        scan-est (if (seq bound-var-cards)
+                   (or (estimate/estimate-pattern-with-bindings
+                        db pattern-info schema-info bound-var-cards)
+                       est)
+                   est)
         e-bound? (and (analyze/free-var? e)
                       (contains? bound-var-cards e))
         join-method (cond
@@ -129,6 +141,7 @@
               :schema-info schema-info
               :pushdown-preds effective-preds
               :estimated-card est
+              :scan-card scan-est
               :output-var-cards (pattern-output-var-cards pattern-info est)
               :join-method join-method
               :vars (:vars pattern-info)
@@ -321,12 +334,25 @@
   (let [a (second (:clause op))]
     (and (some? a) (not (symbol? a)))))
 
+(defn- scan-cost-of
+  "Cost a pattern would have if used as the entity-group's scan, based on
+   bound-aware :scan-card when available, falling back to :estimated-card."
+  [op]
+  (long (or (:scan-card op) (:estimated-card op) 0)))
+
 (defn dp-order-fuse-ops
   "For N pattern ops on same entity var, find optimal (scan, merge-order).
    Uses short-circuit AND ordering: sort merges by ascending
-   merge-cost / (1 - pass-rate). Try each pattern as scan, pick minimum total cost."
+   merge-cost / (1 - pass-rate). Try each pattern as scan, pick minimum total cost.
+
+   Scan selection uses bound-aware :scan-card so a pattern whose value is
+   constrained by upstream context (smaller effective scan size) is preferred
+   over a pattern with all-free positions on the same attribute. Pass-rate
+   computation still uses :estimated-card (the base attribute count) to
+   preserve the existing per-entity match-probability semantics."
   [db pattern-ops total-entities]
   (let [n (count pattern-ops)
+        ;; Pass-rate estimates use base (unconstrained) cardinality.
         estimates (mapv (fn [op]
                           (max 1 (or (:estimated-card op) total-entities)))
                         pattern-ops)]
@@ -342,12 +368,12 @@
           ;; Force scan-only pattern as scan, rest as merges
           {:scan (first scan-only) :merges (vec (concat (rest scan-only) mergeable))}
           (if (seq non-optional)
-            ;; Prefer non-optional as scan
-            (let [sorted (sort-by :estimated-card non-optional)]
+            ;; Prefer non-optional as scan; pick the lowest BOUND-AWARE cost.
+            (let [sorted (sort-by scan-cost-of non-optional)]
               {:scan (first sorted) :merges (vec (concat (rest sorted)
                                                          (filterv :optional? pattern-ops)))})
-            ;; All optional — pick lowest cardinality as scan
-            (let [sorted (sort-by :estimated-card pattern-ops)]
+            ;; All optional — pick lowest scan-cost as scan
+            (let [sorted (sort-by scan-cost-of pattern-ops)]
               {:scan (first sorted) :merges (vec (rest sorted))}))))
       (let [has-non-optional? (some #(not (:optional? %)) pattern-ops)
             candidates
@@ -360,7 +386,10 @@
                              (or (not has-non-optional?)
                                  (not (:optional? (nth pattern-ops si)))))]
               (let [scan-op (nth pattern-ops si)
-                    scan-card (double (nth estimates si))
+                    ;; Use bound-aware :scan-card for the scan-side cost; merges
+                    ;; still use the unconstrained :estimated-card via `estimates`
+                    ;; for pass-rate computation.
+                    scan-card (double (scan-cost-of scan-op))
                     merges (into [] (keep-indexed
                                      (fn [i op]
                                        (when (not= i si)
@@ -381,8 +410,8 @@
         (if (seq candidates)
           (apply min-key :cost candidates)
           ;; Fallback: if no valid scan/merge partitioning exists (multiple variable-attr ops),
-          ;; just pick lowest cardinality as scan
-          (let [sorted (sort-by :estimated-card pattern-ops)]
+          ;; pick lowest BOUND-AWARE cardinality as scan
+          (let [sorted (sort-by scan-cost-of pattern-ops)]
             {:scan (first sorted) :merges (vec (rest sorted))}))))))
 
 ;; ---------------------------------------------------------------------------
@@ -1199,8 +1228,16 @@
                                                 (not (some is-scc-call? body))))
                                    base-bs (filterv is-base? rn-branches)
                                    rec-bs (filterv (complement is-base?) rn-branches)
-                          ;; Head vars are bound within rule branches (from call args / accumulator)
-                                   branch-bound (into bound-vars (filter analyze/free-var?) free-call-args)
+                          ;; Head vars are bound within rule branches (from call args / accumulator).
+                          ;; Recursive rules: head-vars take their values from the accumulator
+                          ;; (one row of the recursive rel) — treat them as bound with a
+                          ;; conservative card-1 placeholder under the bound-var-cards model.
+                                   free-args (filter analyze/free-var? free-call-args)
+                                   branch-bound (cond
+                                                  (map? bound-vars)
+                                                  (into bound-vars (map (fn [v] [v 1])) free-args)
+                                                  :else
+                                                  (into bound-vars free-args))
                                    base-ps (mapv (fn [b]
                                                    (let [renamed (rename-branch-vars b free-call-args seqid db)]
                                                      (create-plan db (vec renamed) branch-bound rules)))
@@ -1268,8 +1305,28 @@
           (let [seqid (gensym "r")
                 expanded (for [branch branches]
                            (rename-branch-vars branch call-args seqid db))
-                ;; Call args that are free vars are bound within the rule body
-                rule-bound (into bound-vars (filter analyze/free-var?) call-args)
+                ;; Build the rule body's bound-var-cards:
+                ;;   - existing outer bound-vars/cards stay (vars truly bound from outside)
+                ;;   - synthetic safe-vars for non-var call-args get card 1 (each is a
+                ;;     single const value, bound by the [(identity X) safe-var] preamble
+                ;;     that rename-branch-vars prepends to the body)
+                ;;   - free call-args that aren't already in bound-vars are rule OUTPUTS,
+                ;;     not body inputs — do NOT add them; estimate-pattern-with-bindings
+                ;;     correctly treats them as free for selectivity.
+                ;;
+                ;; This shape mirrors call-args-safe inside rename-branch-vars; we
+                ;; recompute it here to avoid leaking it across the API.
+                const-safe-vars (keep-indexed
+                                 (fn [i arg]
+                                   (when-not (analyze/free-var? arg)
+                                     (symbol (str "?__const__" i "__auto__" seqid))))
+                                 call-args)
+                ;; Tolerate both legacy set-form bound-vars and new map-form bound-var-cards.
+                rule-bound (cond
+                             (map? bound-vars)
+                             (into bound-vars (map (fn [v] [v 1])) const-safe-vars)
+                             :else
+                             (into bound-vars const-safe-vars))
                 sub-plans (mapv #(create-plan db (vec %) rule-bound rules) expanded)
                 total-est (reduce + 0 (keep (fn [p] (some :estimated-card (:ops p))) sub-plans))]
             {:op :or
@@ -1317,7 +1374,12 @@
          ;; This includes vars from patterns inside NOT/OR/source-prefix.
          ;; Used as enriched bound-vars when building sub-plans, so nested
          ;; NOT/OR know what vars will be available from the outer context.
-         all-clause-vars (into bound-vars
+         ;; bound-vars may be either a Set (legacy) or a Map (var → card).
+         ;; Normalise here: keys + extracted vars build a SET, since this only
+         ;; feeds membership checks (e.g. is-rule? / NOT join-vars validation).
+         all-clause-vars (into (cond (map? bound-vars) (set (keys bound-vars))
+                                     (set? bound-vars) bound-vars
+                                     :else (set bound-vars))
                                (mapcat analyze/extract-vars)
                                where-clauses)
 
@@ -1456,7 +1518,12 @@
          ;; This correctly handles reordering: (not [?e ...]) [?e :name] gets
          ;; reordered to [?e :name] (not [?e ...]), and ?e is bound before NOT.
          _ (loop [remaining ordered-ops
-                  vars-so-far bound-vars]
+                  ;; bound-vars may be a set (legacy) or a map (var → card).
+                  ;; vars-so-far is purely a membership set for NOT validation,
+                  ;; so normalise to a set up front.
+                  vars-so-far (cond (map? bound-vars) (set (keys bound-vars))
+                                    (set? bound-vars) bound-vars
+                                    :else (set bound-vars))]
              (when (seq remaining)
                (let [op (first remaining)]
                  (when (#{:not :not-join} (:op op))

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -909,7 +909,24 @@
 (defn op-cost [op bound-vars]
   (case (:op op)
     (:entity-group :pattern-scan)
-    (group-effective-card op)
+    ;; Optional pattern-scans (LOptionalScan from get-else) need their
+    ;; entity var BOUND before they execute — at runtime the optional path
+    ;; goes through bind-by-fn(get-else), which evaluates per-row over
+    ;; ctx.rels. If the e-var is still free, get-else gets a nil entity
+    ;; and binds the default value with the e-var ALSO nil-bound in the
+    ;; resulting tuple. That nil propagates through subsequent ops as a
+    ;; sentinel "row" the planner thinks is real, producing
+    ;; all-nil-tuple rows in the find result. Source order normally
+    ;; guarantees the binder runs first; the cost-based reorder doesn't,
+    ;; so we have to encode the dependency: an :optional? scan's
+    ;; effective cost is max-cost (un-runnable) until its e-var is in
+    ;; bound-vars. Once bound, it costs the same as a regular pattern-scan.
+    (if (and (:optional? op)
+             (let [e (first (:clause op))]
+               (and (analyze/free-var? e)
+                    (not (contains? bound-vars e)))))
+      max-cost
+      (group-effective-card op))
 
     :predicate
     (if (every? #(contains? bound-vars %) (:vars op)) 0 max-cost)
@@ -967,8 +984,25 @@
    total intermediate cardinality. The greedy phase then inserts non-group
    ops at the earliest point where their dependencies are satisfied."
   [ops]
-  (let [groups (filterv #(#{:entity-group :pattern-scan} (:op %)) ops)
-        non-groups (filterv #(not (#{:entity-group :pattern-scan} (:op %))) ops)]
+  (let [;; LOptionalScan-derived pattern-scans (get-else with default) need
+        ;; their entity var bound BEFORE they execute — at runtime the
+        ;; optional path goes through bind-by-fn(get-else) which evaluates
+        ;; per-row, and a row without the e-var bound emits a tuple where
+        ;; e-var is nil and the bind-var is the default value. That nil-e
+        ;; row poisons every downstream op that uses ?e, surfacing as
+        ;; all-nil-tuple find results in jobtech daynotes tests. Treating
+        ;; optional scans as regular groups lets dp-order-groups place
+        ;; them by cardinality alone (no dependency awareness), so they
+        ;; can land before their binders. Demoting them to non-groups
+        ;; routes them through the cost-based interleaver, which checks
+        ;; bound-vars via op-cost and waits until the e-var is bound.
+        optional-scan? (fn [op]
+                         (and (= :pattern-scan (:op op))
+                              (:optional? op)))
+        groups (filterv #(and (#{:entity-group :pattern-scan} (:op %))
+                              (not (optional-scan? %))) ops)
+        non-groups (filterv #(or (not (#{:entity-group :pattern-scan} (:op %)))
+                                 (optional-scan? %)) ops)]
     (if (empty? groups)
       ;; No groups — pure greedy on non-group ops
       (loop [remaining (set ops)

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -281,6 +281,18 @@
      :idx-ident idx-ident
      :engine-meta engine-meta
      :accepts-entity-filter? (:accepts-entity-filter? engine-meta false)
+     ;; The engine declares its binding requirements via the :input-vars
+     ;; key in its var metadata. Recognised values:
+     ;;   :all-bound  → every input arg must be bound (the safe default;
+     ;;                 matches stratum's three exposed engines, all of
+     ;;                 which need their referenced columns materialised
+     ;;                 before they can run).
+     ;;   :any-bound  → at least one input arg must be bound (for solvers
+     ;;                 that can work backwards from any known value).
+     ;;   nil         → fall back to :all-bound at op-cost time (strict
+     ;;                 default — engines that need looser semantics must
+     ;;                 declare them explicitly).
+     :input-vars-spec (:input-vars engine-meta)
      :estimated-card (or (:estimated-card cost) 100)}))
 
 (defn- function-binding-vars
@@ -903,79 +915,141 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Cost-based ordering for mixed ops (groups + predicates + functions + OR/NOT)
+;;
+;; The contract: each op type declares which vars MUST be bound for the op to
+;; run correctly at execute time. `op-required-vars` is the single source of
+;; truth — adding a new op type means extending this function. `op-cost` then
+;; uses it to decide whether an op is runnable (and at what cost) given the
+;; current bound-vars set.
+;;
+;; The split between "input" vars (must be bound) and "output" vars (produced
+;; by the op) was historically encoded ad-hoc per op type inside op-cost,
+;; which led to drift: e.g. `:external-engine` solver mode used `(some
+;; bound-vars op-vars)` while filter/retrieval used `(every? bound-vars
+;; input-args)`, even though both have the same fundamental need (input
+;; columns must be materialised before the engine can use them). Centralising
+;; the contract here makes it easy to audit and to extend.
 
 (def ^:private max-cost #?(:clj Long/MAX_VALUE :cljs (.-MAX_SAFE_INTEGER js/Number)))
 
-(defn op-cost [op bound-vars]
+(defn op-required-vars
+  "The set of vars that MUST be bound before `op` can execute correctly.
+
+   Returns a tuple [vars policy] where `policy` is one of:
+     :all     — every var in `vars` must be bound
+     :any     — at least one var in `vars` must be bound (used by external
+                engines that can solve from any known column)
+     :none    — op can run unconditionally (producer ops)
+
+   This is consumed by `op-cost`: returning :none means the op is always
+   runnable; :all/:any check `bound-vars` accordingly. `vars` is empty
+   when policy is :none.
+
+   Per op type (see also docstrings in plan-*-op constructors):
+
+     :entity-group, :pattern-scan
+       Producer; emits all its free-var positions. EXCEPT when
+       :optional? is set (LOptionalScan from get-else, which routes
+       through bind-by-fn at execute time and silently binds the e-var
+       to nil if it isn't yet in ctx.rels — see commit c8a11a0e).
+
+     :predicate
+       Pure filter; needs every var it references bound — there are no
+       outputs.
+
+     :function
+       Computes a value from `:args`, binds it to `:binding`. Inputs
+       are the free-var symbols inside :args, recursively.
+
+     :external-engine
+       Honours the `:input-vars` declaration on the engine's var
+       metadata (`:datahike/external-engine`). Stratum's three engines
+       all declare `:all-bound`. A nil/absent declaration falls back
+       to :all on input-args — the safe default. An engine that can
+       work backwards from any one column declares `:any-bound`.
+
+     :rule-lookup
+       Producer; reads from `:rule-accumulators` in ctx (populated by
+       the surrounding :recursive-rule fixpoint), so its dependency is
+       structural, not bound-vars-based.
+
+     :recursive-rule
+       Currently strict: every var in :vars (= all free call-args)
+       must be bound. This prevents the rule from running as a
+       pure producer. Loosening would require knowing per-rule which
+       call-args are inputs vs outputs, which requires rule-body
+       analysis — left for follow-up. Documented here for reference.
+
+     :or, :or-join
+       Branches collectively produce join-vars; we require AT LEAST
+       ONE join-var bound so the branches have some upstream
+       constraint to filter against. Stricter ('all bound') would
+       prevent the OR from running as a producer; looser ('none')
+       would risk Cartesian fan-out from the branches.
+
+     :not, :not-join
+       Anti-join; needs the WHOLE set of join-vars / referenced vars
+       bound so we can subtract from a fully-formed candidate set.
+
+     :passthrough, anything else
+       Unknown / fallback op — treated as un-runnable until it gets
+       a concrete contract."
+  [op]
   (case (:op op)
     (:entity-group :pattern-scan)
-    ;; Optional pattern-scans (LOptionalScan from get-else) need their
-    ;; entity var BOUND before they execute — at runtime the optional path
-    ;; goes through bind-by-fn(get-else), which evaluates per-row over
-    ;; ctx.rels. If the e-var is still free, get-else gets a nil entity
-    ;; and binds the default value with the e-var ALSO nil-bound in the
-    ;; resulting tuple. That nil propagates through subsequent ops as a
-    ;; sentinel "row" the planner thinks is real, producing
-    ;; all-nil-tuple rows in the find result. Source order normally
-    ;; guarantees the binder runs first; the cost-based reorder doesn't,
-    ;; so we have to encode the dependency: an :optional? scan's
-    ;; effective cost is max-cost (un-runnable) until its e-var is in
-    ;; bound-vars. Once bound, it costs the same as a regular pattern-scan.
     (if (and (:optional? op)
              (let [e (first (:clause op))]
-               (and (analyze/free-var? e)
-                    (not (contains? bound-vars e)))))
-      max-cost
-      (group-effective-card op))
+               (analyze/free-var? e)))
+      [#{(first (:clause op))} :all]
+      [#{} :none])
 
     :predicate
-    (if (every? #(contains? bound-vars %) (:vars op)) 0 max-cost)
+    [(set (:vars op)) :all]
 
     :function
-    ;; Use args-free-vars (recursive) so nested expressions like
-    ;; (and (= ?x 1) (not ?y)) correctly report ?x and ?y as inputs
-    ;; instead of an empty set. See args-free-vars docstring.
-    (let [input-vars (args-free-vars (:args op))]
-      (if (every? #(contains? bound-vars %) input-vars) 1 max-cost))
+    [(args-free-vars (:args op)) :all]
 
     :external-engine
-    (if (= :solver (:mode op))
-      ;; Solver mode needs populated context — require at least some of its
-      ;; vars to be bound first (shared vars come from entity-group patterns)
-      (let [op-vars (into #{} (filter analyze/free-var?) (:vars op))]
-        (if (some #(contains? bound-vars %) op-vars)
-          (or (:estimated-card op) 100)
-          max-cost))
-      ;; Filter/retrieval: check args for free var deps
-      (let [input-vars (args-free-vars (:args op))]
-        (if (every? #(contains? bound-vars %) input-vars)
-          (or (:estimated-card op) 100)
-          max-cost)))
+    (let [input-args (args-free-vars (:args op))
+          spec (:input-vars-spec op)]
+      (case spec
+        :any-bound [input-args :any]
+        ;; :all-bound and any unrecognised value default to strict.
+        ;; nil (no declaration) also defaults to strict — the safe
+        ;; assumption.
+        [input-args :all]))
 
     :rule-lookup
-    (or (:estimated-card op) 100)
+    [#{} :none]
 
-    ;; NOT/NOT-JOIN: require ALL referenced vars bound (negation needs full context)
-    (:not :not-join :recursive-rule)
-    (let [required (or (:join-vars op) (:vars op))]
-      (if (every? #(contains? bound-vars %) required)
-        (or (:estimated-card op) 100)
-        max-cost))
+    :recursive-rule
+    [(set (or (:join-vars op) (:vars op))) :all]
 
-    ;; OR/OR-JOIN: join-vars include both input vars (bound from outer context)
-    ;; and output vars (produced by branches). Only input vars need pre-binding.
-    ;; The branches handle unbound join-vars by producing them.
-    ;; execute-or-join's limited-ctx correctly projects to only the bound vars.
+    (:not :not-join)
+    [(set (or (:join-vars op) (:vars op))) :all]
+
     (:or :or-join)
-    (let [join-vars (or (:join-vars op) (:vars op))
-          bound-join (clojure.set/intersection join-vars bound-vars)]
-      (if (seq bound-join)
-        ;; At least one join-var is bound — branches have some constraint
-        (or (:estimated-card op) 100)
-        ;; No join-vars bound yet — can't execute until at least one is bound
-        max-cost))
+    [(set (or (:join-vars op) (:vars op))) :any]
 
-    max-cost))
+    ;; Unknown / passthrough — gate forever (caller must decide what to do).
+    [#{} :all]))
+
+(defn op-cost [op bound-vars]
+  (let [[required policy] (op-required-vars op)
+        ready? (case policy
+                 :none true
+                 :all  (or (empty? required)
+                           (every? #(contains? bound-vars %) required))
+                 :any  (some #(contains? bound-vars %) required))]
+    (if-not ready?
+      max-cost
+      ;; Per-op cost when ready: producers use cardinality, filters cost 0,
+      ;; functions cost 1, others use :estimated-card or fall back to 100.
+      (case (:op op)
+        (:entity-group :pattern-scan) (group-effective-card op)
+        :predicate                    0
+        :function                     1
+        (or (:estimated-card op) 100)))))
 
 (defn order-plan-ops
   "Order plan operations using DP for entity-group ordering and greedy

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -124,11 +124,34 @@
         ;; entity-group (and other op-ordering decisions that should reflect
         ;; upstream constraints). Defaults to the base estimate when
         ;; bound-var-cards is empty.
-        scan-est (if (seq bound-var-cards)
-                   (or (estimate/estimate-pattern-with-bindings
-                        db pattern-info schema-info bound-var-cards)
-                       est)
-                   est)
+        ;;
+        ;; SCAN COST vs OUTPUT CARD: estimate-pattern-with-bindings models
+        ;; the OUTPUT cardinality after applying upstream constraints. For
+        ;; an INDEXED attribute on the v-position, OUTPUT ≈ SCAN COST
+        ;; because AVET yields exactly the matching slice. For a
+        ;; NON-INDEXED v-bound pattern, we lack AVET — execution must scan
+        ;; AEVT for the full attribute and post-filter, so the actual scan
+        ;; cost is `base` regardless of how selective v is. dp-order-fuse-ops
+        ;; uses scan-card as a SCAN COST proxy when picking the entity-
+        ;; group's driving scan; using OUTPUT here would mis-rate a
+        ;; non-indexed v-bound pattern as a cheap scan candidate.
+        v-bound? (and (analyze/free-var? v)
+                      (contains? bound-var-cards v)
+                      (let [vc (get bound-var-cards v)] (number? vc)))
+        bound-aware (when (seq bound-var-cards)
+                      (estimate/estimate-pattern-with-bindings
+                       db pattern-info schema-info bound-var-cards))
+        scan-est (cond
+                   (empty? bound-var-cards) est
+                   ;; Non-indexed attr with v as the only bound free var:
+                   ;; scan cost = base (full AEVT scan + post-filter).
+                   (and (not (:indexed? schema-info))
+                        v-bound?
+                        (or e? (analyze/free-var? e))
+                        (not (and (analyze/free-var? e)
+                                  (contains? bound-var-cards e))))
+                   est
+                   :else (or bound-aware est))
         e-bound? (and (analyze/free-var? e)
                       (contains? bound-var-cards e))
         join-method (cond
@@ -1374,14 +1397,28 @@
          ;; This includes vars from patterns inside NOT/OR/source-prefix.
          ;; Used as enriched bound-vars when building sub-plans, so nested
          ;; NOT/OR know what vars will be available from the outer context.
-         ;; bound-vars may be either a Set (legacy) or a Map (var → card).
-         ;; Normalise here: keys + extracted vars build a SET, since this only
-         ;; feeds membership checks (e.g. is-rule? / NOT join-vars validation).
-         all-clause-vars (into (cond (map? bound-vars) (set (keys bound-vars))
-                                     (set? bound-vars) bound-vars
-                                     :else (set bound-vars))
-                               (mapcat analyze/extract-vars)
-                               where-clauses)
+         ;;
+         ;; bound-vars may be a Map (var → card) under the bound-var-cards
+         ;; model or a Set (legacy interface). When a Map: preserve the
+         ;; outer entries verbatim (so cards reach inner pattern estimation
+         ;; via plan-or-op / plan-rule-op / plan-not-op → create-plan), and
+         ;; mark newly-extracted in-scope vars with a non-numeric sentinel.
+         ;; estimate-pattern-with-bindings's card-of returns nil for
+         ;; non-numbers, so sentinel entries are ignored for cardinality
+         ;; estimation while still passing `contains?` membership checks
+         ;; needed for join-var validation and rule-call detection.
+         all-clause-vars (let [extracted (into #{} (mapcat analyze/extract-vars) where-clauses)]
+                           (cond
+                             (map? bound-vars)
+                             (into bound-vars
+                                   (map (fn [v] [v ::in-scope]))
+                                   (remove (set (keys bound-vars)) extracted))
+
+                             (set? bound-vars)
+                             (into bound-vars extracted)
+
+                             :else
+                             (into (set bound-vars) extracted)))
 
          ;; Pre-compute SCC info for rules (once per plan, not per rule-op)
          scc-info (when rules (compute-rule-sccs rules))
@@ -1389,19 +1426,66 @@
          ;; Step 2: Detect pushdown candidates
          {:keys [pushdowns consumed]} (analyze/detect-pushdown classified bound-vars)
 
-         ;; Step 3: Build raw ops — track consumed pushdown preds
+         ;; Step 3: Build raw ops — track consumed pushdown preds.
+         ;;
+         ;; bvc-eff threads cardinality propagation through the clause stream
+         ;; in classification order: each op's :output-var-cards extends the
+         ;; effective bound-var-cards for SUBSEQUENT ops in the same plan
+         ;; scope. Critical for queries where a function or pattern
+         ;; introduces a tightly-bounded var that a later pattern can use as
+         ;; a probe constraint — e.g. the `(ground inv-map) [[?type ?reverse-type]]`
+         ;; preamble inside the -reverse-edge rule body, which binds
+         ;; ?reverse-type to a card-N collection that the next pattern
+         ;; `[?r :type ?reverse-type]` should use as scan-card. Without
+         ;; this thread, every pattern in the body sees only outer
+         ;; bound-vars and falls back to base attribute estimates,
+         ;; producing wrong scan-vs-merge selection (the regression that
+         ;; made the GraphQL edge fetcher 40×+ slower than legacy).
+         init-bvc (cond (map? bound-vars) bound-vars
+                        (set? bound-vars) (zipmap bound-vars (repeat ::in-scope))
+                        :else (zipmap (set bound-vars) (repeat ::in-scope)))
          {:keys [ops actual-consumed not-ops]}
          (reduce
           (fn [acc ci]
             ;; Check for rule calls (classified as :pattern but first elem is rule name)
-            (let [is-rule-call? (and rules
+            (let [bvc-eff (:bvc-eff acc)
+                  is-rule-call? (and rules
                                      (= :pattern (:type ci))
                                      (symbol? (:e ci))
                                      (not (analyze/free-var? (:e ci)))
                                      (contains? rules (:e ci)))
                   ;; Check for metadata-tagged rule-lookup (from clause version generation)
                   lookup-mode (when is-rule-call?
-                                (:rule-lookup-mode (meta (:clause ci))))]
+                                (:rule-lookup-mode (meta (:clause ci))))
+                  ;; Extend an acc's :bvc-eff with op's :output-var-cards
+                  ;; (numeric entries only — sentinels untouched). Returns acc'.
+                  ;; MIN on collisions keeps the tightest known bound.
+                  ;;
+                  ;; Restricted to FUNCTION ops only: pattern-scan ops also expose
+                  ;; :output-var-cards, but propagating them eagerly would mark
+                  ;; sibling pattern entity-vars (e.g. ?r in `[?r :concept-1 ?c]`
+                  ;; followed by `[?r :type ?t]`) as upstream-bound when planning
+                  ;; the next pattern. dp-order-fuse-ops fuses these into a
+                  ;; single entity-group at execution time — the scan PRODUCES
+                  ;; ?r, it doesn't consume it — so estimating later patterns
+                  ;; with ?r bound yields the both-bound branch min(e,v,base)
+                  ;; which underestimates by ~base/distinct-v×. Function ops
+                  ;; (identity / ground) genuinely bind their output vars
+                  ;; before subsequent ops execute, so threading those is safe.
+                  extend-bvc (fn [acc' op]
+                               (if (and (map? op) (= :function (:op op)))
+                                 (if-let [out (:output-var-cards op)]
+                                   (assoc acc' :bvc-eff
+                                          (reduce-kv
+                                           (fn [m v c]
+                                             (let [cur (get m v)]
+                                               (cond
+                                                 (and (number? cur) (number? c)) (assoc m v (long (min cur c)))
+                                                 (number? c) (assoc m v c)
+                                                 :else m)))
+                                           (:bvc-eff acc') out))
+                                   acc')
+                                 acc'))]
               (if (and is-rule-call? guarded-rules
                        (contains? guarded-rules (:e ci)))
                 ;; Inside a recursive branch plan — emit :rule-lookup
@@ -1411,26 +1495,31 @@
                   (update acc :ops conj (plan-rule-lookup-op rule-ci mode)))
                 (if is-rule-call?
                   (let [rule-ci (assoc ci :type :rule-call
-                                       :vars (into #{} (filter analyze/free-var?) (rest (:clause ci))))]
-                    (update acc :ops conj (plan-rule-op db rule-ci all-clause-vars rules scc-info)))
+                                       :vars (into #{} (filter analyze/free-var?) (rest (:clause ci))))
+                        op (plan-rule-op db rule-ci bvc-eff rules scc-info)]
+                    (-> acc (update :ops conj op) (extend-bvc op)))
 
                   (case (:type ci)
                     :pattern
                     (let [schema-info (analyze/pattern-schema-info db ci)
                           preds (get pushdowns (:clause ci) [])
-                          [op consumed-preds] (plan-pattern-op db ci schema-info preds bound-vars)]
+                          [op consumed-preds] (plan-pattern-op db ci schema-info preds bvc-eff)]
                       (-> acc
                           (update :ops conj op)
-                          (update :actual-consumed into (or consumed-preds #{}))))
+                          (update :actual-consumed into (or consumed-preds #{}))
+                          (extend-bvc op)))
 
-                    :function (update acc :ops conj (plan-function-op ci db))
+                    :function (let [op (plan-function-op ci db)]
+                                (-> acc (update :ops conj op) (extend-bvc op)))
                     :predicate (update acc :ops conj [:maybe-pred ci])
-                    :or (update acc :ops conj (plan-or-op db ci all-clause-vars rules))
-                    :or-join (update acc :ops conj (plan-or-op db ci all-clause-vars rules true))
+                    :or (let [op (plan-or-op db ci bvc-eff rules)]
+                          (-> acc (update :ops conj op) (extend-bvc op)))
+                    :or-join (let [op (plan-or-op db ci bvc-eff rules true)]
+                               (-> acc (update :ops conj op) (extend-bvc op)))
                     ;; Collect NOT ops separately for anti-merge folding
-                    :not (update acc :not-ops conj (plan-not-op db ci all-clause-vars rules))
-                    :not-join (update acc :ops conj (plan-not-op db ci all-clause-vars rules true))
-                    :and (let [sub-plan (create-plan db (vec (:sub-clauses ci)) all-clause-vars rules)]
+                    :not (update acc :not-ops conj (plan-not-op db ci bvc-eff rules))
+                    :not-join (update acc :ops conj (plan-not-op db ci bvc-eff rules true))
+                    :and (let [sub-plan (create-plan db (vec (:sub-clauses ci)) bvc-eff rules)]
                            (update acc :ops into (:ops sub-plan)))
 
                     ;; Source-prefixed clause: ($2 not ...) or [$2 ?e :attr ?v]
@@ -1443,23 +1532,23 @@
                       (case (:type inner-ci)
                         :pattern
                         (let [schema-info (analyze/pattern-schema-info db inner-ci)
-                              [op _] (plan-pattern-op db inner-ci schema-info [] bound-vars)]
-                          (update acc :ops conj (assoc op :source source-sym)))
+                              [op _] (plan-pattern-op db inner-ci schema-info [] bvc-eff)]
+                          (-> acc (update :ops conj (assoc op :source source-sym)) (extend-bvc op)))
                         :not
-                        (let [op (plan-not-op db inner-ci all-clause-vars rules)]
+                        (let [op (plan-not-op db inner-ci bvc-eff rules)]
                           (update acc :ops conj (assoc op :source source-sym)))
                         :not-join
-                        (let [op (plan-not-op db inner-ci all-clause-vars rules true)]
+                        (let [op (plan-not-op db inner-ci bvc-eff rules true)]
                           (update acc :ops conj (assoc op :source source-sym)))
                         :or
-                        (update acc :ops conj (assoc (plan-or-op db inner-ci all-clause-vars rules) :source source-sym))
+                        (update acc :ops conj (assoc (plan-or-op db inner-ci bvc-eff rules) :source source-sym))
                         :or-join
-                        (update acc :ops conj (assoc (plan-or-op db inner-ci all-clause-vars rules true) :source source-sym))
+                        (update acc :ops conj (assoc (plan-or-op db inner-ci bvc-eff rules true) :source source-sym))
                         ;; Source-prefix wrapping another source-prefix or unknown
                         (update acc :ops conj (plan-passthrough-op ci))))
 
                     (update acc :ops conj (plan-passthrough-op ci)))))))
-          {:ops [] :actual-consumed #{} :not-ops []}
+          {:ops [] :actual-consumed #{} :not-ops [] :bvc-eff init-bvc}
           classified)
 
          ;; Collect pattern ops first for predicate sampling

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -82,10 +82,25 @@
 ;; ---------------------------------------------------------------------------
 ;; Pattern plan ops
 
+(defn- pattern-output-var-cards
+  "Per-output-var cardinality upper bounds for a pattern-scan op.
+   Each free var in the pattern is bounded by the pattern's estimated-card
+   (the slice size). For card-one attributes the bound is tight on the
+   entity position; for card-many it is conservative. Refining (e.g. with
+   distinct-v sampling) can tighten value-position bounds in a follow-up."
+  [pattern-info est]
+  (into {}
+        (map (fn [v] [v est]))
+        (filter analyze/free-var? (:vars pattern-info))))
+
 (defn plan-pattern-op
   "Create a plan operation for a pattern clause.
+   `bound-var-cards` is a {var → cardinality} map of upstream-bound vars
+   used for cardinality estimation. Membership-check semantics (`contains?`)
+   match the prior `bound-vars` set, so internal logic that only checks
+   binding without using the cardinality is unchanged.
    Returns [op actually-consumed-pred-clauses]."
-  [db pattern-info schema-info pushdown-preds bound-vars]
+  [db pattern-info schema-info pushdown-preds bound-var-cards]
   (let [{:keys [e a v tx pattern]} pattern-info
         ground? (fn [x] (and (some? x) (not (symbol? x))))
         e? (ground? e)
@@ -94,7 +109,8 @@
         has-avet? (boolean (:avet db))
         index (select-index pattern-info schema-info has-avet? (seq pushdown-preds))
         effective-preds (if (= :avet index) pushdown-preds [])
-        base-est (or (estimate/estimate-pattern db pattern-info schema-info)
+        base-est (or (estimate/estimate-pattern-with-bindings
+                      db pattern-info schema-info (or bound-var-cards {}))
                      (di/-count (:eavt db)))
         ;; Build a partial scan-op for sampling context
         scan-ctx {:clause (:clause pattern-info) :index index}
@@ -102,10 +118,10 @@
               (estimate/estimate-pushdown-range base-est effective-preds db scan-ctx)
               base-est)
         e-bound? (and (analyze/free-var? e)
-                      (contains? bound-vars e))
+                      (contains? bound-var-cards e))
         join-method (cond
                       e-bound? :lookup
-                      (empty? bound-vars) :scan
+                      (empty? bound-var-cards) :scan
                       :else :hash)]
     [(cond-> {:op :pattern-scan
               :clause pattern
@@ -113,6 +129,7 @@
               :schema-info schema-info
               :pushdown-preds effective-preds
               :estimated-card est
+              :output-var-cards (pattern-output-var-cards pattern-info est)
               :join-method join-method
               :vars (:vars pattern-info)
               :e-ground (when e? e)
@@ -230,6 +247,45 @@
      :accepts-entity-filter? (:accepts-entity-filter? engine-meta false)
      :estimated-card (or (:estimated-card cost) 100)}))
 
+(defn- function-binding-vars
+  "Extract free vars from a function-clause :binding spec.
+   Handles BindScalar, BindColl, BindTuple, BindIgnore — but at the planner
+   level :binding is most often the raw symbol or vector form, so we just
+   collect free-var symbols recursively."
+  [binding]
+  (into #{} (filter analyze/free-var?) (analyze/extract-vars binding)))
+
+(defn- function-output-var-cards
+  "Per-binding-var cardinality bounds for a function op.
+     - (identity X)  → bind-var card = 1 (single value)
+     - (ground COLL) → bind-var card = (count COLL) when literal; else nil
+   For other functions we don't know the output cardinality at plan time
+   without sampling, so omit them — downstream tightens via :estimated-card."
+  [fn-sym args binding]
+  (let [bvars (function-binding-vars binding)]
+    (case fn-sym
+      identity
+      (when (= 1 (count bvars))
+        (zipmap bvars (repeat 1)))
+
+      ground
+      (let [coll (first args)]
+        (cond
+          (and (= 1 (count bvars)) (counted? coll))
+          (zipmap bvars (repeat (max 1 (count coll))))
+
+          ;; (ground [[?a ?b]]) tuple-binding shape — coll is a single-element
+          ;; vector wrapping a tuple destructure; the bindings are produced
+          ;; collectively, count is # of tuples in the source.
+          (and (counted? coll) (sequential? (first coll)))
+          (zipmap bvars (repeat (max 1 (count coll))))
+
+          :else nil))
+
+      ;; Unknown function → omit; ops that consume this rel still see
+      ;; :estimated-card for ordering.
+      nil)))
+
 (defn plan-function-op
   "Create a plan op for a function clause. Checks for external engine metadata."
   ([fn-info] (plan-function-op fn-info nil))
@@ -237,13 +293,16 @@
    (let [engine-meta (resolve-external-engine-meta (:fn-sym fn-info))]
      (if engine-meta
        (plan-external-engine-op fn-info engine-meta db)
-       {:op :function
-        :clause (:clause fn-info)
-        :fn-sym (:fn-sym fn-info)
-        :args (:args fn-info)
-        :binding (:binding fn-info)
-        :vars (:vars fn-info)
-        :estimated-card nil}))))
+       (let [out-cards (function-output-var-cards
+                        (:fn-sym fn-info) (:args fn-info) (:binding fn-info))]
+         (cond-> {:op :function
+                  :clause (:clause fn-info)
+                  :fn-sym (:fn-sym fn-info)
+                  :args (:args fn-info)
+                  :binding (:binding fn-info)
+                  :vars (:vars fn-info)
+                  :estimated-card nil}
+           out-cards (assoc :output-var-cards out-cards)))))))
 
 (defn plan-passthrough-op [clause-info]
   {:op :passthrough
@@ -496,6 +555,16 @@
                            scan-card
                            merge-ops)
         output-vars (into #{} (mapcat :vars) (into pattern-ops anti-ops))
+        ;; Per-output-var cardinality. The group's output rel size is `group-card`,
+        ;; which bounds every var the group produces. For tighter per-var bounds
+        ;; we'd need to track which patterns produce which vars + their individual
+        ;; cardinalities — for now the group-level bound suffices for downstream
+        ;; planning decisions (it differentiates a 4k-tuple group from a 150k one).
+        group-card-final (max 1 group-card)
+        output-var-cards (into {}
+                               (comp (filter analyze/free-var?)
+                                     (map (fn [v] [v group-card-final])))
+                               output-vars)
         ;; Merge-ops' pushdown preds can't be applied (merge uses EAVT lookupGE,
         ;; not AVET scan). Collect them so they can be restored as standalone preds.
         merge-lost-preds (into #{} (comp (mapcat :pushdown-preds) (map :pred-clause)) merge-ops)
@@ -506,8 +575,9 @@
                        :scan-op final-scan
                        :merge-ops final-merges
                        :output-vars output-vars
+                       :output-var-cards output-var-cards
                        :vars output-vars
-                       :estimated-card (max 1 group-card)
+                       :estimated-card group-card-final
                        :pipeline (build-pipeline final-scan final-merges db)}
                 source (assoc :source source))]
     {:op eg-op

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -1180,17 +1180,55 @@
                                        [(list 'identity orig) safe])))
                              (map vector call-args-safe call-args))
         replacements (zipmap rule-args call-args-safe)
-        ;; Resolve keyword attrs to entity refs in attribute-refs mode
+        ;; Resolve keyword attrs to entity refs in attribute-refs mode.
+        ;;
+        ;; The resolution must recurse through compound clause forms
+        ;; (or, or-join, and, not, not-join, source-prefixed) to reach
+        ;; data patterns nested inside them. Without recursion, a rule
+        ;; body like `(or-join [...] [?e :attr ?v] ...)` would keep its
+        ;; inner pattern's attribute as a keyword while the outer
+        ;; query's clauses get resolved by substitute-consts-with-lookup-refs
+        ;; — at execute-time the lookup-batch-search path then slices
+        ;; AEVT for the keyword, finds zero datoms (datoms in
+        ;; :attribute-refs? mode are stored with attr=eid, not keyword),
+        ;; and the rule branch silently produces empty results. Surface
+        ;; symptom in jobtech: 3 changelog tests on HistoricalDB return
+        ;; 0 rows instead of the expected change events.
         attr-refs? (:attribute-refs? (dbi/-config db))
-        resolve-clause (fn [clause]
-                         (if (and attr-refs?
-                                  (vector? clause)
-                                  (not (sequential? (first clause)))
-                                  (keyword? (second clause)))
-                           (assoc clause 1 (dbi/-ref-for db (second clause)))
-                           clause))
+        data-pattern? (fn [x]
+                        (and (vector? x)
+                             (let [f (first x)]
+                               (or (and (symbol? f) (analyze/free-var? f))
+                                   (number? f)
+                                   (and (vector? f) (= 2 (count f)))))
+                             (or (keyword? (second x))
+                                 (and (symbol? (second x)) (analyze/free-var? (second x)))
+                                 (number? (second x)))))
+        resolve-attr-in-pattern (fn [pat]
+                                  (if (and attr-refs? (keyword? (second pat)))
+                                    (assoc pat 1 (dbi/-ref-for db (second pat)))
+                                    pat))
+        resolve-recursive (fn resolve-recursive [form]
+                            (cond
+                              ;; Data pattern: resolve its attr.
+                              (data-pattern? form)
+                              (resolve-attr-in-pattern form)
+
+                              ;; Compound list form (or, or-join, and, not, not-join, etc.)
+                              ;; — recurse into elements that look like clauses.
+                              (and (sequential? form)
+                                   (symbol? (first form))
+                                   (#{'or 'or-join 'and 'not 'not-join} (first form)))
+                              (let [head (first form)
+                                    ;; or-join / not-join have a vars vector after the head
+                                    [pre-rest body] (case head
+                                                      (or-join not-join) [(take 2 form) (drop 2 form)]
+                                                      [(take 1 form) (rest form)])]
+                                (concat pre-rest (map resolve-recursive body)))
+
+                              :else form))
         renamed (mapv (fn [c]
-                        (resolve-clause
+                        (resolve-recursive
                          (clojure.walk/postwalk
                           (fn [x]
                             (if (analyze/free-var? x)

--- a/test/datahike/test/query_ir_test.clj
+++ b/test/datahike/test/query_ir_test.clj
@@ -332,3 +332,113 @@
           "Both predicates must be applied — merge-op pushdowns must be restored")
       (is (< (count planner-result) 100)
           "Result should be filtered by both predicates"))))
+
+;; ---------------------------------------------------------------------------
+;; op-required-vars contract — single source of truth for per-op-type binding
+;; requirements consumed by op-cost during cost-based ordering. Tests assert
+;; the documented contract per op type so future refactors don't drift.
+
+(deftest test-op-required-vars
+  (testing ":entity-group / non-optional :pattern-scan are producers"
+    (is (= [#{} :none] (plan/op-required-vars
+                        {:op :pattern-scan :clause '[?e :name ?n] :vars #{'?e '?n}})))
+    (is (= [#{} :none] (plan/op-required-vars
+                        {:op :entity-group :clause '[?e :name ?n] :vars #{'?e '?n}}))))
+
+  (testing ":pattern-scan with :optional? requires its e-var bound"
+    ;; LOptionalScan synthesised from get-else; e is the first clause element.
+    (is (= [#{'?e} :all]
+           (plan/op-required-vars
+            {:op :pattern-scan :optional? true
+             :clause '[?e :concept/deprecated ?d]
+             :default-value false
+             :vars #{'?e '?d}})))
+    ;; If e is ground (a number), no var to require.
+    (is (= [#{} :none]
+           (plan/op-required-vars
+            {:op :pattern-scan :optional? true
+             :clause '[42 :concept/deprecated ?d]
+             :default-value false
+             :vars #{'?d}}))))
+
+  (testing ":predicate requires every referenced var"
+    (is (= [#{'?x '?y} :all]
+           (plan/op-required-vars
+            {:op :predicate :fn-sym '< :args ['?x '?y] :vars #{'?x '?y}}))))
+
+  (testing ":function requires every input-arg var (excludes output binding)"
+    (is (= [#{'?x} :all]
+           (plan/op-required-vars
+            {:op :function :fn-sym 'inc :args ['?x] :binding '?y :vars #{'?x '?y}}))))
+
+  (testing ":external-engine honours :input-vars-spec"
+    ;; :all-bound (or absent) → strict: every input-arg must be bound.
+    ;; args-free-vars filters to free-vars (?…), excluding source symbols
+    ;; like $ — source symbols are always available, never need binding.
+    (let [op {:op :external-engine
+              :args ['$ '?col1 '?col2]
+              :binding '[[?out]]
+              :vars #{'?col1 '?col2 '?out}
+              :input-vars-spec :all-bound}
+          [vars policy] (plan/op-required-vars op)]
+      (is (= :all policy))
+      (is (= #{'?col1 '?col2} vars)))
+    ;; Default (no spec declared) is :all — safer than the legacy `some`
+    ;; check that used to live in op-cost.
+    (let [op {:op :external-engine
+              :args ['$ '?col1]
+              :binding '[?out]
+              :vars #{'?col1 '?out}}
+          [_ policy] (plan/op-required-vars op)]
+      (is (= :all policy)))
+    ;; :any-bound declared → :any.
+    (let [op {:op :external-engine
+              :args ['$ '?col1 '?col2]
+              :binding '[?out]
+              :vars #{'?col1 '?col2 '?out}
+              :input-vars-spec :any-bound}
+          [_ policy] (plan/op-required-vars op)]
+      (is (= :any policy))))
+
+  (testing ":rule-lookup is a producer (accumulator-driven, no pre-bound deps)"
+    (is (= [#{} :none] (plan/op-required-vars
+                        {:op :rule-lookup :rule-name 'some-rule
+                         :call-args ['?a '?b] :mode :main :vars #{'?a '?b}}))))
+
+  (testing ":not / :not-join require the full set of join-vars / referenced vars"
+    (is (= [#{'?e '?n} :all]
+           (plan/op-required-vars {:op :not :vars #{'?e '?n}})))
+    (is (= [#{'?e} :all]
+           (plan/op-required-vars
+            {:op :not-join :vars #{'?e '?n} :join-vars #{'?e}}))))
+
+  (testing ":or / :or-join require AT LEAST one join-var bound"
+    (is (= [#{'?e '?v} :any]
+           (plan/op-required-vars {:op :or :vars #{'?e '?v}})))
+    (is (= [#{'?e} :any]
+           (plan/op-required-vars
+            {:op :or-join :vars #{'?e '?v} :join-vars #{'?e}})))))
+
+(deftest test-op-cost-ready-vs-blocked
+  (testing "op-cost returns max-cost for unsatisfied required vars,
+            finite cost when satisfied"
+    ;; predicate — costs 0 when ready (cheapest filter)
+    (let [op {:op :predicate :args ['?x '?y] :vars #{'?x '?y}}]
+      (is (= 0 (plan/op-cost op #{'?x '?y}))
+          "predicate is the cheapest op type when its inputs are bound")
+      (is (= Long/MAX_VALUE (plan/op-cost op #{'?x}))
+          "missing one input var → blocked"))
+    ;; function — costs 1 when ready
+    (let [op {:op :function :args ['?x] :binding '?y :vars #{'?x '?y}}]
+      (is (= 1 (plan/op-cost op #{'?x}))
+          "function costs 1 when its inputs are bound")
+      (is (= Long/MAX_VALUE (plan/op-cost op #{}))
+          "no input bound → blocked"))
+    ;; or-join — :any policy: at least one join-var must be bound
+    (let [op {:op :or-join :vars #{'?e '?v} :join-vars #{'?e '?v}
+              :estimated-card 50}]
+      (is (= Long/MAX_VALUE (plan/op-cost op #{}))
+          "no join-var bound → blocked")
+      (is (< (plan/op-cost op #{'?e}) Long/MAX_VALUE)
+          "one join-var bound → ready under :any policy"))))
+

--- a/test/datahike/test/query_planner_temporal_test.clj
+++ b/test/datahike/test/query_planner_temporal_test.clj
@@ -62,14 +62,14 @@
         (d/create-database cfg)
         (let [conn (d/connect cfg)]
           (d/transact conn
-                       [{:db/ident :version/id
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/long
-                         :db/unique :db.unique/identity
-                         :db/index true}
-                        {:db/ident :version/tx
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/ref}])
+                      [{:db/ident :version/id
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/long
+                        :db/unique :db.unique/identity
+                        :db/index true}
+                       {:db/ident :version/tx
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/ref}])
           ;; Two version markers, each linked to its own creation tx
           (d/transact conn [{:version/id 1 :version/tx "datomic.tx"}])
           (d/transact conn [{:version/id 2 :version/tx "datomic.tx"}])
@@ -86,12 +86,12 @@
                 ;; rather than an orthogonal legacy edge case.
                 rules   '[[(->inst ?in ?ret)
                            (or-join [?in ?ret]
-                             (and [(int? ?in)]
-                                  [?v :version/id ?in]
-                                  [?v :version/tx ?tx]
-                                  [?tx :db/txInstant ?ret])
-                             (and [(inst? ?in)]
-                                  [(identity ?in) ?ret]))]]
+                                    (and [(int? ?in)]
+                                         [?v :version/id ?in]
+                                         [?v :version/tx ?tx]
+                                         [?tx :db/txInstant ?ret])
+                                    (and [(inst? ?in)]
+                                         [(identity ?in) ?ret]))]]
                 q-form  '[:find ?ret
                           :in $ % ?in-input
                           :where
@@ -133,13 +133,13 @@
         (d/create-database cfg)
         (let [conn (d/connect cfg)]
           (d/transact conn
-                       [{:db/ident :event/marker
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/string
-                         :db/index true}
-                        {:db/ident :event/category
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/string}])
+                      [{:db/ident :event/marker
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/string
+                        :db/index true}
+                       {:db/ident :event/category
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/string}])
           ;; Three transactions with distinct txInstants. A predicate
           ;; bounded between tx2 and tx3 must keep ONLY the middle event.
           (d/transact conn [{:event/marker "e1" :event/category "alpha"}])
@@ -221,20 +221,20 @@
         (d/create-database cfg)
         (let [conn (d/connect cfg)]
           (d/transact conn
-                       [{:db/ident :concept/id
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/string
-                         :db/unique :db.unique/identity
-                         :db/index true}
-                        {:db/ident :relation/concept-1
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/ref}
-                        {:db/ident :relation/concept-2
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/ref}
-                        {:db/ident :relation/percentage
-                         :db/cardinality :db.cardinality/one
-                         :db/valueType :db.type/long}])
+                      [{:db/ident :concept/id
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/string
+                        :db/unique :db.unique/identity
+                        :db/index true}
+                       {:db/ident :relation/concept-1
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/ref}
+                       {:db/ident :relation/concept-2
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/ref}
+                       {:db/ident :relation/percentage
+                        :db/cardinality :db.cardinality/one
+                        :db/valueType :db.type/long}])
           (d/transact conn [{:concept/id "C1"} {:concept/id "C2"}])
           (let [c1 (ffirst (d/q '[:find ?e :where [?e :concept/id "C1"]] (d/db conn)))
                 c2 (ffirst (d/q '[:find ?e :where [?e :concept/id "C2"]] (d/db conn)))]

--- a/test/datahike/test/query_planner_temporal_test.clj
+++ b/test/datahike/test/query_planner_temporal_test.clj
@@ -183,3 +183,85 @@
             (is (= #{["e2"] ["e3"]} (set planner))
                 "planner result must drop e1 (whose ?inst < ?from-inst)")))
         (finally (d/delete-database cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; Bug 3 — LOptionalScan reordered before its entity-var binders
+;;
+;; The planner classifies LOptionalScan ops (synthesized from a
+;; `[(get-else $ ?e :attr default) ?v]` clause) as :pattern-scan in the
+;; physical plan. order-plan-ops puts every :pattern-scan into the
+;; "groups" partition and feeds those to dp-order-groups, which only
+;; considers shared-var connectivity for the join graph — it has no
+;; awareness of the optional scan's runtime constraint that ?e MUST be
+;; bound BEFORE the scan executes. At runtime, the :optional? branch in
+;; execute-plan routes through `legacy/bind-by-fn` with a synthetic
+;; `(get-else $ ?e :attr default)` fn-clause; bind-by-fn evaluates the
+;; fn per row in ctx.rels — and if ?e is still free, the fn gets a nil
+;; entity, returns the default value, and binds the bind-var on a row
+;; where ?e itself is also nil. That nil-?e tuple then propagates
+;; through downstream ops as if it were a real binding, producing
+;; all-nil-tuple find results.
+;;
+;; Surface symptom in jobtech: 2 daynotes test-relation-changes tests
+;; got `event-concept-1 = nil` because fetch-relation-txs (an outer
+;; query with `[?c :concept/id ?input-concept-id]` followed by two
+;; `(or ...)` clauses, three `(get-else …)` clauses, and a range
+;; predicate) had the optional scan for
+;; `:relation/substitutability-percentage` placed BEFORE the OR that
+;; binds ?r. Fixed in src/datahike/query/plan.cljc order-plan-ops by
+;; routing optional pattern-scans through the non-groups partition,
+;; which uses op-cost+bound-vars to wait until the e-var binder has
+;; run.
+
+(deftest test-optional-scan-after-binder
+  (testing "LOptionalScan (get-else with default) is ordered after its
+            entity-var binder so its e-var isn't nil at execute time"
+    (let [cfg (fresh-cfg)]
+      (try
+        (d/create-database cfg)
+        (let [conn (d/connect cfg)]
+          (d/transact conn
+                       [{:db/ident :concept/id
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/string
+                         :db/unique :db.unique/identity
+                         :db/index true}
+                        {:db/ident :relation/concept-1
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/ref}
+                        {:db/ident :relation/concept-2
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/ref}
+                        {:db/ident :relation/percentage
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/long}])
+          (d/transact conn [{:concept/id "C1"} {:concept/id "C2"}])
+          (let [c1 (ffirst (d/q '[:find ?e :where [?e :concept/id "C1"]] (d/db conn)))
+                c2 (ffirst (d/q '[:find ?e :where [?e :concept/id "C2"]] (d/db conn)))]
+            (d/transact conn [{:relation/concept-1 c1
+                               :relation/concept-2 c2
+                               :relation/percentage 50}]))
+
+          (let [hdb (d/history (d/db conn))
+                ;; The query that triggered the bug: ?r is introduced by
+                ;; the (or ...) clause, BEFORE the get-else expects it.
+                ;; The cost-based reorderer must NOT lift the optional
+                ;; scan above the OR.
+                q-form '[:find ?r ?pct
+                         :in $
+                         :where
+                         [?c :concept/id ?cid]
+                         (or [?r :relation/concept-1 ?c]
+                             [?r :relation/concept-2 ?c])
+                         [(get-else $ ?r :relation/percentage 0) ?pct]]
+                {:keys [legacy planner]} (run-both q-form hdb)]
+            (is (= 1 (count legacy))
+                "legacy returns one row with ?r and ?pct bound")
+            (is (= legacy planner)
+                "planner must match legacy — the optional scan must run
+                  AFTER ?r is bound, not before")
+            (is (every? some? (first planner))
+                "planner row must have non-nil values — a pre-fix run
+                  produces a tuple of all-nils because the optional scan
+                  ran with ?r still free")))
+        (finally (d/delete-database cfg))))))

--- a/test/datahike/test/query_planner_temporal_test.clj
+++ b/test/datahike/test/query_planner_temporal_test.clj
@@ -1,0 +1,185 @@
+(ns datahike.test.query-planner-temporal-test
+  "Regression tests for planner bugs surfaced by the jobtech-taxonomy-api
+   test suite. Each test is a minimal repro that compares the planner
+   path against the legacy engine on a HistoricalDB in :attribute-refs?
+   mode — the combination that exposed each bug in production. The tests
+   should pass on both engines; the assertion form is `(= legacy planner)`
+   so a future regression in either path is caught."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.query :as q])
+  (:import [java.util UUID]))
+
+(defn- fresh-cfg
+  "In-memory DB with history enabled and attr-refs on — the mode where
+   datoms are stored as `(e attr-eid v tx)` rather than `(e :keyword v tx)`,
+   so any keyword-attribute pattern that reaches the executor without
+   keyword→eid resolution silently slices an empty range. `:writer
+   {:backend :self}` makes `transact` return its TxReport synchronously
+   so we don't have to deref a Future."
+  []
+  {:store {:backend :memory :id (UUID/randomUUID)}
+   :writer {:backend :self}
+   :schema-flexibility :write
+   :keep-history? true
+   :attribute-refs? true})
+
+(defn- run-both
+  "Execute `q-form` once with the planner enabled and once forced to legacy.
+   Return both result sets so tests can assert equality, capture both into
+   the failure message, and check the planner result independently."
+  [q-form & inputs]
+  {:legacy  (binding [q/*force-legacy* true]
+              (apply d/q q-form inputs))
+   :planner (binding [q/*force-legacy* false]
+              (apply d/q q-form inputs))})
+
+;; ---------------------------------------------------------------------------
+;; Bug 1 — rule body with nested or-join + :attribute-refs? mode
+;;
+;; A rule body that consists of a single compound form (or-join / or / and)
+;; was not having its INNER data patterns' attribute keywords rewritten to
+;; eids. The single-level resolve-clause inside rename-branch-vars only
+;; matched top-level data patterns:
+;;   (and (vector? clause) (not (sequential? (first clause))) ...)
+;; — so for a body like `(or-join [...] (and [?e :attr ?v] ...))` the
+;; clause itself is a list, vector? returns false, the rewrite is skipped,
+;; every nested pattern keeps its keyword, and lookup-batch-search slices
+;; AEVT for the keyword (no match in attr-refs storage), returning 0 rows.
+;;
+;; Surface symptom in jobtech: 3 changelog GraphQL tests on HistoricalDB
+;; returned 0 events instead of 2-5. Fixed in
+;; src/datahike/query/plan.cljc rename-branch-vars by replacing the
+;; one-level resolve-clause with resolve-recursive that descends into
+;; or / or-join / and / not / not-join compound forms.
+
+(deftest test-rule-body-or-join-attr-refs
+  (testing "rule body containing (or-join ...) with data patterns resolves
+            attribute keywords for both engines on HistoricalDB"
+    (let [cfg (fresh-cfg)]
+      (try
+        (d/create-database cfg)
+        (let [conn (d/connect cfg)]
+          (d/transact conn
+                       [{:db/ident :version/id
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/long
+                         :db/unique :db.unique/identity
+                         :db/index true}
+                        {:db/ident :version/tx
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/ref}])
+          ;; Two version markers, each linked to its own creation tx
+          (d/transact conn [{:version/id 1 :version/tx "datomic.tx"}])
+          (d/transact conn [{:version/id 2 :version/tx "datomic.tx"}])
+
+          (let [hdb     (d/history (d/db conn))
+                ;; Rule body is a single (or-join …) compound. Without
+                ;; recursive attr-resolution the planner returns ∅.
+                ;; Legacy can only execute this rule when the input
+                ;; is concretely bound BEFORE the rule call (otherwise
+                ;; legacy sum-rel chokes on heterogeneous branch attrs);
+                ;; the production callers all bind via
+                ;; `[(identity ?in-input) ?in]` first, so we mirror that
+                ;; here to keep the test exercising the bug we fixed
+                ;; rather than an orthogonal legacy edge case.
+                rules   '[[(->inst ?in ?ret)
+                           (or-join [?in ?ret]
+                             (and [(int? ?in)]
+                                  [?v :version/id ?in]
+                                  [?v :version/tx ?tx]
+                                  [?tx :db/txInstant ?ret])
+                             (and [(inst? ?in)]
+                                  [(identity ?in) ?ret]))]]
+                q-form  '[:find ?ret
+                          :in $ % ?in-input
+                          :where
+                          [(identity ?in-input) ?in]
+                          (->inst ?in ?ret)]
+                {:keys [legacy planner]} (run-both q-form hdb rules 1)]
+            (is (= 1 (count legacy))
+                "legacy resolves the rule and returns one tx-instant")
+            (is (= legacy planner)
+                "planner must match legacy under attribute-refs+history")
+            (is (instance? java.util.Date (ffirst planner))
+                "planner returns a real instant, not nil/empty")))
+        (finally (d/delete-database cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; Bug 2 — pushed-down predicate dropped in entity-group temporal fallback
+;;
+;; The planner pushes range predicates like `[(<= ?from ?inst)]` onto the
+;; relevant scan-op's :pushdown-preds and consumes the original clause
+;; (so it never reappears as a standalone :predicate op). On regular DBs
+;; the fused PSS scan path applies the predicate via slice bounds and a
+;; strict-filter; on HistoricalDB / AsOfDB / SinceDB the fallback
+;; delegates to legacy/lookup-batch-search, which has no concept of
+;; :pushdown-preds — the predicate is silently dropped and rows that
+;; would have been filtered out leak through.
+;;
+;; Surface symptom in jobtech: 3 daynotes-test cases returned more rows
+;; than legacy because their `[(<= ?from-version ?inst)]` predicate was
+;; pushed onto the [?tx :db/txInstant ?inst] scan but never evaluated.
+;; Fixed in src/datahike/query/execute.cljc :entity-group temporal
+;; branch by re-applying scan-op + merge-op :pushdown-preds via
+;; legacy/filter-by-pred after the scan/merge/optional/anti phases.
+
+(deftest test-temporal-entity-group-pushdown-pred
+  (testing "range predicate pushed onto entity-group scan-op is applied
+            on HistoricalDB"
+    (let [cfg (fresh-cfg)]
+      (try
+        (d/create-database cfg)
+        (let [conn (d/connect cfg)]
+          (d/transact conn
+                       [{:db/ident :event/marker
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/string
+                         :db/index true}
+                        {:db/ident :event/category
+                         :db/cardinality :db.cardinality/one
+                         :db/valueType :db.type/string}])
+          ;; Three transactions with distinct txInstants. A predicate
+          ;; bounded between tx2 and tx3 must keep ONLY the middle event.
+          (d/transact conn [{:event/marker "e1" :event/category "alpha"}])
+          (Thread/sleep 5)
+          (d/transact conn [{:event/marker "e2" :event/category "beta"}])
+          (Thread/sleep 5)
+          (d/transact conn [{:event/marker "e3" :event/category "alpha"}])
+
+          (let [hdb (d/history (d/db conn))
+                ;; Three event-bearing txs in chronological order. We
+                ;; pick a window that excludes the FIRST event but
+                ;; includes the other two — the predicate must shrink
+                ;; the result set from 3 → 2.
+                event-tx-instants (sort
+                                   (mapv first
+                                         (d/q '[:find ?inst
+                                                :where
+                                                [_ :event/marker ?m ?tx true]
+                                                [?tx :db/txInstant ?inst]]
+                                              hdb)))
+                e1-inst (nth event-tx-instants 0)
+                e3-inst (nth event-tx-instants 2)
+                ;; Range: > e1, ≤ e3 — should keep e2 and e3.
+                from-inst (java.util.Date/from
+                           (.plus (.toInstant ^java.util.Date e1-inst)
+                                  1 java.time.temporal.ChronoUnit/MILLIS))
+                to-inst   e3-inst
+                q-form '[:find ?m
+                         :in $ ?from-inst ?to-inst
+                         :where
+                         [?e :event/marker ?m ?tx true]
+                         [?tx :db/txInstant ?inst]
+                         [(<= ?from-inst ?inst)]
+                         [(<= ?inst ?to-inst)]]
+                {:keys [legacy planner]} (run-both q-form hdb from-inst to-inst)]
+            (is (= 2 (count legacy))
+                "legacy filters out e1, keeps e2 and e3")
+            (is (= legacy planner)
+                "planner must match legacy — pushed-down predicate
+                  must be re-applied in the temporal fallback path")
+            (is (= #{["e2"] ["e3"]} (set planner))
+                "planner result must drop e1 (whose ?inst < ?from-inst)")))
+        (finally (d/delete-database cfg))))))

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -659,3 +659,67 @@
       (is (= #{[4] [6]}
              (binding [q/*force-legacy* false] (d/q query db)))
           "Entities 4 and 6 match: both have val-a == val-b"))))
+
+;; ---------------------------------------------------------------------------
+;; get-else with :attribute-refs? on temporal DB (legacy lookup path)
+
+(deftest test-get-else-attribute-refs-on-as-of
+  ;; Regression: when :attribute-refs? is enabled, every other clause has its
+  ;; keyword attribute resolved to the attribute eid before the planner sees
+  ;; it (via resolve-pattern-lookup-refs). The function form
+  ;; [(get-else $ ?e :attr default) ?v] is classified as :function, so its
+  ;; inner :attr keyword was never visited by that resolution pass — the
+  ;; synthetic LOptionalScan clause carried a keyword while the surrounding
+  ;; merge-clauses carried eids. The fused entity-group execution path
+  ;; resolves keywords at runtime via build-merge-attrs, so the bug only
+  ;; manifested on the legacy (lookup-batch-search) path used by AsOfDB,
+  ;; SinceDB and other temporal wrappers, where the keyword-as-attribute
+  ;; matched nothing in the eid-keyed index → 0 datoms returned for the
+  ;; optional merge → the surrounding entity-group's relation collapsed to
+  ;; 0 tuples via inner-join, even for entities that *did* have the
+  ;; attribute populated.
+  ;;
+  ;; Reported by Jonas Östlund (jobtech-taxonomy-api), where show-versions
+  ;; queries against (d/get-db cfg :next) returned empty result sets.
+  ;;
+  ;; This test only exercises the resolution fix: every entity in the data
+  ;; has the optional attribute populated, so the inner-join path that the
+  ;; legacy lookup still uses for optional merges does not drop any rows.
+  ;; The "default value on miss" semantics of get-else on the temporal path
+  ;; are a separate bug (the legacy path treats every merge — optional or
+  ;; not — as an inner-join) and are out of scope here.
+  (let [cfg {:store {:backend :memory
+                     :id (java.util.UUID/randomUUID)}
+             :attribute-refs? true
+             :keep-history? true
+             :schema-flexibility :write}
+        _ (d/delete-database cfg)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        _ (d/transact conn
+                      [{:db/ident :concept/id :db/valueType :db.type/string
+                        :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                       {:db/ident :concept/type :db/valueType :db.type/string
+                        :db/cardinality :db.cardinality/one}
+                       {:db/ident :concept/legacy-id :db/valueType :db.type/string
+                        :db/cardinality :db.cardinality/one}])
+        _ (d/transact conn [{:concept/id "A" :concept/type "T"
+                             :concept/legacy-id "1384"}
+                            {:concept/id "B" :concept/type "T"
+                             :concept/legacy-id "5678"}])
+        ;; Drive both engines through an as-of DB so the :entity-group op
+        ;; falls into the legacy lookup-batch-search path. Without the fix,
+        ;; the LOptionalScan-derived merge clause keeps :concept/legacy-id
+        ;; as a keyword while the other merge clauses carry attribute eids,
+        ;; the AVET lookup finds nothing, and the planner returns #{}.
+        db (d/as-of @conn (java.util.Date.))
+        query '[:find ?id ?legacy
+                :in $ [?type ...]
+                :where [?c :concept/id ?id]
+                       [?c :concept/type ?type]
+                       [(get-else $ ?c :concept/legacy-id "missing") ?legacy]]]
+    (assert-engines-agree db query [["T"]])
+    (is (= #{["A" "1384"] ["B" "5678"]}
+           (binding [q/*force-legacy* false] (d/q query db ["T"])))
+        "Both concepts found via planner with the synthetic clause's keyword resolved.")
+    (d/release conn)))

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -713,8 +713,8 @@
         query '[:find ?id ?legacy
                 :in $ [?type ...]
                 :where [?c :concept/id ?id]
-                       [?c :concept/type ?type]
-                       [(get-else $ ?c :concept/legacy-id "missing") ?legacy]]]
+                [?c :concept/type ?type]
+                [(get-else $ ?c :concept/legacy-id "missing") ?legacy]]]
     (assert-engines-agree db query [["T"]])
     (is (= #{["A" "1384"] ["B" "missing"]}
            (binding [q/*force-legacy* false] (d/q query db ["T"])))
@@ -734,8 +734,8 @@
 (deftest test-estimate-pattern-with-bindings
   (let [;; A schema with one indexed cardinality-one ref attr
         db (d/db-with (db/empty-db {:friend {:db/valueType   :db.type/ref
-                                              :db/cardinality :db.cardinality/one
-                                              :db/index       true}})
+                                             :db/cardinality :db.cardinality/one
+                                             :db/index       true}})
                       [{:db/id 1}
                        {:db/id 2 :friend 1}
                        {:db/id 3 :friend 1}

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -720,3 +720,53 @@
            (binding [q/*force-legacy* false] (d/q query db ["T"])))
         "Both concepts returned: A with its legacy-id, B with the default.")
     (d/release conn)))
+
+;; ---------------------------------------------------------------------------
+;; estimate-pattern-with-bindings — bound-aware cardinality estimation
+;;
+;; Without bound-var-cards, every pattern with `[?e a ?v]` (a ground, e/v free)
+;; on the same attribute returns the same estimate (= attribute-count). This
+;; collapses scan-vs-merge selection in entity groups when patterns differ only
+;; in which free var is bound from upstream — see the eures regression where
+;; the planner picks the worst pattern as scan. estimate-pattern-with-bindings
+;; uses bound-var cardinalities to differentiate.
+
+(deftest test-estimate-pattern-with-bindings
+  (let [;; A schema with one indexed cardinality-one ref attr
+        db (d/db-with (db/empty-db {:friend {:db/valueType   :db.type/ref
+                                              :db/cardinality :db.cardinality/one
+                                              :db/index       true}})
+                      [{:db/id 1}
+                       {:db/id 2 :friend 1}
+                       {:db/id 3 :friend 1}
+                       {:db/id 4 :friend 2}
+                       {:db/id 5 :friend 3}])
+        ;; Look up the resolved attribute for use in pattern-info
+        analyze (requiring-resolve 'datahike.query.analyze/pattern-schema-info)
+        estimate-with-bindings (requiring-resolve 'datahike.query.estimate/estimate-pattern-with-bindings)
+        estimate (requiring-resolve 'datahike.query.estimate/estimate-pattern)
+        ;; pattern: [?e :friend ?f] — both free
+        pi-free      {:e '?e :a :friend :v '?f :pattern '[?e :friend ?f]}
+        si           (analyze db pi-free)
+        ;; with no bindings, returns attr-total-count
+        base         (estimate db pi-free si)
+        ;; with ?e bound (3 entities have :friend), card-one → ≤ 3
+        with-e-bound (estimate-with-bindings db pi-free si {'?e 3})
+        ;; with ?f bound (small number of distinct friend targets), value-side fan-out
+        with-v-bound (estimate-with-bindings db pi-free si {'?f 1})
+        ;; with both bound: point lookup
+        with-both    (estimate-with-bindings db pi-free si {'?e 3 '?f 1})]
+    (testing "base estimate (no bindings) returns attribute total"
+      (is (>= base 4)
+          (str "base should be ≥ 4 datoms with :friend, got " base)))
+    (testing "entity-bound is ≤ entity cardinality (card-one)"
+      (is (<= with-e-bound 3)
+          (str "with ?e bound to 3 entities, expected ≤ 3, got " with-e-bound)))
+    (testing "value-bound for indexed attr is per-value fan-out"
+      (is (< with-v-bound base)
+          (str "with ?v bound, expected < base " base ", got " with-v-bound)))
+    (testing "both bound is a point lookup"
+      (is (<= with-both 3)
+          (str "both-bound should be ≤ min(3,1,base)≤3, got " with-both)))
+    (testing "empty bindings = base"
+      (is (= base (estimate-with-bindings db pi-free si {}))))))

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -664,30 +664,30 @@
 ;; get-else with :attribute-refs? on temporal DB (legacy lookup path)
 
 (deftest test-get-else-attribute-refs-on-as-of
-  ;; Regression: when :attribute-refs? is enabled, every other clause has its
-  ;; keyword attribute resolved to the attribute eid before the planner sees
-  ;; it (via resolve-pattern-lookup-refs). The function form
-  ;; [(get-else $ ?e :attr default) ?v] is classified as :function, so its
-  ;; inner :attr keyword was never visited by that resolution pass — the
-  ;; synthetic LOptionalScan clause carried a keyword while the surrounding
-  ;; merge-clauses carried eids. The fused entity-group execution path
-  ;; resolves keywords at runtime via build-merge-attrs, so the bug only
-  ;; manifested on the legacy (lookup-batch-search) path used by AsOfDB,
-  ;; SinceDB and other temporal wrappers, where the keyword-as-attribute
-  ;; matched nothing in the eid-keyed index → 0 datoms returned for the
-  ;; optional merge → the surrounding entity-group's relation collapsed to
-  ;; 0 tuples via inner-join, even for entities that *did* have the
-  ;; attribute populated.
+  ;; Regression for two bugs in the planner's handling of get-else on temporal
+  ;; DBs (AsOfDB / SinceDB / HistoricalDB):
+  ;;
+  ;; 1. KEYWORD RESOLUTION. When :attribute-refs? is enabled, every other
+  ;;    data-pattern clause has its keyword attribute resolved to the
+  ;;    attribute eid by resolve-pattern-lookup-refs. The function form
+  ;;    [(get-else $ ?e :attr default) ?v] is classified as :function, so
+  ;;    its inner :attr keyword was never visited by that pass — the
+  ;;    synthetic LOptionalScan clause carried a keyword while surrounding
+  ;;    merge-clauses carried eids. Fused-path resolves keywords at runtime
+  ;;    via build-merge-attrs/resolve-attr, so the bug only manifested on
+  ;;    the legacy lookup-batch-search path. Fixed by resolving the attr
+  ;;    when constructing LOptionalScan in logical.cljc.
+  ;;
+  ;; 2. INNER-JOIN INSTEAD OF LEFT-OUTER. The legacy entity-group path
+  ;;    treats every merge as an inner-join via lookup-batch-search,
+  ;;    including LOptionalScan-derived merges. That drops upstream tuples
+  ;;    whose entity lacks the optional attribute, instead of emitting them
+  ;;    with the default value. Fixed in execute.cljc by routing optional
+  ;;    merges through bind-by-fn (which evaluates -get-else per row),
+  ;;    matching the legacy engine's behavior for the same query.
   ;;
   ;; Reported by Jonas Östlund (jobtech-taxonomy-api), where show-versions
   ;; queries against (d/get-db cfg :next) returned empty result sets.
-  ;;
-  ;; This test only exercises the resolution fix: every entity in the data
-  ;; has the optional attribute populated, so the inner-join path that the
-  ;; legacy lookup still uses for optional merges does not drop any rows.
-  ;; The "default value on miss" semantics of get-else on the temporal path
-  ;; are a separate bug (the legacy path treats every merge — optional or
-  ;; not — as an inner-join) and are out of scope here.
   (let [cfg {:store {:backend :memory
                      :id (java.util.UUID/randomUUID)}
              :attribute-refs? true
@@ -703,15 +703,12 @@
                         :db/cardinality :db.cardinality/one}
                        {:db/ident :concept/legacy-id :db/valueType :db.type/string
                         :db/cardinality :db.cardinality/one}])
+        ;; "A" has the optional attribute, "B" does not — second bug exposed.
         _ (d/transact conn [{:concept/id "A" :concept/type "T"
                              :concept/legacy-id "1384"}
-                            {:concept/id "B" :concept/type "T"
-                             :concept/legacy-id "5678"}])
+                            {:concept/id "B" :concept/type "T"}])
         ;; Drive both engines through an as-of DB so the :entity-group op
-        ;; falls into the legacy lookup-batch-search path. Without the fix,
-        ;; the LOptionalScan-derived merge clause keeps :concept/legacy-id
-        ;; as a keyword while the other merge clauses carry attribute eids,
-        ;; the AVET lookup finds nothing, and the planner returns #{}.
+        ;; falls into the legacy lookup path.
         db (d/as-of @conn (java.util.Date.))
         query '[:find ?id ?legacy
                 :in $ [?type ...]
@@ -719,7 +716,7 @@
                        [?c :concept/type ?type]
                        [(get-else $ ?c :concept/legacy-id "missing") ?legacy]]]
     (assert-engines-agree db query [["T"]])
-    (is (= #{["A" "1384"] ["B" "5678"]}
+    (is (= #{["A" "1384"] ["B" "missing"]}
            (binding [q/*force-legacy* false] (d/q query db ["T"])))
-        "Both concepts found via planner with the synthetic clause's keyword resolved.")
+        "Both concepts returned: A with its legacy-id, B with the default.")
     (d/release conn)))


### PR DESCRIPTION
## Summary

Branch arose from running the [jobtech-taxonomy-api](https://github.com/JobtechSwe/jobtech-taxonomy-api) test suite with `DATAHIKE_QUERY_PLANNER=true`. Started as a perf branch (eures-style query was timing out at 90 s) and grew into a series of correctness fixes once the timeout was unblocked and other regressions surfaced.

End state, all on this branch:

| Suite | Engine | Result |
|---|---|---|
| Datahike focused (rules / or / not / query / fns / planner / planner-temporal / ir / time-variance / attribute-refs) | Planner | **354 / 1824 / 0 failures** |
| Datahike CLJS Node tests (`bb node-cljs-test`) | Planner | **7 / 55 / 0 failures** |
| Jobtech `:base` suite | Planner | **36 / 248 / 0 failures** (was 12 failures / 6 unique tests on `main`) |
| eures-style query on full taxonomy | Planner | **84 ms** (was 90 s timeout on `main`) |

## Fixes by class

### Correctness fixes (jobtech regressions, all also reproducible on `main`)
1. `54ac9717` — `get-else` attribute keyword wasn't being resolved to its eid in `:attribute-refs?` mode.
2. `ab37b307` — optional merge dropped on temporal DBs (AsOfDB / SinceDB / HistoricalDB).
3. `4dfe9422` — optional merge dropped on the legacy `execute-plan` fallback (multi-group / standalone).
4. `2de2c1c6` — rule-body data patterns nested inside compound forms (`(or-join …)`, `(and …)`, `(not …)`) didn't get their attr keywords resolved. Fixes 3 jobtech changelog tests; symptom was 0 events instead of 2-5.
5. `8d3ad6ad` — pushed-down predicates dropped in entity-group temporal fallback (planner consumes the `:predicate` clause and stashes it on the scan-op's `:pushdown-preds`; `lookup-batch-search` ignored that field). Fixes ordering of changelog/daynote events with `[(<= ?from-ts ?inst)]` filters.
6. `c8a11a0e` — LOptionalScan reordered before its entity-var binders (the cost-based reorderer treated it as a regular pattern-scan; at runtime `bind-by-fn(get-else)` with `?e` still free produced a tuple where `?e` itself was bound to nil, poisoning the rest of the plan with all-nil tuples). Fixes 2 jobtech daynotes tests.
7. `f0470918` — `Long/MAX_VALUE` snuck into two places I introduced as a 'comes last' sentinel for `:source-idx` ordering. CLJS doesn't have it; replaced with the standard `#?(:clj :cljs)` reader-conditional + nil-guard. Restores 6 of 7 CLJS Node tests that the source-idx work had broken.

### Performance fixes
8. `701582f3` / `16e94230` / `ef54ae22` — bound-aware pattern cardinality estimation: `estimate-pattern-with-bindings` factors in upstream-bound free-var cardinalities, plan ops expose `:output-var-cards`, and per-LP-node bvc derivation propagates these so scan-vs-merge selection inside an entity-group reflects actual upstream constraints.
9. `ec1396b2` — entity-group legacy fallback was building a cartesian substitution from independent rels (e.g. `?from-id`-rel × `?relation-type`-rel × scan-rel). Fixed by trimming ctx to scan-connected rels for each merge clause and re-joining via `collapse-rels`. This is what unlocked the eures 90 s → 84 ms.
10. `59a2ac14` — source-order directional bound-var-cards propagation: thread bvc forward in `classified` order so a clause's bvc reflects vars *bound by preceding clauses*, not just any sibling. Avoids the over-binding regression where a rule-call was treated as already having its outputs available because a downstream pattern referenced them.

### Cleanup / hardening
11. `b84358ef` — regression tests for the rule-body and pushdown-pred bugs (HistoricalDB, attribute-refs).
12. `61b15f4e` — central `op-required-vars` function: single source of truth for per-op-type binding contracts. `op-cost` now delegates. Fixes the `:external-engine` solver-vs-filter asymmetry by reading `:input-vars` from each engine's `:datahike/external-engine` metadata (Stratum's three engines all already declare `:all-bound`; the planner just wasn't reading it).
13. `6cb5c942` — formatting.

## Architectural note

The cost-based reorderer in `order-plan-ops` partitions ops into 'groups' (DP-ordered by cardinality) and 'non-groups' (cost-interleaved). Each op type's runtime dependencies were previously encoded ad-hoc inside `op-cost`'s case clauses, which had drifted (the c8a11a0e and 61b15f4e fixes were both surface symptoms of this). After 61b15f4e, the contracts are declarative in `op-required-vars` and the partition is structurally redundant — a single dependency-aware ordering pass could replace it. Tracked as a follow-up; out of scope for this PR.

## Test plan
- [x] `clojure -M:test -m kaocha.runner` (focused on planner / rules / or / not / query / fns / planner-temporal / planner / ir / time-variance / attribute-refs)
- [x] `bb node-cljs-test`
- [x] jobtech `:base` test suite with `DATAHIKE_QUERY_PLANNER=true`
- [x] Eures full-taxonomy query (manual, 84 ms ≪ 90 s baseline)
- [ ] CI green