### PR TITLE
fix(query/planner): OR(-JOIN) bind contract uses per-branch produced-vars

### DIFF
--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -312,6 +312,38 @@
         ;; this clause." The execution path itself is reordered later by
         ;; order-plan-ops based on actual cost, independent of this.
         node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db) nodes))
+        ;; Per-node BINDING vars — the free vars a node binds for
+        ;; downstream consumption. Distinct from output-cards (which
+        ;; carries numeric cardinality estimates and is restricted to
+        ;; scan nodes to avoid the sibling-pattern-bound regression
+        ;; called out in the extend-bvc comment block in plan.cljc).
+        ;; Bindedness is the contract that the post-ordering NOT
+        ;; validation and op-required-vars runnability checks rely
+        ;; on; without it, an or-join branch whose :not references a
+        ;; var bound by an outer get-else / function clause is
+        ;; rejected with `Insufficient bindings` even though the var
+        ;; is bound at execute time. We add bindings as ::in-scope
+        ;; sentinels — estimate-pattern-with-bindings' card-of treats
+        ;; non-numeric entries as "bound but unknown card", so this
+        ;; doesn't perturb cardinality estimation.
+        node-binding-vars (fn [^datahike.query.ir.LogicalPlan _logical n]
+                            (cond
+                              (ir/scan? n)
+                              (filter analyze/free-var? (:vars (scan->classified n)))
+                              (instance? datahike.query.ir.LBind n)
+                              (analyze/extract-vars (.-binding ^datahike.query.ir.LBind n))
+                              (instance? datahike.query.ir.LEntityJoin n)
+                              (let [scans (concat (.-scans ^datahike.query.ir.LEntityJoin n) [])]
+                                (mapcat (fn [s] (filter analyze/free-var? (:vars (scan->classified s))))
+                                        scans))
+                              (instance? datahike.query.ir.LUnion n)
+                              (let [jv (.-join_vars ^datahike.query.ir.LUnion n)]
+                                (when jv (vec jv)))
+                              (instance? datahike.query.ir.LRuleCall n)
+                              (let [args (.-call_args ^datahike.query.ir.LRuleCall n)]
+                                (filter analyze/free-var? args))
+                              :else nil))
+        node->binding-vars (zipmap nodes (map #(node-binding-vars logical-plan %) nodes))
         ;; Nodes without :source-idx (AND-flattened sub-plans, etc.) are
         ;; treated as "comes last" via a sentinel beyond any real index.
         ;; #?(:clj Long/MAX_VALUE :cljs js/Number.MAX_SAFE_INTEGER) keeps
@@ -330,7 +362,14 @@
                              (number? c) (assoc m v c)
                              :else m)))
                        acc-map outs))
-        ;; Pre-compute bvc per node from PRECEDING source-idx nodes' outputs.
+        merge-bindings (fn [acc-map vs]
+                         (reduce (fn [m v]
+                                   (if (contains? m v) m (assoc m v ::in-scope)))
+                                 acc-map
+                                 (or vs [])))
+        ;; Pre-compute bvc per node from PRECEDING source-idx nodes'
+        ;; outputs (cardinality, scan-only) and bindings (every binder
+        ;; node).
         node->bvc (into {}
                         (map (fn [n]
                                (let [my-idx (node->src-idx n)
@@ -340,9 +379,11 @@
                                                             (< oi my-idx))))
                                                    nodes)
                                      bvc (reduce (fn [acc o]
-                                                   (if-let [outs (node->output-cards o)]
-                                                     (merge-cards acc outs)
-                                                     acc))
+                                                   (cond-> acc
+                                                     (some? (node->output-cards o))
+                                                     (merge-cards (node->output-cards o))
+                                                     (seq (node->binding-vars o))
+                                                     (merge-bindings (node->binding-vars o))))
                                                  initial-bvc prior)]
                                  [n bvc])))
                         nodes)

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -1056,8 +1056,20 @@
    interleaving for dependency-constrained ops (predicates, functions, etc.).
    The DP phase finds the optimal group execution order by minimizing
    total intermediate cardinality. The greedy phase then inserts non-group
-   ops at the earliest point where their dependencies are satisfied."
-  [ops]
+   ops at the earliest point where their dependencies are satisfied.
+
+   `outer-bound-vars` (optional) seeds the local bound-vars accumulator
+   used by op-cost runnability checks. When this fn is called for a
+   nested plan (e.g. an or-join branch's sub-plan, or a :not body),
+   the outer scope's already-bound vars (or-join shared-vars,
+   ancestor-bound function outputs, …) MUST be seeded — otherwise
+   ops like `:not` whose op-required-vars contract demands those vars
+   bound will be marked unrunnable and surface as `Insufficient
+   bindings` even though they're well-formed at execute time. Top-
+   level callers (create-plan's outer scope) pass `nil` / omit and
+   we treat the outer scope as empty."
+  ([ops] (order-plan-ops ops nil))
+  ([ops outer-bound-vars]
   (let [;; LOptionalScan-derived pattern-scans (get-else with default) need
         ;; their entity var bound BEFORE they execute — at runtime the
         ;; optional path goes through bind-by-fn(get-else) which evaluates
@@ -1076,11 +1088,16 @@
         groups (filterv #(and (#{:entity-group :pattern-scan} (:op %))
                               (not (optional-scan? %))) ops)
         non-groups (filterv #(or (not (#{:entity-group :pattern-scan} (:op %)))
-                                 (optional-scan? %)) ops)]
+                                 (optional-scan? %)) ops)
+        seed-bound (cond
+                     (nil? outer-bound-vars) #{}
+                     (set? outer-bound-vars) outer-bound-vars
+                     (map? outer-bound-vars) (set (keys outer-bound-vars))
+                     :else (set outer-bound-vars))]
     (if (empty? groups)
       ;; No groups — pure greedy on non-group ops
       (loop [remaining (set ops)
-             bound-vars #{}
+             bound-vars seed-bound
              ordered []]
         (if (empty? remaining)
           ordered
@@ -1100,7 +1117,7 @@
           ;; as soon as their dependencies are satisfied
           (loop [group-q (seq ordered-groups)
                  remaining (set non-groups)
-                 bound-vars #{}
+                 bound-vars seed-bound
                  result []]
             (if (and (nil? group-q) (empty? remaining))
               result
@@ -1127,7 +1144,7 @@
                       (recur nil
                              (disj remaining chosen-op)
                              (into bound-vars (:vars chosen-op))
-                             (conj result chosen-op)))))))))))))
+                             (conj result chosen-op))))))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; OR / NOT / Rule plan ops
@@ -1397,16 +1414,37 @@
                                                 (not (some is-scc-call? body))))
                                    base-bs (filterv is-base? rn-branches)
                                    rec-bs (filterv (complement is-base?) rn-branches)
-                          ;; Head vars are bound within rule branches (from call args / accumulator).
-                          ;; Recursive rules: head-vars take their values from the accumulator
-                          ;; (one row of the recursive rel) — treat them as bound with a
-                          ;; conservative card-1 placeholder under the bound-var-cards model.
-                                   free-args (filter analyze/free-var? free-call-args)
-                                   branch-bound (cond
-                                                  (map? bound-vars)
-                                                  (into bound-vars (map (fn [v] [v 1])) free-args)
-                                                  :else
-                                                  (into bound-vars free-args))
+                          ;; Head vars are NOT pre-bound at the start of either
+                          ;; base or recursive branch bodies:
+                          ;;
+                          ;;  - Base branch: head-vars are produced by the body
+                          ;;    (a pattern binds them, a function computes them).
+                          ;;  - Recursive branch: head-vars are produced by the
+                          ;;    branch's rule-lookup op (the accumulator scan),
+                          ;;    which is itself a regular op the planner orders.
+                          ;;    Rule-lookup's outputs propagate through the
+                          ;;    bindedness tracker like any other producer.
+                          ;;
+                          ;; Earlier code added head-vars to branch-bound with a
+                          ;; conservative card-1 placeholder, intending it as a
+                          ;; cardinality hint. Under the new op-required-vars
+                          ;; contract, however, any entry in bound-vars is
+                          ;; treated as runnability-bound — so :function ops
+                          ;; that reference a head-var (e.g. `[(str ?id "/")
+                          ;; ?path]`) would appear runnable from clause-zero,
+                          ;; get cost-ordered AHEAD of the pattern that
+                          ;; actually binds the var, and produce a relation
+                          ;; missing the function's output binding. The
+                          ;; downstream rel-dedup-into! then sees a head-var
+                          ;; missing from :attrs and NPEs.
+                          ;;
+                          ;; Fix: keep branch-bound = the OUTER scope's bound
+                          ;; vars only. Cardinality estimation for patterns
+                          ;; that reference head-vars now correctly treats them
+                          ;; as free (worst-case attribute-total estimate)
+                          ;; until the body's own producer op binds them with
+                          ;; a known card.
+                                   branch-bound bound-vars
                                    base-ps (mapv (fn [b]
                                                    (let [renamed (rename-branch-vars b free-call-args seqid db)]
                                                      (create-plan db (vec renamed) branch-bound rules)))
@@ -1474,29 +1512,30 @@
           (let [seqid (gensym "r")
                 expanded (for [branch branches]
                            (rename-branch-vars branch call-args seqid db))
-                ;; Build the rule body's bound-var-cards:
-                ;;   - existing outer bound-vars/cards stay (vars truly bound from outside)
-                ;;   - synthetic safe-vars for non-var call-args get card 1 (each is a
-                ;;     single const value, bound by the [(identity X) safe-var] preamble
-                ;;     that rename-branch-vars prepends to the body)
-                ;;   - free call-args that aren't already in bound-vars are rule OUTPUTS,
-                ;;     not body inputs — do NOT add them; estimate-pattern-with-bindings
-                ;;     correctly treats them as free for selectivity.
+                ;; Body's bound-vars = outer scope's bound-vars only.
                 ;;
-                ;; This shape mirrors call-args-safe inside rename-branch-vars; we
-                ;; recompute it here to avoid leaking it across the API.
-                const-safe-vars (keep-indexed
-                                 (fn [i arg]
-                                   (when-not (analyze/free-var? arg)
-                                     (symbol (str "?__const__" i "__auto__" seqid))))
-                                 call-args)
-                ;; Tolerate both legacy set-form bound-vars and new map-form bound-var-cards.
-                rule-bound (cond
-                             (map? bound-vars)
-                             (into bound-vars (map (fn [v] [v 1])) const-safe-vars)
-                             :else
-                             (into bound-vars const-safe-vars))
-                sub-plans (mapv #(create-plan db (vec %) rule-bound rules) expanded)
+                ;; The const-safe-vars (synthetic vars wrapping non-var call-args)
+                ;; are produced by the [(identity X) safe-var] preamble that
+                ;; rename-branch-vars prepends to each branch body. They are
+                ;; NOT bound at the start of the body — they're bound by the
+                ;; identity op's execution. Pre-binding them in rule-bound
+                ;; would look like a cardinality hint (card 1, since identity
+                ;; produces a single value) but under the central op-required-
+                ;; vars contract, any entry in bound-vars is read as runnability
+                ;; -bound. A predicate `[(< ?safe 100)]` referencing a pre-
+                ;; bound safe-var would then appear runnable from clause-zero,
+                ;; cost-order ahead of the identity preamble, and run against
+                ;; an empty :rels at execute time.
+                ;;
+                ;; The card-1 cardinality hint we want for downstream
+                ;; estimation reaches subsequent clauses naturally via
+                ;; bvc-eff threading: identity is the first clause processed
+                ;; in create-plan's reduce, its function-output-var-cards
+                ;; map (?safe → 1) is folded into bvc-eff by extend-bvc, and
+                ;; every later clause sees safe-var → 1 in its planning
+                ;; environment without it leaking into the runnability
+                ;; check's seed-bound set.
+                sub-plans (mapv #(create-plan db (vec %) bound-vars rules) expanded)
                 total-est (reduce + 0 (keep (fn [p] (some :estimated-card (:ops p))) sub-plans))]
             {:op :or
              :clause (:clause clause-info)
@@ -1739,9 +1778,16 @@
          ;; Strip internal :merge-lost-preds from entity-group ops
          entity-groups (mapv #(dissoc % :merge-lost-preds) entity-groups)
 
-         ;; Step 4: Order everything together
+         ;; Step 4: Order everything together. Seed the cost-based
+         ;; runnability check with the outer scope's bound-vars so
+         ;; nested plans (or-join branches, :not bodies, …) recognise
+         ;; vars bound by their ancestors. Without the seed, an
+         ;; or-join branch that wraps a `:not` referencing a shared-var
+         ;; bound from the outer scope is rejected with `Insufficient
+         ;; bindings` — the shared-var is bound at execute time but
+         ;; the local order-plan-ops doesn't know that.
          all-ops (into (into (vec entity-groups) other-ops) remaining-nots)
-         ordered-ops (order-plan-ops all-ops)
+         ordered-ops (order-plan-ops all-ops bound-vars)
 
          ;; Step 5: Detect inter-group value joins
          group-joins (detect-inter-group-joins
@@ -1808,5 +1854,9 @@
                                  (assoc op :estimated-card (or new-est (:estimated-card op))))
                                op))
                            remaining-ops)
-        re-ordered (order-plan-ops re-estimated)]
+        ;; Seed re-ordering with bound-vars from the already-executed
+        ;; prefix: the runnability check for the remaining ops has to
+        ;; honour what's already bound or :not / :predicate / :function
+        ;; ops will be wrongly marked as Insufficient.
+        re-ordered (order-plan-ops re-estimated bound-vars)]
     (assoc plan :ops (into (vec executed-ops) re-ordered))))

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -932,6 +932,61 @@
 
 (def ^:private max-cost #?(:clj Long/MAX_VALUE :cljs (.-MAX_SAFE_INTEGER js/Number)))
 
+(declare branch-produced-vars)
+
+(defn- op-produced-vars
+  "Which free-vars an op binds when it runs (its outputs). Used by
+   `branch-produced-vars` to compute what an OR-JOIN branch contributes
+   to its result rel before limit-rel projects to join-vars.
+
+   - Pattern-scans / entity-groups produce all free-var positions of
+     their clause(s).
+   - Function / external-engine produce their :binding free-vars.
+   - Predicate, NOT, NOT-JOIN produce nothing (pure filters).
+   - OR / OR-JOIN: every branch must produce a var for it to be a
+     produced var of the OR — recurse via `branch-produced-vars` and
+     intersect across branches.
+   - Rule calls produce free call-args (the rule body fills them in).
+   - Rule-lookup produces its call-args (read from accumulator).
+   - Anything unknown produces nothing — the safe assumption."
+  [op]
+  (case (:op op)
+    (:entity-group :pattern-scan)
+    (let [scans (cons (:scan-op op) (:merge-ops op))
+          all-clauses (filter some? (cons (:clause op) (map :clause scans)))]
+      (into #{} (filter analyze/free-var?) (mapcat seq all-clauses)))
+
+    :function
+    (into #{} (filter analyze/free-var?) (analyze/extract-vars (:binding op)))
+
+    :external-engine
+    (into #{} (filter analyze/free-var?) (analyze/extract-vars (:binding op)))
+
+    (:rule-call :recursive-rule :rule-lookup)
+    (into #{} (filter analyze/free-var?) (:call-args op))
+
+    (:or :or-join)
+    ;; Vars EVERY branch produces. (See branch-produced-vars / OR-JOIN
+    ;; required-vars docstring for the full reasoning.)
+    (let [branches (:branches op)
+          per-branch (mapv branch-produced-vars branches)]
+      (if (seq per-branch)
+        (reduce clojure.set/intersection (map set per-branch))
+        #{}))
+
+    ;; :predicate, :not, :not-join, :passthrough, :maybe-pred, anything
+    ;; unknown → no produced vars.
+    #{}))
+
+(defn- branch-produced-vars
+  "Vars that an OR-JOIN branch's sub-plan produces internally — the
+   union of `op-produced-vars` over the branch's :ops. Used to compute
+   the OR(-JOIN)'s required-from-outer set."
+  [sub-plan]
+  (reduce (fn [acc op] (clojure.set/union acc (op-produced-vars op)))
+          #{}
+          (:ops sub-plan)))
+
 (defn op-required-vars
   "The set of vars that MUST be bound before `op` can execute correctly.
 
@@ -981,11 +1036,26 @@
        analysis — left for follow-up. Documented here for reference.
 
      :or, :or-join
-       Branches collectively produce join-vars; we require AT LEAST
-       ONE join-var bound so the branches have some upstream
-       constraint to filter against. Stricter ('all bound') would
-       prevent the OR from running as a producer; looser ('none')
-       would risk Cartesian fan-out from the branches.
+       For an OR(-JOIN) to produce a sound rel, every branch's
+       output (after limit-rel projects to join-vars) must contain
+       the FULL set of join-vars; otherwise the cross-branch sum-rel
+       fails with a different-attrs error. A branch's output covers
+       the join-vars produced by its own ops PLUS the join-vars
+       carried in via limited-ctx from the outer scope. So the OR's
+       binding contract is:
+         required-from-outer = join-vars - vars-EVERY-branch-produces
+       i.e. for every join-var, either every branch produces it
+       internally, or it must already be in the outer ctx. Computed
+       here from the planned sub-plans via `branch-produced-vars`,
+       which walks each branch's :ops and unions the vars its
+       producer ops bind. Policy is :all on the resulting set.
+
+       Surface symptom in jobtech: the changelog `(or-join […] …)`
+       has a NOT-only branch that binds nothing of `[?c ?tx ?tx-kind]`
+       except `?tx-kind` (via ground); under the previous :any
+       policy the planner reordered the binder pattern AFTER the
+       OR-JOIN and the NOT-only branch produced a rel without
+       `?tx`, tripping sum-rel against the other branches.
 
      :not, :not-join
        Anti-join; needs the WHOLE set of join-vars / referenced vars
@@ -1029,7 +1099,16 @@
     [(set (or (:join-vars op) (:vars op))) :all]
 
     (:or :or-join)
-    [(set (or (:join-vars op) (:vars op))) :any]
+    ;; Required-from-outer = join-vars MINUS the vars EVERY branch
+    ;; produces. Vars that only some branches produce can't be
+    ;; relied on across the union — they must come from outer ctx.
+    (let [join-vars (set (or (:join-vars op) (:vars op)))
+          per-branch (mapv branch-produced-vars (:branches op))
+          covered    (if (seq per-branch)
+                       (reduce clojure.set/intersection (map set per-branch))
+                       #{})
+          required   (clojure.set/difference join-vars covered)]
+      [required :all])
 
     ;; Unknown / passthrough — gate forever (caller must decide what to do).
     [#{} :all]))
@@ -1070,7 +1149,7 @@
    we treat the outer scope as empty."
   ([ops] (order-plan-ops ops nil))
   ([ops outer-bound-vars]
-  (let [;; LOptionalScan-derived pattern-scans (get-else with default) need
+   (let [;; LOptionalScan-derived pattern-scans (get-else with default) need
         ;; their entity var bound BEFORE they execute — at runtime the
         ;; optional path goes through bind-by-fn(get-else) which evaluates
         ;; per-row, and a row without the e-var bound emits a tuple where
@@ -1082,69 +1161,69 @@
         ;; can land before their binders. Demoting them to non-groups
         ;; routes them through the cost-based interleaver, which checks
         ;; bound-vars via op-cost and waits until the e-var is bound.
-        optional-scan? (fn [op]
-                         (and (= :pattern-scan (:op op))
-                              (:optional? op)))
-        groups (filterv #(and (#{:entity-group :pattern-scan} (:op %))
-                              (not (optional-scan? %))) ops)
-        non-groups (filterv #(or (not (#{:entity-group :pattern-scan} (:op %)))
-                                 (optional-scan? %)) ops)
-        seed-bound (cond
-                     (nil? outer-bound-vars) #{}
-                     (set? outer-bound-vars) outer-bound-vars
-                     (map? outer-bound-vars) (set (keys outer-bound-vars))
-                     :else (set outer-bound-vars))]
-    (if (empty? groups)
+         optional-scan? (fn [op]
+                          (and (= :pattern-scan (:op op))
+                               (:optional? op)))
+         groups (filterv #(and (#{:entity-group :pattern-scan} (:op %))
+                               (not (optional-scan? %))) ops)
+         non-groups (filterv #(or (not (#{:entity-group :pattern-scan} (:op %)))
+                                  (optional-scan? %)) ops)
+         seed-bound (cond
+                      (nil? outer-bound-vars) #{}
+                      (set? outer-bound-vars) outer-bound-vars
+                      (map? outer-bound-vars) (set (keys outer-bound-vars))
+                      :else (set outer-bound-vars))]
+     (if (empty? groups)
       ;; No groups — pure greedy on non-group ops
-      (loop [remaining (set ops)
-             bound-vars seed-bound
-             ordered []]
-        (if (empty? remaining)
-          ordered
-          (let [scored (map (fn [op] [op (op-cost op bound-vars)]) remaining)
-                executable (filter #(< (second %) max-cost) scored)
-                best (first (sort-by second (if (seq executable) executable scored)))
-                [chosen-op _] best]
-            (recur (disj remaining chosen-op)
-                   (into bound-vars (:vars chosen-op))
-                   (conj ordered chosen-op)))))
+       (loop [remaining (set ops)
+              bound-vars seed-bound
+              ordered []]
+         (if (empty? remaining)
+           ordered
+           (let [scored (map (fn [op] [op (op-cost op bound-vars)]) remaining)
+                 executable (filter #(< (second %) max-cost) scored)
+                 best (first (sort-by second (if (seq executable) executable scored)))
+                 [chosen-op _] best]
+             (recur (disj remaining chosen-op)
+                    (into bound-vars (:vars chosen-op))
+                    (conj ordered chosen-op)))))
       ;; DP-order groups, then greedily interleave non-group ops
-      (let [dp-order (dp-order-groups groups)
-            ordered-groups (mapv #(nth groups %) dp-order)]
-        (if (empty? non-groups)
-          ordered-groups
+       (let [dp-order (dp-order-groups groups)
+             ordered-groups (mapv #(nth groups %) dp-order)]
+         (if (empty? non-groups)
+           ordered-groups
           ;; Interleave: walk the group order, inserting non-group ops
           ;; as soon as their dependencies are satisfied
-          (loop [group-q (seq ordered-groups)
-                 remaining (set non-groups)
-                 bound-vars seed-bound
-                 result []]
-            (if (and (nil? group-q) (empty? remaining))
-              result
+           (loop [group-q (seq ordered-groups)
+                  remaining (set non-groups)
+                  bound-vars seed-bound
+                  result []]
+             (if (and (nil? group-q) (empty? remaining))
+               result
               ;; First, flush any non-group ops whose deps are now satisfied
-              (let [ready (filterv (fn [op] (< (op-cost op bound-vars) max-cost)) remaining)]
-                (if (seq ready)
+               (let [ready (filterv (fn [op] (< (op-cost op bound-vars) max-cost)) remaining)]
+                 (if (seq ready)
                   ;; Insert the cheapest ready non-group op
-                  (let [best (first (sort-by #(op-cost % bound-vars) ready))]
-                    (recur group-q
-                           (disj remaining best)
-                           (into bound-vars (:vars best))
-                           (conj result best)))
+                   (let [best (first (sort-by #(op-cost % bound-vars) ready))]
+                     (recur group-q
+                            (disj remaining best)
+                            (into bound-vars (:vars best))
+                            (conj result best)))
                   ;; No ready non-group ops — emit next group
-                  (if group-q
-                    (let [g (first group-q)]
-                      (recur (next group-q)
-                             remaining
-                             (into bound-vars (:vars g))
-                             (conj result g)))
+                   (if group-q
+                     (let [g (first group-q)]
+                       (recur (next group-q)
+                              remaining
+                              (into bound-vars (:vars g))
+                              (conj result g)))
                     ;; No more groups but remaining ops still unready — force them
-                    (let [scored (map (fn [op] [op (op-cost op bound-vars)]) remaining)
-                          best (first (sort-by second scored))
-                          [chosen-op _] best]
-                      (recur nil
-                             (disj remaining chosen-op)
-                             (into bound-vars (:vars chosen-op))
-                             (conj result chosen-op))))))))))))))
+                     (let [scored (map (fn [op] [op (op-cost op bound-vars)]) remaining)
+                           best (first (sort-by second scored))
+                           [chosen-op _] best]
+                       (recur nil
+                              (disj remaining chosen-op)
+                              (into bound-vars (:vars chosen-op))
+                              (conj result chosen-op))))))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; OR / NOT / Rule plan ops

--- a/test/datahike/test/query_ir_test.clj
+++ b/test/datahike/test/query_ir_test.clj
@@ -412,10 +412,11 @@
            (plan/op-required-vars
             {:op :not-join :vars #{'?e '?n} :join-vars #{'?e}}))))
 
-  (testing ":or / :or-join require AT LEAST one join-var bound"
-    (is (= [#{'?e '?v} :any]
+  (testing ":or / :or-join require all join-vars NOT covered by every branch"
+    ;; No :branches → no branch covers any var → all join-vars required.
+    (is (= [#{'?e '?v} :all]
            (plan/op-required-vars {:op :or :vars #{'?e '?v}})))
-    (is (= [#{'?e} :any]
+    (is (= [#{'?e} :all]
            (plan/op-required-vars
             {:op :or-join :vars #{'?e '?v} :join-vars #{'?e}})))))
 
@@ -434,11 +435,14 @@
           "function costs 1 when its inputs are bound")
       (is (= Long/MAX_VALUE (plan/op-cost op #{}))
           "no input bound → blocked"))
-    ;; or-join — :any policy: at least one join-var must be bound
+    ;; or-join — :all policy on join-vars NOT covered by every branch.
+    ;; With no :branches, no var is covered → all join-vars required.
     (let [op {:op :or-join :vars #{'?e '?v} :join-vars #{'?e '?v}
               :estimated-card 50}]
       (is (= Long/MAX_VALUE (plan/op-cost op #{}))
           "no join-var bound → blocked")
-      (is (< (plan/op-cost op #{'?e}) Long/MAX_VALUE)
-          "one join-var bound → ready under :any policy"))))
+      (is (= Long/MAX_VALUE (plan/op-cost op #{'?e}))
+          "one join-var bound but not all → still blocked under :all policy")
+      (is (< (plan/op-cost op #{'?e '?v}) Long/MAX_VALUE)
+          "all join-vars bound → ready"))))
 


### PR DESCRIPTION
## Summary
- Previous OR(-JOIN) `op-required-vars` policy (`:any`, "at least one join-var bound") let the cost-based reorderer place a binder pattern AFTER an or-join whose NOT-only branch produced a rel missing those vars. After `limit-rel` projection, sibling branches had different attr sets and `sum-rel` raised `Can't sum relations with different attrs`.
- Compute required-from-outer per-branch: `join-vars - (intersection of branch-produces)`. A join-var is "covered" only if EVERY branch produces it internally; otherwise it must come from outer ctx (`:all` policy).
- Two new helpers in `plan.cljc`: `op-produced-vars` (vars an op binds — scans, fns, rule-calls, external-engines; recurses into nested OR via branch-intersection) and `branch-produced-vars` (union over a planned branch's `:ops`).
- Surfaced by jobtech changelog queries on top of #819 (`794167fc`); that commit fixed the cardinality half of the bound-vars contract but left the binding contract on `:any`.

## Test plan
- [x] `DATAHIKE_QUERY_PLANNER=true clj -M:test -m kaocha.runner` focused on `query-test`, `query-rules-test`, `query-or-test`, `query-not-test`, `query-fns-test`, `query-planner-test`, `query-planner-temporal-test`, `query-ir-test`, `time-variance-test` → 333 tests, 1725 assertions, **0 failures**
- [x] jobtech-taxonomy-api `:base` suite (`DATAHIKE_QUERY_PLANNER=true`) → 42/260/1 — matches legacy `DATAHIKE_QUERY_PLANNER=false` baseline (1 unrelated date-fixture flake present in both)
- [x] Updated `query_ir_test.clj` unit asserts for the new policy: an OR with no `:branches` data covers nothing, so all join-vars are required (`:all`)
- [x] `clj -M:ffix` clean