### PR TITLE
feat(optimistic): add datahike.optimistic overlay primitive (experimental)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,9 @@ konserve
 konserve-sync
 persistent-sorted-set
 /.agent-shell/
+
+# Local-only tooling/scratch artefacts
+.codex
+**/.settings/
+/plugins/
+/test/integration/

--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,21 @@
         com.github.pkpkpk/cljs-cache                {:mvn/version "1.0.21"}
         org.roaringbitmap/RoaringBitmap             {:mvn/version "1.3.0"}}
 
- :paths ["src" "target/classes" "resources"]
+ ;; The published jar packs `src` + `src-kabel` + `src-hitchhiker-tree`
+ ;; (see `config.edn` `:build :clj :src-dirs`). Listing them here keeps
+ ;; `:local/root` consumers' classpath aligned with mvn-consumer's, so
+ ;; downstream code that uses `datahike.kabel.*` or
+ ;; `datahike.index.hitchhiker-tree` works the same regardless of how
+ ;; the dependency is wired. Their *runtime* deps (kabel,
+ ;; io.replikativ/hitchhiker-tree) remain in the `:test` alias — opt-in,
+ ;; same as for mvn consumers, who must declare those themselves to use
+ ;; the optional namespaces.
+ ;;
+ ;; The longer-term direction is a real split into separate artifacts
+ ;; (`datahike-kabel`, `datahike-hitchhiker-tree`) so the optional bits
+ ;; aren't on every consumer's classpath unconditionally; this layout
+ ;; is the preparation step.
+ :paths ["src" "src-kabel" "src-hitchhiker-tree" "target/classes" "resources"]
 
  :deps/prep-lib {:ensure "target/classes"
                  :alias :build

--- a/doc/README.md
+++ b/doc/README.md
@@ -67,6 +67,7 @@ For experienced users building production systems:
 - **[Compiled Query Engine](./query-engine.md)** - Fused scan execution, ORDER BY, query result cache, `d/explain` (experimental)
 - **[Secondary Indices](./secondary-indices.md)** - Full-text search, vector similarity, columnar aggregates (experimental)
 - **[Distributed Architecture](./distributed.md)** - Distributed Index Space and real-time sync with Kabel
+- **[Optimistic Overlay](./optimistic-overlay.md)** - Zero-latency UI updates over a remote writer via `d/with` (experimental)
 - **[Versioning](./versioning.md)** - Git-like branching and merging (beta)
 - **[Norms](./norms.md)** - Database migration system
 - **[Unstructured Input Support](./unstructured.md)** - Schema inference from JSON/EDN (experimental)

--- a/doc/cljs-support.md
+++ b/doc/cljs-support.md
@@ -92,6 +92,12 @@ This architecture means:
 - Updates are replicated to the client's TieredStore via konserve-sync
 - Queries run locally against the synchronized in-memory store
 
+For UIs where the round-trip latency is user-visible, see the
+[Optimistic Overlay](optimistic-overlay.md) — `datahike.optimistic`
+layers pending transactions on top of `@conn` via `d/with` so
+listeners see the change immediately, then reconcile when the writer
+confirms. Experimental.
+
 ## JavaScript API
 
 For JavaScript/TypeScript applications, Datahike provides a Promise-based API.

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -1,10 +1,9 @@
 # Optimistic Overlay (`datahike.optimistic`)
 
-**Status: Experimental** — Stable enough for client-side prototyping.
-Exercised under same-conn concurrency (concurrent `opt/transact!`s,
-interleaved direct `d/transact!`s, writer batching, Case J unique-
-collisions); not yet exercised across multiple peers writing to the
-same store over a real Kabel connection.
+**Status: Experimental** — Stable enough for client-side
+prototyping. Exercised under same-conn concurrency (concurrent
+`opt/transact!`s, interleaved direct `d/transact!`s, writer
+batching, unique-constraint collisions).
 
 ## What it does
 
@@ -54,18 +53,23 @@ but the overlay won't *invent* a merged state.
 
 ;; one-time wiring per conn
 (opt/register! conn
-  {:ttl-ms 30000                                  ;; default per-entry timeout
-   :on-conflict (fn [conflicts]                   ;; see Conflicts below
+  {:ttl-ms 30000                              ;; per-entry timeout
+   :on-conflict (fn [conflicts]               ;; toast on conflict (set-changed)
                   (toast "your edit may not save"))})
 
-;; subscribe — fires on every effective-db change with the new db
+;; pick the listener style that matches your UI:
+;;
+;; (a) re-render the world from a db value (Reagent + datascript-style,
+;;     vanilla React with state derived from @conn). Coalesced — one
+;;     fire per @conn change or overlay change:
 (opt/listen! conn ::ui
              (fn [eff-db] (rerender-ui! eff-db)))
 
-;; or, for differential UI layers (posh-style materialized views,
-;; redux-style reducers), subscribe to tx-reports instead
+;; (b) keep a materialized view in sync via deltas (posh, redux-style
+;;     reducers, re-frame subscriptions). Per-event — one fire per
+;;     logical change, with the tx-data delta to apply:
 (opt/listen-tx! conn ::ui
-                (fn [{:keys [db-before db-after tx-data origin ov-id]}]
+                (fn [{:keys [tx-data origin]}]
                   (apply-deltas-to-ui-state! tx-data)))
 
 ;; submit an optimistic write
@@ -95,29 +99,52 @@ Attach / detach the overlay state. Idempotent. `opts`:
   {:type :optimistic/timeout})`.
 - `:on-conflict` (function, optional) — `(fn [conflicts])`, fires
   when the set of conflicting entries changes. See
-  [Conflicts (Case J)](#conflicts-case-j).
+  [Conflicts](#conflicts).
 
 `unregister!` cancels in-flight entries with an
 `:optimistic/cancelled` error on their `:result`.
 
 ### `(listen! conn k f)` / `(unlisten! conn k)`
 
-Register `(fn [effective-db])` under key `k`. Fires whenever the
-overlay or `@conn` changes. The argument is the *effective* db —
-`@conn` with all applicable overlay entries layered on top.
-Conflicting entries (see Case J) are excluded from the view.
+Register `(fn [effective-db])` under key `k`. **Coalesced**: fires
+once per @conn change or overlay change with the current
+effective-db (= `@conn` with all applicable overlay entries on top;
+conflicting entries excluded from the view).
+
+For UIs that just re-render from the new db value.
 
 ### `(listen-tx! conn k f)` / `(unlisten-tx! conn k)`
 
-Register `(fn [tx-report])` under key `k`. Fires once per logical
-change with a Datahike-style tx-report carrying the delta a consumer
-should apply to their derived view. See
+Register `(fn [tx-report])` under key `k`. **Per-event**: fires once
+per logical change with a Datahike-style tx-report carrying the
+*delta* to apply to a derived view. See
 [Tx-report events](#tx-report-events).
+
+For UIs that maintain a materialized view incrementally (posh,
+redux-style reducers, etc.).
+
+`listen!` and `listen-tx!` are complementary, not alternatives:
+they answer different questions ("what's the new state?" vs "what
+deltas should I apply?") at different granularities (coalesced vs
+per-event). Pick whichever matches your UI layer; you can register
+both if some parts of your UI prefer one and others the other.
 
 ### `(on-conflict! conn k f)` / `(off-conflict! conn k)`
 
-Additional conflict listeners beyond the one registerable at
-`register!` time. Same signature, same semantics.
+Register a *set-changed* callback `(fn [conflicts])` — fires when
+the set of conflicting overlay entries gains or loses members, with
+the current vector of conflicting entries (each carrying `:ov-id`,
+`:tx-data`, `:predicted-tx-data`, `:last-conflict-error`). For UI
+patterns like "show a 'your edit may not save' toast when conflicts
+exist."
+
+This is *not* a tx-report stream — for tx-data deltas on conflict
+transitions, use `listen-tx!` and filter for the `:overlay-conflict`
+and `:overlay-resolve` origins.
+
+A single callback can also be passed via `:on-conflict` in
+`register!`; `on-conflict!` adds further callbacks under different
+keys.
 
 ### `(transact! conn tx-data opts?)`
 
@@ -205,7 +232,7 @@ writer's tx-report for `:conn-advance`).
 | `:overlay-add`      | `opt/transact!` accepted, entry added                                     | Predicted datoms from eager `d/with`                                    |
 | `:conn-advance`     | Any `d/transact!` through this conn (own *or* a direct call by other code) | The durable writer's `:tx-data`                                         |
 | `:overlay-realized` | Own entry's `:expected-max-tx` was reached; the entry was dropped         | Retracts of any *stale* predictions (EID-shift cleanup; empty when not needed) |
-| `:overlay-conflict` | Entry became un-applicable on top of current `@conn` (Case J)             | Retracts of the entry's prediction                                      |
+| `:overlay-conflict` | Entry became un-applicable on top of current `@conn`                      | Retracts of the entry's prediction                                      |
 | `:overlay-resolve`  | Previously-conflicting entry became applicable again                      | Re-adds of the entry's prediction                                       |
 | `:overlay-drop`     | Dispatch failed for a non-conflicting entry                               | Retracts of the entry's prediction                                      |
 | `:ttl`              | Entry's TTL elapsed                                                       | Retracts of the entry's prediction                                      |
@@ -388,7 +415,7 @@ For foreign `d/transact!`s on the same conn, the writer-listener
 still fires and emits `:conn-advance` — eff-db consumers see those
 durable changes — but nothing gets cached (no ov-id is involved).
 
-### Conflicts (Case J)
+### Conflicts
 
 An overlay entry can become *un-applicable* on top of `@conn` — for
 example, a concurrent peer or direct `d/transact!` commits a value
@@ -462,33 +489,18 @@ EIDs match — `retract-stale` returns empty and no
 
 ## v1 limits
 
-- **Cross-peer scenarios are unstudied.** Same-conn concurrency
-  (concurrent `opt/transact!`s, interleaved direct `d/transact!`s,
-  Case J unique-collisions, writer batching) is exercised by the
-  smoke tests. *Multiple* peers writing to the same store over a
-  real Kabel connection — where `@conn` may advance via
-  `on-db-sync!` from a write none of your dispatches knows about —
-  is structurally supported by the `:max-tx` watermark argument but
-  hasn't been put on the bench yet.
 - **`:conn-advance` only fires for writes routed through
   `d/transact!`.** The writer-listener hook is registered via
   `d/listen`, which only triggers when `d/transact!` completes (the
-  writer walks `(:listeners (meta connection))` after each successful
-  commit). Two scenarios advance `@conn` without going through that
-  path, and tx-listeners miss the delta in both:
-    - A custom `:dispatch-fn` that never calls `d/transact!` (e.g.,
-      fires off an HTTP POST against a non-Datahike server and the
-      durable state lives only on the remote side). The overlay's
-      `:overlay-add` still fires, but if `@conn` never gets the
-      durable change there's no `:conn-advance` to follow it.
-      Mitigation: route the durable write through `d/transact!`
-      somewhere — even just to mirror server state into the local
-      conn.
-    - A foreign Kabel-peer write that echoes in via `on-db-sync!`
-      and `reset!`s the atom directly. `add-watch` fires (so eff-db
-      `listen!` consumers see it), but `d/listen` does not.
-      Mitigation: none in v1; an open follow-up would emit a
-      `:conn-advance` from `on-db-sync!`.
+  writer walks `(:listeners (meta connection))` after each
+  successful commit). A custom `:dispatch-fn` that never calls
+  `d/transact!` (e.g., fires off an HTTP POST against a non-Datahike
+  server and the durable state lives only on the remote side) won't
+  produce a `:conn-advance` for that durable write. The overlay's
+  `:overlay-add` still fires, but if `@conn` never gets the durable
+  change there's no `:conn-advance` to follow it. Mitigation: route
+  the durable write through `d/transact!` somewhere — even just to
+  mirror server state into the local conn.
 - **`retract-stale` precision requires default-dispatch.** Only
   `default-dispatch` correlates writer-tx-data with `:ov-id` (it
   has both in scope when its per-call promise resolves) and caches

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -152,7 +152,9 @@ tx-report))`. For app-level RPCs, pass `:dispatch-fn` with this
 contract:
 
 - Takes no arguments.
-- Returns a **deref-able** (CLJ) or **`core.async` channel** (CLJS).
+- Returns a **`core.async` channel** (preferred; works uniformly on
+  both platforms and parks rather than blocks) or a **deref-able**
+  (CLJ only; spawns an `a/thread` to wait on).
 - On success: yields `{:reply X :max-tx N}` where `N` is the
   `:max-tx` of the durable commit your RPC produced. `X` is what
   gets put on `:result`.
@@ -161,21 +163,23 @@ contract:
   the entry drops, listeners re-fire, the error lands on `:result`.
 
 ```clojure
+(require '[clojure.core.async :as a])
+
 (opt/transact! conn tx-data
   {:dispatch-fn
    (fn []
-     (let [p (promise)]
-       (future
-         (let [report @(d/transact! conn enriched-tx-data)]
-           (deliver p {:reply  report
-                       :max-tx (:max-tx (:db-after report))})))
-       p))})
+     (let [out (a/chan 1)]
+       (a/go
+         (let [report (a/<! (d/transact! conn enriched-tx-data))]
+           (a/put! out {:reply  report
+                        :max-tx (:max-tx (:db-after report))})))
+       out))})
 ```
 
-If your dispatch yields success without `:max-tx`, the wrapper falls
-back to drop-on-resolve — same behavior as a non-streaming `d/transact`
-on the local writer, with the gap acknowledged in the *Identity
-assumption* below.
+`d/transact!` returns a `throwable-promise` which itself implements
+`core.async/ReadPort` (and `put!`s the Throwable as a value on
+failure — no re-throw), so `<!` reads the reply uniformly on both
+platforms. No extra thread, no extra promise.
 
 ## Conflicts (Case J)
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -49,6 +49,13 @@ via Datahike's `d/with` — and reconcile when the durable update lands.
 ;; with the *effective* db (overlay applied on top of @conn).
 (opt/listen! conn ::ui (fn [eff-db] (rerender-ui! eff-db)))
 
+;; or subscribe to tx-reports if you have a differential UI layer
+;; (posh-style materialized views, redux-style reducers, etc.) — see
+;; "Tx-report listeners" below.
+(opt/listen-tx! conn ::ui
+                (fn [{:keys [db-before db-after tx-data origin ov-id]}]
+                  (apply-deltas-to-ui-state! tx-data)))
+
 ;; submit an optimistic write
 (let [{:keys [ov-id result]}
       (opt/transact! conn [{:entity/uuid (random-uuid)
@@ -197,6 +204,76 @@ The dispatch is still in flight. When it resolves:
 The `:on-conflict` callback gives the UI a place to warn the user
 ("your edit may not save") *before* the server's verdict arrives —
 useful when the server response is slow.
+
+## Tx-report listeners
+
+For UI layers that maintain a materialized derived view (posh-style
+query subscriptions, redux-style reducers, anything keyed by
+`[entity attribute value]`), the eff-db listener forces a full
+recompute on every event. `listen-tx!` instead delivers Datahike-style
+**tx-reports** so the UI can apply incremental deltas:
+
+```clojure
+(opt/listen-tx! conn :my-key
+  (fn [{:keys [db-before db-after tx-data origin ov-id]}]
+    ;; tx-data is a vector of #datahike/Datom [e a v t added?]
+    (doseq [d tx-data]
+      (if (dd/datom-added d)
+        (assert-datom! ui-state [(.-e d) (.-a d) (.-v d)])
+        (retract-datom! ui-state [(.-e d) (.-a d) (.-v d)])))))
+```
+
+### Event types (`:origin`)
+
+| Origin | When it fires | `:tx-data` contains |
+|---|---|---|
+| `:overlay-add` | `opt/transact!` accepted, entry added | The predicted datoms from eager `d/with` |
+| `:conn-advance` | Any `d/transact!` through this conn (your own or a direct call) | The durable writer's `:tx-data` |
+| `:overlay-realized` | Your own write's `:expected-max-tx` was reached, entry dropped | Retracts of any *stale predictions* whose EIDs differed from the writer's (empty when EIDs matched) |
+| `:overlay-conflict` | An entry's prediction becomes un-applicable on top of current `@conn` (Case J) | Retracts of the entry's prediction |
+| `:overlay-resolve` | A previously-conflicting entry becomes applicable again | Re-adds of the entry's prediction |
+| `:overlay-drop` | Dispatch failed for a non-conflicting entry | Retracts of the entry's prediction |
+| `:ttl` | Entry's TTL elapsed | Retracts of the entry's prediction |
+
+`:ov-id` is present on entry-scoped events (`:overlay-add`,
+`:overlay-realized`, `:overlay-drop`, `:overlay-conflict`,
+`:overlay-resolve`, `:ttl`). The `:conn-advance` from the writer
+itself has no `:ov-id`.
+
+### Convergence guarantee
+
+Apply the `:tx-data` of every event in order to your derived view
+(asserting added datoms, retracting non-added ones). The result is
+**always equivalent to `:db-after`** — the consumer's incremental
+view stays in sync with `effective-db`, regardless of what happened:
+
+- happy path: `+predicted` then `+writer + retract-stale-predictions`,
+- failure: `+predicted` then `-predicted`,
+- TTL: `+predicted` then `-predicted`,
+- concurrent peer write makes us conflict: `+predicted` then
+  `-predicted`, then `+peer-writes` from `:conn-advance`,
+- concurrent peer's retraction unblocks our entry: `+peer-retract`
+  then `+predicted`.
+
+The EID-shift case (`:db.cardinality/many` with tempids; client- and
+server-assigned EIDs differ) is handled by emitting *retracts of
+stale predictions* alongside the writer's tx-data. Consumers see the
+EID swap explicitly. Keying by stable attributes (`:entity/uuid`) is
+strongly recommended.
+
+### v1 limits on tx-reports
+
+- **Custom `:dispatch-fn` that bypasses `d/transact!`** (e.g., a
+  remote HTTP POST whose echo comes in via a separate mechanism): no
+  `:conn-advance` fires for the durable write. The dispatch path's
+  `:overlay-realized` still emits stale-retract cleanup; for the
+  durable adds, route them through `d/transact!` (or a wrapper) so the
+  writer-listener fires.
+- **Foreign-peer writes via konserve-sync** (multi-peer Kabel
+  scenarios where another peer's write echoes in via `on-db-sync!` but
+  doesn't go through `d/transact!`): no `:conn-advance` fires.
+  Standard `listen!` consumers still see `effective-db` updates from
+  these writes; only `listen-tx!` consumers miss the delta.
 
 ## TTL
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -23,8 +23,8 @@ interaction path.
 The invariant is one sentence:
 
 > **An entry is visible from `transact!` return until `@conn` has
-> demonstrably reflected its effect, the dispatch failed, or the
-> entry's TTL expired.**
+> demonstrably reflected its effect, the durable transact failed,
+> or the entry's TTL expired.**
 
 See [How it works](#how-it-works) for why that holds.
 
@@ -57,20 +57,19 @@ but the overlay won't *invent* a merged state.
    :on-conflict (fn [conflicts]               ;; toast on conflict (set-changed)
                   (toast "your edit may not save"))})
 
-;; pick the listener style that matches your UI:
+;; subscribe to tx-reports — pick the granularity that fits your UI:
 ;;
-;; (a) re-render the world from a db value (Reagent + datascript-style,
-;;     vanilla React with state derived from @conn). Coalesced — one
-;;     fire per @conn change or overlay change:
+;; (a) re-render from a db value (Reagent + datascript-style, vanilla
+;;     React with state derived from @conn). Ignore :tx-data, use
+;;     :db-after directly:
 (opt/listen! conn ::ui
-             (fn [eff-db] (rerender-ui! eff-db)))
+             (fn [{:keys [db-after]}] (rerender-ui! db-after)))
 
 ;; (b) keep a materialized view in sync via deltas (posh, redux-style
-;;     reducers, re-frame subscriptions). Per-event — one fire per
-;;     logical change, with the tx-data delta to apply:
-(opt/listen-tx! conn ::ui
-                (fn [{:keys [tx-data origin]}]
-                  (apply-deltas-to-ui-state! tx-data)))
+;;     reducers, re-frame subscriptions). Use :tx-data and :origin:
+(opt/listen! conn ::ui
+             (fn [{:keys [tx-data origin]}]
+               (apply-deltas-to-ui-state! tx-data)))
 
 ;; submit an optimistic write
 (let [{:keys [ov-id result]} (opt/transact! conn [{:entity/uuid (random-uuid)
@@ -106,28 +105,14 @@ Attach / detach the overlay state. Idempotent. `opts`:
 
 ### `(listen! conn k f)` / `(unlisten! conn k)`
 
-Register `(fn [effective-db])` under key `k`. **Coalesced**: fires
-once per @conn change or overlay change with the current
-effective-db (= `@conn` with all applicable overlay entries on top;
-conflicting entries excluded from the view).
-
-For UIs that just re-render from the new db value.
-
-### `(listen-tx! conn k f)` / `(unlisten-tx! conn k)`
-
-Register `(fn [tx-report])` under key `k`. **Per-event**: fires once
-per logical change with a Datahike-style tx-report carrying the
-*delta* to apply to a derived view. See
+Register `(fn [tx-report])` under key `k`. Fires once per logical
+change to the overlay or `@conn` with a Datahike-style tx-report
+carrying the *delta* to apply to a derived view. See
 [Tx-report events](#tx-report-events).
 
-For UIs that maintain a materialized view incrementally (posh,
-redux-style reducers, etc.).
-
-`listen!` and `listen-tx!` are complementary, not alternatives:
-they answer different questions ("what's the new state?" vs "what
-deltas should I apply?") at different granularities (coalesced vs
-per-event). Pick whichever matches your UI layer; you can register
-both if some parts of your UI prefer one and others the other.
+State-snapshot consumers (Reagent, React from `@conn`) can ignore
+`:tx-data` and re-render from `:db-after`. Delta consumers
+(posh, redux-style reducers) apply `:tx-data` incrementally.
 
 ### `(on-conflict! conn k f)` / `(off-conflict! conn k)`
 
@@ -139,7 +124,7 @@ patterns like "show a 'your edit may not save' toast when conflicts
 exist."
 
 This is *not* a tx-report stream — for tx-data deltas on conflict
-transitions, use `listen-tx!` and filter for the `:overlay-conflict`
+transitions, use `listen!` and filter for the `:overlay-conflict`
 and `:overlay-resolve` origins.
 
 A single callback can also be passed via `:on-conflict` in
@@ -151,12 +136,11 @@ keys.
 Submit an optimistic write. Returns `{:ov-id uuid :result <chan>}`.
 Eagerly validates `tx-data` via `d/with` against the current
 effective-db; on validation failure throws synchronously and the
-overlay is untouched.
+overlay is untouched. Otherwise routes the durable write through
+the conn's writer (`d/transact!`) in the background.
 
 `opts`:
 
-- `:dispatch-fn` — substitute the conn's default writer with your own
-  RPC. See [The `:dispatch-fn` contract](#the-dispatch-fn-contract).
 - `:ttl-ms` — override the conn's default TTL for this call;
   `nil` to disable.
 
@@ -169,44 +153,9 @@ fields stripped — `:ov-id`, `:tx-data`, `:predicted-tx-data`,
 `:submitted-at`, `:expires-at`, `:expected-max-tx`, `:conflicting?`,
 `:last-conflict-error`.
 
-### The `:dispatch-fn` contract
-
-By default, `transact!` routes through the conn's writer (calls
-`d/transact!` internally). For app-level RPCs or server-side
-bootstrap (creating related entities, custom validation, etc.),
-pass a `:dispatch-fn`:
-
-- Takes no arguments.
-- Returns a `core.async` channel that yields a single value: either
-  `{:reply X :max-tx N}` on success — where `N` is the `:max-tx` of
-  the durable commit your RPC produced — or a `Throwable` /
-  `js/Error` on failure. A thrown exception during the call is also
-  accepted; the wrapper normalizes throw and yield-an-error onto the
-  same failure path.
-- `X` is what gets put on `:result`.
-
-```clojure
-(opt/transact! conn tx-data
-  {:dispatch-fn
-   (fn []
-     (let [out (a/chan 1)]
-       (a/go
-         (let [report (a/<! (d/transact! conn enriched-tx-data))]
-           (a/put! out {:reply  report
-                        :max-tx (:max-tx (:db-after report))})))
-       out))})
-```
-
-`d/transact!` returns a `throwable-promise` which itself implements
-`core.async/ReadPort` (and puts the Throwable as a value on failure
-— no re-throw), so `<!` works uniformly on both platforms.
-
-For tx-report consumers (`listen-tx!`) the dispatch-fn affects
-delta-event quality — see [v1 limits](#v1-limits).
-
 ## Tx-report events
 
-`listen-tx!` callbacks receive a Datahike-style tx-report:
+`listen!` callbacks receive a Datahike-style tx-report:
 
 ```clojure
 {:db-before <effective-db at the start of the event>
@@ -255,7 +204,7 @@ single responsibility:
 | Field               | Set when                                                                              | Used for                                                                                                  |
 |---------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
 | `:ov-id` (uuid)     | At `opt/transact!` submit, client-minted                                              | **Correlation key** — identifies the entry across the whole lifecycle (overlay mutations, listener events, writer-tx cache lookup). |
-| `:expected-max-tx`  | After dispatch resolves with `{:reply :max-tx N}`                                     | **Watermark** — "drop the entry when `(:max-tx @conn) >= N`."                                            |
+| `:expected-max-tx`  | After `d/transact!` resolves; equals `(:max-tx (:db-after report))`                   | **Watermark** — "drop the entry when `(:max-tx @conn) >= N`."                                            |
 | `:predicted-tx-data` | At submit, from eager `d/with`'s tx-report                                            | Datoms shipped on `:overlay-add`; the input to `retract-stale` on `:overlay-realized`.                    |
 
 `:max-tx` is the watermark; `:ov-id` is the correlation key.
@@ -272,36 +221,35 @@ USER
  │     1. eager d/with → predicted-tx-data
  │     2. append entry to overlay (with :ov-id, no :expected-max-tx yet)
  │     3. emit :overlay-add tx-report
- │     4. spawn dispatch go-block (calls default-dispatch)
+ │     4. spawn dispatch go-block (calls d/transact!)
  ▼
 WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
  │
- │  default-dispatch calls d/transact! and awaits its per-call promise
+ │  go-block awaits the per-call promise from d/transact!
  │  → writer commits (possibly batching with other in-flight transacts)
  │  → reset! @conn  ────────────────────────────────────────────────────────┐
  │                                                                          │
  │                                                                          ▼
  │                                                                 ┌──────────────────┐
  │                                                                 │ add-watch fires  │
- │                                                                 │ (drop-caught-up: │
- │                                                                 │  expected-max-tx │
- │                                                                 │  still nil →     │
- │                                                                 │  no drop;        │
- │                                                                 │  fire-listeners) │
+ │                                                                 │ on-conn-advance: │
+ │                                                                 │ - recompute      │
+ │                                                                 │   conflict set   │
+ │                                                                 │ - try-drop-and-  │
+ │                                                                 │   emit-realized  │
+ │                                                                 │   (no entry yet  │
+ │                                                                 │    has expected- │
+ │                                                                 │    max-tx, so    │
+ │                                                                 │    nothing drops)│
  │                                                                 └──────────────────┘
  │                                                                          │
  │  writer's go-block delivers per-call tx-report ──────────────────────────┤
- │  → conn-listener fires (eff-db consumers' :conn-advance event):          │
- │      • emits :conn-advance tx-report                                     │
- │      • (no caching here — see below)                                     │
+ │  → conn-listener fires :conn-advance tx-report                           │
  │                                                                          ▼
- │  → promise resolves → default-dispatch's go-block reads its
- │    own per-call tx-report (1:1 mapping; batching shares
- │    :max-tx but per-call :tx-data is distinct):
- │      • caches writer's :tx-data keyed by ov-id
- │      • puts {:reply :max-tx} on internal channel
- │
- │  → optimistic-transact's go-block resumes:
+ │  → promise resolves → go-block reads its own per-call tx-report
+ │    (1:1 mapping; batching shares :max-tx but per-call :tx-data
+ │    is distinct):
+ │      • cache writer's :tx-data keyed by ov-id
  │      • set :expected-max-tx on the entry
  │      • call try-drop-and-emit-realized!  ──────────────────┐
  │      • deliver reply on :result                            │
@@ -324,12 +272,12 @@ WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
                                             └───────────────────────────────────┘
 ```
 
-For the typical happy path (default-dispatch + matching EIDs)
-the events to a tx-report consumer are: `:overlay-add` →
-`:conn-advance` → (no `:overlay-realized` — `retract-stale` returns
-empty when prediction EIDs already match the writer's). For the
-EID-shift case (tempids), a final `:overlay-realized` cleans up the
-stale local-EID prediction.
+For the typical happy path (matching EIDs) the events to a
+`listen!` consumer are: `:overlay-add` → `:conn-advance` → (no
+`:overlay-realized` — `retract-stale` returns empty when prediction
+EIDs already match the writer's). For the EID-shift case (tempids),
+a final `:overlay-realized` cleans up the stale local-EID
+prediction.
 
 ### Soundness: `:ov-id` correlates, `:max-tx` watermarks
 
@@ -356,8 +304,9 @@ that snapshot contains every commit ≤ M, including ours.
 
 **Correlation.** Watermark alone doesn't say *which entry* belongs
 to which writer tx-report — and that matters because the writer
-can batch (see below). For correlation we use `:ov-id`, threaded
-through `:tx-meta` on the durable transact.
+can batch (see below). For correlation we use `:ov-id`, which is
+in scope inside `transact!`'s go-block when the per-call promise
+resolves.
 
 ### Correlating by `:ov-id` (handles batching)
 
@@ -369,21 +318,20 @@ callback. So **N batched transactions all report the same
 `:max-tx`** — the watermark works for all of them simultaneously,
 but it can't tell them apart.
 
-The watcher (`d/listen` hook) sees this batched aggregate semantics:
-N fires, each with its own per-tx `:tx-data` but a shared
-`:max-tx`. Keying a cache by `:max-tx` would collide.
+The `d/listen` writer-listener sees this batched aggregate
+semantics: N fires, each with its own per-tx `:tx-data` but a
+shared `:max-tx`. Keying a cache by `:max-tx` would collide.
 
 But each call to **`d/transact!` itself** returns a per-call promise
 that resolves with that specific call's tx-report — the writer
 wires each commit's per-callback channel back to the specific
-caller. So `default-dispatch` does the caching:
+caller. So `transact!`'s go-block caches per-call:
 
 ```clojure
-(a/go
-  (let [report (a/<! (d/transact! conn tx-data))]
-    ;; report is THIS call's tx-report, with its own :tx-data
-    (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
-    (put! out {:reply report :max-tx (:max-tx (:db-after report))})))
+(let [report (<?- (d/transact! conn tx-data))]
+  ;; report is THIS call's tx-report, with its own :tx-data
+  (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
+  ...)
 ```
 
 `ov-id` is in lexical scope; the per-call tx-report is what the
@@ -393,17 +341,14 @@ batching ambiguity.
 The drop+emit logic itself lives in a single helper —
 `try-drop-and-emit-realized!` — called from two trigger points:
 
-- The dispatch's own go-block, immediately after stamping
-  `:expected-max-tx`. For default-dispatch on `:self`/`:kabel`,
-  `@conn` is already past `:max-tx` at this moment (the writer's
-  `reset!` ran before our promise delivered), so the helper drops
-  here.
-- `on-conn-advance` (the `add-watch` callback), after
-  `fire-listeners!` on every `@conn` change. This covers the
-  custom-`:dispatch-fn`-with-future-`:max-tx` case, where the
-  dispatch resolves before `@conn` has caught up — the entry waits
-  in the overlay for a later commit to bump `@conn` past its
-  watermark.
+- The go-block, immediately after stamping `:expected-max-tx`. For
+  `:self`/`:kabel`, `@conn` is already past `:max-tx` at this
+  moment (the writer's `reset!` ran before our promise delivered),
+  so the helper drops here.
+- `on-conn-advance` (the `add-watch` callback) on every `@conn`
+  change. This covers any case where `@conn`'s advance happens to
+  reach an entry's watermark later — e.g. if the writer's `reset!`
+  lagged our promise.
 
 The helper uses an atomic `swap-vals!` inside `drop-caught-up!` —
 each entry is removed by exactly one swap. Both triggers can fire
@@ -412,8 +357,8 @@ after a `reset!`), but only one will see the entry "in old, not in
 new" and emit the event. No double-emit.
 
 For foreign `d/transact!`s on the same conn, the writer-listener
-still fires and emits `:conn-advance` — eff-db consumers see those
-durable changes — but nothing gets cached (no ov-id is involved).
+still fires and emits `:conn-advance` — consumers see those
+durable changes — but nothing gets cached (no `:ov-id` is involved).
 
 ### Conflicts
 
@@ -428,7 +373,7 @@ claim. When this happens:
 - It's **marked** `:conflicting? true` with `:last-conflict-error`.
 - `:on-conflict` callbacks fire whenever the set of conflicting
   entries changes.
-- A tx-report consumer gets an `:overlay-conflict` event with
+- A `listen!` consumer gets an `:overlay-conflict` event with
   retracts of the entry's prediction; the consumer's incremental
   view excludes the conflicting entry.
 
@@ -458,7 +403,7 @@ per-conn heartbeat ticks once a second and reaps expired entries:
   the late reply is silently discarded — `:result` is exactly-once-
   delivery (`compare-and-set!` on a per-entry flag). The durable
   effect, if any, still surfaces via `@conn` advancing through
-  normal sync (and a `:conn-advance` to tx-listeners).
+  normal sync (and a `:conn-advance` to listeners).
 
 Override per-conn at `register!` (`:ttl-ms 60000`, `:ttl-ms nil` to
 disable) or per call (`(opt/transact! conn data {:ttl-ms 60000})`).
@@ -477,7 +422,7 @@ happens:
   `[e a v]` isn't in the writer's tx-data — cleaning up the stale
   local-EID version.
 
-A `listen-tx!` consumer that keys by `:entity/uuid` sees this as
+A `listen!` consumer that keys by `:entity/uuid` sees this as
 "same logical entity, EID changed." A consumer keyed by EID sees
 two entities momentarily and then the local EID retracted. Use
 uuid-keyed views and you never see the flicker.
@@ -493,28 +438,11 @@ EIDs match — `retract-stale` returns empty and no
   `d/transact!`.** The writer-listener hook is registered via
   `d/listen`, which only triggers when `d/transact!` completes (the
   writer walks `(:listeners (meta connection))` after each
-  successful commit). A custom `:dispatch-fn` that never calls
-  `d/transact!` (e.g., fires off an HTTP POST against a non-Datahike
-  server and the durable state lives only on the remote side) won't
-  produce a `:conn-advance` for that durable write. The overlay's
-  `:overlay-add` still fires, but if `@conn` never gets the durable
-  change there's no `:conn-advance` to follow it. Mitigation: route
-  the durable write through `d/transact!` somewhere — even just to
-  mirror server state into the local conn.
-- **`retract-stale` precision requires default-dispatch.** Only
-  `default-dispatch` correlates writer-tx-data with `:ov-id` (it
-  has both in scope when its per-call promise resolves) and caches
-  it for later. The drop+emit path uses that cache: on hit,
-  `retract-stale` produces an empty event for matching EIDs and a
-  precise event for EID-shift; on miss, the path falls back to
-  full-negate of the prediction. A custom `:dispatch-fn` — even
-  one that internally calls `d/transact!` — doesn't share
-  `default-dispatch`'s scope, so its entries take the full-negate
-  fallback. The consumer view still converges (the unrelated
-  `:conn-advance` for the durable commit carries its own tx-data
-  on top), but the matching-EID optimization (suppressing the
-  `:overlay-realized` event entirely when nothing needs cleanup)
-  is skipped.
+  successful commit). Foreign writes that bypass `d/transact!` (a
+  direct `reset!` on `@conn` from external sync code, for example)
+  don't fire `:conn-advance`. Mitigation: route durable writes
+  through `d/transact!` somewhere — even just to mirror server
+  state into the local conn.
 - **Pending entries are not persisted.** Overlay state is in-memory;
   a page reload drops in-flight optimistic entries. Persistence
   (IndexedDB on browser, file on Node) is an open follow-up — see
@@ -523,11 +451,14 @@ EIDs match — `retract-stale` returns empty and no
   on `:result`. Two failure paths, two mental models — programmer
   errors in tx-data are categorically different from runtime server
   rejection.
-- **Listener fires twice per successful `transact!`** (once on
-  overlay-add, once when `@conn` advances with the durable datoms).
-  Both events show the correct effective db — no incorrect
-  intermediate state — but it's redundant. Consumers can dedupe by
-  comparing `:max-tx` if they care.
+- **`listen!` fires twice per successful `transact!`** (once on
+  `:overlay-add`, once on `:conn-advance` when `@conn` advances with
+  the durable datoms; plus a third on `:overlay-realized` for the
+  EID-shift case). All events show the correct effective db — no
+  incorrect intermediate state — but consumers maintaining a
+  materialized view will process each event. Stateless re-render
+  consumers can dedupe by comparing `:max-tx` of `:db-after` if they
+  care.
 
 ## See also
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -1,38 +1,51 @@
 # Optimistic Overlay (`datahike.optimistic`)
 
 **Status: Experimental** — Stable enough for client-side prototyping.
-Exercised under same-conn concurrency (concurrent `opt/transact!`s and
-interleaved direct `d/transact!`s, including the unique-collision
-Case J path); not yet exercised across multiple peers writing to the
+Exercised under same-conn concurrency (concurrent `opt/transact!`s,
+interleaved direct `d/transact!`s, writer batching, Case J unique-
+collisions); not yet exercised across multiple peers writing to the
 same store over a real Kabel connection.
 
-The `datahike.optimistic` namespace adds a thin overlay on top of a
-Datahike connection that lets UIs render a transaction's effect
-immediately, before the underlying writer has confirmed it. The
-durable update lands later; the overlay reconciles automatically.
+## What it does
 
-The primitive is small (one namespace, no wire-protocol changes) and
-works wherever Datahike runs — JVM, ClojureScript on Node, ClojureScript
-in the browser. It is most useful when the conn's writer is remote
-(e.g. the Kabel writer over a WebSocket) and the round-trip is visible
-to the user.
+A thin overlay over a Datahike connection that lets UIs render a
+transaction's effect **immediately** — locally, via `d/with` — while
+the durable writer commits in the background. When the durable
+update lands the overlay reconciles automatically; if the writer
+rejects, the optimistic effect rolls back.
 
-## Motivation
+The primitive works wherever Datahike runs (JVM, ClojureScript on
+Node, browser) and on top of any writer that conforms to Datahike's
+standard `dispatch!` protocol — `:self` (default), `:kabel`
+(WebSocket streaming), `:datahike-server` (HTTP). It's most useful
+when the writer is remote and the round-trip is on the user's
+interaction path.
 
-A write through a streaming writer like Kabel goes:
+The invariant is one sentence:
 
-1. `d/transact!` dispatches the tx to the server.
-2. Server applies the tx and replies with a tx-report.
-3. konserve-sync echoes the new `:db` key back to the client.
-4. The client's `@conn` advances; the UI re-renders.
+> **An entry is visible from `transact!` return until `@conn` has
+> demonstrably reflected its effect, the dispatch failed, or the
+> entry's TTL expired.**
 
-That whole loop is on the user's interaction path. For chat sends,
-block edits, page creation, the lag is perceptible.
+See [How it works](#how-it-works) for why that holds.
 
-The overlay lets the UI render the post-tx state at step 1 — locally,
-via Datahike's `d/with` — and reconcile when the durable update lands.
+## When to use this
 
-## Usage
+**Yes** — your UI re-renders from `@conn` (or a derived view) and the
+writer round-trip is perceptible. Chat sends, block edits, page
+creation, anywhere users see lag between click and screen update.
+The overlay shrinks the perceived latency to zero while the durable
+write proceeds in the background.
+
+**No** — your domain needs *server-authoritative* conflict
+resolution beyond what eager `d/with` validation gives you. The
+overlay is not a CRDT: optimistic writes go through your normal
+durable writer, with the writer's normal conflict semantics
+(uniqueness, schema validation, etc.). If the server rejects, you
+get the rejection through `:result` and the overlay rolls back —
+but the overlay won't *invent* a merged state.
+
+## Quick start
 
 ```clojure
 (require '[datahike.api :as d]
@@ -41,132 +54,111 @@ via Datahike's `d/with` — and reconcile when the durable update lands.
 
 ;; one-time wiring per conn
 (opt/register! conn
-  {:ttl-ms 30000                            ;; per-entry timeout, default 30s
-   :on-conflict (fn [conflicts]             ;; see "Conflicts" below
+  {:ttl-ms 30000                                  ;; default per-entry timeout
+   :on-conflict (fn [conflicts]                   ;; see Conflicts below
                   (toast "your edit may not save"))})
 
-;; subscribe — fires on overlay add, overlay drop, and @conn advance,
-;; with the *effective* db (overlay applied on top of @conn).
-(opt/listen! conn ::ui (fn [eff-db] (rerender-ui! eff-db)))
+;; subscribe — fires on every effective-db change with the new db
+(opt/listen! conn ::ui
+             (fn [eff-db] (rerender-ui! eff-db)))
 
-;; or subscribe to tx-reports if you have a differential UI layer
-;; (posh-style materialized views, redux-style reducers, etc.) — see
-;; "Tx-report listeners" below.
+;; or, for differential UI layers (posh-style materialized views,
+;; redux-style reducers), subscribe to tx-reports instead
 (opt/listen-tx! conn ::ui
                 (fn [{:keys [db-before db-after tx-data origin ov-id]}]
                   (apply-deltas-to-ui-state! tx-data)))
 
 ;; submit an optimistic write
-(let [{:keys [ov-id result]}
-      (opt/transact! conn [{:entity/uuid (random-uuid)
-                            :S.Page/title "Untitled"}])]
-  ;; result is a 1-buffer chan; takes deliver the server tx-report on
-  ;; success, or a Throwable / js/Error on failure.
+(let [{:keys [ov-id result]} (opt/transact! conn [{:entity/uuid (random-uuid)
+                                                    :S.Page/title "Untitled"}])]
+  ;; result is a 1-buffer channel yielding the server reply on success
+  ;; or a Throwable / js/Error on failure (validation, server rejection,
+  ;; TTL timeout, or unregister! while pending).
   (let [reply (<! result)]
     (when (instance? Throwable reply)
       (notify-user! "Save failed:" reply))))
 
-;; teardown when the conn is no longer needed
+;; teardown
 (opt/unlisten!  conn ::ui)
 (opt/unregister! conn)
 ```
 
-`(opt/effective-db conn)` returns the overlay-applied db value
-synchronously, useful for one-shot reads outside a listener context.
-`(opt/pending conn)` returns the current pending entries (with
-`:conflicting?` and `:last-conflict-error` flags surfaced).
+## API reference
 
-## Consistency Model
+### `(register! conn opts?)` / `(unregister! conn)`
 
-The overlay maintains one invariant:
+Attach / detach the overlay state. Idempotent. `opts`:
 
-> **An entry is visible from `transact!` return until `@conn` has
-> demonstrably reflected its effect, the dispatch failed, or the
-> entry's TTL expired.**
+- `:ttl-ms` (default `30000`; `nil` to disable) — per-entry timeout.
+  An entry whose dispatch hasn't resolved by then is dropped, with
+  a `:result` of `(ex-info "Optimistic transaction timed out"
+  {:type :optimistic/timeout})`.
+- `:on-conflict` (function, optional) — `(fn [conflicts])`, fires
+  when the set of conflicting entries changes. See
+  [Conflicts (Case J)](#conflicts-case-j).
 
-Three things make this hold against all the interference modes we've
-tested.
+`unregister!` cancels in-flight entries with an
+`:optimistic/cancelled` error on their `:result`.
 
-### 1. `max-tx` is a sound watermark
+### `(listen! conn k f)` / `(unlisten! conn k)`
 
-When the dispatch resolves successfully, the reply carries the durable
-write's `:max-tx`. The overlay stamps the entry with that value as
-`:expected-max-tx`. A `@conn` watcher drops the entry the first time
-`(:max-tx @conn) >= :expected-max-tx`.
+Register `(fn [effective-db])` under key `k`. Fires whenever the
+overlay or `@conn` changes. The argument is the *effective* db —
+`@conn` with all applicable overlay entries layered on top.
+Conflicting entries (see Case J) are excluded from the view.
 
-That's not a property of `:max-tx` as a number; it rests on three
-structural facts of Datahike:
+### `(listen-tx! conn k f)` / `(unlisten-tx! conn k)`
 
-- **Monotonic assignment.** The writer assigns `:max-tx` to each
-  commit in strictly increasing order; no two commits get the same
-  value.
-- **Snapshot completeness.** Each `:db` value the writer publishes is
-  a fully indexed, closed snapshot — the result of applying every
-  commit ≤ its own `:max-tx`. The chain of `db_N` values is totally
-  ordered, and each is a superset (in history) of all earlier ones.
-- **Atomic `@conn` update.** konserve-sync's `on-db-sync!` (kabel) and
-  the `:self` writer's commit loop both `reset!` the conn atom with a
-  fully-materialized `:db` value. There is no window where `:max-tx`
-  has advanced but the indexes haven't.
+Register `(fn [tx-report])` under key `k`. Fires once per logical
+change with a Datahike-style tx-report carrying the delta a consumer
+should apply to their derived view. See
+[Tx-report events](#tx-report-events).
 
-So when we see `(:max-tx @conn) >= M`, the local `@conn` *is* a
-snapshot `db_N` with `N >= M`, fully materialized, containing every
-commit ≤ M — including ours.
+### `(on-conflict! conn k f)` / `(off-conflict! conn k)`
 
-If our entry's datoms have since been retracted by a later commit,
-`@conn`'s current view doesn't have them, and that is the right answer
-— the overlay's job is to predict ahead, not to override the durable
-truth.
+Additional conflict listeners beyond the one registerable at
+`register!` time. Same signature, same semantics.
 
-### 2. The default writer chain already gates `@conn` advance
+### `(transact! conn tx-data opts?)`
 
-Both shipped writers wait for `@conn` to advance before returning the
-tx-report:
+Submit an optimistic write. Returns `{:ov-id uuid :result <chan>}`.
+Eagerly validates `tx-data` via `d/with` against the current
+effective-db; on validation failure throws synchronously and the
+overlay is untouched.
 
-- **`:self`** does `(reset! connection commit-db)` *before*
-  `(>! callback tx-report)` (`writer.cljc:128`).
-- **`:kabel`** registers a waiter keyed by `expected-max-tx` and only
-  resolves the dispatch once `on-sync-update!` observes `@conn` past
-  it (`kabel/writer.cljc:99-131`).
+`opts`:
 
-The overlay's watermark logic is the structural belt-and-suspenders.
-With these writers, the sync-check immediately after setting
-`:expected-max-tx` finds `@conn` already caught up and drops the entry
-right there.
+- `:dispatch-fn` — substitute the conn's default writer with your own
+  RPC. See [The `:dispatch-fn` contract](#the-dispatch-fn-contract).
+- `:ttl-ms` — override the conn's default TTL for this call;
+  `nil` to disable.
 
-### 3. Idempotent upsert covers the window
+### `(effective-db conn)` / `(pending conn)`
 
-Between `transact!` and the dispatch resolving, multiple things can
-fire the watcher (a concurrent peer write, a direct `d/transact!`, our
-own writer's commit). Each fire recomputes the effective-db by folding
-all overlay entries through `d/with` on top of `@conn`. Per the
-identity assumption (entities keyed by a stable attribute like
-`:entity/uuid`), re-applying an entry whose datoms already landed in
-`@conn` is an idempotent upsert — no double application, no flicker.
+`effective-db` returns the current effective db value (overlay
+applied on top of `@conn`) synchronously, useful outside listener
+contexts. `pending` returns current overlay entries with internal
+fields stripped — `:ov-id`, `:tx-data`, `:predicted-tx-data`,
+`:submitted-at`, `:expires-at`, `:expected-max-tx`, `:conflicting?`,
+`:last-conflict-error`.
 
-## The `:dispatch-fn` Contract
+### The `:dispatch-fn` contract
 
-By default, `transact!` routes through the conn's writer
-(`d/transact!`) and extracts `:max-tx` from `(:max-tx (:db-after
-tx-report))`. For app-level RPCs, pass `:dispatch-fn` with this
-contract:
+By default, `transact!` routes through the conn's writer (calls
+`d/transact!` internally). For app-level RPCs or server-side
+bootstrap (creating related entities, custom validation, etc.),
+pass a `:dispatch-fn`:
 
 - Takes no arguments.
-- Returns a **`core.async` channel** that yields a single value
-  (typically a `promise-chan` or the channel of an `a/go`/`a/thread`
-  block). Datahike's own `throwable-promise` returned by
-  `d/transact!` implements `ReadPort` and qualifies.
-- On success: yields `{:reply X :max-tx N}` where `N` is the
-  `:max-tx` of the durable commit your RPC produced. `X` is what
-  gets put on `:result`.
-- On failure: throws (CLJ) or yields a `Throwable` / `js/Error` on
-  the channel. The wrapper normalizes both onto the same failure
-  path — the entry drops, listeners re-fire, the error lands on
-  `:result`.
+- Returns a `core.async` channel that yields a single value: either
+  `{:reply X :max-tx N}` on success — where `N` is the `:max-tx` of
+  the durable commit your RPC produced — or a `Throwable` /
+  `js/Error` on failure. A thrown exception during the call is also
+  accepted; the wrapper normalizes throw and yield-an-error onto the
+  same failure path.
+- `X` is what gets put on `:result`.
 
 ```clojure
-(require '[clojure.core.async :as a])
-
 (opt/transact! conn tx-data
   {:dispatch-fn
    (fn []
@@ -179,213 +171,296 @@ contract:
 ```
 
 `d/transact!` returns a `throwable-promise` which itself implements
-`core.async/ReadPort` (and `put!`s the Throwable as a value on
-failure — no re-throw), so `<!` reads the reply uniformly on both
-platforms.
+`core.async/ReadPort` (and puts the Throwable as a value on failure
+— no re-throw), so `<!` works uniformly on both platforms.
 
-## Conflicts (Case J)
+For tx-report consumers (`listen-tx!`) the dispatch-fn affects
+delta-event quality — see [v1 limits](#v1-limits).
 
-A pending overlay entry can become un-applicable on top of `@conn`:
-a concurrent peer or direct `d/transact!` may have written something
-the entry's `d/with` would now reject (e.g. a `:db.unique/value`
-collision). When this happens:
+## Tx-report events
 
-- The entry stays in the overlay — we don't yet know the server's
-  verdict.
-- It is **excluded** from `effective-db` — re-applying it would throw.
-- It is **marked** `:conflicting? true` and carries
-  `:last-conflict-error`.
-- The `:on-conflict` callback (if registered) fires whenever the set
-  of conflicting entries changes.
-
-The dispatch is still in flight. When it resolves:
-
-- **Success** (the server reconciled or our timing missed): the entry
-  was actually fine. `@conn` advances with our datoms; the entry's
-  watermark drops it. The view converges.
-- **Failure** (server rejection): the conflict was real. The entry
-  drops, listeners re-fire with the rolled-back view, the throwable
-  lands on `:result`.
-
-The `:on-conflict` callback gives the UI a place to warn the user
-("your edit may not save") *before* the server's verdict arrives —
-useful when the server response is slow.
-
-## Tx-report listeners
-
-For UI layers that maintain a materialized derived view (posh-style
-query subscriptions, redux-style reducers, anything keyed by
-`[entity attribute value]`), the eff-db listener forces a full
-recompute on every event. `listen-tx!` instead delivers Datahike-style
-**tx-reports** so the UI can apply incremental deltas:
+`listen-tx!` callbacks receive a Datahike-style tx-report:
 
 ```clojure
-(opt/listen-tx! conn :my-key
-  (fn [{:keys [db-before db-after tx-data origin ov-id]}]
-    ;; tx-data is a vector of #datahike/Datom [e a v t added?]
-    (doseq [d tx-data]
-      (if (dd/datom-added d)
-        (assert-datom! ui-state [(.-e d) (.-a d) (.-v d)])
-        (retract-datom! ui-state [(.-e d) (.-a d) (.-v d)])))))
+{:db-before <effective-db at the start of the event>
+ :db-after  <effective-db at the end>
+ :tx-data   <vector of #datahike/Datom [e a v t added?]>
+ :tempids   <map; present on :overlay-add and :conn-advance>
+ :tx-meta   <map;  present on :overlay-add and :conn-advance>
+ :origin    <see below>
+ :ov-id     <uuid, present on entry-scoped origins>}
 ```
 
-### Shape compatibility with `d/transact!`
-
-The tx-report is a plain map (not a `TxReport` record), but its core
-keys (`:db-before`, `:db-after`, `:tx-data`) match Datahike's
-`TxReport` exactly — same names, same value types (the datoms in
-`:tx-data` are real `#datahike/Datom` records). On `:overlay-add` and
-`:conn-advance` events the report also carries the originating
-`:tempids` and `:tx-meta`, so a consumer that destructures
-`{:keys [db-before db-after tx-data tempids tx-meta]}` works on both
-optimistic events and Datahike's native tx-reports. On derived events
-(`:overlay-drop`, `:overlay-conflict`, `:overlay-resolve`, `:ttl`,
-`:overlay-realized`) those two keys are absent — there's no underlying
-transact to source them from.
-
-The map additionally carries `:origin` (always) and `:ov-id` (on
-entry-scoped events) so consumers can distinguish event sources.
+The core keys (`:db-before`, `:db-after`, `:tx-data`) match
+`datahike.db/TxReport` exactly — the same destructure works on both
+optimistic events and Datahike's native tx-reports. `:tempids` and
+`:tx-meta` are passed through on the two origins that have a
+real source for them (eager `d/with` for `:overlay-add`; the
+writer's tx-report for `:conn-advance`).
 
 ### Event types (`:origin`)
 
-| Origin | When it fires | `:tx-data` contains |
-|---|---|---|
-| `:overlay-add` | `opt/transact!` accepted, entry added | The predicted datoms from eager `d/with` |
-| `:conn-advance` | Any `d/transact!` through this conn (your own or a direct call) | The durable writer's `:tx-data` |
-| `:overlay-realized` | Your own write's `:expected-max-tx` was reached, entry dropped | Retracts of any *stale predictions* whose EIDs differed from the writer's (empty when EIDs matched) |
-| `:overlay-conflict` | An entry's prediction becomes un-applicable on top of current `@conn` (Case J) | Retracts of the entry's prediction |
-| `:overlay-resolve` | A previously-conflicting entry becomes applicable again | Re-adds of the entry's prediction |
-| `:overlay-drop` | Dispatch failed for a non-conflicting entry | Retracts of the entry's prediction |
-| `:ttl` | Entry's TTL elapsed | Retracts of the entry's prediction |
-
-`:ov-id` is present on entry-scoped events (`:overlay-add`,
-`:overlay-realized`, `:overlay-drop`, `:overlay-conflict`,
-`:overlay-resolve`, `:ttl`). The `:conn-advance` from the writer
-itself has no `:ov-id`.
+| Origin              | When                                                                      | `:tx-data`                                                              |
+|---------------------|---------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `:overlay-add`      | `opt/transact!` accepted, entry added                                     | Predicted datoms from eager `d/with`                                    |
+| `:conn-advance`     | Any `d/transact!` through this conn (own *or* a direct call by other code) | The durable writer's `:tx-data`                                         |
+| `:overlay-realized` | Own entry's `:expected-max-tx` was reached; the entry was dropped         | Retracts of any *stale* predictions (EID-shift cleanup; empty when not needed) |
+| `:overlay-conflict` | Entry became un-applicable on top of current `@conn` (Case J)             | Retracts of the entry's prediction                                      |
+| `:overlay-resolve`  | Previously-conflicting entry became applicable again                      | Re-adds of the entry's prediction                                       |
+| `:overlay-drop`     | Dispatch failed for a non-conflicting entry                               | Retracts of the entry's prediction                                      |
+| `:ttl`              | Entry's TTL elapsed                                                       | Retracts of the entry's prediction                                      |
 
 ### Convergence guarantee
 
-Apply the `:tx-data` of every event in order to your derived view
-(asserting added datoms, retracting non-added ones). The result is
-**always equivalent to `:db-after`** — the consumer's incremental
-view stays in sync with `effective-db`, regardless of what happened:
+Apply each event's `:tx-data` in order to your derived view
+(asserting added datoms, retracting non-added). **The result is
+always equivalent to `:db-after`.** This is the property the
+internals are designed to maintain — see
+[Soundness](#soundness-ov-id-correlates-max-tx-watermarks).
 
-- happy path: `+predicted` then `+writer + retract-stale-predictions`,
-- failure: `+predicted` then `-predicted`,
-- TTL: `+predicted` then `-predicted`,
-- concurrent peer write makes us conflict: `+predicted` then
-  `-predicted`, then `+peer-writes` from `:conn-advance`,
-- concurrent peer's retraction unblocks our entry: `+peer-retract`
-  then `+predicted`.
+## How it works
 
-The EID-shift case (`:db.cardinality/many` with tempids; client- and
-server-assigned EIDs differ) is handled by emitting *retracts of
-stale predictions* alongside the writer's tx-data. Consumers see the
-EID swap explicitly. Keying by stable attributes (`:entity/uuid`) is
-strongly recommended.
+### The three identifiers
 
-### v1 limit on tx-reports
+Each overlay entry has three distinct identifiers, each with a
+single responsibility:
 
-`:conn-advance` events fire from a `d/listen` hook on the conn,
-which only triggers when `d/transact!` completes (the writer
-walks `(:listeners (meta connection))` after each successful
-commit). Two scenarios advance `@conn` *without* going through
-that path, and tx-listeners miss the delta in both:
+| Field               | Set when                                                                              | Used for                                                                                                  |
+|---------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `:ov-id` (uuid)     | At `opt/transact!` submit, client-minted                                              | **Correlation key** — identifies the entry across the whole lifecycle (overlay mutations, listener events, writer-tx cache lookup). |
+| `:expected-max-tx`  | After dispatch resolves with `{:reply :max-tx N}`                                     | **Watermark** — "drop the entry when `(:max-tx @conn) >= N`."                                            |
+| `:predicted-tx-data` | At submit, from eager `d/with`'s tx-report                                            | Datoms shipped on `:overlay-add`; the input to `retract-stale` on `:overlay-realized`.                    |
 
-- **A custom `:dispatch-fn` that never calls `d/transact!`** — e.g.
-  fires off an HTTP POST against a non-Datahike server and the
-  durable state lives only on the remote side. The overlay's
-  `:overlay-add` and `:overlay-realized` events still fire, but the
-  consumer's incremental view loses the optimistic data on
-  `:overlay-realized` with nothing replacing it. Mitigation:
-  route the durable write through `d/transact!` somewhere — even
-  just to mirror server state into the local conn.
+`:max-tx` is the watermark; `:ov-id` is the correlation key.
+Mixing the two leads to subtle bugs under writer batching (see
+[Correlating by ov-id](#correlating-by-ov-id-handles-batching)
+below).
 
-- **A foreign Kabel-peer write** — another peer commits, and your
-  local `@conn` advances via konserve-sync's `on-db-sync!`, which
-  `reset!`s the atom directly. `add-watch` fires (so eff-db
-  `listen!` consumers see it), but `d/listen` does not, so
-  tx-listeners miss the delta. Mitigation: none in v1; an open
-  follow-up would emit a `:conn-advance` tx-report from
-  `on-db-sync!`.
+### Lifecycle of one optimistic write
 
-## TTL
+```
+USER
+ │
+ │  (opt/transact! conn [{:name "alice"}])
+ │     1. eager d/with → predicted-tx-data
+ │     2. append entry to overlay (with :ov-id, no :expected-max-tx yet)
+ │     3. emit :overlay-add tx-report
+ │     4. spawn dispatch go-block
+ ▼
+WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
+ │
+ │  default-dispatch injects {::ov-id ov-id} into tx-meta and calls d/transact!
+ │  → writer commits (possibly batching with other in-flight transacts)
+ │  → reset! @conn  ────────────────────────────────────────────────────────┐
+ │                                                                          │
+ │                                                                          ▼
+ │                                                                 ┌──────────────────┐
+ │                                                                 │ add-watch fires  │
+ │                                                                 │ (drop-caught-up: │
+ │                                                                 │  expected-max-tx │
+ │                                                                 │  still nil →     │
+ │                                                                 │  no drop;        │
+ │                                                                 │  fire-listeners) │
+ │                                                                 └──────────────────┘
+ │                                                                          │
+ │  writer's go-block delivers tx-report to the callback ──────────────────┤
+ │  → conn-listener fires (our writer-listener hook):                       │
+ │      • caches writer's :tx-data keyed by ov-id (from :tx-meta)           │
+ │      • emits :conn-advance tx-report                                     │
+ │                                                                          ▼
+ │                                                                ┌───────────────────┐
+ │  promise resolves → default-dispatch's go-block reads result   │ dispatch go-block │
+ │  → optimistic-transact's go-block resumes:                     │ resumes:          │
+ │      • set :expected-max-tx                                    │   - dropping? T   │
+ │      • dropping? = (:max-tx @conn) >= max-tx ⇒ true            │   - sync-drop     │
+ │      • sync-drop entry                                         │   - retract-stale │
+ │      • take writer-tx-cache by ov-id; compute retract-stale    │   - emit          │
+ │      • emit :overlay-realized (empty when EIDs match)          │   - deliver result│
+ │      • put reply on :result                                    └───────────────────┘
+ ▼
+:result chan yields the tx-report
+```
+
+For the typical happy path (default-dispatch + matching EIDs)
+the events to a tx-report consumer are: `:overlay-add` →
+`:conn-advance` → (no `:overlay-realized` — `retract-stale` returns
+empty when prediction EIDs already match the writer's). For the
+EID-shift case (tempids), a final `:overlay-realized` cleans up the
+stale local-EID prediction.
+
+### Soundness: `:ov-id` correlates, `:max-tx` watermarks
+
+**Watermark.** When `(:max-tx @conn) >= M` and `M` is the `:max-tx`
+the writer assigned to *our* commit, our datoms are necessarily in
+`@conn`. This is **not** a property of `:max-tx` as a number — it's
+a property of the snapshot family that `:max-tx` labels into. Three
+structural facts of Datahike make it sound:
+
+1. **Monotonic assignment.** The writer assigns `:max-tx` to each
+   commit in strictly increasing order; no two commits share a value.
+2. **Snapshot completeness.** Each `:db` value the writer publishes
+   is a closed snapshot — the result of applying every commit up to
+   and including its own `:max-tx`. The chain of `db_N` values is
+   totally ordered, each a superset (in history) of all earlier ones.
+3. **Atomic `@conn` update.** `on-db-sync!` (kabel) and the `:self`
+   writer's commit loop both `reset!` the conn atom with a fully-
+   materialized `:db` value. No window where `:max-tx` has advanced
+   but the indexes haven't caught up.
+
+So observing `(:max-tx @conn) >= M` means `@conn` *is* some `db_N`
+with `N >= M`, fully materialized — and by snapshot completeness
+that snapshot contains every commit ≤ M, including ours.
+
+**Correlation.** Watermark alone doesn't say *which entry* belongs
+to which writer tx-report — and that matters because the writer
+can batch (see below). For correlation we use `:ov-id`, threaded
+through `:tx-meta` on the durable transact.
+
+### Correlating by `:ov-id` (handles batching)
+
+Datahike's writer drains its commit-queue greedily — `writer.cljc`'s
+commit-loop polls for queued transactions and commits them as one
+batch. Inside the batch the writer overwrites each tx-report's
+`:db-after` with the batch's commit-db before delivering to the
+callback. So **N batched transactions report the same `:max-tx`** —
+the watermark works for *all* of them simultaneously, but it can't
+tell them apart.
+
+If we keyed the writer-tx cache by `:max-tx`, the N writer-listener
+calls would all write the same slot and overwrite each other; the
+sync-drop paths would read the *last* tx-data for all N entries and
+emit nonsense `retract-stale` events.
+
+`default-dispatch` injects `{::ov-id ov-id}` into the `d/transact!`
+arg-map's `:tx-meta`. The writer only augments `:tx-meta` (it adds
+`:db/commitId`) — it preserves whatever else is there. Each batched
+tx-report carries its own original `:ov-id`. The writer-listener
+extracts it, caches by ov-id, and each entry's sync-drop reads its
+own writer tx-data back. Cache collisions disappear.
+
+Foreign `d/transact!`s on the same conn (no `::ov-id` tag) still
+emit `:conn-advance` to the eff-db listeners — they just don't go
+through the cache (there's nothing to correlate).
+
+### Conflicts (Case J)
+
+An overlay entry can become *un-applicable* on top of `@conn` — for
+example, a concurrent peer or direct `d/transact!` commits a value
+that violates a `:db.unique/value` constraint our entry was about to
+claim. When this happens:
+
+- The entry stays in the overlay (we don't yet know the server's
+  verdict).
+- It's **excluded** from `effective-db` — re-applying it would throw.
+- It's **marked** `:conflicting? true` with `:last-conflict-error`.
+- `:on-conflict` callbacks fire whenever the set of conflicting
+  entries changes.
+- A tx-report consumer gets an `:overlay-conflict` event with
+  retracts of the entry's prediction; the consumer's incremental
+  view excludes the conflicting entry.
+
+The dispatch is still in flight. When it resolves:
+
+- **Success** (the conflict was transient — concurrent peer
+  retracted, etc.): the entry was fine after all. `@conn` advances
+  with our datoms; the entry's watermark drops it.
+  `retract-stale` cleans up any stale-EID prediction. A previously
+  conflicting entry that becomes applicable again first emits
+  `:overlay-resolve` (re-adding the prediction), then the
+  normal `:overlay-realized` cleanup.
+- **Failure** (the conflict was real): `:result` yields the error,
+  the entry drops; the consumer's view already reflects the
+  rollback via the earlier `:overlay-conflict` event.
+
+### TTL
 
 Each entry carries an `:expires-at` (default `now + 30000ms`). A
 per-conn heartbeat ticks once a second and reaps expired entries:
 
 - The entry's `:result` chan receives an `ex-info` tagged
   `{:type :optimistic/timeout}`.
-- The entry is dropped from the overlay and listeners re-fire.
-- If the server then *eventually* succeeds, the late reply is silently
-  discarded — `:result` is exactly-once-delivery (the `compare-and-set!`
-  on `:result-delivered?` is the gate). The durable effect surfaces
-  via `@conn` advancing through normal sync.
+- The entry is dropped from the overlay and a `:ttl` tx-report
+  fires with retracts of the prediction.
+- If the dispatch *does* eventually resolve after the TTL fired,
+  the late reply is silently discarded — `:result` is exactly-once-
+  delivery (`compare-and-set!` on a per-entry flag). The durable
+  effect, if any, still surfaces via `@conn` advancing through
+  normal sync (and a `:conn-advance` to tx-listeners).
 
-Override the default at registration (`:ttl-ms 60000`, `:ttl-ms nil`
-to disable) or per call (`(opt/transact! conn data {:ttl-ms 60000})`).
+Override per-conn at `register!` (`:ttl-ms 60000`, `:ttl-ms nil` to
+disable) or per call (`(opt/transact! conn data {:ttl-ms 60000})`).
 
-## Identity Assumption
+## Identity assumption
 
-Tempid resolution may differ between the overlay's `d/with` and the
-underlying writer (different numeric EIDs for the same logical
-entity). Applications should identify entities by a stable attribute
-— e.g. `:entity/uuid` minted client-side — rather than by EID. The
-overlay applies with one EID, the writer applies with another, both
-resolve the same `:entity/uuid` lookups, and re-application on top of
-`@conn` after echo is an idempotent upsert.
+The overlay assumes entities are identified by a **stable attribute**
+(e.g., `:entity/uuid` minted client-side), not by EID. Tempid
+resolution may differ between the overlay's `d/with` and the durable
+writer — local EID 42 might land at server EID 17. When that
+happens:
 
-## Relation to the Kabel Writer
+- `:overlay-add` ships predicted datoms with local EIDs.
+- `:conn-advance` ships writer datoms with server EIDs.
+- `:overlay-realized` ships retracts of any predicted datoms whose
+  `[e a v]` isn't in the writer's tx-data — cleaning up the stale
+  local-EID version.
 
-The overlay sits *in front of* the writer; it does not replace it.
-With a Kabel-backed conn:
+A `listen-tx!` consumer that keys by `:entity/uuid` sees this as
+"same logical entity, EID changed." A consumer keyed by EID sees
+two entities momentarily and then the local EID retracted. Use
+uuid-keyed views and you never see the flicker.
 
-```clojure
-{:store  {:backend :file :path "/data" :id #uuid "..."}
- :writer {:backend :kabel :peer-id #uuid "..." :local-peer kabel-peer}}
-```
+For non-tempid transactions (using existing EIDs or upserting via
+lookup-refs against pre-existing uuid entities), local and writer
+EIDs match — `retract-stale` returns empty and no
+`:overlay-realized` event fires.
 
-`(opt/transact! conn tx-data)` will:
+## v1 limits
 
-1. Append an overlay entry, fire listeners (UI shows the change).
-2. Dispatch via `d/transact!` → KabelWriter → server transact →
-   konserve-sync echo → `@conn` advance → KabelWriter's wait-ch
-   resolves → tx-report delivered.
-3. Stamp the entry with `:expected-max-tx` from the tx-report.
-4. Sync-check: `@conn` is already caught up (Kabel gated on it). Drop.
-5. Deliver the tx-report on `:result`.
-
-If your server side does more than a plain `d/transact` (creates
-related entities, runs custom validation, etc.), pass `:dispatch-fn`
-so the overlay is decoupled from the wire path. Remember to include
-`:max-tx` in your success shape.
-
-## V1 Limits
-
-- **Conn-bound branches are stable.** Switching a conn between
-  branches is not supported in Datahike (each branch is its own
-  conn) — so the overlay assumes a stable branch per conn for the
-  lifetime of `register!`.
-- **Writer queue durability is the writer's problem.** If the Kabel
-  WebSocket drops between dispatch and echo, the dispatch fails or
-  the entry's TTL expires. Restoring a pending queue on reconnect
-  belongs in the Kabel writer, not the overlay. Open follow-up.
 - **Cross-peer scenarios are unstudied.** Same-conn concurrency
-  (concurrent `opt/transact!`s on one conn, interleaved direct
-  `d/transact!`s, Case J unique-collision) is exercised by the smoke
-  tests. *Multiple* peers writing to the same store over a real
-  Kabel connection — where `@conn` may advance via `on-db-sync!` from
-  a write none of your dispatches knows about — is structurally
-  supported by the `:max-tx` watermark argument but hasn't been put
-  on the bench yet.
-- **No IndexedDB persistence of pending entries.** Overlay state is
-  in-memory; a page reload drops in-flight optimistic entries.
+  (concurrent `opt/transact!`s, interleaved direct `d/transact!`s,
+  Case J unique-collisions, writer batching) is exercised by the
+  smoke tests. *Multiple* peers writing to the same store over a
+  real Kabel connection — where `@conn` may advance via
+  `on-db-sync!` from a write none of your dispatches knows about —
+  is structurally supported by the `:max-tx` watermark argument but
+  hasn't been put on the bench yet.
+- **`:conn-advance` only fires for writes routed through
+  `d/transact!`.** The writer-listener hook is registered via
+  `d/listen`, which only triggers when `d/transact!` completes (the
+  writer walks `(:listeners (meta connection))` after each successful
+  commit). Two scenarios advance `@conn` without going through that
+  path, and tx-listeners miss the delta in both:
+    - A custom `:dispatch-fn` that never calls `d/transact!` (e.g.,
+      fires off an HTTP POST against a non-Datahike server and the
+      durable state lives only on the remote side). The overlay's
+      `:overlay-add` still fires, but if `@conn` never gets the
+      durable change there's no `:conn-advance` to follow it.
+      Mitigation: route the durable write through `d/transact!`
+      somewhere — even just to mirror server state into the local
+      conn.
+    - A foreign Kabel-peer write that echoes in via `on-db-sync!`
+      and `reset!`s the atom directly. `add-watch` fires (so eff-db
+      `listen!` consumers see it), but `d/listen` does not.
+      Mitigation: none in v1; an open follow-up would emit a
+      `:conn-advance` from `on-db-sync!`.
+- **Stale-prediction cleanup (`:overlay-realized`) only fires for
+  default-dispatch and for custom dispatches that route through
+  `d/transact!`.** A custom `:dispatch-fn` that bypasses `d/transact!`
+  doesn't get the `::ov-id` round-trip through `:tx-meta`, so the
+  writer-tx-cache has nothing to correlate against. The consumer's
+  incremental view still rolls back via the watcher-drop path (with
+  full-negate of the prediction) when `@conn` eventually catches up,
+  but the EID-shift refinement is skipped.
+- **Pending entries are not persisted.** Overlay state is in-memory;
+  a page reload drops in-flight optimistic entries. Persistence
+  (IndexedDB on browser, file on Node) is an open follow-up — see
+  the Kabel writer queue durability work.
 - **Eager validation throws synchronously**; server-side errors arrive
-  on the result channel. Two failure paths, two mental models —
-  programmer errors in tx-data are categorically different from
-  runtime server rejection.
+  on `:result`. Two failure paths, two mental models — programmer
+  errors in tx-data are categorically different from runtime server
+  rejection.
 - **Listener fires twice per successful `transact!`** (once on
-  overlay add, once when `@conn` advances with the durable datoms).
+  overlay-add, once when `@conn` advances with the durable datoms).
   Both events show the correct effective db — no incorrect
   intermediate state — but it's redundant. Consumers can dedupe by
   comparing `:max-tx` if they care.

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -268,22 +268,33 @@ WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
  │      • emits :conn-advance tx-report                                     │
  │      • (no caching here — see below)                                     │
  │                                                                          ▼
- │  → promise resolves → default-dispatch's go-block reads its       ┌───────────────────┐
- │    own per-call tx-report (1:1 mapping; batching shares           │ dispatch go-block │
- │    :max-tx but per-call :tx-data is distinct):                    │ resumes:          │
- │      • caches writer's :tx-data keyed by ov-id                    │   - dropping? T   │
- │      • puts {:reply :max-tx} on internal channel                  │   - sync-drop     │
- │                                                                   │     (swap-vals!,  │
- │  → optimistic-transact's go-block resumes:                        │      we-dropped?  │
- │      • set :expected-max-tx                                       │      check)       │
- │      • dropping? = (:max-tx @conn) >= max-tx ⇒ true               │   - retract-stale │
- │      • sync-drop entry via swap-vals!; if WE removed it:          │     via cache     │
- │        - take writer-tx-cache by ov-id                            │   - emit          │
- │        - compute retract-stale                                    │   - deliver result│
- │        - emit :overlay-realized (empty when EIDs match)           └───────────────────┘
- │      • put reply on :result
- ▼
-:result chan yields the tx-report
+ │  → promise resolves → default-dispatch's go-block reads its
+ │    own per-call tx-report (1:1 mapping; batching shares
+ │    :max-tx but per-call :tx-data is distinct):
+ │      • caches writer's :tx-data keyed by ov-id
+ │      • puts {:reply :max-tx} on internal channel
+ │
+ │  → optimistic-transact's go-block resumes:
+ │      • set :expected-max-tx on the entry
+ │      • call try-drop-and-emit-realized!  ──────────────────┐
+ │      • deliver reply on :result                            │
+ ▼                                                            ▼
+:result chan yields the tx-report           ┌───────────────────────────────────┐
+                                            │ try-drop-and-emit-realized!       │
+                                            │ (the single drop+emit path; the   │
+                                            │  watcher's on-conn-advance calls  │
+                                            │  it too on later @conn changes):  │
+                                            │   • drop-caught-up! atomically    │
+                                            │     removes entries whose         │
+                                            │     :expected-max-tx ≤ @conn      │
+                                            │     :max-tx, returns the entries  │
+                                            │     THIS swap actually removed    │
+                                            │   • for each dropped entry:       │
+                                            │     - take writer-tx-cache        │
+                                            │     - retract-stale (cache hit)   │
+                                            │       or negate (cache miss)      │
+                                            │     - emit :overlay-realized      │
+                                            └───────────────────────────────────┘
 ```
 
 For the typical happy path (default-dispatch + matching EIDs)
@@ -352,11 +363,26 @@ caller. So `default-dispatch` does the caching:
 promise yields. No tx-meta round-trip, no schema modification, no
 batching ambiguity.
 
-The watcher then reads the cache by `ov-id` when it drops a stale
-entry. Both paths (dispatch's sync-drop and watcher's
-`drop-caught-up!`) use atomic `swap-vals!` with a `we-dropped?`
-check so only the path that actually removed the entry emits the
-`:overlay-realized` event — no double-emit even if they race.
+The drop+emit logic itself lives in a single helper —
+`try-drop-and-emit-realized!` — called from two trigger points:
+
+- The dispatch's own go-block, immediately after stamping
+  `:expected-max-tx`. For default-dispatch on `:self`/`:kabel`,
+  `@conn` is already past `:max-tx` at this moment (the writer's
+  `reset!` ran before our promise delivered), so the helper drops
+  here.
+- `on-conn-advance` (the `add-watch` callback), after
+  `fire-listeners!` on every `@conn` change. This covers the
+  custom-`:dispatch-fn`-with-future-`:max-tx` case, where the
+  dispatch resolves before `@conn` has caught up — the entry waits
+  in the overlay for a later commit to bump `@conn` past its
+  watermark.
+
+The helper uses an atomic `swap-vals!` inside `drop-caught-up!` —
+each entry is removed by exactly one swap. Both triggers can fire
+for the same advance (e.g., when the dispatch resumes immediately
+after a `reset!`), but only one will see the entry "in old, not in
+new" and emit the event. No double-emit.
 
 For foreign `d/transact!`s on the same conn, the writer-listener
 still fires and emits `:conn-advance` — eff-db consumers see those
@@ -463,16 +489,20 @@ EIDs match — `retract-stale` returns empty and no
       `listen!` consumers see it), but `d/listen` does not.
       Mitigation: none in v1; an open follow-up would emit a
       `:conn-advance` from `on-db-sync!`.
-- **EID-shift cleanup (`:overlay-realized` with `retract-stale`)
-  only fires for default-dispatch.** Only `default-dispatch` knows
-  which `d/transact!` call corresponds to which overlay entry
-  (`ov-id` is in scope when the per-call promise resolves, so we
-  cache `:tx-data` by `ov-id` there). A custom `:dispatch-fn` —
-  even one that internally calls `d/transact!` — doesn't share that
-  scope; the writer-tx-cache has nothing to correlate against. The
-  consumer's incremental view still rolls back via the watcher-drop
-  path (full-negate of the prediction) when `@conn` catches up, but
-  the precise EID-shift refinement is skipped.
+- **`retract-stale` precision requires default-dispatch.** Only
+  `default-dispatch` correlates writer-tx-data with `:ov-id` (it
+  has both in scope when its per-call promise resolves) and caches
+  it for later. The drop+emit path uses that cache: on hit,
+  `retract-stale` produces an empty event for matching EIDs and a
+  precise event for EID-shift; on miss, the path falls back to
+  full-negate of the prediction. A custom `:dispatch-fn` — even
+  one that internally calls `d/transact!` — doesn't share
+  `default-dispatch`'s scope, so its entries take the full-negate
+  fallback. The consumer view still converges (the unrelated
+  `:conn-advance` for the durable commit carries its own tx-data
+  on top), but the matching-EID optimization (suppressing the
+  `:overlay-realized` event entirely when nothing needs cleanup)
+  is skipped.
 - **Pending entries are not persisted.** Overlay state is in-memory;
   a page reload drops in-flight optimistic entries. Persistence
   (IndexedDB on browser, file on Node) is an open follow-up — see

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -1,0 +1,172 @@
+# Optimistic Overlay (`datahike.optimistic`)
+
+**Status: Experimental** — The API may still change. Stable enough for
+client-side prototyping; not yet exercised under multi-writer or
+concurrent-peer load.
+
+The `datahike.optimistic` namespace adds a thin overlay on top of a
+Datahike connection that lets UIs render a transaction's effect
+immediately, before the underlying writer has confirmed it. When the
+write lands (or fails), listeners re-fire with the new effective
+database.
+
+The primitive is small (one namespace, no wire-protocol changes) and
+works wherever Datahike runs — JVM, ClojureScript on Node, ClojureScript
+in the browser. It is most useful when the conn's writer is remote
+(e.g. the Kabel writer over a WebSocket) and the round-trip is visible
+to the user.
+
+## Motivation
+
+A write through a streaming writer like Kabel goes:
+
+1. `d/transact!` dispatches the tx to the server.
+2. Server applies the tx and replies.
+3. `konserve-sync` echoes the new `:db` key back to the client.
+4. The client's `@conn` advances; the UI re-renders.
+
+That whole loop is on the user's interaction path. For chat sends,
+block edits, page creation, the lag is perceptible.
+
+The overlay lets the UI render the post-tx state at step 1 — locally,
+via Datahike's `d/with` — and reconcile when the durable update lands.
+
+## Usage
+
+```clojure
+(require '[datahike.api :as d]
+         '[datahike.optimistic :as opt]
+         '[clojure.core.async :refer [<!]])
+
+;; one-time wiring per conn
+(opt/register! conn)
+
+;; subscribe — fires on overlay add, overlay drop, and @conn advance,
+;; with the *effective* db (overlay applied on top of @conn)
+(opt/listen! conn ::ui (fn [eff-db]
+                         (rerender-ui! eff-db)))
+
+;; submit an optimistic write
+(let [{:keys [ov-id result]}
+      (opt/transact! conn [{:entity/uuid (random-uuid)
+                            :S.Page/title "Untitled"}])]
+  ;; result is a 1-buffer chan; takes deliver the server tx-report on
+  ;; success, or a Throwable / js/Error on failure.
+  (let [reply (<! result)]
+    (when (instance? Throwable reply)
+      (notify-user! "Save failed:" reply))))
+
+;; teardown when the conn is no longer needed
+(opt/unlisten!  conn ::ui)
+(opt/unregister! conn)
+```
+
+`(opt/effective-db conn)` returns the overlay-applied db value
+synchronously, useful for one-shot reads outside a listener context.
+`(opt/pending conn)` returns the current pending entries.
+
+## How it works
+
+Each registered conn carries an *overlay* — a vector of pending
+entries — and a set of listeners.
+
+**Append.** `transact!` first runs `d/with` on the current effective
+db. If the tx-data is malformed (schema violation, etc.), the call
+throws synchronously and nothing is added. Otherwise an entry
+`{:ov-id, :tx-data, :status :pending, :submitted-at}` is appended and
+listeners fire with the new effective db.
+
+**Effective db.** `(reduce d/db-with @conn @overlay)` — entries marked
+`:transacting?` are skipped (see below).
+
+**Dispatch.** The transact wrapper hands the tx to the writer
+(`d/transact!`) by default. A `:dispatch-fn` opt lets the caller
+substitute their own RPC (e.g. an `invoke-remote` that does
+server-side bootstrap beyond a plain Datahike transact); whatever it
+yields gets put on the `:result` channel.
+
+**Removal.** Entries are matched and removed by `:ov-id`:
+
+  - On dispatch success, `transact!` drops the entry; the conn-watcher
+    has already fired listeners with the post-write effective db.
+  - On dispatch failure, `transact!` drops the entry, fires listeners
+    (rolling back the optimistic visibility), and puts the error on
+    `:result`.
+  - `unregister!` drops every entry tied to that conn.
+
+The conn-watcher itself does not remove entries — its only job is to
+fire listeners when `@conn` advances, so UI consumers see the new
+effective db whether the advance came from our own writer or from a
+`konserve-sync` echo of someone else's write.
+
+**The `:transacting?` marker.** Just before dispatch, `transact!`
+marks the entry as `:transacting?`. The conn-watcher fires during
+`d/transact!`'s own `swap!`; without the marker, the listener would
+re-apply the entry's tx-data via `d/with` on top of a `@conn` that
+already has those datoms, briefly double-applying them. The marker
+makes `effective-db*` skip that entry while it's mid-flight.
+
+## Identity assumption
+
+Tempid resolution may differ between the overlay's `d/with` and the
+underlying transact (different numeric EIDs for the same logical
+entity). Applications should identify entities by a stable attribute
+— e.g. `:entity/uuid` minted client-side — rather than by EID.
+Overlay applies with one EID, the writer applies with another, both
+resolve the same `:entity/uuid` lookups.
+
+## Relation to the Kabel writer
+
+The overlay sits *in front of* the writer; it does not replace it.
+With a Kabel-backed conn:
+
+```clojure
+{:store  {:backend :file :path "/data" :id #uuid "..."}
+ :writer {:backend :kabel :peer-id #uuid "..." :local-peer kabel-peer}}
+```
+
+`(opt/transact! conn tx-data)` will:
+
+1. Append an overlay entry, fire listeners (UI shows the change).
+2. Dispatch via `d/transact!` → KabelWriter → server transact →
+   konserve-sync echo → `@conn` advances.
+3. Drop the entry; conn-watcher fires listeners with the durable
+   effective db.
+
+If your server side does more than a plain `d/transact` (e.g. creates
+related entities, runs custom validation), pass `:dispatch-fn` so the
+overlay is decoupled from the wire path:
+
+```clojure
+(opt/transact! conn tx-data
+               {:dispatch-fn #(my-app/create-page-rpc! page-uuid title)})
+```
+
+## Limits in v1
+
+- **Single-writer-per-conn assumption.** Overlay entry removal is
+  driven by your own `transact!` calls. Concurrent peers writing to
+  the same store are fine for sync but unstudied for the overlay's
+  reconciliation behaviour.
+- **No IndexedDB persistence of pending entries.** Overlay state is
+  in-memory; a page reload drops in-flight optimistic entries. (Linear
+  and InstantDB persist their pending queues; this can be added later.)
+- **No global rejection broadcaster.** A failed transact rejects via
+  the `:result` channel of the caller. There is no separate
+  subscription for "tell me about all failed mutations." If you have a
+  cross-cutting toast layer, wire it from the caller side for now.
+- **Listener fires twice per successful transact** (once on append,
+  once on conn advance). Both events show the correct effective db —
+  no incorrect intermediate state — but it's redundant. Consumers can
+  dedupe by comparing the `:max-tx` if they care.
+- **Eager validation throws synchronously**; server-side errors arrive
+  on the result channel. Two failure paths, two mental models — kept
+  distinct because programmer errors in tx-data are categorically
+  different from runtime server rejection.
+
+## See also
+
+- [Distributed Architecture](./distributed.md) — Kabel writer, the
+  most common reason to want this primitive.
+- [ClojureScript Support](./cljs-support.md) — backends and async
+  caveats for browser/Node.

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -1,7 +1,10 @@
 # Optimistic Overlay (`datahike.optimistic`)
 
-**Status: Experimental** — Stable enough for client-side prototyping;
-not yet exercised under multi-writer or concurrent-peer load.
+**Status: Experimental** — Stable enough for client-side prototyping.
+Exercised under same-conn concurrency (concurrent `opt/transact!`s and
+interleaved direct `d/transact!`s, including the unique-collision
+Case J path); not yet exercised across multiple peers writing to the
+same store over a real Kabel connection.
 
 The `datahike.optimistic` namespace adds a thin overlay on top of a
 Datahike connection that lets UIs render a transaction's effect
@@ -256,16 +259,25 @@ so the overlay is decoupled from the wire path. Remember to include
   WebSocket drops between dispatch and echo, the dispatch fails or
   the entry's TTL expires. Restoring a pending queue on reconnect
   belongs in the Kabel writer, not the overlay. Open follow-up.
-- **Single-writer-per-conn assumption.** Overlay entry removal is
-  driven by your own `transact!` calls and the watermark logic.
-  Multiple peers writing to the same store are fine for sync but
-  unstudied for adversarial overlay scenarios.
+- **Cross-peer scenarios are unstudied.** Same-conn concurrency
+  (concurrent `opt/transact!`s on one conn, interleaved direct
+  `d/transact!`s, Case J unique-collision) is exercised by the smoke
+  tests. *Multiple* peers writing to the same store over a real
+  Kabel connection — where `@conn` may advance via `on-db-sync!` from
+  a write none of your dispatches knows about — is structurally
+  supported by the `:max-tx` watermark argument but hasn't been put
+  on the bench yet.
 - **No IndexedDB persistence of pending entries.** Overlay state is
   in-memory; a page reload drops in-flight optimistic entries.
 - **Eager validation throws synchronously**; server-side errors arrive
   on the result channel. Two failure paths, two mental models —
   programmer errors in tx-data are categorically different from
   runtime server rejection.
+- **Listener fires twice per successful `transact!`** (once on
+  overlay add, once when `@conn` advances with the durable datoms).
+  Both events show the correct effective db — no incorrect
+  intermediate state — but it's redundant. Consumers can dedupe by
+  comparing `:max-tx` if they care.
 
 ## See also
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -245,11 +245,11 @@ USER
  │     1. eager d/with → predicted-tx-data
  │     2. append entry to overlay (with :ov-id, no :expected-max-tx yet)
  │     3. emit :overlay-add tx-report
- │     4. spawn dispatch go-block
+ │     4. spawn dispatch go-block (calls default-dispatch)
  ▼
 WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
  │
- │  default-dispatch injects {::ov-id ov-id} into tx-meta and calls d/transact!
+ │  default-dispatch calls d/transact! and awaits its per-call promise
  │  → writer commits (possibly batching with other in-flight transacts)
  │  → reset! @conn  ────────────────────────────────────────────────────────┐
  │                                                                          │
@@ -263,20 +263,25 @@ WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
  │                                                                 │  fire-listeners) │
  │                                                                 └──────────────────┘
  │                                                                          │
- │  writer's go-block delivers tx-report to the callback ───────────────────┤
- │  → conn-listener fires (our writer-listener hook):                       │
- │      • caches writer's :tx-data keyed by ov-id (from :tx-meta)           │
+ │  writer's go-block delivers per-call tx-report ──────────────────────────┤
+ │  → conn-listener fires (eff-db consumers' :conn-advance event):          │
  │      • emits :conn-advance tx-report                                     │
+ │      • (no caching here — see below)                                     │
  │                                                                          ▼
- │                                                                ┌───────────────────┐
- │  promise resolves → default-dispatch's go-block reads result   │ dispatch go-block │
- │  → optimistic-transact's go-block resumes:                     │ resumes:          │
- │      • set :expected-max-tx                                    │   - dropping? T   │
- │      • dropping? = (:max-tx @conn) >= max-tx ⇒ true            │   - sync-drop     │
- │      • sync-drop entry                                         │   - retract-stale │
- │      • take writer-tx-cache by ov-id; compute retract-stale    │   - emit          │
- │      • emit :overlay-realized (empty when EIDs match)          │   - deliver result│
- │      • put reply on :result                                    └───────────────────┘
+ │  → promise resolves → default-dispatch's go-block reads its       ┌───────────────────┐
+ │    own per-call tx-report (1:1 mapping; batching shares           │ dispatch go-block │
+ │    :max-tx but per-call :tx-data is distinct):                    │ resumes:          │
+ │      • caches writer's :tx-data keyed by ov-id                    │   - dropping? T   │
+ │      • puts {:reply :max-tx} on internal channel                  │   - sync-drop     │
+ │                                                                   │     (swap-vals!,  │
+ │  → optimistic-transact's go-block resumes:                        │      we-dropped?  │
+ │      • set :expected-max-tx                                       │      check)       │
+ │      • dropping? = (:max-tx @conn) >= max-tx ⇒ true               │   - retract-stale │
+ │      • sync-drop entry via swap-vals!; if WE removed it:          │     via cache     │
+ │        - take writer-tx-cache by ov-id                            │   - emit          │
+ │        - compute retract-stale                                    │   - deliver result│
+ │        - emit :overlay-realized (empty when EIDs match)           └───────────────────┘
+ │      • put reply on :result
  ▼
 :result chan yields the tx-report
 ```
@@ -321,26 +326,41 @@ through `:tx-meta` on the durable transact.
 Datahike's writer drains its commit-queue greedily — `writer.cljc`'s
 commit-loop polls for queued transactions and commits them as one
 batch. Inside the batch the writer overwrites each tx-report's
-`:db-after` with the batch's commit-db before delivering to the
-callback. So **N batched transactions report the same `:max-tx`** —
-the watermark works for *all* of them simultaneously, but it can't
-tell them apart.
+`:db-after` with the batch's `commit-db` before delivering to each
+callback. So **N batched transactions all report the same
+`:max-tx`** — the watermark works for all of them simultaneously,
+but it can't tell them apart.
 
-If we keyed the writer-tx cache by `:max-tx`, the N writer-listener
-calls would all write the same slot and overwrite each other; the
-sync-drop paths would read the *last* tx-data for all N entries and
-emit nonsense `retract-stale` events.
+The watcher (`d/listen` hook) sees this batched aggregate semantics:
+N fires, each with its own per-tx `:tx-data` but a shared
+`:max-tx`. Keying a cache by `:max-tx` would collide.
 
-`default-dispatch` injects `{::ov-id ov-id}` into the `d/transact!`
-arg-map's `:tx-meta`. The writer only augments `:tx-meta` (it adds
-`:db/commitId`) — it preserves whatever else is there. Each batched
-tx-report carries its own original `:ov-id`. The writer-listener
-extracts it, caches by ov-id, and each entry's sync-drop reads its
-own writer tx-data back. Cache collisions disappear.
+But each call to **`d/transact!` itself** returns a per-call promise
+that resolves with that specific call's tx-report — the writer
+wires each commit's per-callback channel back to the specific
+caller. So `default-dispatch` does the caching:
 
-Foreign `d/transact!`s on the same conn (no `::ov-id` tag) still
-emit `:conn-advance` to the eff-db listeners — they just don't go
-through the cache (there's nothing to correlate).
+```clojure
+(a/go
+  (let [report (a/<! (d/transact! conn tx-data))]
+    ;; report is THIS call's tx-report, with its own :tx-data
+    (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
+    (put! out {:reply report :max-tx (:max-tx (:db-after report))})))
+```
+
+`ov-id` is in lexical scope; the per-call tx-report is what the
+promise yields. No tx-meta round-trip, no schema modification, no
+batching ambiguity.
+
+The watcher then reads the cache by `ov-id` when it drops a stale
+entry. Both paths (dispatch's sync-drop and watcher's
+`drop-caught-up!`) use atomic `swap-vals!` with a `we-dropped?`
+check so only the path that actually removed the entry emits the
+`:overlay-realized` event — no double-emit even if they race.
+
+For foreign `d/transact!`s on the same conn, the writer-listener
+still fires and emits `:conn-advance` — eff-db consumers see those
+durable changes — but nothing gets cached (no ov-id is involved).
 
 ### Conflicts (Case J)
 
@@ -443,14 +463,16 @@ EIDs match — `retract-stale` returns empty and no
       `listen!` consumers see it), but `d/listen` does not.
       Mitigation: none in v1; an open follow-up would emit a
       `:conn-advance` from `on-db-sync!`.
-- **Stale-prediction cleanup (`:overlay-realized`) only fires for
-  default-dispatch and for custom dispatches that route through
-  `d/transact!`.** A custom `:dispatch-fn` that bypasses `d/transact!`
-  doesn't get the `::ov-id` round-trip through `:tx-meta`, so the
-  writer-tx-cache has nothing to correlate against. The consumer's
-  incremental view still rolls back via the watcher-drop path (with
-  full-negate of the prediction) when `@conn` eventually catches up,
-  but the EID-shift refinement is skipped.
+- **EID-shift cleanup (`:overlay-realized` with `retract-stale`)
+  only fires for default-dispatch.** Only `default-dispatch` knows
+  which `d/transact!` call corresponds to which overlay entry
+  (`ov-id` is in scope when the per-call promise resolves, so we
+  cache `:tx-data` by `ov-id` there). A custom `:dispatch-fn` —
+  even one that internally calls `d/transact!` — doesn't share that
+  scope; the writer-tx-cache has nothing to correlate against. The
+  consumer's incremental view still rolls back via the watcher-drop
+  path (full-negate of the prediction) when `@conn` catches up, but
+  the precise EID-shift refinement is skipped.
 - **Pending entries are not persisted.** Overlay state is in-memory;
   a page reload drops in-flight optimistic entries. Persistence
   (IndexedDB on browser, file on Node) is an open follow-up — see

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -263,7 +263,7 @@ WRITER  (the conn's `d/transact!` flow — :self / :kabel / :datahike-server)
  │                                                                 │  fire-listeners) │
  │                                                                 └──────────────────┘
  │                                                                          │
- │  writer's go-block delivers tx-report to the callback ──────────────────┤
+ │  writer's go-block delivers tx-report to the callback ───────────────────┤
  │  → conn-listener fires (our writer-listener hook):                       │
  │      • caches writer's :tx-data keyed by ov-id (from :tx-meta)           │
  │      • emits :conn-advance tx-report                                     │

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -223,6 +223,23 @@ recompute on every event. `listen-tx!` instead delivers Datahike-style
         (retract-datom! ui-state [(.-e d) (.-a d) (.-v d)])))))
 ```
 
+### Shape compatibility with `d/transact!`
+
+The tx-report is a plain map (not a `TxReport` record), but its core
+keys (`:db-before`, `:db-after`, `:tx-data`) match Datahike's
+`TxReport` exactly — same names, same value types (the datoms in
+`:tx-data` are real `#datahike/Datom` records). On `:overlay-add` and
+`:conn-advance` events the report also carries the originating
+`:tempids` and `:tx-meta`, so a consumer that destructures
+`{:keys [db-before db-after tx-data tempids tx-meta]}` works on both
+optimistic events and Datahike's native tx-reports. On derived events
+(`:overlay-drop`, `:overlay-conflict`, `:overlay-resolve`, `:ttl`,
+`:overlay-realized`) those two keys are absent — there's no underlying
+transact to source them from.
+
+The map additionally carries `:origin` (always) and `:ov-id` (on
+entry-scoped events) so consumers can distinguish event sources.
+
 ### Event types (`:origin`)
 
 | Origin | When it fires | `:tx-data` contains |

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -284,19 +284,30 @@ stale predictions* alongside the writer's tx-data. Consumers see the
 EID swap explicitly. Keying by stable attributes (`:entity/uuid`) is
 strongly recommended.
 
-### v1 limits on tx-reports
+### v1 limit on tx-reports
 
-- **Custom `:dispatch-fn` that bypasses `d/transact!`** (e.g., a
-  remote HTTP POST whose echo comes in via a separate mechanism): no
-  `:conn-advance` fires for the durable write. The dispatch path's
-  `:overlay-realized` still emits stale-retract cleanup; for the
-  durable adds, route them through `d/transact!` (or a wrapper) so the
-  writer-listener fires.
-- **Foreign-peer writes via konserve-sync** (multi-peer Kabel
-  scenarios where another peer's write echoes in via `on-db-sync!` but
-  doesn't go through `d/transact!`): no `:conn-advance` fires.
-  Standard `listen!` consumers still see `effective-db` updates from
-  these writes; only `listen-tx!` consumers miss the delta.
+`:conn-advance` events fire from a `d/listen` hook on the conn,
+which only triggers when `d/transact!` completes (the writer
+walks `(:listeners (meta connection))` after each successful
+commit). Two scenarios advance `@conn` *without* going through
+that path, and tx-listeners miss the delta in both:
+
+- **A custom `:dispatch-fn` that never calls `d/transact!`** — e.g.
+  fires off an HTTP POST against a non-Datahike server and the
+  durable state lives only on the remote side. The overlay's
+  `:overlay-add` and `:overlay-realized` events still fire, but the
+  consumer's incremental view loses the optimistic data on
+  `:overlay-realized` with nothing replacing it. Mitigation:
+  route the durable write through `d/transact!` somewhere — even
+  just to mirror server state into the local conn.
+
+- **A foreign Kabel-peer write** — another peer commits, and your
+  local `@conn` advances via konserve-sync's `on-db-sync!`, which
+  `reset!`s the atom directly. `add-watch` fires (so eff-db
+  `listen!` consumers see it), but `d/listen` does not, so
+  tx-listeners miss the delta. Mitigation: none in v1; an open
+  follow-up would emit a `:conn-advance` tx-report from
+  `on-db-sync!`.
 
 ## TTL
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -152,15 +152,17 @@ tx-report))`. For app-level RPCs, pass `:dispatch-fn` with this
 contract:
 
 - Takes no arguments.
-- Returns a **`core.async` channel** (preferred; works uniformly on
-  both platforms and parks rather than blocks) or a **deref-able**
-  (CLJ only; spawns an `a/thread` to wait on).
+- Returns a **`core.async` channel** that yields a single value
+  (typically a `promise-chan` or the channel of an `a/go`/`a/thread`
+  block). Datahike's own `throwable-promise` returned by
+  `d/transact!` implements `ReadPort` and qualifies.
 - On success: yields `{:reply X :max-tx N}` where `N` is the
   `:max-tx` of the durable commit your RPC produced. `X` is what
   gets put on `:result`.
-- On failure: throws (CLJ) or yields a `Throwable` / `js/Error`
-  (CLJS). The wrapper normalizes both onto the same failure path —
-  the entry drops, listeners re-fire, the error lands on `:result`.
+- On failure: throws (CLJ) or yields a `Throwable` / `js/Error` on
+  the channel. The wrapper normalizes both onto the same failure
+  path — the entry drops, listeners re-fire, the error lands on
+  `:result`.
 
 ```clojure
 (require '[clojure.core.async :as a])
@@ -179,7 +181,7 @@ contract:
 `d/transact!` returns a `throwable-promise` which itself implements
 `core.async/ReadPort` (and `put!`s the Throwable as a value on
 failure — no re-throw), so `<!` reads the reply uniformly on both
-platforms. No extra thread, no extra promise.
+platforms.
 
 ## Conflicts (Case J)
 

--- a/doc/optimistic-overlay.md
+++ b/doc/optimistic-overlay.md
@@ -1,14 +1,12 @@
 # Optimistic Overlay (`datahike.optimistic`)
 
-**Status: Experimental** — The API may still change. Stable enough for
-client-side prototyping; not yet exercised under multi-writer or
-concurrent-peer load.
+**Status: Experimental** — Stable enough for client-side prototyping;
+not yet exercised under multi-writer or concurrent-peer load.
 
 The `datahike.optimistic` namespace adds a thin overlay on top of a
 Datahike connection that lets UIs render a transaction's effect
-immediately, before the underlying writer has confirmed it. When the
-write lands (or fails), listeners re-fire with the new effective
-database.
+immediately, before the underlying writer has confirmed it. The
+durable update lands later; the overlay reconciles automatically.
 
 The primitive is small (one namespace, no wire-protocol changes) and
 works wherever Datahike runs — JVM, ClojureScript on Node, ClojureScript
@@ -21,8 +19,8 @@ to the user.
 A write through a streaming writer like Kabel goes:
 
 1. `d/transact!` dispatches the tx to the server.
-2. Server applies the tx and replies.
-3. `konserve-sync` echoes the new `:db` key back to the client.
+2. Server applies the tx and replies with a tx-report.
+3. konserve-sync echoes the new `:db` key back to the client.
 4. The client's `@conn` advances; the UI re-renders.
 
 That whole loop is on the user's interaction path. For chat sends,
@@ -39,12 +37,14 @@ via Datahike's `d/with` — and reconcile when the durable update lands.
          '[clojure.core.async :refer [<!]])
 
 ;; one-time wiring per conn
-(opt/register! conn)
+(opt/register! conn
+  {:ttl-ms 30000                            ;; per-entry timeout, default 30s
+   :on-conflict (fn [conflicts]             ;; see "Conflicts" below
+                  (toast "your edit may not save"))})
 
 ;; subscribe — fires on overlay add, overlay drop, and @conn advance,
-;; with the *effective* db (overlay applied on top of @conn)
-(opt/listen! conn ::ui (fn [eff-db]
-                         (rerender-ui! eff-db)))
+;; with the *effective* db (overlay applied on top of @conn).
+(opt/listen! conn ::ui (fn [eff-db] (rerender-ui! eff-db)))
 
 ;; submit an optimistic write
 (let [{:keys [ov-id result]}
@@ -63,59 +63,165 @@ via Datahike's `d/with` — and reconcile when the durable update lands.
 
 `(opt/effective-db conn)` returns the overlay-applied db value
 synchronously, useful for one-shot reads outside a listener context.
-`(opt/pending conn)` returns the current pending entries.
+`(opt/pending conn)` returns the current pending entries (with
+`:conflicting?` and `:last-conflict-error` flags surfaced).
 
-## How it works
+## Consistency Model
 
-Each registered conn carries an *overlay* — a vector of pending
-entries — and a set of listeners.
+The overlay maintains one invariant:
 
-**Append.** `transact!` first runs `d/with` on the current effective
-db. If the tx-data is malformed (schema violation, etc.), the call
-throws synchronously and nothing is added. Otherwise an entry
-`{:ov-id, :tx-data, :status :pending, :submitted-at}` is appended and
-listeners fire with the new effective db.
+> **An entry is visible from `transact!` return until `@conn` has
+> demonstrably reflected its effect, the dispatch failed, or the
+> entry's TTL expired.**
 
-**Effective db.** `(reduce d/db-with @conn @overlay)` — entries marked
-`:transacting?` are skipped (see below).
+Three things make this hold against all the interference modes we've
+tested.
 
-**Dispatch.** The transact wrapper hands the tx to the writer
-(`d/transact!`) by default. A `:dispatch-fn` opt lets the caller
-substitute their own RPC (e.g. an `invoke-remote` that does
-server-side bootstrap beyond a plain Datahike transact); whatever it
-yields gets put on the `:result` channel.
+### 1. `max-tx` is a sound watermark
 
-**Removal.** Entries are matched and removed by `:ov-id`:
+When the dispatch resolves successfully, the reply carries the durable
+write's `:max-tx`. The overlay stamps the entry with that value as
+`:expected-max-tx`. A `@conn` watcher drops the entry the first time
+`(:max-tx @conn) >= :expected-max-tx`.
 
-  - On dispatch success, `transact!` drops the entry; the conn-watcher
-    has already fired listeners with the post-write effective db.
-  - On dispatch failure, `transact!` drops the entry, fires listeners
-    (rolling back the optimistic visibility), and puts the error on
-    `:result`.
-  - `unregister!` drops every entry tied to that conn.
+That's not a property of `:max-tx` as a number; it rests on three
+structural facts of Datahike:
 
-The conn-watcher itself does not remove entries — its only job is to
-fire listeners when `@conn` advances, so UI consumers see the new
-effective db whether the advance came from our own writer or from a
-`konserve-sync` echo of someone else's write.
+- **Monotonic assignment.** The writer assigns `:max-tx` to each
+  commit in strictly increasing order; no two commits get the same
+  value.
+- **Snapshot completeness.** Each `:db` value the writer publishes is
+  a fully indexed, closed snapshot — the result of applying every
+  commit ≤ its own `:max-tx`. The chain of `db_N` values is totally
+  ordered, and each is a superset (in history) of all earlier ones.
+- **Atomic `@conn` update.** konserve-sync's `on-db-sync!` (kabel) and
+  the `:self` writer's commit loop both `reset!` the conn atom with a
+  fully-materialized `:db` value. There is no window where `:max-tx`
+  has advanced but the indexes haven't.
 
-**The `:transacting?` marker.** Just before dispatch, `transact!`
-marks the entry as `:transacting?`. The conn-watcher fires during
-`d/transact!`'s own `swap!`; without the marker, the listener would
-re-apply the entry's tx-data via `d/with` on top of a `@conn` that
-already has those datoms, briefly double-applying them. The marker
-makes `effective-db*` skip that entry while it's mid-flight.
+So when we see `(:max-tx @conn) >= M`, the local `@conn` *is* a
+snapshot `db_N` with `N >= M`, fully materialized, containing every
+commit ≤ M — including ours.
 
-## Identity assumption
+If our entry's datoms have since been retracted by a later commit,
+`@conn`'s current view doesn't have them, and that is the right answer
+— the overlay's job is to predict ahead, not to override the durable
+truth.
+
+### 2. The default writer chain already gates `@conn` advance
+
+Both shipped writers wait for `@conn` to advance before returning the
+tx-report:
+
+- **`:self`** does `(reset! connection commit-db)` *before*
+  `(>! callback tx-report)` (`writer.cljc:128`).
+- **`:kabel`** registers a waiter keyed by `expected-max-tx` and only
+  resolves the dispatch once `on-sync-update!` observes `@conn` past
+  it (`kabel/writer.cljc:99-131`).
+
+The overlay's watermark logic is the structural belt-and-suspenders.
+With these writers, the sync-check immediately after setting
+`:expected-max-tx` finds `@conn` already caught up and drops the entry
+right there.
+
+### 3. Idempotent upsert covers the window
+
+Between `transact!` and the dispatch resolving, multiple things can
+fire the watcher (a concurrent peer write, a direct `d/transact!`, our
+own writer's commit). Each fire recomputes the effective-db by folding
+all overlay entries through `d/with` on top of `@conn`. Per the
+identity assumption (entities keyed by a stable attribute like
+`:entity/uuid`), re-applying an entry whose datoms already landed in
+`@conn` is an idempotent upsert — no double application, no flicker.
+
+## The `:dispatch-fn` Contract
+
+By default, `transact!` routes through the conn's writer
+(`d/transact!`) and extracts `:max-tx` from `(:max-tx (:db-after
+tx-report))`. For app-level RPCs, pass `:dispatch-fn` with this
+contract:
+
+- Takes no arguments.
+- Returns a **deref-able** (CLJ) or **`core.async` channel** (CLJS).
+- On success: yields `{:reply X :max-tx N}` where `N` is the
+  `:max-tx` of the durable commit your RPC produced. `X` is what
+  gets put on `:result`.
+- On failure: throws (CLJ) or yields a `Throwable` / `js/Error`
+  (CLJS). The wrapper normalizes both onto the same failure path —
+  the entry drops, listeners re-fire, the error lands on `:result`.
+
+```clojure
+(opt/transact! conn tx-data
+  {:dispatch-fn
+   (fn []
+     (let [p (promise)]
+       (future
+         (let [report @(d/transact! conn enriched-tx-data)]
+           (deliver p {:reply  report
+                       :max-tx (:max-tx (:db-after report))})))
+       p))})
+```
+
+If your dispatch yields success without `:max-tx`, the wrapper falls
+back to drop-on-resolve — same behavior as a non-streaming `d/transact`
+on the local writer, with the gap acknowledged in the *Identity
+assumption* below.
+
+## Conflicts (Case J)
+
+A pending overlay entry can become un-applicable on top of `@conn`:
+a concurrent peer or direct `d/transact!` may have written something
+the entry's `d/with` would now reject (e.g. a `:db.unique/value`
+collision). When this happens:
+
+- The entry stays in the overlay — we don't yet know the server's
+  verdict.
+- It is **excluded** from `effective-db` — re-applying it would throw.
+- It is **marked** `:conflicting? true` and carries
+  `:last-conflict-error`.
+- The `:on-conflict` callback (if registered) fires whenever the set
+  of conflicting entries changes.
+
+The dispatch is still in flight. When it resolves:
+
+- **Success** (the server reconciled or our timing missed): the entry
+  was actually fine. `@conn` advances with our datoms; the entry's
+  watermark drops it. The view converges.
+- **Failure** (server rejection): the conflict was real. The entry
+  drops, listeners re-fire with the rolled-back view, the throwable
+  lands on `:result`.
+
+The `:on-conflict` callback gives the UI a place to warn the user
+("your edit may not save") *before* the server's verdict arrives —
+useful when the server response is slow.
+
+## TTL
+
+Each entry carries an `:expires-at` (default `now + 30000ms`). A
+per-conn heartbeat ticks once a second and reaps expired entries:
+
+- The entry's `:result` chan receives an `ex-info` tagged
+  `{:type :optimistic/timeout}`.
+- The entry is dropped from the overlay and listeners re-fire.
+- If the server then *eventually* succeeds, the late reply is silently
+  discarded — `:result` is exactly-once-delivery (the `compare-and-set!`
+  on `:result-delivered?` is the gate). The durable effect surfaces
+  via `@conn` advancing through normal sync.
+
+Override the default at registration (`:ttl-ms 60000`, `:ttl-ms nil`
+to disable) or per call (`(opt/transact! conn data {:ttl-ms 60000})`).
+
+## Identity Assumption
 
 Tempid resolution may differ between the overlay's `d/with` and the
-underlying transact (different numeric EIDs for the same logical
+underlying writer (different numeric EIDs for the same logical
 entity). Applications should identify entities by a stable attribute
-— e.g. `:entity/uuid` minted client-side — rather than by EID.
-Overlay applies with one EID, the writer applies with another, both
-resolve the same `:entity/uuid` lookups.
+— e.g. `:entity/uuid` minted client-side — rather than by EID. The
+overlay applies with one EID, the writer applies with another, both
+resolve the same `:entity/uuid` lookups, and re-application on top of
+`@conn` after echo is an idempotent upsert.
 
-## Relation to the Kabel writer
+## Relation to the Kabel Writer
 
 The overlay sits *in front of* the writer; it does not replace it.
 With a Kabel-backed conn:
@@ -129,40 +235,37 @@ With a Kabel-backed conn:
 
 1. Append an overlay entry, fire listeners (UI shows the change).
 2. Dispatch via `d/transact!` → KabelWriter → server transact →
-   konserve-sync echo → `@conn` advances.
-3. Drop the entry; conn-watcher fires listeners with the durable
-   effective db.
+   konserve-sync echo → `@conn` advance → KabelWriter's wait-ch
+   resolves → tx-report delivered.
+3. Stamp the entry with `:expected-max-tx` from the tx-report.
+4. Sync-check: `@conn` is already caught up (Kabel gated on it). Drop.
+5. Deliver the tx-report on `:result`.
 
-If your server side does more than a plain `d/transact` (e.g. creates
-related entities, runs custom validation), pass `:dispatch-fn` so the
-overlay is decoupled from the wire path:
+If your server side does more than a plain `d/transact` (creates
+related entities, runs custom validation, etc.), pass `:dispatch-fn`
+so the overlay is decoupled from the wire path. Remember to include
+`:max-tx` in your success shape.
 
-```clojure
-(opt/transact! conn tx-data
-               {:dispatch-fn #(my-app/create-page-rpc! page-uuid title)})
-```
+## V1 Limits
 
-## Limits in v1
-
+- **Conn-bound branches are stable.** Switching a conn between
+  branches is not supported in Datahike (each branch is its own
+  conn) — so the overlay assumes a stable branch per conn for the
+  lifetime of `register!`.
+- **Writer queue durability is the writer's problem.** If the Kabel
+  WebSocket drops between dispatch and echo, the dispatch fails or
+  the entry's TTL expires. Restoring a pending queue on reconnect
+  belongs in the Kabel writer, not the overlay. Open follow-up.
 - **Single-writer-per-conn assumption.** Overlay entry removal is
-  driven by your own `transact!` calls. Concurrent peers writing to
-  the same store are fine for sync but unstudied for the overlay's
-  reconciliation behaviour.
+  driven by your own `transact!` calls and the watermark logic.
+  Multiple peers writing to the same store are fine for sync but
+  unstudied for adversarial overlay scenarios.
 - **No IndexedDB persistence of pending entries.** Overlay state is
-  in-memory; a page reload drops in-flight optimistic entries. (Linear
-  and InstantDB persist their pending queues; this can be added later.)
-- **No global rejection broadcaster.** A failed transact rejects via
-  the `:result` channel of the caller. There is no separate
-  subscription for "tell me about all failed mutations." If you have a
-  cross-cutting toast layer, wire it from the caller side for now.
-- **Listener fires twice per successful transact** (once on append,
-  once on conn advance). Both events show the correct effective db —
-  no incorrect intermediate state — but it's redundant. Consumers can
-  dedupe by comparing the `:max-tx` if they care.
+  in-memory; a page reload drops in-flight optimistic entries.
 - **Eager validation throws synchronously**; server-side errors arrive
-  on the result channel. Two failure paths, two mental models — kept
-  distinct because programmer errors in tx-data are categorically
-  different from runtime server rejection.
+  on the result channel. Two failure paths, two mental models —
+  programmer errors in tx-data are categorically different from
+  runtime server rejection.
 
 ## See also
 

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -28,6 +28,7 @@
   writer."
   (:require [datahike.api :as d]
             [datahike.datom :as dd]
+            [replikativ.logging :as log]
             #?(:clj  [clojure.core.async :as a :refer [chan put! alts! timeout close!]]
                :cljs [clojure.core.async :as a :refer [chan put! alts! timeout close!]])
             [superv.async #?(:clj :refer :cljs :refer-macros) [<?-]]))
@@ -114,6 +115,39 @@
                     (not (dd/datom-added d))))
         datoms))
 
+;; -----------------------------------------------------------------------------
+;; Writer-tx cache (max-tx → tx-data, FIFO-evicted)
+;; -----------------------------------------------------------------------------
+
+(def ^:private writer-tx-cache-max 64)
+
+(defn- cache-writer-tx!
+  [cache max-tx tx-data]
+  (when max-tx
+    (swap! cache
+           (fn [{:keys [by-tx order]}]
+             (let [by-tx (assoc by-tx max-tx tx-data)
+                   order (conj order max-tx)]
+               (if (> (count order) writer-tx-cache-max)
+                 (let [evict (peek order)]
+                   {:by-tx (dissoc by-tx evict) :order (pop order)})
+                 {:by-tx by-tx :order order}))))))
+
+(defn- take-writer-tx!
+  "Pop the cached writer tx-data for `max-tx`, removing it from the
+  cache. Returns nil if absent (e.g. for entries whose dispatch
+  bypassed `d/transact!`, in which case no writer-listener fired)."
+  [cache max-tx]
+  (when max-tx
+    (let [[old _] (swap-vals! cache
+                              (fn [{:keys [by-tx order]}]
+                                {:by-tx (dissoc by-tx max-tx)
+                                 :order (into #?(:clj clojure.lang.PersistentQueue/EMPTY
+                                                 :cljs #queue [])
+                                              (remove #(= % max-tx))
+                                              order)}))]
+      (get-in old [:by-tx max-tx]))))
+
 (defn- retract-stale
   "Return retract-form datoms for any *added* datoms in `predicted` whose
   `[e a v]` does NOT appear (as an addition) in `realized`. Used to roll
@@ -147,10 +181,11 @@
   [conn report]
   (when-let [{:keys [tx-listeners]} (conn-state conn)]
     (when (seq @tx-listeners)
-      (doseq [[_ f] @tx-listeners]
+      (doseq [[k f] @tx-listeners]
         (try (f report)
              (catch #?(:clj Throwable :cljs :default) e
-               (println "datahike.optimistic tx-listener error:" e)))))))
+               (log/error :datahike.optimistic/tx-listener-error
+                          {:key k :origin (:origin report) :error e})))))))
 
 (defn- emit-conflict-transitions!
   "Compare prior and current conflict sets; emit `:overlay-conflict`
@@ -190,20 +225,22 @@
           old-conflict-ids @last-conflict-ids
           db-before (or @last-effective-db @conn)]
       (mark-conflicts! overlay conflicts)
-      (doseq [[_ f] @listeners]
+      (doseq [[k f] @listeners]
         (try (f db)
              (catch #?(:clj Throwable :cljs :default) e
-               (println "datahike.optimistic listener error:" e))))
+               (log/error :datahike.optimistic/listener-error
+                          {:key k :error e}))))
       ;; Conflict-list listeners (high-level set-changed event)
       (when (not= new-conflict-ids old-conflict-ids)
         (reset! last-conflict-ids new-conflict-ids)
         (let [sanitized (->> @overlay
                              (filter :conflicting?)
                              (mapv #(dissoc % :result-ch :result-delivered?)))]
-          (doseq [[_ f] @on-conflicts]
+          (doseq [[k f] @on-conflicts]
             (try (f sanitized)
                  (catch #?(:clj Throwable :cljs :default) e
-                   (println "datahike.optimistic on-conflict error:" e))))))
+                   (log/error :datahike.optimistic/on-conflict-error
+                              {:key k :error e}))))))
       ;; Tx-report emissions for conflict transitions
       (when (not= new-conflict-ids old-conflict-ids)
         (let [entries-by-id (into {} (map (juxt :ov-id identity)) @overlay)]
@@ -231,29 +268,71 @@
 
 (defn- drop-caught-up!
   "Atomically remove entries whose `:expected-max-tx` is <= the new
-  @conn's `:max-tx`. The dispatch already delivered its :reply on
-  `:result-ch` when it set `:expected-max-tx` — there is no further
-  signal to fire on the result channel here.
-
-  Returns true iff any entry was dropped."
+  @conn's `:max-tx`. Returns the seq of removed entries (for the
+  caller to emit `:overlay-realized` events from)."
   [overlay new-max]
-  (let [[old new] (swap-vals! overlay
-                              (fn [v]
-                                (filterv
-                                 (fn [{:keys [expected-max-tx]}]
-                                   (not (and expected-max-tx
-                                             new-max
-                                             (>= new-max expected-max-tx))))
-                                 v)))]
-    (not= (count old) (count new))))
+  (let [caught-up? (fn [{:keys [expected-max-tx]}]
+                     (and expected-max-tx new-max (>= new-max expected-max-tx)))
+        [old _new] (swap-vals! overlay
+                               (fn [v] (filterv (complement caught-up?) v)))]
+    (filterv caught-up? old)))
+
+(defn- enqueue-pending-realized!
+  "Park dropped entries in `pending-realized` until the writer-listener
+  populates the cache. add-watch fires synchronously inside `reset!`,
+  while the conn's writer-listener fires *after* — so at watcher-drop
+  time the cache is empty for own writes. The writer-listener then
+  drains matching entries from this queue once it has the realized
+  tx-data."
+  [pending-realized dropped db-before db-after]
+  (when (seq dropped)
+    (swap! pending-realized
+           into
+           (mapv (fn [e]
+                   {:ov-id             (:ov-id e)
+                    :predicted-tx-data (:predicted-tx-data e)
+                    :expected-max-tx   (:expected-max-tx e)
+                    :db-before         db-before
+                    :db-after          db-after})
+                 dropped))))
+
+(defn- drain-pending-realized!
+  "When the writer-listener fires for `max-tx`, drain any pending
+  entries with `:expected-max-tx == max-tx` and emit their
+  `:overlay-realized` events using the just-cached writer-tx-data."
+  [conn max-tx]
+  (when-let [{:keys [pending-realized writer-tx-cache]} (conn-state conn)]
+    (let [match? (fn [pr] (= (:expected-max-tx pr) max-tx))
+          [old _] (swap-vals! pending-realized
+                              (fn [v] (filterv (complement match?) v)))
+          eligible (filterv match? old)]
+      (doseq [pr eligible]
+        (let [server-tx-data (take-writer-tx! writer-tx-cache max-tx)
+              stale-retracts (when server-tx-data
+                               (retract-stale (:predicted-tx-data pr)
+                                              server-tx-data))]
+          (when (seq stale-retracts)
+            (emit-tx! conn {:db-before (:db-before pr)
+                            :db-after  (:db-after pr)
+                            :tx-data   stale-retracts
+                            :origin    :overlay-realized
+                            :ov-id     (:ov-id pr)})))))))
 
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    (when-let [{:keys [overlay]} (conn-state conn)]
-      (drop-caught-up! overlay (:max-tx new-db)))
-    ;; Fire listeners whether or not anything was dropped — @conn moved,
-    ;; so the effective-db moved with it, and consumers expect a tick.
-    (fire-listeners! conn)))
+    (let [{:keys [overlay pending-realized last-effective-db]} (conn-state conn)
+          db-before (or @last-effective-db @conn)
+          dropped (when overlay (drop-caught-up! overlay (:max-tx new-db)))]
+      ;; Fire listeners whether or not anything was dropped — @conn
+      ;; moved, so the effective-db moved with it, and consumers
+      ;; expect a tick.
+      (fire-listeners! conn)
+      ;; The writer-listener (which fires AFTER us for own writes) will
+      ;; drain these and emit :overlay-realized once it has the
+      ;; realized tx-data. Foreign writes leave entries stranded here
+      ;; (no writer-listener fires) — v1 limit, see doc.
+      (enqueue-pending-realized! pending-realized dropped
+                                 db-before (effective-db conn)))))
 
 ;; -----------------------------------------------------------------------------
 ;; TTL heartbeat
@@ -304,7 +383,7 @@
       (when-not (= port stop-ch)
         (try (expire-due! conn)
              (catch #?(:clj Throwable :cljs :default) e
-               (println "datahike.optimistic heartbeat error:" e)))
+               (log/error :datahike.optimistic/heartbeat-error {:error e})))
         (recur)))))
 
 ;; -----------------------------------------------------------------------------
@@ -389,7 +468,20 @@
              watch-key         (keyword "datahike.optimistic"
                                         (str "watch-" (random-uuid)))
              writer-listen-key (keyword "datahike.optimistic"
-                                        (str "writer-" (random-uuid)))]
+                                        (str "writer-" (random-uuid)))
+             ;; Cache of writer's tx-data per `:max-tx`, populated by
+             ;; the writer-listener and consumed by the dispatch path
+             ;; (and by `drain-pending-realized!` for watcher-dropped
+             ;; entries) to compose correct `:overlay-realized`
+             ;; stale-retracts. Capped via FIFO so pathological
+             ;; direct-write traffic can't grow it without bound.
+             writer-tx-cache   (atom {:by-tx {} :order #?(:clj clojure.lang.PersistentQueue/EMPTY
+                                                          :cljs #queue [])})
+             ;; Queue of entries the watcher dropped before the
+             ;; writer-listener had a chance to cache the realized
+             ;; tx-data. The writer-listener drains this when it
+             ;; fires with a matching `:max-tx`.
+             pending-realized  (atom [])]
          (swap! *state assoc conn
                 {:overlay           overlay
                  :listeners         listeners
@@ -397,31 +489,38 @@
                  :on-conflicts      on-conflicts
                  :last-conflict-ids last-conflict-ids
                  :last-effective-db last-effective-db
+                 :writer-tx-cache   writer-tx-cache
+                 :pending-realized  pending-realized
                  :heartbeat-stop    heartbeat-stop
                  :ttl-ms            ttl-ms
                  :watch-key         watch-key
                  :writer-listen-key writer-listen-key})
-       ;; The conn's writer-listener fires for every successful
-       ;; `d/transact!` through this conn — whether it came from our
-       ;; own `opt/transact!`'s default dispatch OR a direct call by
-       ;; other code. We emit a `:conn-advance` tx-report carrying the
-       ;; writer's `:tx-data` so consumers stay in sync with all
-       ;; durable changes, not just our own.
-       ;;
-       ;; This fires AFTER `reset!` (so @conn is advanced) and BEFORE
-       ;; the d/transact! caller's promise resolves — meaning by the
-       ;; time our own dispatch's go-block resumes, the :conn-advance
-       ;; has already been emitted, and the dispatch path only needs
-       ;; to emit any stale-retract follow-up.
+         ;; The conn's writer-listener fires for every successful
+         ;; `d/transact!` through this conn — whether it came from our
+         ;; own `opt/transact!`'s default dispatch OR a direct call by
+         ;; other code. We cache the writer's `:tx-data` per `:max-tx`
+         ;; (for later `:overlay-realized` composition) AND emit a
+         ;; `:conn-advance` tx-report immediately so consumers stay in
+         ;; sync with all durable changes.
          (d/listen conn writer-listen-key
                    (fn [tx-report]
-                     (let [db-before (or @last-effective-db @conn)]
+                     (let [max-tx (:max-tx (:db-after tx-report))
+                           tx-data (vec (:tx-data tx-report))
+                           db-before (or @last-effective-db @conn)]
+                       (cache-writer-tx! writer-tx-cache max-tx tx-data)
                        (emit-tx! conn {:db-before db-before
                                        :db-after  (effective-db conn)
-                                       :tx-data   (vec (:tx-data tx-report))
+                                       :tx-data   tx-data
                                        :tempids   (:tempids tx-report)
                                        :tx-meta   (:tx-meta tx-report)
-                                       :origin    :conn-advance}))))
+                                       :origin    :conn-advance})
+                       ;; The watcher may have already dropped entries
+                       ;; for this `max-tx` (it fires inside `reset!`,
+                       ;; before this conn-listener does); their
+                       ;; `:overlay-realized` event was deferred until
+                       ;; now so we have the realized tx-data to
+                       ;; compose retract-stale against.
+                       (drain-pending-realized! conn max-tx))))
          (add-watch conn watch-key
                     (fn [_ _ old new] (on-conn-advance conn old new)))
          (start-heartbeat! conn heartbeat-stop))))
@@ -470,23 +569,26 @@
     {:db-before <effective-db at the start of the event>
      :db-after  <effective-db at the end>
      :tx-data   <vector of #datahike/Datom [e a v t added?]>
-     :origin    :overlay-add | :conn-advance | :overlay-drop
-              | :overlay-conflict | :overlay-resolve | :ttl
+     :origin    :overlay-add | :conn-advance | :overlay-realized
+              | :overlay-drop | :overlay-conflict | :overlay-resolve
+              | :ttl
      :ov-id     <uuid, only for entry-scoped origins>}
 
   The `:tx-data` is the *delta* a consumer should apply to their
   derived view to bring it in line with `:db-after`. For successful
   optimistic writes, an `:overlay-add` event ships the predicted
-  datoms; a follow-up `:conn-advance` event ships the durable writer's
-  datoms plus retracts of any prediction datoms that landed at
-  different EIDs (the EID-shift handling — see
-  `doc/optimistic-overlay.md`). On failure / TTL / conflict, the
-  prediction's additions are emitted as retracts so a consumer
-  applying tx-data incrementally always converges to `@conn`.
+  datoms; a follow-up `:conn-advance` event ships the durable
+  writer's datoms; and an `:overlay-realized` event ships any
+  retracts of stale-EID predictions (the EID-shift case — empty
+  and so suppressed when predicted EIDs already matched the
+  writer's, the common case under stable-attribute identity). On
+  failure / TTL / conflict, the prediction's additions are emitted
+  as retracts so a consumer applying tx-data incrementally always
+  converges to `@conn`.
 
-  Foreign-peer writes that bypass `d/transact!` do not currently emit
-  tx-reports (v1 limit). Standard `listen!` consumers still see
-  `effective-db` updates from foreign writes."
+  Foreign-peer writes that bypass `d/transact!` do not currently
+  emit `:conn-advance` tx-reports (v1 limit). Standard `listen!`
+  consumers still see `effective-db` updates from foreign writes."
   [conn k f]
   (when-not (conn-state conn)
     (throw (ex-info "Conn not registered for optimistic updates"
@@ -550,7 +652,7 @@
   pass `:ttl-ms nil` to disable the TTL for this call."
   ([conn tx-data] (transact! conn tx-data {}))
   ([conn tx-data {:keys [dispatch-fn] :as opts}]
-   (let [{:keys [overlay] :as st}
+   (let [{:keys [overlay writer-tx-cache] :as st}
          (or (conn-state conn)
              (throw (ex-info "Conn not registered for optimistic updates"
                              {:conn conn})))
@@ -615,30 +717,31 @@
                      ;; `dispatch-fn` contract requires :max-tx, so we
                      ;; drop the entry iff @conn has caught up. The
                      ;; watcher will drop it later if @conn is still
-                     ;; behind at this point.
-                     dropping? (and max-tx conn-max (>= conn-max max-tx))
-                     db-before-drop (effective-db conn)
-                     _ (when dropping?
-                         (swap! overlay
-                                #(filterv (fn [e] (not= (:ov-id e) ov-id)) %)))
-                     ;; The writer's tx-data was already emitted as
-                     ;; :conn-advance by our writer-listener. The only
-                     ;; remaining work is the stale-retract follow-up:
-                     ;; if the writer landed our datoms at different
-                     ;; EIDs than our local prediction (tempid shift),
-                     ;; retract the stale prediction here. Use the
-                     ;; reply's :tx-data when we have it (default
-                     ;; dispatch); else empty.
-                     server-tx-data (or (some-> reply :tx-data vec) [])]
+                     ;; behind at this point — and will emit any
+                     ;; needed `:overlay-realized` itself via
+                     ;; `emit-overlay-realized!`.
+                     dropping? (and max-tx conn-max (>= conn-max max-tx))]
                  (when dropping?
-                   (let [stale-retracts (retract-stale predicted-tx-data
-                                                       server-tx-data)]
-                     (when (seq stale-retracts)
-                       (emit-tx! conn {:db-before db-before-drop
-                                       :db-after  (effective-db conn)
-                                       :tx-data   stale-retracts
-                                       :origin    :overlay-realized
-                                       :ov-id     ov-id}))))))
+                   (let [db-before-drop (effective-db conn)
+                         _ (swap! overlay
+                                  #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))
+                         ;; Use the writer-listener's cached tx-data
+                         ;; (consumed exactly-once). The cache is
+                         ;; empty only when the dispatch bypassed
+                         ;; `d/transact!` — see the v1 limit in the
+                         ;; doc; we skip :overlay-realized in that
+                         ;; case rather than over-retract from a
+                         ;; reply of unknown shape.
+                         server-tx-data (take-writer-tx! writer-tx-cache max-tx)]
+                     (when server-tx-data
+                       (let [stale-retracts (retract-stale predicted-tx-data
+                                                           server-tx-data)]
+                         (when (seq stale-retracts)
+                           (emit-tx! conn {:db-before db-before-drop
+                                           :db-after  (effective-db conn)
+                                           :tx-data   stale-retracts
+                                           :origin    :overlay-realized
+                                           :ov-id     ov-id}))))))))
              (deliver-result! entry reply)))
          (catch #?(:clj Throwable :cljs :default) e
            ;; Drop the entry if still present; fire eff-db listeners;

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -331,31 +331,21 @@
     out))
 
 (defn- run-user-dispatch
-  "Invoke the user's `:dispatch-fn` and route the result (or any
-  throw / yielded-error) onto a single channel. Caller reads with
+  "Invoke the user's `:dispatch-fn` and route its result (or any
+  thrown/yielded error) onto a single channel. Caller reads with
   `<?-` to unify throw and yield-an-error.
 
-  CLJ: dispatch-fn may return either a `core.async` `ReadPort`
-  (channel / `promise-chan` / `throwable-promise`) or a plain
-  deref-able (`clojure.core/promise`, `future`). ReadPort returns
-  are awaited in a `go` block (no dedicated OS thread); deref-ables
-  fall through to `a/thread`. CLJS: always a channel."
+  Contract: dispatch-fn returns a `core.async` channel (typically
+  a `promise-chan` or the channel of an `a/go` / `a/thread` block).
+  This includes Datahike's own `throwable-promise` returned by
+  `d/transact!`, which implements `ReadPort`."
   [dispatch-fn]
   (let [out (chan 1)]
-    #?(:clj
-       (let [r (try (dispatch-fn) (catch Throwable e e))]
-         (cond
-           (instance? Throwable r) (put! out r)
-           (satisfies? clojure.core.async.impl.protocols/ReadPort r)
-           (a/go (put! out (a/<! r)))
-           :else
-           (a/thread
-             (try (put! out (deref r))
-                  (catch Throwable e (put! out e))))))
-       :cljs
-       (a/go
-         (try (put! out (a/<! (dispatch-fn)))
-              (catch :default e (put! out e)))))
+    (a/go
+      (try
+        (put! out (a/<! (dispatch-fn)))
+        (catch #?(:clj Throwable :cljs :default) e
+          (put! out e))))
     out))
 
 ;; -----------------------------------------------------------------------------
@@ -546,13 +536,15 @@
 
   Pass `:dispatch-fn` to substitute your own RPC. Contract:
    - takes no arguments
-   - returns a deref-able (CLJ) or `core.async` channel (CLJS) that
-     either yields `{:reply X :max-tx N}` on success — where `N` is the
-     `:max-tx` of the durable commit produced by your RPC — or
-     throws / yields a `Throwable` / `js/Error` on failure.
-   - The wrapper normalizes throw vs yield-an-error onto the same
-     failure path.
+   - returns a `core.async` channel that yields a single value:
+     either `{:reply X :max-tx N}` on success — where `N` is the
+     `:max-tx` of the durable commit produced by your RPC — or a
+     `Throwable` / `js/Error`. A thrown exception during the call is
+     also accepted; the wrapper normalizes throw and
+     yield-an-error onto the same failure path.
    - `X` is what gets put on `:result`.
+   - Datahike's own `throwable-promise` returned by `d/transact!`
+     implements `ReadPort` and satisfies this contract directly.
 
   Pass `:ttl-ms` to override the conn's default TTL for this call;
   pass `:ttl-ms nil` to disable the TTL for this call."

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -313,46 +313,49 @@
 
 (defn- default-dispatch
   "Wrap the conn's writer (`d/transact!`) and conform to the
-  `{:reply :max-tx}` contract."
+  `{:reply :max-tx}` contract.
+
+  `d/transact!` returns a `throwable-promise` on CLJ which implements
+  `core.async/ReadPort` (and on failure puts the Throwable as a value
+  on the inner chan, not as a re-throw). So `<!` works uniformly on
+  both platforms — no need to spin a dedicated OS thread via
+  `a/thread` just to wait on the deref."
   [conn tx-data]
   (let [out (chan 1)]
-    #?(:clj
-       (a/thread
-         (try
-           (let [report @(d/transact! conn tx-data)]
-             (put! out {:reply report
-                        :max-tx (:max-tx (:db-after report))}))
-           (catch Throwable e (put! out e))))
-       :cljs
-       (a/go
-         (let [report (a/<! (d/transact! conn tx-data))]
-           (if (throwable? report)
-             (put! out report)
-             (put! out {:reply report
-                        :max-tx (:max-tx (:db-after report))})))))
+    (a/go
+      (let [report (a/<! (d/transact! conn tx-data))]
+        (if (throwable? report)
+          (put! out report)
+          (put! out {:reply report
+                     :max-tx (:max-tx (:db-after report))}))))
     out))
 
 (defn- run-user-dispatch
   "Invoke the user's `:dispatch-fn` and route the result (or any
   throw / yielded-error) onto a single channel. Caller reads with
-  `<?-` to unify throw and yield-an-error."
+  `<?-` to unify throw and yield-an-error.
+
+  CLJ: dispatch-fn may return either a `core.async` `ReadPort`
+  (channel / `promise-chan` / `throwable-promise`) or a plain
+  deref-able (`clojure.core/promise`, `future`). ReadPort returns
+  are awaited in a `go` block (no dedicated OS thread); deref-ables
+  fall through to `a/thread`. CLJS: always a channel."
   [dispatch-fn]
   (let [out (chan 1)]
     #?(:clj
-       (a/thread
-         (try
-           (let [v @(dispatch-fn)]
-             ;; @ on a `throwable-promise` throws; on a plain promise
-             ;; with a Throwable value, we'd get the value back — pass
-             ;; it through and let the consumer's <?- normalize.
-             (put! out v))
-           (catch Throwable e (put! out e))))
+       (let [r (try (dispatch-fn) (catch Throwable e e))]
+         (cond
+           (instance? Throwable r) (put! out r)
+           (satisfies? clojure.core.async.impl.protocols/ReadPort r)
+           (a/go (put! out (a/<! r)))
+           :else
+           (a/thread
+             (try (put! out (deref r))
+                  (catch Throwable e (put! out e))))))
        :cljs
        (a/go
-         (try
-           (let [v (a/<! (dispatch-fn))]
-             (put! out v))
-           (catch :default e (put! out e)))))
+         (try (put! out (a/<! (dispatch-fn)))
+              (catch :default e (put! out e)))))
     out))
 
 ;; -----------------------------------------------------------------------------

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -27,6 +27,7 @@
   resolution may differ between the overlay's `d/with` and the durable
   writer."
   (:require [datahike.api :as d]
+            [datahike.datom :as dd]
             #?(:clj  [clojure.core.async :as a :refer [chan put! alts! timeout close!]]
                :cljs [clojure.core.async :as a :refer [chan put! alts! timeout close!]])
             [superv.async #?(:clj :refer :cljs :refer-macros) [<?-]]))
@@ -93,6 +94,34 @@
     []))
 
 ;; -----------------------------------------------------------------------------
+;; Datom helpers for tx-report deltas
+;; -----------------------------------------------------------------------------
+
+(defn- key-eav [d]
+  [(.-e d) (.-a d) (.-v d)])
+
+(defn- negate-additions
+  "Convert added datoms in `datoms` into their retract form. Skips
+  already-retracted datoms (idempotent)."
+  [datoms]
+  (->> datoms
+       (filter dd/datom-added)
+       (mapv (fn [d] (dd/datom (.-e d) (.-a d) (.-v d) (dd/datom-tx d) false)))))
+
+(defn- retract-stale
+  "Return retract-form datoms for any *added* datoms in `predicted` whose
+  `[e a v]` does NOT appear (as an addition) in `realized`. Used to roll
+  back stale local-EID predictions when the durable writer commits the
+  same logical entity at a different EID. When predicted and realized
+  EIDs match (common case), returns an empty vector."
+  [predicted realized]
+  (let [realized-keys (into #{} (comp (filter dd/datom-added) (map key-eav)) realized)]
+    (->> predicted
+         (filter dd/datom-added)
+         (remove (fn [d] (realized-keys (key-eav d))))
+         (mapv (fn [d] (dd/datom (.-e d) (.-a d) (.-v d) (dd/datom-tx d) false))))))
+
+;; -----------------------------------------------------------------------------
 ;; Listener firing
 ;; -----------------------------------------------------------------------------
 
@@ -106,18 +135,62 @@
                             :last-conflict-error err)))
                  entries))))
 
+(defn- emit-tx!
+  "Fire all tx-listeners with the given tx-report. Skips silently when
+  no tx-listeners are registered."
+  [conn report]
+  (when-let [{:keys [tx-listeners]} (conn-state conn)]
+    (when (seq @tx-listeners)
+      (doseq [[_ f] @tx-listeners]
+        (try (f report)
+             (catch #?(:clj Throwable :cljs :default) e
+               (println "datahike.optimistic tx-listener error:" e)))))))
+
+(defn- emit-conflict-transitions!
+  "Compare prior and current conflict sets; emit `:overlay-conflict`
+  tx-reports for entries that just became un-applicable, and
+  `:overlay-resolve` tx-reports for entries that just became applicable
+  again. Each emitted report carries the entry's predicted-tx-data
+  (retracted for new conflicts, re-added for resolutions)."
+  [conn old-conflict-ids new-conflict-ids entries-by-id db-before db-after]
+  (let [newly-conflict (clojure.set/difference new-conflict-ids old-conflict-ids)
+        newly-resolved (clojure.set/difference old-conflict-ids new-conflict-ids)]
+    (when (seq newly-conflict)
+      (let [retracts (vec (mapcat (fn [ov-id]
+                                    (negate-additions
+                                     (:predicted-tx-data (entries-by-id ov-id))))
+                                  newly-conflict))]
+        (when (seq retracts)
+          (emit-tx! conn {:db-before db-before
+                          :db-after  db-after
+                          :tx-data   retracts
+                          :origin    :overlay-conflict}))))
+    (when (seq newly-resolved)
+      (let [adds (vec (mapcat (fn [ov-id]
+                                (filter dd/datom-added
+                                        (:predicted-tx-data (entries-by-id ov-id))))
+                              newly-resolved))]
+        (when (seq adds)
+          (emit-tx! conn {:db-before db-before
+                          :db-after  db-after
+                          :tx-data   adds
+                          :origin    :overlay-resolve}))))))
+
 (defn- fire-listeners! [conn]
-  (when-let [{:keys [overlay listeners on-conflicts last-conflict-ids]}
+  (when-let [{:keys [overlay listeners on-conflicts last-conflict-ids last-effective-db]}
              (conn-state conn)]
     (let [snapshot @overlay
           {:keys [db conflicts]} (recompute @conn snapshot)
-          new-conflict-ids (set (keys conflicts))]
+          new-conflict-ids (set (keys conflicts))
+          old-conflict-ids @last-conflict-ids
+          db-before (or @last-effective-db @conn)]
       (mark-conflicts! overlay conflicts)
       (doseq [[_ f] @listeners]
         (try (f db)
              (catch #?(:clj Throwable :cljs :default) e
                (println "datahike.optimistic listener error:" e))))
-      (when (not= new-conflict-ids @last-conflict-ids)
+      ;; Conflict-list listeners (high-level set-changed event)
+      (when (not= new-conflict-ids old-conflict-ids)
         (reset! last-conflict-ids new-conflict-ids)
         (let [sanitized (->> @overlay
                              (filter :conflicting?)
@@ -125,7 +198,13 @@
           (doseq [[_ f] @on-conflicts]
             (try (f sanitized)
                  (catch #?(:clj Throwable :cljs :default) e
-                   (println "datahike.optimistic on-conflict error:" e)))))))))
+                   (println "datahike.optimistic on-conflict error:" e))))))
+      ;; Tx-report emissions for conflict transitions
+      (when (not= new-conflict-ids old-conflict-ids)
+        (let [entries-by-id (into {} (map (juxt :ov-id identity)) @overlay)]
+          (emit-conflict-transitions! conn old-conflict-ids new-conflict-ids
+                                      entries-by-id db-before db)))
+      (reset! last-effective-db db))))
 
 ;; -----------------------------------------------------------------------------
 ;; Exactly-once :result delivery
@@ -180,13 +259,15 @@
 (defn- expire-due!
   "Atomically remove entries whose TTL has elapsed; deliver a
   TimeoutException on each one's :result-ch (exactly-once via
-  `deliver-result!`); fire listeners if anything moved."
+  `deliver-result!`); fire eff-db listeners; emit one :ttl tx-report
+  per expired entry (retracting its predicted-tx-data)."
   [conn]
-  (when-let [{:keys [overlay]} (conn-state conn)]
+  (when-let [{:keys [overlay last-effective-db]} (conn-state conn)]
     (let [now (now-ms)
           expired? (fn [{:keys [expires-at]}]
                      (and expires-at (< expires-at now)))
-          [old new] (swap-vals! overlay #(filterv (complement expired?) %))
+          db-before (or @last-effective-db @conn)
+          [old _] (swap-vals! overlay #(filterv (complement expired?) %))
           gone (filterv expired? old)]
       (when (seq gone)
         (doseq [e gone]
@@ -196,7 +277,21 @@
                                      :ov-id (:ov-id e)
                                      :submitted-at (:submitted-at e)
                                      :expires-at (:expires-at e)})))
-        (fire-listeners! conn)))))
+        ;; Compute new effective-db once and fire eff-db listeners.
+        (fire-listeners! conn)
+        ;; Emit a :ttl tx-report per expired entry — each retracts its
+        ;; predicted additions (unless the entry was already conflicting,
+        ;; in which case its prediction was already retracted via
+        ;; :overlay-conflict and there's nothing further to roll back).
+        (let [db-after (effective-db conn)]
+          (doseq [e gone
+                  :when (and (not (:conflicting? e))
+                             (seq (:predicted-tx-data e)))]
+            (emit-tx! conn {:db-before db-before
+                            :db-after  db-after
+                            :tx-data   (negate-additions (:predicted-tx-data e))
+                            :origin    :ttl
+                            :ov-id     (:ov-id e)})))))))
 
 (defn- start-heartbeat! [conn stop-ch]
   (a/go-loop []
@@ -282,21 +377,47 @@
    (when-not (conn-state conn)
      (let [overlay           (atom [])
            listeners         (atom {})
+           tx-listeners      (atom {})
            on-conflicts      (atom (if on-conflict
                                      {::default-on-conflict on-conflict}
                                      {}))
            last-conflict-ids (atom #{})
+           last-effective-db (atom nil)
            heartbeat-stop    (chan)
            watch-key         (keyword "datahike.optimistic"
-                                      (str "watch-" (random-uuid)))]
+                                      (str "watch-" (random-uuid)))
+           writer-listen-key (keyword "datahike.optimistic"
+                                      (str "writer-" (random-uuid)))]
        (swap! *state assoc conn
               {:overlay           overlay
                :listeners         listeners
+               :tx-listeners      tx-listeners
                :on-conflicts      on-conflicts
                :last-conflict-ids last-conflict-ids
+               :last-effective-db last-effective-db
                :heartbeat-stop    heartbeat-stop
                :ttl-ms            ttl-ms
-               :watch-key         watch-key})
+               :watch-key         watch-key
+               :writer-listen-key writer-listen-key})
+       ;; The conn's writer-listener fires for every successful
+       ;; `d/transact!` through this conn — whether it came from our
+       ;; own `opt/transact!`'s default dispatch OR a direct call by
+       ;; other code. We emit a `:conn-advance` tx-report carrying the
+       ;; writer's `:tx-data` so consumers stay in sync with all
+       ;; durable changes, not just our own.
+       ;;
+       ;; This fires AFTER `reset!` (so @conn is advanced) and BEFORE
+       ;; the d/transact! caller's promise resolves — meaning by the
+       ;; time our own dispatch's go-block resumes, the :conn-advance
+       ;; has already been emitted, and the dispatch path only needs
+       ;; to emit any stale-retract follow-up.
+       (d/listen conn writer-listen-key
+                 (fn [tx-report]
+                   (let [db-before (or @last-effective-db @conn)]
+                     (emit-tx! conn {:db-before db-before
+                                     :db-after  (effective-db conn)
+                                     :tx-data   (vec (:tx-data tx-report))
+                                     :origin    :conn-advance}))))
        (add-watch conn watch-key
                   (fn [_ _ old new] (on-conn-advance conn old new)))
        (start-heartbeat! conn heartbeat-stop)))
@@ -307,8 +428,10 @@
   by delivering an `:optimistic/cancelled` error on their :result chan.
   Stops the heartbeat and clears all overlay state."
   [conn]
-  (when-let [{:keys [watch-key heartbeat-stop overlay]} (conn-state conn)]
+  (when-let [{:keys [watch-key writer-listen-key heartbeat-stop overlay]}
+             (conn-state conn)]
     (remove-watch conn watch-key)
+    (d/unlisten conn writer-listen-key)
     (close! heartbeat-stop)
     (doseq [e @overlay]
       (deliver-result! e
@@ -333,6 +456,43 @@
 (defn unlisten! [conn k]
   (when-let [{:keys [listeners]} (conn-state conn)]
     (swap! listeners dissoc k))
+  nil)
+
+(defn listen-tx!
+  "Register a tx-report listener `(fn [tx-report])` under key `k`.
+  Fires once per logical change to the overlay or @conn, with a
+  Datahike-style tx-report:
+
+    {:db-before <effective-db at the start of the event>
+     :db-after  <effective-db at the end>
+     :tx-data   <vector of #datahike/Datom [e a v t added?]>
+     :origin    :overlay-add | :conn-advance | :overlay-drop
+              | :overlay-conflict | :overlay-resolve | :ttl
+     :ov-id     <uuid, only for entry-scoped origins>}
+
+  The `:tx-data` is the *delta* a consumer should apply to their
+  derived view to bring it in line with `:db-after`. For successful
+  optimistic writes, an `:overlay-add` event ships the predicted
+  datoms; a follow-up `:conn-advance` event ships the durable writer's
+  datoms plus retracts of any prediction datoms that landed at
+  different EIDs (the EID-shift handling — see
+  `doc/optimistic-overlay.md`). On failure / TTL / conflict, the
+  prediction's additions are emitted as retracts so a consumer
+  applying tx-data incrementally always converges to `@conn`.
+
+  Foreign-peer writes that bypass `d/transact!` do not currently emit
+  tx-reports (v1 limit). Standard `listen!` consumers still see
+  `effective-db` updates from foreign writes."
+  [conn k f]
+  (when-not (conn-state conn)
+    (throw (ex-info "Conn not registered for optimistic updates"
+                    {:conn conn})))
+  (swap! (:tx-listeners (conn-state conn)) assoc k f)
+  nil)
+
+(defn unlisten-tx! [conn k]
+  (when-let [{:keys [tx-listeners]} (conn-state conn)]
+    (swap! tx-listeners dissoc k))
   nil)
 
 (defn on-conflict!
@@ -388,9 +548,13 @@
          (or (conn-state conn)
              (throw (ex-info "Conn not registered for optimistic updates"
                              {:conn conn})))
-         ;; Eager validation — throws on schema/type violations,
-         ;; nothing enters the overlay.
-         _validate (d/with (effective-db conn) tx-data)
+         ;; Eager validation against the current effective-db — throws
+         ;; on schema/type violations, nothing enters the overlay. Reuse
+         ;; the result to cache the predicted tx-data shipped to
+         ;; tx-listeners on :overlay-add.
+         db-before-add     (effective-db conn)
+         validate-report   (d/with db-before-add tx-data)
+         predicted-tx-data (vec (:tx-data validate-report))
          ov-id        (random-uuid)
          submitted-at (now-ms)
          ttl-ms       (if (contains? opts :ttl-ms) (:ttl-ms opts) (:ttl-ms st))
@@ -398,6 +562,7 @@
          result-ch    (chan 1)
          entry        {:ov-id               ov-id
                        :tx-data             tx-data
+                       :predicted-tx-data   predicted-tx-data
                        :submitted-at        submitted-at
                        :expires-at          expires-at
                        :expected-max-tx     nil
@@ -407,6 +572,12 @@
                        :result-delivered?   (atom false)}]
      (swap! overlay conj entry)
      (fire-listeners! conn)
+     ;; tx-report for the optimistic add. db-after is the new effective-db.
+     (emit-tx! conn {:db-before db-before-add
+                     :db-after  (effective-db conn)
+                     :tx-data   predicted-tx-data
+                     :origin    :overlay-add
+                     :ov-id     ov-id})
      (a/go
        (try
          (let [val (<?- (if dispatch-fn
@@ -418,9 +589,7 @@
                      {:type :optimistic/invalid-dispatch :got val})))
            (let [{:keys [reply max-tx]} val
                  ;; Mark the entry with its watermark — the watcher
-                 ;; will drop it when @conn :max-tx catches up. If the
-                 ;; entry is no longer present (heartbeat / unregister!
-                 ;; raced ahead), this swap! is a no-op.
+                 ;; will drop it when @conn :max-tx catches up.
                  [_old new-overlay]
                  (swap-vals! overlay
                              (fn [v]
@@ -431,25 +600,52 @@
                                      v)))
                  still-present? (some #(= (:ov-id %) ov-id) new-overlay)]
              (when still-present?
-               ;; Sync drop: if @conn already advanced past max-tx
-               ;; (default `:self` writer commits before returning),
-               ;; the watcher already fired but couldn't drop because
-               ;; :expected-max-tx wasn't set yet. Catch that here.
-               (when (and max-tx (>= (:max-tx @conn) max-tx))
-                 (swap! overlay #(filterv (fn [e] (not= (:ov-id e) ov-id)) %)))
-               ;; If the user's dispatch-fn neglected :max-tx, fall
-               ;; back to drop-on-resolve so the entry doesn't linger
-               ;; forever (silently — documented contract requires it).
-               (when (nil? max-tx)
-                 (swap! overlay #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))))
+               (let [conn-max (:max-tx @conn)
+                     synced? (and max-tx conn-max (>= conn-max max-tx))
+                     force-drop? (nil? max-tx)
+                     dropping? (or synced? force-drop?)
+                     db-before-drop (effective-db conn)
+                     _ (when dropping?
+                         (swap! overlay
+                                #(filterv (fn [e] (not= (:ov-id e) ov-id)) %)))
+                     ;; The writer's tx-data was already emitted as
+                     ;; :conn-advance by our writer-listener. The only
+                     ;; remaining work is the stale-retract follow-up:
+                     ;; if the writer landed our datoms at different
+                     ;; EIDs than our local prediction (tempid shift),
+                     ;; retract the stale prediction here. Use the
+                     ;; reply's :tx-data when we have it (default
+                     ;; dispatch); else empty.
+                     server-tx-data (or (some-> reply :tx-data vec) [])]
+                 (when dropping?
+                   (let [stale-retracts (retract-stale predicted-tx-data
+                                                       server-tx-data)]
+                     (when (seq stale-retracts)
+                       (emit-tx! conn {:db-before db-before-drop
+                                       :db-after  (effective-db conn)
+                                       :tx-data   stale-retracts
+                                       :origin    :overlay-realized
+                                       :ov-id     ov-id}))))))
              (deliver-result! entry reply)))
          (catch #?(:clj Throwable :cljs :default) e
-           ;; Drop the entry if still present; fire listeners; deliver
-           ;; the error. `deliver-result!` is exactly-once, so a prior
-           ;; TTL/cancel won't be clobbered.
-           (let [[old new] (swap-vals! overlay
-                                       #(filterv (fn [x] (not= (:ov-id x) ov-id)) %))]
+           ;; Drop the entry if still present; fire eff-db listeners;
+           ;; emit :overlay-drop tx-report retracting predictions;
+           ;; deliver the error.
+           (let [db-before-drop (effective-db conn)
+                 [old new] (swap-vals! overlay
+                                       #(filterv (fn [x] (not= (:ov-id x) ov-id)) %))
+                 dropped-entry (first (filter #(= (:ov-id %) ov-id) old))]
              (when (not= (count old) (count new))
-               (fire-listeners! conn)))
+               (fire-listeners! conn)
+               (when (and dropped-entry
+                          (not (:conflicting? dropped-entry))
+                          (seq (:predicted-tx-data dropped-entry)))
+                 (emit-tx! conn
+                           {:db-before db-before-drop
+                            :db-after  (effective-db conn)
+                            :tx-data   (negate-additions
+                                        (:predicted-tx-data dropped-entry))
+                            :origin    :overlay-drop
+                            :ov-id     ov-id}))))
            (deliver-result! entry e))))
      {:ov-id ov-id :result result-ch})))

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -100,13 +100,19 @@
 (defn- key-eav [d]
   [(.-e d) (.-a d) (.-v d)])
 
-(defn- negate-additions
-  "Convert added datoms in `datoms` into their retract form. Skips
-  already-retracted datoms (idempotent)."
+(defn- negate
+  "Flip the added? flag on every datom — assertions become retracts and
+  vice versa. Used to roll back an entry's effect on the consumer's
+  view when the dispatch failed / TTL fired / a conflict appeared.
+
+  Both directions matter: if the original tx-data was a retract (e.g.
+  `[[:db/retract 1 :name \"old\"]]`), the `:overlay-add` event shipped
+  the retract to the consumer; rolling it back means re-asserting."
   [datoms]
-  (->> datoms
-       (filter dd/datom-added)
-       (mapv (fn [d] (dd/datom (.-e d) (.-a d) (.-v d) (dd/datom-tx d) false)))))
+  (mapv (fn [d]
+          (dd/datom (.-e d) (.-a d) (.-v d) (dd/datom-tx d)
+                    (not (dd/datom-added d))))
+        datoms))
 
 (defn- retract-stale
   "Return retract-form datoms for any *added* datoms in `predicted` whose
@@ -157,7 +163,7 @@
         newly-resolved (clojure.set/difference old-conflict-ids new-conflict-ids)]
     (when (seq newly-conflict)
       (let [retracts (vec (mapcat (fn [ov-id]
-                                    (negate-additions
+                                    (negate
                                      (:predicted-tx-data (entries-by-id ov-id))))
                                   newly-conflict))]
         (when (seq retracts)
@@ -166,14 +172,13 @@
                           :tx-data   retracts
                           :origin    :overlay-conflict}))))
     (when (seq newly-resolved)
-      (let [adds (vec (mapcat (fn [ov-id]
-                                (filter dd/datom-added
-                                        (:predicted-tx-data (entries-by-id ov-id))))
-                              newly-resolved))]
-        (when (seq adds)
+      (let [restored (vec (mapcat (fn [ov-id]
+                                    (:predicted-tx-data (entries-by-id ov-id)))
+                                  newly-resolved))]
+        (when (seq restored)
           (emit-tx! conn {:db-before db-before
                           :db-after  db-after
-                          :tx-data   adds
+                          :tx-data   restored
                           :origin    :overlay-resolve}))))))
 
 (defn- fire-listeners! [conn]
@@ -289,7 +294,7 @@
                              (seq (:predicted-tx-data e)))]
             (emit-tx! conn {:db-before db-before
                             :db-after  db-after
-                            :tx-data   (negate-additions (:predicted-tx-data e))
+                            :tx-data   (negate (:predicted-tx-data e))
                             :origin    :ttl
                             :ov-id     (:ov-id e)})))))))
 
@@ -417,6 +422,8 @@
                      (emit-tx! conn {:db-before db-before
                                      :db-after  (effective-db conn)
                                      :tx-data   (vec (:tx-data tx-report))
+                                     :tempids   (:tempids tx-report)
+                                     :tx-meta   (:tx-meta tx-report)
                                      :origin    :conn-advance}))))
        (add-watch conn watch-key
                   (fn [_ _ old new] (on-conn-advance conn old new)))
@@ -573,9 +580,14 @@
      (swap! overlay conj entry)
      (fire-listeners! conn)
      ;; tx-report for the optimistic add. db-after is the new effective-db.
+     ;; :tempids and :tx-meta come from the eager d/with — same shape as
+     ;; a Datahike TxReport so consumers can use one code path for both
+     ;; optimistic and durable reports.
      (emit-tx! conn {:db-before db-before-add
                      :db-after  (effective-db conn)
                      :tx-data   predicted-tx-data
+                     :tempids   (:tempids validate-report)
+                     :tx-meta   (:tx-meta validate-report)
                      :origin    :overlay-add
                      :ov-id     ov-id})
      (a/go
@@ -643,7 +655,7 @@
                  (emit-tx! conn
                            {:db-before db-before-drop
                             :db-after  (effective-db conn)
-                            :tx-data   (negate-additions
+                            :tx-data   (negate
                                         (:predicted-tx-data dropped-entry))
                             :origin    :overlay-drop
                             :ov-id     ov-id}))))

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -378,32 +378,36 @@
   Additional on-conflict listeners can be registered later via
   `on-conflict!`."
   ([conn] (register! conn {}))
-  ([conn {:keys [ttl-ms on-conflict] :or {ttl-ms default-ttl-ms}}]
-   (when-not (conn-state conn)
-     (let [overlay           (atom [])
-           listeners         (atom {})
-           tx-listeners      (atom {})
-           on-conflicts      (atom (if on-conflict
-                                     {::default-on-conflict on-conflict}
-                                     {}))
-           last-conflict-ids (atom #{})
-           last-effective-db (atom nil)
-           heartbeat-stop    (chan)
-           watch-key         (keyword "datahike.optimistic"
-                                      (str "watch-" (random-uuid)))
-           writer-listen-key (keyword "datahike.optimistic"
-                                      (str "writer-" (random-uuid)))]
-       (swap! *state assoc conn
-              {:overlay           overlay
-               :listeners         listeners
-               :tx-listeners      tx-listeners
-               :on-conflicts      on-conflicts
-               :last-conflict-ids last-conflict-ids
-               :last-effective-db last-effective-db
-               :heartbeat-stop    heartbeat-stop
-               :ttl-ms            ttl-ms
-               :watch-key         watch-key
-               :writer-listen-key writer-listen-key})
+  ([conn {:keys [on-conflict] :as opts}]
+   ;; Resolve ttl-ms via `contains?` so an explicit `:ttl-ms nil`
+   ;; reaches us as nil (= disable), instead of being overwritten by
+   ;; an `:or` default.
+   (let [ttl-ms (if (contains? opts :ttl-ms) (:ttl-ms opts) default-ttl-ms)]
+     (when-not (conn-state conn)
+       (let [overlay           (atom [])
+             listeners         (atom {})
+             tx-listeners      (atom {})
+             on-conflicts      (atom (if on-conflict
+                                       {::default-on-conflict on-conflict}
+                                       {}))
+             last-conflict-ids (atom #{})
+             last-effective-db (atom nil)
+             heartbeat-stop    (chan)
+             watch-key         (keyword "datahike.optimistic"
+                                        (str "watch-" (random-uuid)))
+             writer-listen-key (keyword "datahike.optimistic"
+                                        (str "writer-" (random-uuid)))]
+         (swap! *state assoc conn
+                {:overlay           overlay
+                 :listeners         listeners
+                 :tx-listeners      tx-listeners
+                 :on-conflicts      on-conflicts
+                 :last-conflict-ids last-conflict-ids
+                 :last-effective-db last-effective-db
+                 :heartbeat-stop    heartbeat-stop
+                 :ttl-ms            ttl-ms
+                 :watch-key         watch-key
+                 :writer-listen-key writer-listen-key})
        ;; The conn's writer-listener fires for every successful
        ;; `d/transact!` through this conn — whether it came from our
        ;; own `opt/transact!`'s default dispatch OR a direct call by
@@ -416,18 +420,18 @@
        ;; time our own dispatch's go-block resumes, the :conn-advance
        ;; has already been emitted, and the dispatch path only needs
        ;; to emit any stale-retract follow-up.
-       (d/listen conn writer-listen-key
-                 (fn [tx-report]
-                   (let [db-before (or @last-effective-db @conn)]
-                     (emit-tx! conn {:db-before db-before
-                                     :db-after  (effective-db conn)
-                                     :tx-data   (vec (:tx-data tx-report))
-                                     :tempids   (:tempids tx-report)
-                                     :tx-meta   (:tx-meta tx-report)
-                                     :origin    :conn-advance}))))
-       (add-watch conn watch-key
-                  (fn [_ _ old new] (on-conn-advance conn old new)))
-       (start-heartbeat! conn heartbeat-stop)))
+         (d/listen conn writer-listen-key
+                   (fn [tx-report]
+                     (let [db-before (or @last-effective-db @conn)]
+                       (emit-tx! conn {:db-before db-before
+                                       :db-after  (effective-db conn)
+                                       :tx-data   (vec (:tx-data tx-report))
+                                       :tempids   (:tempids tx-report)
+                                       :tx-meta   (:tx-meta tx-report)
+                                       :origin    :conn-advance}))))
+         (add-watch conn watch-key
+                    (fn [_ _ old new] (on-conn-advance conn old new)))
+         (start-heartbeat! conn heartbeat-stop))))
    conn))
 
 (defn unregister!
@@ -595,7 +599,7 @@
          (let [val (<?- (if dispatch-fn
                           (run-user-dispatch dispatch-fn)
                           (default-dispatch conn tx-data)))]
-           (when-not (and (map? val) (contains? val :reply))
+           (when-not (and (map? val) (contains? val :reply) (contains? val :max-tx))
              (throw (ex-info
                      "dispatch-fn returned an invalid shape; expected {:reply :max-tx}"
                      {:type :optimistic/invalid-dispatch :got val})))
@@ -613,9 +617,11 @@
                  still-present? (some #(= (:ov-id %) ov-id) new-overlay)]
              (when still-present?
                (let [conn-max (:max-tx @conn)
-                     synced? (and max-tx conn-max (>= conn-max max-tx))
-                     force-drop? (nil? max-tx)
-                     dropping? (or synced? force-drop?)
+                     ;; `dispatch-fn` contract requires :max-tx, so we
+                     ;; drop the entry iff @conn has caught up. The
+                     ;; watcher will drop it later if @conn is still
+                     ;; behind at this point.
+                     dropping? (and max-tx conn-max (>= conn-max max-tx))
                      db-before-drop (effective-db conn)
                      _ (when dropping?
                          (swap! overlay

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -1,0 +1,233 @@
+(ns datahike.optimistic
+  "Optimistic-overlay helpers over a Datahike connection.
+
+  Layers pending client-submitted transactions on top of the durable @conn
+  value via `d/db-with`, exposing the result as `effective-db`. Pending
+  entries are dropped automatically when @conn advances past their
+  expected max-tx, and on transact failure they are dropped immediately
+  with listeners notified.
+
+  Usage:
+
+    (require '[datahike.optimistic :as opt])
+
+    (opt/register! conn)
+    (opt/listen! conn ::ui (fn [eff-db] (rerender! eff-db)))
+    (opt/transact! conn [{:db/id -1 :name \"alice\"}])
+    ...
+    (opt/unlisten! conn ::ui)
+    (opt/unregister! conn)
+
+  Identity assumption: applications should identify entities by a stable
+  attribute (e.g. :entity/uuid minted client-side) rather than by EID,
+  since tempid resolution may differ between the overlay's `d/with` and
+  the underlying transact."
+  (:require [datahike.api :as d]
+            #?(:clj  [clojure.core.async :as a :refer [chan put!]]
+               :cljs [clojure.core.async :as a :refer [chan put!]
+                      :refer-macros [go]])))
+
+;; -----------------------------------------------------------------------------
+;; Per-connection state
+;; -----------------------------------------------------------------------------
+
+(defonce ^:private *state (atom {}))
+
+(defn- conn-state [conn]
+  (get @*state conn))
+
+;; -----------------------------------------------------------------------------
+;; Effective DB
+;; -----------------------------------------------------------------------------
+
+(defn- effective-db*
+  "Reduce overlay entries with `d/db-with` over base-db. Entries marked
+  `:transacting?` are skipped — those have already been handed to the
+  underlying writer and are about to land in @conn, so re-applying them
+  would double their datoms in the view."
+  [base-db overlay-vec]
+  (reduce (fn [db {:keys [tx-data]}]
+            (:db-after (d/with db tx-data)))
+          base-db
+          (remove :transacting? overlay-vec)))
+
+(defn effective-db
+  "Return the db value with all pending optimistic entries applied on top.
+  Returns @conn unchanged if conn is not registered."
+  [conn]
+  (if-let [{:keys [overlay]} (conn-state conn)]
+    (effective-db* @conn @overlay)
+    @conn))
+
+(defn pending
+  "Return a vector of pending overlay entries for conn (empty if none /
+  not registered)."
+  [conn]
+  (if-let [{:keys [overlay]} (conn-state conn)]
+    @overlay
+    []))
+
+;; -----------------------------------------------------------------------------
+;; Listeners
+;; -----------------------------------------------------------------------------
+
+(defn- fire-listeners! [conn]
+  (when-let [{:keys [listeners]} (conn-state conn)]
+    (let [eff-db (try
+                   (effective-db conn)
+                   (catch #?(:clj Throwable :cljs :default) e
+                     ;; Overlay re-application failed against current @conn.
+                     ;; Fall back to base; UI may temporarily lose optimistic
+                     ;; visibility for entries that became invalid.
+                     (println "datahike.optimistic: effective-db failed, falling back:" e)
+                     @conn))]
+      (doseq [[_ f] @listeners]
+        (try
+          (f eff-db)
+          (catch #?(:clj Throwable :cljs :default) e
+            (println "datahike.optimistic listener error:" e)))))))
+
+(defn- on-conn-advance [conn old-db new-db]
+  (when (not= (:max-tx old-db) (:max-tx new-db))
+    ;; @conn changed — UI needs the new effective-db. We do *not* drop
+    ;; pending entries here: matching is by `:ov-id` and is handled in
+    ;; `transact!` itself (success and failure paths). Predicted max-tx
+    ;; would be unreliable under concurrent writers, so we don't try.
+    (fire-listeners! conn)))
+
+;; -----------------------------------------------------------------------------
+;; Public API
+;; -----------------------------------------------------------------------------
+
+(defn register!
+  "Register a conn for optimistic updates. Idempotent. Returns conn."
+  [conn]
+  (when-not (conn-state conn)
+    (let [overlay   (atom [])
+          listeners (atom {})
+          watch-key (keyword "datahike.optimistic"
+                             (str "watch-" (random-uuid)))]
+      (swap! *state assoc conn
+             {:overlay overlay :listeners listeners :watch-key watch-key})
+      (add-watch conn watch-key
+                 (fn [_ _ old new] (on-conn-advance conn old new)))))
+  conn)
+
+(defn unregister!
+  "Detach overlay from conn. Drops all pending entries (no rollback fired)."
+  [conn]
+  (when-let [{:keys [watch-key]} (conn-state conn)]
+    (remove-watch conn watch-key)
+    (swap! *state dissoc conn))
+  nil)
+
+(defn listen!
+  "Register a listener `f` of one arg (effective-db) under key `k`.
+  The listener fires whenever @conn advances or the overlay changes
+  (entry added on transact!, entry dropped on conn-advance or rejection)."
+  [conn k f]
+  (when-not (conn-state conn)
+    (throw (ex-info "Conn not registered for optimistic updates"
+                    {:conn conn})))
+  (let [{:keys [listeners]} (conn-state conn)]
+    (swap! listeners assoc k f))
+  nil)
+
+(defn unlisten!
+  [conn k]
+  (when-let [{:keys [listeners]} (conn-state conn)]
+    (swap! listeners dissoc k))
+  nil)
+
+(defn transact!
+  "Optimistic transact.
+
+  Eagerly validates `tx-data` via `d/with`, appends an overlay entry,
+  fires listeners with the optimistic effective-db, then dispatches the
+  write. Validation errors throw synchronously (overlay untouched);
+  dispatch errors are delivered on the `:result` channel and the entry
+  is dropped before listeners re-fire with the rolled-back effective-db.
+
+  Returns `{:ov-id uuid :result <chan>}`:
+   - `:ov-id`  — client-minted UUID identifying this entry; useful for
+                 correlating with listener events.
+   - `:result` — a 1-buffer channel that yields exactly one value: the
+                 server reply on success, or a Throwable (CLJ) /
+                 js/Error (CLJS) on failure.
+
+  Dispatch defaults to `(d/transact! conn tx-data)` — routes through the
+  conn's writer (`:self`, `:kabel`, …) and yields a Datahike tx-report.
+
+  Pass `:dispatch-fn` in opts to substitute your own RPC — for cases
+  where the server side does more than a plain Datahike transact (e.g.
+  an `invoke-remote` that creates additional entities, runs server-side
+  validation, etc.). Contract:
+   - takes no arguments
+   - returns a deref-able (CLJ) / `core.async` channel (CLJS) that
+     yields the server reply on success or throws/yields-an-error
+   - the value it yields is what gets put on `:result` — the wrapper
+     does not interpret it."
+  ([conn tx-data] (transact! conn tx-data {}))
+  ([conn tx-data {:keys [dispatch-fn] :as _opts}]
+   (let [{:keys [overlay]} (or (conn-state conn)
+                               (throw (ex-info "Conn not registered for optimistic updates"
+                                               {:conn conn})))
+         ov-id     (random-uuid)
+        ;; Eager validation: run `d/with` against the current
+        ;; effective-db so malformed/schema-violating tx surfaces
+        ;; synchronously before we add anything to the overlay.
+        ;; The result is otherwise discarded — entries are matched and
+        ;; removed by `:ov-id`, so we don't need the predicted max-tx.
+         _validate (d/with (effective-db conn) tx-data) ;; throws on invalid tx
+         entry     {:ov-id        ov-id
+                    :tx-data      tx-data
+                    :status       :pending
+                    :submitted-at #?(:clj  (System/currentTimeMillis)
+                                     :cljs (.getTime (js/Date.)))}
+         result-ch (chan 1)]
+     (swap! overlay conj entry)
+     (fire-listeners! conn)
+    ;; Mark :transacting? right before dispatch so the conn-watch fires
+    ;; during d/transact!'s swap! sees effective-db = new-base (without our
+    ;; entry being re-applied via d/with on top of datoms that just landed).
+     (swap! overlay
+            (fn [entries]
+              (mapv #(if (= (:ov-id %) ov-id)
+                       (assoc % :transacting? true)
+                       %)
+                    entries)))
+     (let [drop-entry! (fn []
+                         (swap! overlay
+                                (fn [entries]
+                                  (filterv (fn [e] (not= (:ov-id e) ov-id))
+                                           entries))))]
+      ;; Default dispatch: route through the conn's writer (`d/transact!`).
+      ;; Custom dispatch is for app-level RPCs whose server side does more
+      ;; than a plain Datahike transact (e.g. multi-entity bootstrap).
+      ;; In CLJ d/transact! returns a Future-like; in CLJS a promise-chan.
+       #?(:clj
+          (a/thread
+            (try
+              (let [reply (if dispatch-fn
+                            @(dispatch-fn)
+                            @(d/transact! conn tx-data))]
+                (drop-entry!) ;; conn-watch already ran fire-listeners! with
+                             ;; our :transacting? entry skipped — effective
+                             ;; -db is already correct; no fire needed here.
+                (put! result-ch reply))
+              (catch Throwable e
+                (drop-entry!)
+                (fire-listeners! conn)
+                (put! result-ch e))))
+          :cljs
+          (a/go
+            (let [reply (try
+                          (a/<! (if dispatch-fn
+                                  (dispatch-fn)
+                                  (d/transact! conn tx-data)))
+                          (catch :default e e))]
+              (drop-entry!)
+              (when (instance? js/Error reply)
+                (fire-listeners! conn))
+              (put! result-ch reply)))))
+     {:ov-id ov-id :result result-ch})))

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -2,12 +2,13 @@
   "Optimistic-overlay helpers over a Datahike connection.
 
   Layers pending client-submitted transactions on top of the durable @conn
-  value via `d/with`, exposing the result as `effective-db`.
+  value via `d/with`, exposing the effect as a tx-report stream to
+  `listen!` and the resulting effective db value via `effective-db`.
 
   An entry remains visible until @conn has demonstrably caught up to the
-  transaction's effect (the writer-assigned `:max-tx`), the dispatch
-  failed, or a per-entry TTL elapsed. See `doc/optimistic-overlay.md` for
-  the full consistency model.
+  transaction's effect (the writer-assigned `:max-tx`), the durable
+  transact failed, or a per-entry TTL elapsed. See
+  `doc/optimistic-overlay.md` for the full consistency model.
 
   Usage:
 
@@ -16,7 +17,9 @@
     (opt/register! conn
       {:ttl-ms 30000
        :on-conflict (fn [conflicts] ...)})
-    (opt/listen!   conn ::ui (fn [eff-db] (rerender! eff-db)))
+    (opt/listen!   conn ::ui
+                   (fn [{:keys [tx-data db-after origin]}]
+                     (apply-deltas-or-rerender ...)))
     (opt/transact! conn [{:db/id -1 :name \"alice\"}])
     ...
     (opt/unlisten!   conn ::ui)
@@ -104,7 +107,7 @@
 (defn- negate
   "Flip the added? flag on every datom — assertions become retracts and
   vice versa. Used to roll back an entry's effect on the consumer's
-  view when the dispatch failed / TTL fired / a conflict appeared.
+  view when the durable transact failed / TTL fired / a conflict appeared.
 
   Both directions matter: if the original tx-data was a retract (e.g.
   `[[:db/retract 1 :name \"old\"]]`), the `:overlay-add` event shipped
@@ -127,9 +130,11 @@
 ;; across batched entries. Keying by ov-id keeps each entry's writer-
 ;; tx-data distinct.
 ;;
-;; The ov-id is conveyed via `:tx-meta {::ov-id ov-id}` injected by
-;; `default-dispatch` into the `d/transact!` arg-map; the writer
-;; preserves `:tx-meta` on the tx-report.
+;; Each call to `d/transact!` returns its own per-call promise that
+;; yields THIS specific tx's tx-report — even when the writer batched
+;; the commits internally. We cache the writer's `:tx-data` keyed by
+;; `:ov-id` inside `transact!`'s go-block, where both pieces of
+;; information are naturally in scope when the per-call promise resolves.
 
 (defn- cache-writer-tx!
   [cache ov-id tx-data]
@@ -138,8 +143,8 @@
 
 (defn- take-writer-tx!
   "Pop the cached writer tx-data for `ov-id`, removing it from the
-  cache. Returns nil if absent (e.g. for foreign `d/transact!`s or
-  custom dispatches that bypassed our `::ov-id` tx-meta convention)."
+  cache. Returns nil if absent (e.g. foreign `d/transact!`s that
+  bypassed our overlay)."
   [cache ov-id]
   (when ov-id
     (let [[old _] (swap-vals! cache dissoc ov-id)]
@@ -174,14 +179,14 @@
 
 (defn- emit-tx!
   "Fire all tx-listeners with the given tx-report. Skips silently when
-  no tx-listeners are registered."
+  no listeners are registered."
   [conn report]
-  (when-let [{:keys [tx-listeners]} (conn-state conn)]
-    (when (seq @tx-listeners)
-      (doseq [[k f] @tx-listeners]
+  (when-let [{:keys [listeners]} (conn-state conn)]
+    (when (seq @listeners)
+      (doseq [[k f] @listeners]
         (try (f report)
              (catch #?(:clj Throwable :cljs :default) e
-               (log/error :datahike.optimistic/tx-listener-error
+               (log/error :datahike.optimistic/listener-error
                           {:key k :origin (:origin report) :error e})))))))
 
 (defn- emit-conflict-transitions!
@@ -213,8 +218,14 @@
                           :tx-data   restored
                           :origin    :overlay-resolve}))))))
 
-(defn- fire-listeners! [conn]
-  (when-let [{:keys [overlay listeners on-conflicts last-conflict-ids last-effective-db]}
+(defn- recompute-and-emit-conflicts!
+  "Recompute effective-db, mark conflicts on overlay entries, fire
+  on-conflict callbacks if the conflict set changed, and emit
+  conflict-transition tx-reports. Updates `last-effective-db` to the
+  current effective view. Does NOT fire `listen!` callbacks (each
+  caller emits per-event tx-reports via `emit-tx!`)."
+  [conn]
+  (when-let [{:keys [overlay on-conflicts last-conflict-ids last-effective-db]}
              (conn-state conn)]
     (let [snapshot @overlay
           {:keys [db conflicts]} (recompute @conn snapshot)
@@ -222,12 +233,6 @@
           old-conflict-ids @last-conflict-ids
           db-before (or @last-effective-db @conn)]
       (mark-conflicts! overlay conflicts)
-      (doseq [[k f] @listeners]
-        (try (f db)
-             (catch #?(:clj Throwable :cljs :default) e
-               (log/error :datahike.optimistic/listener-error
-                          {:key k :error e}))))
-      ;; Conflict-list listeners (high-level set-changed event)
       (when (not= new-conflict-ids old-conflict-ids)
         (reset! last-conflict-ids new-conflict-ids)
         (let [sanitized (->> @overlay
@@ -237,9 +242,7 @@
             (try (f sanitized)
                  (catch #?(:clj Throwable :cljs :default) e
                    (log/error :datahike.optimistic/on-conflict-error
-                              {:key k :error e}))))))
-      ;; Tx-report emissions for conflict transitions
-      (when (not= new-conflict-ids old-conflict-ids)
+                              {:key k :error e})))))
         (let [entries-by-id (into {} (map (juxt :ov-id identity)) @overlay)]
           (emit-conflict-transitions! conn old-conflict-ids new-conflict-ids
                                       entries-by-id db-before db)))
@@ -264,10 +267,10 @@
 ;; -----------------------------------------------------------------------------
 ;;
 ;; Two events can cause an entry to "catch up" (= `@conn :max-tx` reaches the
-;; entry's `:expected-max-tx`): the dispatch resuming with its watermark for
-;; the default-dispatch case (`@conn` already advanced by the writer), or a
-;; later `@conn` change for the custom-dispatch-with-future-`:max-tx` case.
-;; Both events go through the same code:
+;; entry's `:expected-max-tx`): the dispatch resuming with its watermark
+;; (`@conn` already advanced by the writer), or a later `@conn` change
+;; (the writer's `reset!` lagged the per-call promise delivery). Both
+;; events go through the same code:
 ;;
 ;;   * `drop-caught-up!`  — atomic `swap-vals!`; returns only the entries
 ;;                          this swap actually removed (race-free against a
@@ -292,11 +295,11 @@
 (defn- emit-overlay-realized!
   "Emit one `:overlay-realized` tx-report per dropped entry.
 
-  Prefer `retract-stale` over the cached writer-tx-data — accurate for
-  both matching-EID (returns empty → no event) and EID-shift (returns
-  only the stale prediction datoms). For entries whose writer-tx-data
-  was never cached (custom-`:dispatch-fn` bypassed `d/transact!`),
-  fall back to full-negate as best-effort cleanup."
+  `retract-stale` is accurate for both matching-EID (returns empty →
+  event suppressed) and EID-shift (returns only the stale prediction
+  datoms). For entries whose writer-tx-data was never cached (foreign
+  `d/transact!`s that bypassed our overlay), fall back to full-negate
+  as best-effort cleanup."
   [conn dropped db-before db-after]
   (when-let [{:keys [writer-tx-cache]} (conn-state conn)]
     (doseq [e dropped]
@@ -324,11 +327,9 @@
 
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    ;; @conn moved — re-fire eff-db listeners with the new view.
-    (fire-listeners! conn)
-    ;; Then catch up any entries whose `:expected-max-tx` was reached
-    ;; by this advance (custom-dispatch-with-future-`:max-tx` case;
-    ;; the default-dispatch path has its own eager call below).
+    ;; @conn moved — recompute conflict set, then catch up any entries
+    ;; whose `:expected-max-tx` was reached by this advance.
+    (recompute-and-emit-conflicts! conn)
     (try-drop-and-emit-realized! conn)))
 
 ;; -----------------------------------------------------------------------------
@@ -340,7 +341,7 @@
 (defn- expire-due!
   "Atomically remove entries whose TTL has elapsed; deliver a
   TimeoutException on each one's :result-ch (exactly-once via
-  `deliver-result!`); fire eff-db listeners; emit one :ttl tx-report
+  `deliver-result!`); recompute conflict set; emit one :ttl tx-report
   per expired entry (retracting its predicted-tx-data)."
   [conn]
   (when-let [{:keys [overlay last-effective-db]} (conn-state conn)]
@@ -358,8 +359,7 @@
                                      :ov-id (:ov-id e)
                                      :submitted-at (:submitted-at e)
                                      :expires-at (:expires-at e)})))
-        ;; Compute new effective-db once and fire eff-db listeners.
-        (fire-listeners! conn)
+        (recompute-and-emit-conflicts! conn)
         ;; Emit a :ttl tx-report per expired entry — each retracts its
         ;; predicted additions (unless the entry was already conflicting,
         ;; in which case its prediction was already retracted via
@@ -384,53 +384,6 @@
         (recur)))))
 
 ;; -----------------------------------------------------------------------------
-;; Dispatch normalization
-;; -----------------------------------------------------------------------------
-
-(defn- default-dispatch
-  "Wrap the conn's writer (`d/transact!`) and conform to the
-  `{:reply :max-tx}` contract.
-
-  Each call to `d/transact!` returns its own per-call promise that
-  resolves with the tx-report for THIS specific tx — even under
-  writer batching, where the commit-loop replaces `:db-after`
-  uniformly across the batch but each tx-report keeps its own
-  `:tx-data` and `:tempids`. We cache the writer's `:tx-data` by
-  `:ov-id` here, *after* the promise resolves: that's the only spot
-  in the flow where we have both pieces of information together
-  without needing a tx-meta round-trip (which would require schema-
-  on-write to declare a special attribute)."
-  [conn tx-data ov-id]
-  (let [out (chan 1)]
-    (a/go
-      (let [report (a/<! (d/transact! conn tx-data))]
-        (if (throwable? report)
-          (put! out report)
-          (let [{:keys [writer-tx-cache]} (conn-state conn)]
-            (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
-            (put! out {:reply report
-                       :max-tx (:max-tx (:db-after report))})))))
-    out))
-
-(defn- run-user-dispatch
-  "Invoke the user's `:dispatch-fn` and route its result (or any
-  thrown/yielded error) onto a single channel. Caller reads with
-  `<?-` to unify throw and yield-an-error.
-
-  Contract: dispatch-fn returns a `core.async` channel (typically
-  a `promise-chan` or the channel of an `a/go` / `a/thread` block).
-  This includes Datahike's own `throwable-promise` returned by
-  `d/transact!`, which implements `ReadPort`."
-  [dispatch-fn]
-  (let [out (chan 1)]
-    (a/go
-      (try
-        (put! out (a/<! (dispatch-fn)))
-        (catch #?(:clj Throwable :cljs :default) e
-          (put! out e))))
-    out))
-
-;; -----------------------------------------------------------------------------
 ;; Public API
 ;; -----------------------------------------------------------------------------
 
@@ -446,9 +399,9 @@
                   Per-call override via `transact!`'s opts.
     :on-conflict  `(fn [conflicts])` — fired when the set of conflicting
                   entries changes. `conflicts` is a vector of pending
-                  entries currently un-applicable on top of @conn (see
-                  Case J in the doc). Each carries `:ov-id`, `:tx-data`,
-                  `:last-conflict-error`, etc.
+                  entries currently un-applicable on top of @conn. Each
+                  carries `:ov-id`, `:tx-data`, `:last-conflict-error`,
+                  etc.
 
   Additional on-conflict listeners can be registered later via
   `on-conflict!`."
@@ -461,7 +414,6 @@
      (when-not (conn-state conn)
        (let [overlay           (atom [])
              listeners         (atom {})
-             tx-listeners      (atom {})
              on-conflicts      (atom (if on-conflict
                                        {::default-on-conflict on-conflict}
                                        {}))
@@ -469,7 +421,7 @@
              ;; Seed `last-effective-db` with the current state so the
              ;; very first emitted tx-report has an accurate
              ;; `:db-before` even if a foreign `d/transact!` lands
-             ;; before any overlay activity has fired `fire-listeners!`.
+             ;; before any overlay activity has fired.
              last-effective-db (atom @conn)
              heartbeat-stop    (chan)
              watch-key         (keyword "datahike.optimistic"
@@ -477,18 +429,16 @@
              writer-listen-key (keyword "datahike.optimistic"
                                         (str "writer-" (random-uuid)))
              ;; Cache of writer's tx-data per `:ov-id`, populated by
-             ;; `default-dispatch` after its per-call promise resolves
-             ;; (where ov-id is in scope) and consumed by both the
-             ;; dispatch's sync-drop path and the watcher's
-             ;; `on-conn-advance` to compose correct
-             ;; `:overlay-realized` stale-retracts. Bounded naturally
-             ;; by the number of in-flight optimistic transacts —
-             ;; each ov-id is consumed exactly once on its drop.
+             ;; `transact!`'s go-block when its per-call promise
+             ;; resolves (ov-id is in scope there) and consumed by
+             ;; `emit-overlay-realized!` to compose correct
+             ;; `:overlay-realized` stale-retracts. Bounded by the
+             ;; number of in-flight optimistic transacts — each ov-id
+             ;; is consumed exactly once on its drop.
              writer-tx-cache   (atom {})]
          (swap! *state assoc conn
                 {:overlay           overlay
                  :listeners         listeners
-                 :tx-listeners      tx-listeners
                  :on-conflicts      on-conflicts
                  :last-conflict-ids last-conflict-ids
                  :last-effective-db last-effective-db
@@ -498,11 +448,10 @@
                  :watch-key         watch-key
                  :writer-listen-key writer-listen-key})
          ;; Emit :conn-advance for every successful d/transact!
-         ;; through this conn — our own AND foreign — so eff-db and
-         ;; tx-report consumers stay in sync with all durable changes.
-         ;; We don't cache here: correlation (writer-tx-data ↔ ov-id)
-         ;; happens directly in `default-dispatch`, where ov-id is
-         ;; naturally in scope when the per-call promise resolves.
+         ;; through this conn — our own AND foreign — so consumers
+         ;; stay in sync with all durable changes. The writer-tx-cache
+         ;; is populated by `transact!`'s go-block (where ov-id is in
+         ;; scope), not here.
          (d/listen conn writer-listen-key
                    (fn [tx-report]
                      (let [db-before (or @last-effective-db @conn)]
@@ -536,23 +485,6 @@
   nil)
 
 (defn listen!
-  "Register a listener `(fn [effective-db])` under key `k`. Fires
-  whenever the overlay changes or @conn advances. The argument is the
-  effective db — @conn with all currently-applicable overlay entries
-  layered on top (conflicting entries excluded; see `:on-conflict`)."
-  [conn k f]
-  (when-not (conn-state conn)
-    (throw (ex-info "Conn not registered for optimistic updates"
-                    {:conn conn})))
-  (swap! (:listeners (conn-state conn)) assoc k f)
-  nil)
-
-(defn unlisten! [conn k]
-  (when-let [{:keys [listeners]} (conn-state conn)]
-    (swap! listeners dissoc k))
-  nil)
-
-(defn listen-tx!
   "Register a tx-report listener `(fn [tx-report])` under key `k`.
   Fires once per logical change to the overlay or @conn, with a
   Datahike-style tx-report:
@@ -577,24 +509,31 @@
   as retracts so a consumer applying tx-data incrementally always
   converges to `@conn`.
 
+  For UIs that just re-render from a db value, ignore `:tx-data`
+  and use `:db-after` directly.
+
   Foreign-peer writes that bypass `d/transact!` do not currently
-  emit `:conn-advance` tx-reports (v1 limit). Standard `listen!`
-  consumers still see `effective-db` updates from foreign writes."
+  emit `:conn-advance` tx-reports (v1 limit)."
   [conn k f]
   (when-not (conn-state conn)
     (throw (ex-info "Conn not registered for optimistic updates"
                     {:conn conn})))
-  (swap! (:tx-listeners (conn-state conn)) assoc k f)
+  (swap! (:listeners (conn-state conn)) assoc k f)
   nil)
 
-(defn unlisten-tx! [conn k]
-  (when-let [{:keys [tx-listeners]} (conn-state conn)]
-    (swap! tx-listeners dissoc k))
+(defn unlisten! [conn k]
+  (when-let [{:keys [listeners]} (conn-state conn)]
+    (swap! listeners dissoc k))
   nil)
 
 (defn on-conflict!
   "Register a conflict-listener `(fn [conflicts])` under key `k`.
-  Fires whenever the set of conflicting entries changes."
+  Fires whenever the set of conflicting entries changes — useful for
+  one-off UX hooks like 'show a toast when conflicts exist'.
+
+  This is *not* a tx-report stream — for tx-data deltas on conflict
+  transitions, use `listen!` and filter for the `:overlay-conflict`
+  and `:overlay-resolve` origins."
   [conn k f]
   (when-not (conn-state conn)
     (throw (ex-info "Conn not registered for optimistic updates"
@@ -612,65 +551,55 @@
 
   Eagerly validates `tx-data` via `d/with` against the current
   effective-db; on validation failure throws synchronously and the
-  overlay is untouched. Otherwise appends a pending entry, fires
-  listeners with the optimistic effective-db, and dispatches the write
-  in the background.
+  overlay is untouched. Otherwise appends a pending entry, emits an
+  `:overlay-add` tx-report to listeners, and routes the durable write
+  through the conn's writer (`d/transact!`) in the background.
 
   Returns `{:ov-id uuid :result <chan>}`:
    - `:ov-id`  — client-minted UUID identifying this entry.
-   - `:result` — 1-buffer channel; yields the dispatch's :reply on
+   - `:result` — 1-buffer channel; yields the writer's tx-report on
                  success or a `Throwable`/`js/Error` on failure
                  (validation, server rejection, TTL timeout, or
-                 unregister! while pending).
-
-  Dispatch defaults to the conn's writer (`d/transact!`); the wrapper
-  extracts `(:max-tx (:db-after tx-report))` and uses it as the
-  watermark for dropping the entry from the overlay.
-
-  Pass `:dispatch-fn` to substitute your own RPC. Contract:
-   - takes no arguments
-   - returns a `core.async` channel that yields a single value:
-     either `{:reply X :max-tx N}` on success — where `N` is the
-     `:max-tx` of the durable commit produced by your RPC — or a
-     `Throwable` / `js/Error`. A thrown exception during the call is
-     also accepted; the wrapper normalizes throw and
-     yield-an-error onto the same failure path.
-   - `X` is what gets put on `:result`.
-   - Datahike's own `throwable-promise` returned by `d/transact!`
-     implements `ReadPort` and satisfies this contract directly.
+                 `unregister!` while pending).
 
   Pass `:ttl-ms` to override the conn's default TTL for this call;
   pass `:ttl-ms nil` to disable the TTL for this call."
   ([conn tx-data] (transact! conn tx-data {}))
-  ([conn tx-data {:keys [dispatch-fn] :as opts}]
-   (let [{:keys [overlay] :as st}
+  ([conn tx-data opts]
+   (let [{:keys [overlay writer-tx-cache] :as st}
          (or (conn-state conn)
              (throw (ex-info "Conn not registered for optimistic updates"
                              {:conn conn})))
          ;; Eager validation against the current effective-db — throws
          ;; on schema/type violations, nothing enters the overlay. Reuse
          ;; the result to cache the predicted tx-data shipped to
-         ;; tx-listeners on :overlay-add.
+         ;; listeners on :overlay-add.
          db-before-add     (effective-db conn)
          validate-report   (d/with db-before-add tx-data)
          predicted-tx-data (vec (:tx-data validate-report))
-         ov-id        (random-uuid)
-         submitted-at (now-ms)
-         ttl-ms       (if (contains? opts :ttl-ms) (:ttl-ms opts) (:ttl-ms st))
-         expires-at   (when ttl-ms (+ submitted-at ttl-ms))
-         result-ch    (chan 1)
-         entry        {:ov-id               ov-id
-                       :tx-data             tx-data
-                       :predicted-tx-data   predicted-tx-data
-                       :submitted-at        submitted-at
-                       :expires-at          expires-at
-                       :expected-max-tx     nil
-                       :conflicting?        false
-                       :last-conflict-error nil
-                       :result-ch           result-ch
-                       :result-delivered?   (atom false)}]
+         ov-id             (random-uuid)
+         submitted-at      (now-ms)
+         ttl-ms            (if (contains? opts :ttl-ms) (:ttl-ms opts) (:ttl-ms st))
+         expires-at        (when ttl-ms (+ submitted-at ttl-ms))
+         result-ch         (chan 1)
+         entry             {:ov-id               ov-id
+                            :tx-data             tx-data
+                            :predicted-tx-data   predicted-tx-data
+                            :submitted-at        submitted-at
+                            :expires-at          expires-at
+                            :expected-max-tx     nil
+                            :conflicting?        false
+                            :last-conflict-error nil
+                            :result-ch           result-ch
+                            :result-delivered?   (atom false)}
+         ;; Test-only escape hatch: a nullary fn returning a channel
+         ;; that yields either `{:reply X :max-tx N}` on success or a
+         ;; Throwable / js/Error on failure. NOT part of the public
+         ;; contract — used by the test suite to gate dispatch timing
+         ;; for race / TTL / conflict scenarios.
+         test-dispatch     (::dispatch-fn opts)]
      (swap! overlay conj entry)
-     (fire-listeners! conn)
+     (recompute-and-emit-conflicts! conn)
      ;; tx-report for the optimistic add. db-after is the new effective-db.
      ;; :tempids and :tx-meta come from the eager d/with — same shape as
      ;; a Datahike TxReport so consumers can use one code path for both
@@ -684,32 +613,31 @@
                      :ov-id     ov-id})
      (a/go
        (try
-         (let [val (<?- (if dispatch-fn
-                          (run-user-dispatch dispatch-fn)
-                          (default-dispatch conn tx-data ov-id)))]
-           (when-not (and (map? val) (contains? val :reply) (contains? val :max-tx))
-             (throw (ex-info
-                     "dispatch-fn returned an invalid shape; expected {:reply :max-tx}"
-                     {:type :optimistic/invalid-dispatch :got val})))
-           (let [{:keys [reply max-tx]} val]
-             ;; Stamp the watermark and let the single drop+emit path
-             ;; handle the rest. If @conn has already caught up (the
-             ;; default-dispatch case — writer's `reset!` ran before
-             ;; the per-call promise delivered), `try-drop-and-emit-
-             ;; realized!` drops the entry here. Otherwise it stays
-             ;; until the watcher's `on-conn-advance` triggers the
-             ;; same path on the next @conn change.
-             (swap! overlay
-                    (fn [v]
-                      (mapv (fn [e]
-                              (if (= (:ov-id e) ov-id)
-                                (assoc e :expected-max-tx max-tx)
-                                e))
-                            v)))
-             (try-drop-and-emit-realized! conn)
-             (deliver-result! entry reply)))
+         (let [[reply max-tx]
+               (if test-dispatch
+                 (let [v (<?- (test-dispatch))]
+                   [(:reply v) (:max-tx v)])
+                 (let [report (<?- (d/transact! conn tx-data))]
+                   (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
+                   [report (:max-tx (:db-after report))]))]
+           ;; Stamp the watermark and let the single drop+emit path
+           ;; handle the rest. On the happy path @conn has already
+           ;; caught up (the writer's `reset!` ran before our promise
+           ;; delivered), so `try-drop-and-emit-realized!` drops the
+           ;; entry here. Otherwise it stays until the watcher's
+           ;; `on-conn-advance` triggers the same path on the next
+           ;; @conn change.
+           (swap! overlay
+                  (fn [v]
+                    (mapv (fn [e]
+                            (if (= (:ov-id e) ov-id)
+                              (assoc e :expected-max-tx max-tx)
+                              e))
+                          v)))
+           (try-drop-and-emit-realized! conn)
+           (deliver-result! entry reply))
          (catch #?(:clj Throwable :cljs :default) e
-           ;; Drop the entry if still present; fire eff-db listeners;
+           ;; Drop the entry if still present; recompute conflicts;
            ;; emit :overlay-drop tx-report retracting predictions;
            ;; deliver the error.
            (let [db-before-drop (effective-db conn)
@@ -717,7 +645,7 @@
                                        #(filterv (fn [x] (not= (:ov-id x) ov-id)) %))
                  dropped-entry (first (filter #(= (:ov-id %) ov-id) old))]
              (when (not= (count old) (count new))
-               (fire-listeners! conn)
+               (recompute-and-emit-conflicts! conn)
                (when (and dropped-entry
                           (not (:conflicting? dropped-entry))
                           (seq (:predicted-tx-data dropped-entry)))

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -2,30 +2,34 @@
   "Optimistic-overlay helpers over a Datahike connection.
 
   Layers pending client-submitted transactions on top of the durable @conn
-  value via `d/db-with`, exposing the result as `effective-db`. Pending
-  entries are dropped automatically when @conn advances past their
-  expected max-tx, and on transact failure they are dropped immediately
-  with listeners notified.
+  value via `d/with`, exposing the result as `effective-db`.
+
+  An entry remains visible until @conn has demonstrably caught up to the
+  transaction's effect (the writer-assigned `:max-tx`), the dispatch
+  failed, or a per-entry TTL elapsed. See `doc/optimistic-overlay.md` for
+  the full consistency model.
 
   Usage:
 
     (require '[datahike.optimistic :as opt])
 
-    (opt/register! conn)
-    (opt/listen! conn ::ui (fn [eff-db] (rerender! eff-db)))
+    (opt/register! conn
+      {:ttl-ms 30000
+       :on-conflict (fn [conflicts] ...)})
+    (opt/listen!   conn ::ui (fn [eff-db] (rerender! eff-db)))
     (opt/transact! conn [{:db/id -1 :name \"alice\"}])
     ...
-    (opt/unlisten! conn ::ui)
+    (opt/unlisten!   conn ::ui)
     (opt/unregister! conn)
 
-  Identity assumption: applications should identify entities by a stable
-  attribute (e.g. :entity/uuid minted client-side) rather than by EID,
-  since tempid resolution may differ between the overlay's `d/with` and
-  the underlying transact."
+  Identity assumption: identify entities by a stable attribute
+  (`:entity/uuid` minted client-side) rather than by EID — tempid
+  resolution may differ between the overlay's `d/with` and the durable
+  writer."
   (:require [datahike.api :as d]
-            #?(:clj  [clojure.core.async :as a :refer [chan put!]]
-               :cljs [clojure.core.async :as a :refer [chan put!]
-                      :refer-macros [go]])))
+            #?(:clj  [clojure.core.async :as a :refer [chan put! alts! timeout close!]]
+               :cljs [clojure.core.async :as a :refer [chan put! alts! timeout close!]])
+            [superv.async #?(:clj :refer :cljs :refer-macros) [<?-]]))
 
 ;; -----------------------------------------------------------------------------
 ;; Per-connection state
@@ -36,198 +40,416 @@
 (defn- conn-state [conn]
   (get @*state conn))
 
+(defn- now-ms []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.getTime (js/Date.))))
+
+(defn- throwable? [v]
+  #?(:clj  (instance? Throwable v)
+     :cljs (instance? js/Error v)))
+
 ;; -----------------------------------------------------------------------------
-;; Effective DB
+;; Effective DB + conflict detection
 ;; -----------------------------------------------------------------------------
 
-(defn- effective-db*
-  "Reduce overlay entries with `d/db-with` over base-db. Entries marked
-  `:transacting?` are skipped — those have already been handed to the
-  underlying writer and are about to land in @conn, so re-applying them
-  would double their datoms in the view."
+(defn- recompute
+  "Pure fold over overlay entries.
+   Returns {:db <db-after-all-non-conflicting-applied>
+            :conflicts {ov-id error}}.
+
+   An entry whose `d/with` throws is excluded from the produced db and
+   recorded in `:conflicts`. The overlay itself is not mutated here —
+   the caller is responsible for surfacing conflict status."
   [base-db overlay-vec]
-  (reduce (fn [db {:keys [tx-data]}]
-            (:db-after (d/with db tx-data)))
-          base-db
-          (remove :transacting? overlay-vec)))
+  (reduce (fn [{:keys [db conflicts]} {:keys [ov-id tx-data]}]
+            (try
+              {:db (:db-after (d/with db tx-data)) :conflicts conflicts}
+              (catch #?(:clj Throwable :cljs :default) e
+                {:db db :conflicts (assoc conflicts ov-id e)})))
+          {:db base-db :conflicts {}}
+          overlay-vec))
 
 (defn effective-db
-  "Return the db value with all pending optimistic entries applied on top.
-  Returns @conn unchanged if conn is not registered."
+  "Return the db value with all currently-applicable optimistic entries
+  on top. Entries whose `d/with` would throw against the current @conn
+  (Case J — conflict) are excluded from the view but stay in the overlay
+  until their dispatch resolves or their TTL expires.
+
+  Returns @conn unchanged if `conn` is not registered."
   [conn]
   (if-let [{:keys [overlay]} (conn-state conn)]
-    (effective-db* @conn @overlay)
+    (:db (recompute @conn @overlay))
     @conn))
 
 (defn pending
-  "Return a vector of pending overlay entries for conn (empty if none /
-  not registered)."
+  "Return current pending entries for conn (empty vector if none / not
+  registered). Internal fields (`:result-ch`, `:result-delivered?`)
+  are stripped — entries carry `:ov-id`, `:tx-data`, `:submitted-at`,
+  `:expires-at`, `:expected-max-tx`, `:conflicting?`,
+  `:last-conflict-error`."
   [conn]
   (if-let [{:keys [overlay]} (conn-state conn)]
-    @overlay
+    (mapv #(dissoc % :result-ch :result-delivered?) @overlay)
     []))
 
 ;; -----------------------------------------------------------------------------
-;; Listeners
+;; Listener firing
 ;; -----------------------------------------------------------------------------
 
+(defn- mark-conflicts! [overlay conflict-map]
+  (swap! overlay
+         (fn [entries]
+           (mapv (fn [e]
+                   (let [err (get conflict-map (:ov-id e))]
+                     (assoc e
+                            :conflicting? (some? err)
+                            :last-conflict-error err)))
+                 entries))))
+
 (defn- fire-listeners! [conn]
-  (when-let [{:keys [listeners]} (conn-state conn)]
-    (let [eff-db (try
-                   (effective-db conn)
-                   (catch #?(:clj Throwable :cljs :default) e
-                     ;; Overlay re-application failed against current @conn.
-                     ;; Fall back to base; UI may temporarily lose optimistic
-                     ;; visibility for entries that became invalid.
-                     (println "datahike.optimistic: effective-db failed, falling back:" e)
-                     @conn))]
+  (when-let [{:keys [overlay listeners on-conflicts last-conflict-ids]}
+             (conn-state conn)]
+    (let [snapshot @overlay
+          {:keys [db conflicts]} (recompute @conn snapshot)
+          new-conflict-ids (set (keys conflicts))]
+      (mark-conflicts! overlay conflicts)
       (doseq [[_ f] @listeners]
-        (try
-          (f eff-db)
-          (catch #?(:clj Throwable :cljs :default) e
-            (println "datahike.optimistic listener error:" e)))))))
+        (try (f db)
+             (catch #?(:clj Throwable :cljs :default) e
+               (println "datahike.optimistic listener error:" e))))
+      (when (not= new-conflict-ids @last-conflict-ids)
+        (reset! last-conflict-ids new-conflict-ids)
+        (let [sanitized (->> @overlay
+                             (filter :conflicting?)
+                             (mapv #(dissoc % :result-ch :result-delivered?)))]
+          (doseq [[_ f] @on-conflicts]
+            (try (f sanitized)
+                 (catch #?(:clj Throwable :cljs :default) e
+                   (println "datahike.optimistic on-conflict error:" e)))))))))
+
+;; -----------------------------------------------------------------------------
+;; Exactly-once :result delivery
+;; -----------------------------------------------------------------------------
+
+(defn- deliver-result! [entry value]
+  ;; Whichever code path (dispatch success/failure, TTL expiry,
+  ;; unregister!) gets here first wins. Others are no-ops, so a
+  ;; full :result-ch buffer can never block a producer. Entries
+  ;; that were injected directly into the overlay (tests / advanced
+  ;; users) won't carry a `:result-delivered?` atom — skip them.
+  (when-let [flag (:result-delivered? entry)]
+    (when (compare-and-set! flag false true)
+      (put! (:result-ch entry) value))))
+
+;; -----------------------------------------------------------------------------
+;; Watcher: drop entries whose @conn caught up
+;; -----------------------------------------------------------------------------
+
+(defn- drop-caught-up!
+  "Atomically remove entries whose `:expected-max-tx` is <= the new
+  @conn's `:max-tx`. The dispatch already delivered its :reply on
+  `:result-ch` when it set `:expected-max-tx` — there is no further
+  signal to fire on the result channel here.
+
+  Returns true iff any entry was dropped."
+  [overlay new-max]
+  (let [[old new] (swap-vals! overlay
+                              (fn [v]
+                                (filterv
+                                 (fn [{:keys [expected-max-tx]}]
+                                   (not (and expected-max-tx
+                                             new-max
+                                             (>= new-max expected-max-tx))))
+                                 v)))]
+    (not= (count old) (count new))))
 
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    ;; @conn changed — UI needs the new effective-db. We do *not* drop
-    ;; pending entries here: matching is by `:ov-id` and is handled in
-    ;; `transact!` itself (success and failure paths). Predicted max-tx
-    ;; would be unreliable under concurrent writers, so we don't try.
+    (when-let [{:keys [overlay]} (conn-state conn)]
+      (drop-caught-up! overlay (:max-tx new-db)))
+    ;; Fire listeners whether or not anything was dropped — @conn moved,
+    ;; so the effective-db moved with it, and consumers expect a tick.
     (fire-listeners! conn)))
+
+;; -----------------------------------------------------------------------------
+;; TTL heartbeat
+;; -----------------------------------------------------------------------------
+
+(def ^:private heartbeat-tick-ms 1000)
+
+(defn- expire-due!
+  "Atomically remove entries whose TTL has elapsed; deliver a
+  TimeoutException on each one's :result-ch (exactly-once via
+  `deliver-result!`); fire listeners if anything moved."
+  [conn]
+  (when-let [{:keys [overlay]} (conn-state conn)]
+    (let [now (now-ms)
+          expired? (fn [{:keys [expires-at]}]
+                     (and expires-at (< expires-at now)))
+          [old new] (swap-vals! overlay #(filterv (complement expired?) %))
+          gone (filterv expired? old)]
+      (when (seq gone)
+        (doseq [e gone]
+          (deliver-result! e
+                           (ex-info "Optimistic transaction timed out"
+                                    {:type :optimistic/timeout
+                                     :ov-id (:ov-id e)
+                                     :submitted-at (:submitted-at e)
+                                     :expires-at (:expires-at e)})))
+        (fire-listeners! conn)))))
+
+(defn- start-heartbeat! [conn stop-ch]
+  (a/go-loop []
+    (let [[_ port] (alts! [stop-ch (timeout heartbeat-tick-ms)])]
+      (when-not (= port stop-ch)
+        (try (expire-due! conn)
+             (catch #?(:clj Throwable :cljs :default) e
+               (println "datahike.optimistic heartbeat error:" e)))
+        (recur)))))
+
+;; -----------------------------------------------------------------------------
+;; Dispatch normalization
+;; -----------------------------------------------------------------------------
+
+(defn- default-dispatch
+  "Wrap the conn's writer (`d/transact!`) and conform to the
+  `{:reply :max-tx}` contract."
+  [conn tx-data]
+  (let [out (chan 1)]
+    #?(:clj
+       (a/thread
+         (try
+           (let [report @(d/transact! conn tx-data)]
+             (put! out {:reply report
+                        :max-tx (:max-tx (:db-after report))}))
+           (catch Throwable e (put! out e))))
+       :cljs
+       (a/go
+         (let [report (a/<! (d/transact! conn tx-data))]
+           (if (throwable? report)
+             (put! out report)
+             (put! out {:reply report
+                        :max-tx (:max-tx (:db-after report))})))))
+    out))
+
+(defn- run-user-dispatch
+  "Invoke the user's `:dispatch-fn` and route the result (or any
+  throw / yielded-error) onto a single channel. Caller reads with
+  `<?-` to unify throw and yield-an-error."
+  [dispatch-fn]
+  (let [out (chan 1)]
+    #?(:clj
+       (a/thread
+         (try
+           (let [v @(dispatch-fn)]
+             ;; @ on a `throwable-promise` throws; on a plain promise
+             ;; with a Throwable value, we'd get the value back — pass
+             ;; it through and let the consumer's <?- normalize.
+             (put! out v))
+           (catch Throwable e (put! out e))))
+       :cljs
+       (a/go
+         (try
+           (let [v (a/<! (dispatch-fn))]
+             (put! out v))
+           (catch :default e (put! out e)))))
+    out))
 
 ;; -----------------------------------------------------------------------------
 ;; Public API
 ;; -----------------------------------------------------------------------------
 
+(def ^:private default-ttl-ms 30000)
+
 (defn register!
-  "Register a conn for optimistic updates. Idempotent. Returns conn."
-  [conn]
-  (when-not (conn-state conn)
-    (let [overlay   (atom [])
-          listeners (atom {})
-          watch-key (keyword "datahike.optimistic"
-                             (str "watch-" (random-uuid)))]
-      (swap! *state assoc conn
-             {:overlay overlay :listeners listeners :watch-key watch-key})
-      (add-watch conn watch-key
-                 (fn [_ _ old new] (on-conn-advance conn old new)))))
-  conn)
+  "Register a conn for optimistic updates. Idempotent — a second call
+  with the same conn has no effect. Returns conn.
+
+  Options (all optional):
+    :ttl-ms       Default per-entry TTL in ms. Defaults to 30000.
+                  Pass `nil` to disable the TTL by default for this conn.
+                  Per-call override via `transact!`'s opts.
+    :on-conflict  `(fn [conflicts])` — fired when the set of conflicting
+                  entries changes. `conflicts` is a vector of pending
+                  entries currently un-applicable on top of @conn (see
+                  Case J in the doc). Each carries `:ov-id`, `:tx-data`,
+                  `:last-conflict-error`, etc.
+
+  Additional on-conflict listeners can be registered later via
+  `on-conflict!`."
+  ([conn] (register! conn {}))
+  ([conn {:keys [ttl-ms on-conflict] :or {ttl-ms default-ttl-ms}}]
+   (when-not (conn-state conn)
+     (let [overlay           (atom [])
+           listeners         (atom {})
+           on-conflicts      (atom (if on-conflict
+                                     {::default-on-conflict on-conflict}
+                                     {}))
+           last-conflict-ids (atom #{})
+           heartbeat-stop    (chan)
+           watch-key         (keyword "datahike.optimistic"
+                                      (str "watch-" (random-uuid)))]
+       (swap! *state assoc conn
+              {:overlay           overlay
+               :listeners         listeners
+               :on-conflicts      on-conflicts
+               :last-conflict-ids last-conflict-ids
+               :heartbeat-stop    heartbeat-stop
+               :ttl-ms            ttl-ms
+               :watch-key         watch-key})
+       (add-watch conn watch-key
+                  (fn [_ _ old new] (on-conn-advance conn old new)))
+       (start-heartbeat! conn heartbeat-stop)))
+   conn))
 
 (defn unregister!
-  "Detach overlay from conn. Drops all pending entries (no rollback fired)."
+  "Detach the overlay from conn. Cancels any in-flight pending entries
+  by delivering an `:optimistic/cancelled` error on their :result chan.
+  Stops the heartbeat and clears all overlay state."
   [conn]
-  (when-let [{:keys [watch-key]} (conn-state conn)]
+  (when-let [{:keys [watch-key heartbeat-stop overlay]} (conn-state conn)]
     (remove-watch conn watch-key)
+    (close! heartbeat-stop)
+    (doseq [e @overlay]
+      (deliver-result! e
+                       (ex-info "Optimistic conn unregistered while entry pending"
+                                {:type  :optimistic/cancelled
+                                 :ov-id (:ov-id e)})))
     (swap! *state dissoc conn))
   nil)
 
 (defn listen!
-  "Register a listener `f` of one arg (effective-db) under key `k`.
-  The listener fires whenever @conn advances or the overlay changes
-  (entry added on transact!, entry dropped on conn-advance or rejection)."
+  "Register a listener `(fn [effective-db])` under key `k`. Fires
+  whenever the overlay changes or @conn advances. The argument is the
+  effective db — @conn with all currently-applicable overlay entries
+  layered on top (conflicting entries excluded; see `:on-conflict`)."
   [conn k f]
   (when-not (conn-state conn)
     (throw (ex-info "Conn not registered for optimistic updates"
                     {:conn conn})))
-  (let [{:keys [listeners]} (conn-state conn)]
-    (swap! listeners assoc k f))
+  (swap! (:listeners (conn-state conn)) assoc k f)
   nil)
 
-(defn unlisten!
-  [conn k]
+(defn unlisten! [conn k]
   (when-let [{:keys [listeners]} (conn-state conn)]
     (swap! listeners dissoc k))
+  nil)
+
+(defn on-conflict!
+  "Register a conflict-listener `(fn [conflicts])` under key `k`.
+  Fires whenever the set of conflicting entries changes."
+  [conn k f]
+  (when-not (conn-state conn)
+    (throw (ex-info "Conn not registered for optimistic updates"
+                    {:conn conn})))
+  (swap! (:on-conflicts (conn-state conn)) assoc k f)
+  nil)
+
+(defn off-conflict! [conn k]
+  (when-let [{:keys [on-conflicts]} (conn-state conn)]
+    (swap! on-conflicts dissoc k))
   nil)
 
 (defn transact!
   "Optimistic transact.
 
-  Eagerly validates `tx-data` via `d/with`, appends an overlay entry,
-  fires listeners with the optimistic effective-db, then dispatches the
-  write. Validation errors throw synchronously (overlay untouched);
-  dispatch errors are delivered on the `:result` channel and the entry
-  is dropped before listeners re-fire with the rolled-back effective-db.
+  Eagerly validates `tx-data` via `d/with` against the current
+  effective-db; on validation failure throws synchronously and the
+  overlay is untouched. Otherwise appends a pending entry, fires
+  listeners with the optimistic effective-db, and dispatches the write
+  in the background.
 
   Returns `{:ov-id uuid :result <chan>}`:
-   - `:ov-id`  — client-minted UUID identifying this entry; useful for
-                 correlating with listener events.
-   - `:result` — a 1-buffer channel that yields exactly one value: the
-                 server reply on success, or a Throwable (CLJ) /
-                 js/Error (CLJS) on failure.
+   - `:ov-id`  — client-minted UUID identifying this entry.
+   - `:result` — 1-buffer channel; yields the dispatch's :reply on
+                 success or a `Throwable`/`js/Error` on failure
+                 (validation, server rejection, TTL timeout, or
+                 unregister! while pending).
 
-  Dispatch defaults to `(d/transact! conn tx-data)` — routes through the
-  conn's writer (`:self`, `:kabel`, …) and yields a Datahike tx-report.
+  Dispatch defaults to the conn's writer (`d/transact!`); the wrapper
+  extracts `(:max-tx (:db-after tx-report))` and uses it as the
+  watermark for dropping the entry from the overlay.
 
-  Pass `:dispatch-fn` in opts to substitute your own RPC — for cases
-  where the server side does more than a plain Datahike transact (e.g.
-  an `invoke-remote` that creates additional entities, runs server-side
-  validation, etc.). Contract:
+  Pass `:dispatch-fn` to substitute your own RPC. Contract:
    - takes no arguments
-   - returns a deref-able (CLJ) / `core.async` channel (CLJS) that
-     yields the server reply on success or throws/yields-an-error
-   - the value it yields is what gets put on `:result` — the wrapper
-     does not interpret it."
+   - returns a deref-able (CLJ) or `core.async` channel (CLJS) that
+     either yields `{:reply X :max-tx N}` on success — where `N` is the
+     `:max-tx` of the durable commit produced by your RPC — or
+     throws / yields a `Throwable` / `js/Error` on failure.
+   - The wrapper normalizes throw vs yield-an-error onto the same
+     failure path.
+   - `X` is what gets put on `:result`.
+
+  Pass `:ttl-ms` to override the conn's default TTL for this call;
+  pass `:ttl-ms nil` to disable the TTL for this call."
   ([conn tx-data] (transact! conn tx-data {}))
-  ([conn tx-data {:keys [dispatch-fn] :as _opts}]
-   (let [{:keys [overlay]} (or (conn-state conn)
-                               (throw (ex-info "Conn not registered for optimistic updates"
-                                               {:conn conn})))
-         ov-id     (random-uuid)
-        ;; Eager validation: run `d/with` against the current
-        ;; effective-db so malformed/schema-violating tx surfaces
-        ;; synchronously before we add anything to the overlay.
-        ;; The result is otherwise discarded — entries are matched and
-        ;; removed by `:ov-id`, so we don't need the predicted max-tx.
-         _validate (d/with (effective-db conn) tx-data) ;; throws on invalid tx
-         entry     {:ov-id        ov-id
-                    :tx-data      tx-data
-                    :status       :pending
-                    :submitted-at #?(:clj  (System/currentTimeMillis)
-                                     :cljs (.getTime (js/Date.)))}
-         result-ch (chan 1)]
+  ([conn tx-data {:keys [dispatch-fn] :as opts}]
+   (let [{:keys [overlay] :as st}
+         (or (conn-state conn)
+             (throw (ex-info "Conn not registered for optimistic updates"
+                             {:conn conn})))
+         ;; Eager validation — throws on schema/type violations,
+         ;; nothing enters the overlay.
+         _validate (d/with (effective-db conn) tx-data)
+         ov-id        (random-uuid)
+         submitted-at (now-ms)
+         ttl-ms       (if (contains? opts :ttl-ms) (:ttl-ms opts) (:ttl-ms st))
+         expires-at   (when ttl-ms (+ submitted-at ttl-ms))
+         result-ch    (chan 1)
+         entry        {:ov-id               ov-id
+                       :tx-data             tx-data
+                       :submitted-at        submitted-at
+                       :expires-at          expires-at
+                       :expected-max-tx     nil
+                       :conflicting?        false
+                       :last-conflict-error nil
+                       :result-ch           result-ch
+                       :result-delivered?   (atom false)}]
      (swap! overlay conj entry)
      (fire-listeners! conn)
-    ;; Mark :transacting? right before dispatch so the conn-watch fires
-    ;; during d/transact!'s swap! sees effective-db = new-base (without our
-    ;; entry being re-applied via d/with on top of datoms that just landed).
-     (swap! overlay
-            (fn [entries]
-              (mapv #(if (= (:ov-id %) ov-id)
-                       (assoc % :transacting? true)
-                       %)
-                    entries)))
-     (let [drop-entry! (fn []
-                         (swap! overlay
-                                (fn [entries]
-                                  (filterv (fn [e] (not= (:ov-id e) ov-id))
-                                           entries))))]
-      ;; Default dispatch: route through the conn's writer (`d/transact!`).
-      ;; Custom dispatch is for app-level RPCs whose server side does more
-      ;; than a plain Datahike transact (e.g. multi-entity bootstrap).
-      ;; In CLJ d/transact! returns a Future-like; in CLJS a promise-chan.
-       #?(:clj
-          (a/thread
-            (try
-              (let [reply (if dispatch-fn
-                            @(dispatch-fn)
-                            @(d/transact! conn tx-data))]
-                (drop-entry!) ;; conn-watch already ran fire-listeners! with
-                             ;; our :transacting? entry skipped — effective
-                             ;; -db is already correct; no fire needed here.
-                (put! result-ch reply))
-              (catch Throwable e
-                (drop-entry!)
-                (fire-listeners! conn)
-                (put! result-ch e))))
-          :cljs
-          (a/go
-            (let [reply (try
-                          (a/<! (if dispatch-fn
-                                  (dispatch-fn)
-                                  (d/transact! conn tx-data)))
-                          (catch :default e e))]
-              (drop-entry!)
-              (when (instance? js/Error reply)
-                (fire-listeners! conn))
-              (put! result-ch reply)))))
+     (a/go
+       (try
+         (let [val (<?- (if dispatch-fn
+                          (run-user-dispatch dispatch-fn)
+                          (default-dispatch conn tx-data)))]
+           (when-not (and (map? val) (contains? val :reply))
+             (throw (ex-info
+                     "dispatch-fn returned an invalid shape; expected {:reply :max-tx}"
+                     {:type :optimistic/invalid-dispatch :got val})))
+           (let [{:keys [reply max-tx]} val
+                 ;; Mark the entry with its watermark — the watcher
+                 ;; will drop it when @conn :max-tx catches up. If the
+                 ;; entry is no longer present (heartbeat / unregister!
+                 ;; raced ahead), this swap! is a no-op.
+                 [_old new-overlay]
+                 (swap-vals! overlay
+                             (fn [v]
+                               (mapv (fn [e]
+                                       (if (= (:ov-id e) ov-id)
+                                         (assoc e :expected-max-tx max-tx)
+                                         e))
+                                     v)))
+                 still-present? (some #(= (:ov-id %) ov-id) new-overlay)]
+             (when still-present?
+               ;; Sync drop: if @conn already advanced past max-tx
+               ;; (default `:self` writer commits before returning),
+               ;; the watcher already fired but couldn't drop because
+               ;; :expected-max-tx wasn't set yet. Catch that here.
+               (when (and max-tx (>= (:max-tx @conn) max-tx))
+                 (swap! overlay #(filterv (fn [e] (not= (:ov-id e) ov-id)) %)))
+               ;; If the user's dispatch-fn neglected :max-tx, fall
+               ;; back to drop-on-resolve so the entry doesn't linger
+               ;; forever (silently — documented contract requires it).
+               (when (nil? max-tx)
+                 (swap! overlay #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))))
+             (deliver-result! entry reply)))
+         (catch #?(:clj Throwable :cljs :default) e
+           ;; Drop the entry if still present; fire listeners; deliver
+           ;; the error. `deliver-result!` is exactly-once, so a prior
+           ;; TTL/cancel won't be clobbered.
+           (let [[old new] (swap-vals! overlay
+                                       #(filterv (fn [x] (not= (:ov-id x) ov-id)) %))]
+             (when (not= (count old) (count new))
+               (fire-listeners! conn)))
+           (deliver-result! entry e))))
      {:ov-id ov-id :result result-ch})))

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -444,19 +444,24 @@
                                        {::default-on-conflict on-conflict}
                                        {}))
              last-conflict-ids (atom #{})
-             last-effective-db (atom nil)
+             ;; Seed `last-effective-db` with the current state so the
+             ;; very first emitted tx-report has an accurate
+             ;; `:db-before` even if a foreign `d/transact!` lands
+             ;; before any overlay activity has fired `fire-listeners!`.
+             last-effective-db (atom @conn)
              heartbeat-stop    (chan)
              watch-key         (keyword "datahike.optimistic"
                                         (str "watch-" (random-uuid)))
              writer-listen-key (keyword "datahike.optimistic"
                                         (str "writer-" (random-uuid)))
              ;; Cache of writer's tx-data per `:ov-id`, populated by
-             ;; the writer-listener and consumed by the dispatch path
-             ;; (and by `drain-pending-realized!` for watcher-dropped
-             ;; entries) to compose correct `:overlay-realized`
-             ;; stale-retracts. Bounded naturally by the number of
-             ;; in-flight optimistic transacts — each ov-id is
-             ;; consumed exactly once on its corresponding drop.
+             ;; `default-dispatch` after its per-call promise resolves
+             ;; (where ov-id is in scope) and consumed by both the
+             ;; dispatch's sync-drop path and the watcher's
+             ;; `on-conn-advance` to compose correct
+             ;; `:overlay-realized` stale-retracts. Bounded naturally
+             ;; by the number of in-flight optimistic transacts —
+             ;; each ov-id is consumed exactly once on its drop.
              writer-tx-cache   (atom {})]
          (swap! *state assoc conn
                 {:overlay           overlay
@@ -470,18 +475,12 @@
                  :ttl-ms            ttl-ms
                  :watch-key         watch-key
                  :writer-listen-key writer-listen-key})
-         ;; The conn's writer-listener fires for every successful
-         ;; `d/transact!` through this conn — whether it came from our
-         ;; own `opt/transact!`'s default dispatch OR a direct call by
-         ;; other code. We cache the writer's `:tx-data` per `:max-tx`
-         ;; (for later `:overlay-realized` composition) AND emit a
-         ;; `:conn-advance` tx-report immediately so consumers stay in
-         ;; sync with all durable changes.
-         ;; Emit :conn-advance for every successful d/transact! through
-         ;; this conn — our own AND foreign. We don't cache here:
-         ;; correlation (writer-tx-data ↔ ov-id) happens directly in
-         ;; `default-dispatch`, where ov-id is naturally in scope when
-         ;; the per-call promise resolves.
+         ;; Emit :conn-advance for every successful d/transact!
+         ;; through this conn — our own AND foreign — so eff-db and
+         ;; tx-report consumers stay in sync with all durable changes.
+         ;; We don't cache here: correlation (writer-tx-data ↔ ov-id)
+         ;; happens directly in `default-dispatch`, where ov-id is
+         ;; naturally in scope when the per-call promise resolves.
          (d/listen conn writer-listen-key
                    (fn [tx-report]
                      (let [db-before (or @last-effective-db @conn)]

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -276,29 +276,32 @@
 
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    (let [{:keys [overlay last-effective-db]} (conn-state conn)
+    (let [{:keys [overlay last-effective-db writer-tx-cache]} (conn-state conn)
           db-before (or @last-effective-db @conn)
           dropped (when overlay (drop-caught-up! overlay (:max-tx new-db)))]
       ;; @conn moved — re-fire eff-db listeners with the new view.
       (fire-listeners! conn)
-      ;; Entries reach this path only via a custom `:dispatch-fn` that
-      ;; resolved with `:max-tx` ahead of `@conn` (and so couldn't
-      ;; sync-drop). For default-dispatch the dispatch's sync-drop
-      ;; runs first — `:expected-max-tx` is still `nil` when this
-      ;; watcher fires (during writer's `reset!`, before the
-      ;; conn-listener), so `drop-caught-up!` skips those.
+      ;; `drop-caught-up!` returns only the entries this swap actually
+      ;; removed — atomic against a concurrent dispatch-path drop.
+      ;; (Each entry can be dropped by exactly one path. The other path's
+      ;; swap is a no-op and its `we-dropped?` flag will be false, so
+      ;; it won't double-emit.)
       ;;
-      ;; We don't have correlated writer tx-data here (the cache is
-      ;; keyed by ov-id, and the writer-listener that would have
-      ;; cached it didn't fire under that ov-id). Emit full-negate of
-      ;; the prediction — rolls the consumer's view back to baseline.
-      ;; Any concurrent `:conn-advance` from an unrelated `d/transact!`
-      ;; that happened to bump @conn past this entry's expected
-      ;; carries its own tx-data; the consumer composes them.
+      ;; For each dropped entry, prefer `retract-stale` over the cached
+      ;; writer-tx-data — accurate for both matching-EID (returns empty
+      ;; → no event) and EID-shift (returns only the stale prediction
+      ;; datoms). For entries whose writer-tx-data was never cached
+      ;; (the custom-`:dispatch-fn`-bypasses-`d/transact!` case),
+      ;; fall back to full-negate as best-effort cleanup; the consumer
+      ;; view rolls back to baseline and any concurrent `:conn-advance`
+      ;; from an unrelated commit carries its own tx-data on top.
       (when (seq dropped)
         (let [db-after (effective-db conn)]
           (doseq [e dropped]
-            (let [retracts (negate (:predicted-tx-data e))]
+            (let [server-tx-data (take-writer-tx! writer-tx-cache (:ov-id e))
+                  retracts (if server-tx-data
+                             (retract-stale (:predicted-tx-data e) server-tx-data)
+                             (negate (:predicted-tx-data e)))]
               (when (seq retracts)
                 (emit-tx! conn {:db-before db-before
                                 :db-after  db-after
@@ -366,26 +369,25 @@
   "Wrap the conn's writer (`d/transact!`) and conform to the
   `{:reply :max-tx}` contract.
 
-  `d/transact!` returns a `throwable-promise` on CLJ which implements
-  `core.async/ReadPort` (and on failure puts the Throwable as a value
-  on the inner chan, not as a re-throw). So `<!` works uniformly on
-  both platforms — no need to spin a dedicated OS thread via
-  `a/thread` just to wait on the deref.
-
-  We inject `::ov-id` into `:tx-meta` so the writer-listener can
-  correlate the resulting tx-report back to the originating overlay
-  entry. The writer preserves `:tx-meta` on its tx-report — even
-  across batched commits, where multiple tx-reports share one
-  `:max-tx`. See the cache-keying notes above."
+  Each call to `d/transact!` returns its own per-call promise that
+  resolves with the tx-report for THIS specific tx — even under
+  writer batching, where the commit-loop replaces `:db-after`
+  uniformly across the batch but each tx-report keeps its own
+  `:tx-data` and `:tempids`. We cache the writer's `:tx-data` by
+  `:ov-id` here, *after* the promise resolves: that's the only spot
+  in the flow where we have both pieces of information together
+  without needing a tx-meta round-trip (which would require schema-
+  on-write to declare a special attribute)."
   [conn tx-data ov-id]
   (let [out (chan 1)]
     (a/go
-      (let [report (a/<! (d/transact! conn {:tx-data tx-data
-                                            :tx-meta {::ov-id ov-id}}))]
+      (let [report (a/<! (d/transact! conn tx-data))]
         (if (throwable? report)
           (put! out report)
-          (put! out {:reply report
-                     :max-tx (:max-tx (:db-after report))}))))
+          (let [{:keys [writer-tx-cache]} (conn-state conn)]
+            (cache-writer-tx! writer-tx-cache ov-id (vec (:tx-data report)))
+            (put! out {:reply report
+                       :max-tx (:max-tx (:db-after report))})))))
     out))
 
 (defn- run-user-dispatch
@@ -475,19 +477,17 @@
          ;; (for later `:overlay-realized` composition) AND emit a
          ;; `:conn-advance` tx-report immediately so consumers stay in
          ;; sync with all durable changes.
+         ;; Emit :conn-advance for every successful d/transact! through
+         ;; this conn — our own AND foreign. We don't cache here:
+         ;; correlation (writer-tx-data ↔ ov-id) happens directly in
+         ;; `default-dispatch`, where ov-id is naturally in scope when
+         ;; the per-call promise resolves.
          (d/listen conn writer-listen-key
                    (fn [tx-report]
-                     (let [tx-data (vec (:tx-data tx-report))
-                           ov-id (get-in tx-report [:tx-meta ::ov-id])
-                           db-before (or @last-effective-db @conn)]
-                       ;; Cache only for own writes (those carrying our
-                       ;; tx-meta tag) — foreign d/transact!s on this
-                       ;; conn still get a :conn-advance event but
-                       ;; aren't correlated to an overlay entry.
-                       (cache-writer-tx! writer-tx-cache ov-id tx-data)
+                     (let [db-before (or @last-effective-db @conn)]
                        (emit-tx! conn {:db-before db-before
                                        :db-after  (effective-db conn)
-                                       :tx-data   tx-data
+                                       :tx-data   (vec (:tx-data tx-report))
                                        :tempids   (:tempids tx-report)
                                        :tx-meta   (:tx-meta tx-report)
                                        :origin    :conn-advance}))))
@@ -685,35 +685,33 @@
              (when still-present?
                (let [conn-max (:max-tx @conn)
                      ;; `dispatch-fn` contract requires :max-tx, so we
-                     ;; drop the entry iff @conn has caught up. The
-                     ;; watcher will drop it later if @conn is still
-                     ;; behind at this point — and will emit any
-                     ;; needed `:overlay-realized` itself via
-                     ;; `emit-overlay-realized!`.
+                     ;; drop the entry iff @conn has caught up. If it
+                     ;; hasn't, the watcher will drop it later when
+                     ;; @conn does — and the watcher's path uses the
+                     ;; same cache, so the cleanup is identical.
                      dropping? (and max-tx conn-max (>= conn-max max-tx))]
                  (when dropping?
                    (let [db-before-drop (effective-db conn)
-                         _ (swap! overlay
-                                  #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))
-                         ;; Use the writer-listener's cached tx-data
-                         ;; keyed by our ov-id (consumed
-                         ;; exactly-once). Empty only when the
-                         ;; dispatch bypassed `d/transact!` or didn't
-                         ;; carry our `::ov-id` tx-meta tag — see
-                         ;; the v1 limit in the doc; we skip
-                         ;; :overlay-realized in that case rather
-                         ;; than over-retract from a reply of unknown
-                         ;; shape.
-                         server-tx-data (take-writer-tx! writer-tx-cache ov-id)]
-                     (when server-tx-data
-                       (let [stale-retracts (retract-stale predicted-tx-data
-                                                           server-tx-data)]
-                         (when (seq stale-retracts)
-                           (emit-tx! conn {:db-before db-before-drop
-                                           :db-after  (effective-db conn)
-                                           :tx-data   stale-retracts
-                                           :origin    :overlay-realized
-                                           :ov-id     ov-id}))))))))
+                         [old new] (swap-vals! overlay
+                                               #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))
+                         ;; Only emit if WE removed the entry. If the
+                         ;; watcher's `drop-caught-up!` already
+                         ;; removed it (because add-watch fired
+                         ;; between `set :expected-max-tx` and here),
+                         ;; the watcher already emitted using the
+                         ;; same cache — don't double-emit.
+                         we-dropped? (not= (count old) (count new))]
+                     (when we-dropped?
+                       (let [server-tx-data (take-writer-tx! writer-tx-cache ov-id)]
+                         (when server-tx-data
+                           (let [stale-retracts (retract-stale predicted-tx-data
+                                                               server-tx-data)]
+                             (when (seq stale-retracts)
+                               (emit-tx! conn {:db-before db-before-drop
+                                               :db-after  (effective-db conn)
+                                               :tx-data   stale-retracts
+                                               :origin    :overlay-realized
+                                               :ov-id     ov-id}))))))))))
              (deliver-result! entry reply)))
          (catch #?(:clj Throwable :cljs :default) e
            ;; Drop the entry if still present; fire eff-db listeners;

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -116,37 +116,34 @@
         datoms))
 
 ;; -----------------------------------------------------------------------------
-;; Writer-tx cache (max-tx → tx-data, FIFO-evicted)
+;; Writer-tx cache (ov-id → tx-data)
 ;; -----------------------------------------------------------------------------
-
-(def ^:private writer-tx-cache-max 64)
+;;
+;; Cache is keyed by the per-entry `:ov-id`, NOT by `:max-tx`. The
+;; writer can batch multiple transactions into one commit; in a batch
+;; of N, all N tx-reports get the *same* `:max-tx` (the writer
+;; overwrites `:db-after` with the batch's commit-db before delivering
+;; — see `writer.cljc` commit-loop). Keying by max-tx would collide
+;; across batched entries. Keying by ov-id keeps each entry's writer-
+;; tx-data distinct.
+;;
+;; The ov-id is conveyed via `:tx-meta {::ov-id ov-id}` injected by
+;; `default-dispatch` into the `d/transact!` arg-map; the writer
+;; preserves `:tx-meta` on the tx-report.
 
 (defn- cache-writer-tx!
-  [cache max-tx tx-data]
-  (when max-tx
-    (swap! cache
-           (fn [{:keys [by-tx order]}]
-             (let [by-tx (assoc by-tx max-tx tx-data)
-                   order (conj order max-tx)]
-               (if (> (count order) writer-tx-cache-max)
-                 (let [evict (peek order)]
-                   {:by-tx (dissoc by-tx evict) :order (pop order)})
-                 {:by-tx by-tx :order order}))))))
+  [cache ov-id tx-data]
+  (when ov-id
+    (swap! cache assoc ov-id tx-data)))
 
 (defn- take-writer-tx!
-  "Pop the cached writer tx-data for `max-tx`, removing it from the
-  cache. Returns nil if absent (e.g. for entries whose dispatch
-  bypassed `d/transact!`, in which case no writer-listener fired)."
-  [cache max-tx]
-  (when max-tx
-    (let [[old _] (swap-vals! cache
-                              (fn [{:keys [by-tx order]}]
-                                {:by-tx (dissoc by-tx max-tx)
-                                 :order (into #?(:clj clojure.lang.PersistentQueue/EMPTY
-                                                 :cljs #queue [])
-                                              (remove #(= % max-tx))
-                                              order)}))]
-      (get-in old [:by-tx max-tx]))))
+  "Pop the cached writer tx-data for `ov-id`, removing it from the
+  cache. Returns nil if absent (e.g. for foreign `d/transact!`s or
+  custom dispatches that bypassed our `::ov-id` tx-meta convention)."
+  [cache ov-id]
+  (when ov-id
+    (let [[old _] (swap-vals! cache dissoc ov-id)]
+      (get old ov-id))))
 
 (defn- retract-stale
   "Return retract-form datoms for any *added* datoms in `predicted` whose
@@ -277,62 +274,37 @@
                                (fn [v] (filterv (complement caught-up?) v)))]
     (filterv caught-up? old)))
 
-(defn- enqueue-pending-realized!
-  "Park dropped entries in `pending-realized` until the writer-listener
-  populates the cache. add-watch fires synchronously inside `reset!`,
-  while the conn's writer-listener fires *after* — so at watcher-drop
-  time the cache is empty for own writes. The writer-listener then
-  drains matching entries from this queue once it has the realized
-  tx-data."
-  [pending-realized dropped db-before db-after]
-  (when (seq dropped)
-    (swap! pending-realized
-           into
-           (mapv (fn [e]
-                   {:ov-id             (:ov-id e)
-                    :predicted-tx-data (:predicted-tx-data e)
-                    :expected-max-tx   (:expected-max-tx e)
-                    :db-before         db-before
-                    :db-after          db-after})
-                 dropped))))
-
-(defn- drain-pending-realized!
-  "When the writer-listener fires for `max-tx`, drain any pending
-  entries with `:expected-max-tx == max-tx` and emit their
-  `:overlay-realized` events using the just-cached writer-tx-data."
-  [conn max-tx]
-  (when-let [{:keys [pending-realized writer-tx-cache]} (conn-state conn)]
-    (let [match? (fn [pr] (= (:expected-max-tx pr) max-tx))
-          [old _] (swap-vals! pending-realized
-                              (fn [v] (filterv (complement match?) v)))
-          eligible (filterv match? old)]
-      (doseq [pr eligible]
-        (let [server-tx-data (take-writer-tx! writer-tx-cache max-tx)
-              stale-retracts (when server-tx-data
-                               (retract-stale (:predicted-tx-data pr)
-                                              server-tx-data))]
-          (when (seq stale-retracts)
-            (emit-tx! conn {:db-before (:db-before pr)
-                            :db-after  (:db-after pr)
-                            :tx-data   stale-retracts
-                            :origin    :overlay-realized
-                            :ov-id     (:ov-id pr)})))))))
-
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    (let [{:keys [overlay pending-realized last-effective-db]} (conn-state conn)
+    (let [{:keys [overlay last-effective-db]} (conn-state conn)
           db-before (or @last-effective-db @conn)
           dropped (when overlay (drop-caught-up! overlay (:max-tx new-db)))]
-      ;; Fire listeners whether or not anything was dropped — @conn
-      ;; moved, so the effective-db moved with it, and consumers
-      ;; expect a tick.
+      ;; @conn moved — re-fire eff-db listeners with the new view.
       (fire-listeners! conn)
-      ;; The writer-listener (which fires AFTER us for own writes) will
-      ;; drain these and emit :overlay-realized once it has the
-      ;; realized tx-data. Foreign writes leave entries stranded here
-      ;; (no writer-listener fires) — v1 limit, see doc.
-      (enqueue-pending-realized! pending-realized dropped
-                                 db-before (effective-db conn)))))
+      ;; Entries reach this path only via a custom `:dispatch-fn` that
+      ;; resolved with `:max-tx` ahead of `@conn` (and so couldn't
+      ;; sync-drop). For default-dispatch the dispatch's sync-drop
+      ;; runs first — `:expected-max-tx` is still `nil` when this
+      ;; watcher fires (during writer's `reset!`, before the
+      ;; conn-listener), so `drop-caught-up!` skips those.
+      ;;
+      ;; We don't have correlated writer tx-data here (the cache is
+      ;; keyed by ov-id, and the writer-listener that would have
+      ;; cached it didn't fire under that ov-id). Emit full-negate of
+      ;; the prediction — rolls the consumer's view back to baseline.
+      ;; Any concurrent `:conn-advance` from an unrelated `d/transact!`
+      ;; that happened to bump @conn past this entry's expected
+      ;; carries its own tx-data; the consumer composes them.
+      (when (seq dropped)
+        (let [db-after (effective-db conn)]
+          (doseq [e dropped]
+            (let [retracts (negate (:predicted-tx-data e))]
+              (when (seq retracts)
+                (emit-tx! conn {:db-before db-before
+                                :db-after  db-after
+                                :tx-data   retracts
+                                :origin    :overlay-realized
+                                :ov-id     (:ov-id e)})))))))))
 
 ;; -----------------------------------------------------------------------------
 ;; TTL heartbeat
@@ -398,11 +370,18 @@
   `core.async/ReadPort` (and on failure puts the Throwable as a value
   on the inner chan, not as a re-throw). So `<!` works uniformly on
   both platforms — no need to spin a dedicated OS thread via
-  `a/thread` just to wait on the deref."
-  [conn tx-data]
+  `a/thread` just to wait on the deref.
+
+  We inject `::ov-id` into `:tx-meta` so the writer-listener can
+  correlate the resulting tx-report back to the originating overlay
+  entry. The writer preserves `:tx-meta` on its tx-report — even
+  across batched commits, where multiple tx-reports share one
+  `:max-tx`. See the cache-keying notes above."
+  [conn tx-data ov-id]
   (let [out (chan 1)]
     (a/go
-      (let [report (a/<! (d/transact! conn tx-data))]
+      (let [report (a/<! (d/transact! conn {:tx-data tx-data
+                                            :tx-meta {::ov-id ov-id}}))]
         (if (throwable? report)
           (put! out report)
           (put! out {:reply report
@@ -469,19 +448,14 @@
                                         (str "watch-" (random-uuid)))
              writer-listen-key (keyword "datahike.optimistic"
                                         (str "writer-" (random-uuid)))
-             ;; Cache of writer's tx-data per `:max-tx`, populated by
+             ;; Cache of writer's tx-data per `:ov-id`, populated by
              ;; the writer-listener and consumed by the dispatch path
              ;; (and by `drain-pending-realized!` for watcher-dropped
              ;; entries) to compose correct `:overlay-realized`
-             ;; stale-retracts. Capped via FIFO so pathological
-             ;; direct-write traffic can't grow it without bound.
-             writer-tx-cache   (atom {:by-tx {} :order #?(:clj clojure.lang.PersistentQueue/EMPTY
-                                                          :cljs #queue [])})
-             ;; Queue of entries the watcher dropped before the
-             ;; writer-listener had a chance to cache the realized
-             ;; tx-data. The writer-listener drains this when it
-             ;; fires with a matching `:max-tx`.
-             pending-realized  (atom [])]
+             ;; stale-retracts. Bounded naturally by the number of
+             ;; in-flight optimistic transacts — each ov-id is
+             ;; consumed exactly once on its corresponding drop.
+             writer-tx-cache   (atom {})]
          (swap! *state assoc conn
                 {:overlay           overlay
                  :listeners         listeners
@@ -490,7 +464,6 @@
                  :last-conflict-ids last-conflict-ids
                  :last-effective-db last-effective-db
                  :writer-tx-cache   writer-tx-cache
-                 :pending-realized  pending-realized
                  :heartbeat-stop    heartbeat-stop
                  :ttl-ms            ttl-ms
                  :watch-key         watch-key
@@ -504,23 +477,20 @@
          ;; sync with all durable changes.
          (d/listen conn writer-listen-key
                    (fn [tx-report]
-                     (let [max-tx (:max-tx (:db-after tx-report))
-                           tx-data (vec (:tx-data tx-report))
+                     (let [tx-data (vec (:tx-data tx-report))
+                           ov-id (get-in tx-report [:tx-meta ::ov-id])
                            db-before (or @last-effective-db @conn)]
-                       (cache-writer-tx! writer-tx-cache max-tx tx-data)
+                       ;; Cache only for own writes (those carrying our
+                       ;; tx-meta tag) — foreign d/transact!s on this
+                       ;; conn still get a :conn-advance event but
+                       ;; aren't correlated to an overlay entry.
+                       (cache-writer-tx! writer-tx-cache ov-id tx-data)
                        (emit-tx! conn {:db-before db-before
                                        :db-after  (effective-db conn)
                                        :tx-data   tx-data
                                        :tempids   (:tempids tx-report)
                                        :tx-meta   (:tx-meta tx-report)
-                                       :origin    :conn-advance})
-                       ;; The watcher may have already dropped entries
-                       ;; for this `max-tx` (it fires inside `reset!`,
-                       ;; before this conn-listener does); their
-                       ;; `:overlay-realized` event was deferred until
-                       ;; now so we have the realized tx-data to
-                       ;; compose retract-stale against.
-                       (drain-pending-realized! conn max-tx))))
+                                       :origin    :conn-advance}))))
          (add-watch conn watch-key
                     (fn [_ _ old new] (on-conn-advance conn old new)))
          (start-heartbeat! conn heartbeat-stop))))
@@ -695,7 +665,7 @@
        (try
          (let [val (<?- (if dispatch-fn
                           (run-user-dispatch dispatch-fn)
-                          (default-dispatch conn tx-data)))]
+                          (default-dispatch conn tx-data ov-id)))]
            (when-not (and (map? val) (contains? val :reply) (contains? val :max-tx))
              (throw (ex-info
                      "dispatch-fn returned an invalid shape; expected {:reply :max-tx}"
@@ -726,13 +696,15 @@
                          _ (swap! overlay
                                   #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))
                          ;; Use the writer-listener's cached tx-data
-                         ;; (consumed exactly-once). The cache is
-                         ;; empty only when the dispatch bypassed
-                         ;; `d/transact!` — see the v1 limit in the
-                         ;; doc; we skip :overlay-realized in that
-                         ;; case rather than over-retract from a
-                         ;; reply of unknown shape.
-                         server-tx-data (take-writer-tx! writer-tx-cache max-tx)]
+                         ;; keyed by our ov-id (consumed
+                         ;; exactly-once). Empty only when the
+                         ;; dispatch bypassed `d/transact!` or didn't
+                         ;; carry our `::ov-id` tx-meta tag — see
+                         ;; the v1 limit in the doc; we skip
+                         ;; :overlay-realized in that case rather
+                         ;; than over-retract from a reply of unknown
+                         ;; shape.
+                         server-tx-data (take-writer-tx! writer-tx-cache ov-id)]
                      (when server-tx-data
                        (let [stale-retracts (retract-stale predicted-tx-data
                                                            server-tx-data)]

--- a/src/datahike/optimistic.cljc
+++ b/src/datahike/optimistic.cljc
@@ -260,13 +260,28 @@
       (put! (:result-ch entry) value))))
 
 ;; -----------------------------------------------------------------------------
-;; Watcher: drop entries whose @conn caught up
+;; Catch-up: drop overlay entries whose @conn caught up, emit :overlay-realized
 ;; -----------------------------------------------------------------------------
+;;
+;; Two events can cause an entry to "catch up" (= `@conn :max-tx` reaches the
+;; entry's `:expected-max-tx`): the dispatch resuming with its watermark for
+;; the default-dispatch case (`@conn` already advanced by the writer), or a
+;; later `@conn` change for the custom-dispatch-with-future-`:max-tx` case.
+;; Both events go through the same code:
+;;
+;;   * `drop-caught-up!`  — atomic `swap-vals!`; returns only the entries
+;;                          this swap actually removed (race-free against a
+;;                          concurrent caller — exactly one swap wins per
+;;                          entry).
+;;   * `emit-overlay-realized!` — for each dropped entry, retract-stale via
+;;                                 the cache when present, else full-negate.
+;;
+;; `try-drop-and-emit-realized!` is the single entry point both triggers call.
 
 (defn- drop-caught-up!
-  "Atomically remove entries whose `:expected-max-tx` is <= the new
-  @conn's `:max-tx`. Returns the seq of removed entries (for the
-  caller to emit `:overlay-realized` events from)."
+  "Atomically remove entries whose `:expected-max-tx` is <= `new-max`.
+  Returns the entries this swap actually removed (race-free: a concurrent
+  caller's swap returns the entries IT removed, with no overlap)."
   [overlay new-max]
   (let [caught-up? (fn [{:keys [expected-max-tx]}]
                      (and expected-max-tx new-max (>= new-max expected-max-tx)))
@@ -274,40 +289,47 @@
                                (fn [v] (filterv (complement caught-up?) v)))]
     (filterv caught-up? old)))
 
+(defn- emit-overlay-realized!
+  "Emit one `:overlay-realized` tx-report per dropped entry.
+
+  Prefer `retract-stale` over the cached writer-tx-data — accurate for
+  both matching-EID (returns empty → no event) and EID-shift (returns
+  only the stale prediction datoms). For entries whose writer-tx-data
+  was never cached (custom-`:dispatch-fn` bypassed `d/transact!`),
+  fall back to full-negate as best-effort cleanup."
+  [conn dropped db-before db-after]
+  (when-let [{:keys [writer-tx-cache]} (conn-state conn)]
+    (doseq [e dropped]
+      (let [server-tx-data (take-writer-tx! writer-tx-cache (:ov-id e))
+            retracts (if server-tx-data
+                       (retract-stale (:predicted-tx-data e) server-tx-data)
+                       (negate (:predicted-tx-data e)))]
+        (when (seq retracts)
+          (emit-tx! conn {:db-before db-before
+                          :db-after  db-after
+                          :tx-data   retracts
+                          :origin    :overlay-realized
+                          :ov-id     (:ov-id e)}))))))
+
+(defn- try-drop-and-emit-realized!
+  "Single entry point for both the watcher and dispatch triggers. Drops
+  any caught-up entries and emits `:overlay-realized` for the entries
+  THIS call actually removed."
+  [conn]
+  (when-let [{:keys [overlay last-effective-db]} (conn-state conn)]
+    (let [db-before (or @last-effective-db @conn)
+          dropped (drop-caught-up! overlay (:max-tx @conn))]
+      (when (seq dropped)
+        (emit-overlay-realized! conn dropped db-before (effective-db conn))))))
+
 (defn- on-conn-advance [conn old-db new-db]
   (when (not= (:max-tx old-db) (:max-tx new-db))
-    (let [{:keys [overlay last-effective-db writer-tx-cache]} (conn-state conn)
-          db-before (or @last-effective-db @conn)
-          dropped (when overlay (drop-caught-up! overlay (:max-tx new-db)))]
-      ;; @conn moved — re-fire eff-db listeners with the new view.
-      (fire-listeners! conn)
-      ;; `drop-caught-up!` returns only the entries this swap actually
-      ;; removed — atomic against a concurrent dispatch-path drop.
-      ;; (Each entry can be dropped by exactly one path. The other path's
-      ;; swap is a no-op and its `we-dropped?` flag will be false, so
-      ;; it won't double-emit.)
-      ;;
-      ;; For each dropped entry, prefer `retract-stale` over the cached
-      ;; writer-tx-data — accurate for both matching-EID (returns empty
-      ;; → no event) and EID-shift (returns only the stale prediction
-      ;; datoms). For entries whose writer-tx-data was never cached
-      ;; (the custom-`:dispatch-fn`-bypasses-`d/transact!` case),
-      ;; fall back to full-negate as best-effort cleanup; the consumer
-      ;; view rolls back to baseline and any concurrent `:conn-advance`
-      ;; from an unrelated commit carries its own tx-data on top.
-      (when (seq dropped)
-        (let [db-after (effective-db conn)]
-          (doseq [e dropped]
-            (let [server-tx-data (take-writer-tx! writer-tx-cache (:ov-id e))
-                  retracts (if server-tx-data
-                             (retract-stale (:predicted-tx-data e) server-tx-data)
-                             (negate (:predicted-tx-data e)))]
-              (when (seq retracts)
-                (emit-tx! conn {:db-before db-before
-                                :db-after  db-after
-                                :tx-data   retracts
-                                :origin    :overlay-realized
-                                :ov-id     (:ov-id e)})))))))))
+    ;; @conn moved — re-fire eff-db listeners with the new view.
+    (fire-listeners! conn)
+    ;; Then catch up any entries whose `:expected-max-tx` was reached
+    ;; by this advance (custom-dispatch-with-future-`:max-tx` case;
+    ;; the default-dispatch path has its own eager call below).
+    (try-drop-and-emit-realized! conn)))
 
 ;; -----------------------------------------------------------------------------
 ;; TTL heartbeat
@@ -621,7 +643,7 @@
   pass `:ttl-ms nil` to disable the TTL for this call."
   ([conn tx-data] (transact! conn tx-data {}))
   ([conn tx-data {:keys [dispatch-fn] :as opts}]
-   (let [{:keys [overlay writer-tx-cache] :as st}
+   (let [{:keys [overlay] :as st}
          (or (conn-state conn)
              (throw (ex-info "Conn not registered for optimistic updates"
                              {:conn conn})))
@@ -669,48 +691,22 @@
              (throw (ex-info
                      "dispatch-fn returned an invalid shape; expected {:reply :max-tx}"
                      {:type :optimistic/invalid-dispatch :got val})))
-           (let [{:keys [reply max-tx]} val
-                 ;; Mark the entry with its watermark — the watcher
-                 ;; will drop it when @conn :max-tx catches up.
-                 [_old new-overlay]
-                 (swap-vals! overlay
-                             (fn [v]
-                               (mapv (fn [e]
-                                       (if (= (:ov-id e) ov-id)
-                                         (assoc e :expected-max-tx max-tx)
-                                         e))
-                                     v)))
-                 still-present? (some #(= (:ov-id %) ov-id) new-overlay)]
-             (when still-present?
-               (let [conn-max (:max-tx @conn)
-                     ;; `dispatch-fn` contract requires :max-tx, so we
-                     ;; drop the entry iff @conn has caught up. If it
-                     ;; hasn't, the watcher will drop it later when
-                     ;; @conn does — and the watcher's path uses the
-                     ;; same cache, so the cleanup is identical.
-                     dropping? (and max-tx conn-max (>= conn-max max-tx))]
-                 (when dropping?
-                   (let [db-before-drop (effective-db conn)
-                         [old new] (swap-vals! overlay
-                                               #(filterv (fn [e] (not= (:ov-id e) ov-id)) %))
-                         ;; Only emit if WE removed the entry. If the
-                         ;; watcher's `drop-caught-up!` already
-                         ;; removed it (because add-watch fired
-                         ;; between `set :expected-max-tx` and here),
-                         ;; the watcher already emitted using the
-                         ;; same cache — don't double-emit.
-                         we-dropped? (not= (count old) (count new))]
-                     (when we-dropped?
-                       (let [server-tx-data (take-writer-tx! writer-tx-cache ov-id)]
-                         (when server-tx-data
-                           (let [stale-retracts (retract-stale predicted-tx-data
-                                                               server-tx-data)]
-                             (when (seq stale-retracts)
-                               (emit-tx! conn {:db-before db-before-drop
-                                               :db-after  (effective-db conn)
-                                               :tx-data   stale-retracts
-                                               :origin    :overlay-realized
-                                               :ov-id     ov-id}))))))))))
+           (let [{:keys [reply max-tx]} val]
+             ;; Stamp the watermark and let the single drop+emit path
+             ;; handle the rest. If @conn has already caught up (the
+             ;; default-dispatch case — writer's `reset!` ran before
+             ;; the per-call promise delivered), `try-drop-and-emit-
+             ;; realized!` drops the entry here. Otherwise it stays
+             ;; until the watcher's `on-conn-advance` triggers the
+             ;; same path on the next @conn change.
+             (swap! overlay
+                    (fn [v]
+                      (mapv (fn [e]
+                              (if (= (:ov-id e) ov-id)
+                                (assoc e :expected-max-tx max-tx)
+                                e))
+                            v)))
+             (try-drop-and-emit-realized! conn)
              (deliver-result! entry reply)))
          (catch #?(:clj Throwable :cljs :default) e
            ;; Drop the entry if still present; fire eff-db listeners;

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -8,7 +8,8 @@
             [cljs.nodejs :as nodejs]
             ;; Sibling test namespaces — included so `bb node-cljs-test`
             ;; covers them too.
-            [datahike.test.cljs-pattern-scan-test]))
+            [datahike.test.cljs-pattern-scan-test]
+            [datahike.test.optimistic-smoke-test]))
 
 ;; Hook cljs.test's end-of-run callback so the Node process exits with
 ;; status 0 only when all tests pass. The previous setup always exited
@@ -352,4 +353,5 @@
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
-               'datahike.test.cljs-pattern-scan-test))
+               'datahike.test.cljs-pattern-scan-test
+               'datahike.test.optimistic-smoke-test))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -9,7 +9,7 @@
             ;; Sibling test namespaces — included so `bb node-cljs-test`
             ;; covers them too.
             [datahike.test.cljs-pattern-scan-test]
-            [datahike.test.optimistic-smoke-test]))
+            [datahike.test.optimistic-test]))
 
 ;; Hook cljs.test's end-of-run callback so the Node process exits with
 ;; status 0 only when all tests pass. The previous setup always exited
@@ -354,4 +354,4 @@
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.cljs-pattern-scan-test
-               'datahike.test.optimistic-smoke-test))
+               'datahike.test.optimistic-test))

--- a/test/datahike/test/optimistic_smoke_test.cljc
+++ b/test/datahike/test/optimistic_smoke_test.cljc
@@ -1,13 +1,19 @@
 (ns datahike.test.optimistic-smoke-test
-  "Cross-platform smoke test for `datahike.optimistic`.
+  "Cross-platform smoke + invariant tests for `datahike.optimistic`.
 
-   Validates the core API on both CLJ and CLJS-Node:
+   Covers:
      - register! / unregister!
      - listen! / unlisten!
      - transact! happy path (channel delivers tx-report)
      - transact! eager-validation rejection (synchronous throw)
      - effective-db reduces overlay over @conn
-     - external @conn advances re-fire listeners with correct effective-db"
+     - external @conn advances re-fire listeners with correct effective-db
+     - concurrent transacts: each entry stays visible while the other is in flight
+     - default-dispatch closes the visibility gap (hammered reads see no flicker)
+     - custom dispatch with :max-tx closes the gap likewise
+     - Case J (conflict): conflicting entry hides from view, surfaces via
+       :on-conflict, drops on dispatch failure
+     - TTL expiry yields TimeoutException on :result"
   #?(:clj  (:require [clojure.test :refer [deftest is testing]]
                      [datahike.api :as d]
                      [datahike.optimistic :as opt]
@@ -51,9 +57,7 @@
       (let [{:keys [ov-id result]} (opt/transact! conn [{:name "bob"}])
             reply (<! result)]
         (is (some? ov-id) "ov-id is set")
-        (is (not (#?(:clj instance? :cljs instance?)
-                  #?(:clj Throwable :cljs js/Error)
-                  reply))
+        (is (not (instance? #?(:clj Throwable :cljs js/Error) reply))
             "reply is not an exception")
         (is (some? (:db-after reply)) "reply is a tx-report")
         (is (= 0 (count (opt/pending conn))) "pending drained after success")
@@ -83,20 +87,213 @@
     (opt/register! conn)
     (opt/listen! conn ::probe (fn [eff-db] (swap! events conj (names eff-db))))
     (testing "manually-stacked overlay entries survive an external @conn advance"
-      ;; Manually inject an entry that bypasses transact!. Removal is
-      ;; only ever by `:ov-id` from transact! itself, so the watcher
-      ;; never drops it on its own.
+      ;; Manual entry has no :expected-max-tx, so the watcher's
+      ;; max-tx drop never removes it; it persists until unregister!.
       (let [{:keys [overlay]} (#'opt/conn-state conn)
             ov-id (random-uuid)]
         (swap! overlay conj
                {:ov-id   ov-id
-                :tx-data [{:name "carol"}]
-                :status  :pending})
-        ;; External transact (simulates konserve-sync echo / another peer)
+                :tx-data [{:name "carol"}]})
         (<! (d/transact! conn [{:name "dave"}]))
         (is (= 1 (count (opt/pending conn)))
             "manual entry survives external advance")
         (is (= ["alice" "dave"] (names @conn)) "base has dave only")
         (is (= ["alice" "carol" "dave"] (names (opt/effective-db conn)))
             "effective-db includes carol via overlay")))
+    (opt/unregister! conn)))
+
+;; A gate-as-dispatch lets us hold a transact!'s reply until we choose.
+;; New contract: dispatch-fn yields {:reply X :max-tx N}. We set N = 0 so
+;; the wrapper's sync drop check (@conn :max-tx >= 0) drops the entry
+;; immediately on resolution — no flapping while @conn marches on.
+(defn- make-gate []
+  #?(:clj (promise) :cljs (a/chan 1)))
+
+(defn- open-gate! [gate]
+  #?(:clj (deliver gate {:reply {:ok true} :max-tx 0})
+     :cljs (a/put! gate {:reply {:ok true} :max-tx 0})))
+
+(deftest-async concurrent-transacts-keep-each-other-visible
+  ;; An in-flight optimistic entry must stay visible while another
+  ;; concurrent transact! runs. (The original :transacting? bug:
+  ;; effective-db skipped flagged entries, opening a visibility gap
+  ;; between dispatch and @conn advance — freshly-created entities
+  ;; flickered in the DOM diff.)
+  (let [conn   (<! (setup))
+        events (atom [])
+        gate1  (make-gate)
+        gate2  (make-gate)]
+    (opt/register! conn)
+    (opt/listen! conn ::probe (fn [eff-db] (swap! events conj (names eff-db))))
+    (testing "an in-flight entry survives a concurrent transact!'s listener fire"
+      (let [t1 (opt/transact! conn [{:name "bob"}]
+                              {:dispatch-fn (fn [] gate1)})]
+        (is (contains? (set (names (opt/effective-db conn))) "bob")
+            "bob visible immediately after T1's optimistic transact!")
+        (let [t2 (opt/transact! conn [{:name "carol"}]
+                                {:dispatch-fn (fn [] gate2)})]
+          (is (contains? (set (names (opt/effective-db conn))) "bob")
+              "bob STILL visible after a concurrent transact!")
+          (is (contains? (set (names (opt/effective-db conn))) "carol")
+              "carol visible via its own overlay entry")
+          (is (every? #(contains? (set %) "bob") @events)
+              "NO listener event ever dropped the in-flight bob entry")
+          (is (some #(contains? (set %) "carol") @events)
+              "the concurrent transact! did fire a listener event")
+          (open-gate! gate1)
+          (open-gate! gate2)
+          (<! (:result t1))
+          (<! (:result t2))
+          (is (= 0 (count (opt/pending conn))) "overlay drained after both resolve"))))
+    (opt/unlisten! conn ::probe)
+    (opt/unregister! conn)))
+
+(deftest-async default-dispatch-no-gap
+  ;; Invariant: with the default writer dispatch, the optimistic value
+  ;; is continuously visible in effective-db from `transact!` return
+  ;; until the dispatch resolves — and onward via @conn. No flicker
+  ;; even under a heavy concurrent reader.
+  (let [conn (<! (setup))
+        stop? (atom false)
+        samples (atom [])
+        hammer
+        #?(:clj (future (while (not @stop?)
+                          (swap! samples conj (set (names (opt/effective-db conn))))))
+           :cljs nil)] ;; CLJS: skip the hammer; the invariant holds by construction
+    (opt/register! conn {:ttl-ms nil})
+    (testing "no sample after submit loses the optimistic name"
+      (let [{:keys [result]} (opt/transact! conn [{:name "bob"}])]
+        (<! result)
+        #?(:clj (do (reset! stop? true) @hammer))
+        (is (= ["alice" "bob"] (names (opt/effective-db conn))))
+        #?(:clj
+           (let [after-submit @samples]
+             ;; Every snapshot taken while bob was either in overlay or in
+             ;; @conn must include bob. We allow snapshots taken before
+             ;; the overlay was populated (the very first samples).
+             (is (every? (fn [s] (or (contains? s "bob") (= s #{"alice"}) (empty? s)))
+                         after-submit)
+                 "snapshots are either pre-submit (alice-only) or post-submit (include bob)")))))
+    (opt/unregister! conn)))
+
+(deftest-async custom-dispatch-with-max-tx-no-gap
+  ;; Custom dispatch-fns that honor the {:reply :max-tx} contract also
+  ;; close the gap — the watcher drops the entry only after @conn has
+  ;; demonstrably caught up.
+  (let [conn (<! (setup))]
+    (opt/register! conn {:ttl-ms nil})
+    (testing "good custom dispatch closes the gap"
+      (let [{:keys [result]}
+            (opt/transact! conn [{:name "carol"}]
+                           {:dispatch-fn
+                            (fn []
+                              #?(:clj
+                                 (let [p (promise)]
+                                   (future
+                                     (let [r @(d/transact! conn [{:name "carol"}])]
+                                       (deliver p {:reply r
+                                                   :max-tx (:max-tx (:db-after r))})))
+                                   p)
+                                 :cljs
+                                 (let [ch (a/chan 1)]
+                                   (go (let [r (<! (d/transact! conn [{:name "carol"}]))]
+                                         (a/put! ch {:reply r
+                                                     :max-tx (:max-tx (:db-after r))})))
+                                   ch)))})]
+        (<! result)
+        (is (contains? (set (names (opt/effective-db conn))) "carol"))
+        (is (= 0 (count (opt/pending conn))) "overlay drained after dispatch resolved")))
+    (opt/unregister! conn)))
+
+;; A dispatch-fn that resolves only when an external `release-ch` closes
+;; or yields a value. Used to hold an optimistic entry in flight while
+;; the test asserts intermediate state. The resolver thunk is called
+;; *after* release; its return must conform to {:reply :max-tx} or be
+;; a Throwable / js/Error (the wrapper normalizes both).
+(defn- gated-dispatch [release-ch resolver]
+  (fn []
+    #?(:clj
+       (let [p (promise)]
+         (a/thread
+           (a/<!! release-ch)
+           (deliver p (try (resolver)
+                           (catch Throwable e e))))
+         p)
+       :cljs
+       (let [out (a/chan 1)]
+         (go
+           (a/<! release-ch)
+           (try (a/put! out (resolver))
+                (catch :default e (a/put! out e))))
+         out))))
+
+(deftest-async conflict-surfaces-via-on-conflict
+  ;; Case J: an in-flight overlay entry becomes un-applicable because a
+  ;; concurrent direct write seized a unique value. The entry hides
+  ;; from the view, the :on-conflict callback fires, and once the gate
+  ;; opens the server rejects → :result yields the throwable.
+  (let [cfg (mk-cfg)
+        _ (<! #?(:clj (go (d/create-database cfg)) :cljs (d/create-database cfg)))
+        conn (<! #?(:clj (go (d/connect cfg)) :cljs (d/connect cfg {:sync? false})))
+        _ (<! (d/transact! conn [{:db/ident :slot :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one
+                                  :db/unique :db.unique/value}
+                                 {:db/ident :who :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one}]))
+        conflicts (atom [])
+        release (a/chan)]
+    (opt/register! conn {:ttl-ms 5000
+                         :on-conflict (fn [cs] (swap! conflicts conj (mapv :ov-id cs)))})
+    (let [opt-res (opt/transact! conn [{:slot "S" :who "alice"}]
+                                 {:dispatch-fn
+                                  (gated-dispatch
+                                   release
+                                   (fn []
+                                     (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
+                                       (if (instance? #?(:clj Throwable :cljs js/Error) r)
+                                         r
+                                         {:reply r :max-tx (:max-tx (:db-after r))}))))})]
+      (<! (a/timeout 20))
+      (is (contains?
+           (set (->> (d/q '[:find ?w :where [?e :who ?w]] (opt/effective-db conn))
+                     (map first)))
+           "alice")
+          "alice optimistically visible before the conflict")
+      (<! (d/transact! conn [{:slot "S" :who "mallory"}]))
+      (<! (a/timeout 100))
+      (let [eff-who (set (->> (d/q '[:find ?w :where [?e :who ?w]] (opt/effective-db conn))
+                              (map first)))]
+        (is (contains? eff-who "mallory") "mallory visible")
+        (is (not (contains? eff-who "alice")) "alice excluded from view (conflict)")
+        (is (some (fn [e] (true? (:conflicting? e))) (opt/pending conn))
+            "pending entry marked :conflicting?")
+        (is (seq @conflicts) "on-conflict fired"))
+      (a/close! release)
+      (let [reply (<! (:result opt-res))]
+        (is (instance? #?(:clj Throwable :cljs js/Error) reply)
+            ":result yields the server's rejection")))
+    (<! (a/timeout 50))
+    (is (= 0 (count (opt/pending conn))) "overlay drained")
+    (is (= [] (last @conflicts)) "on-conflict cleared once entry removed")
+    (opt/unregister! conn)))
+
+(deftest-async ttl-expires-then-fires-result
+  ;; An entry whose dispatch never resolves expires after :ttl-ms and
+  ;; the :result chan yields a TimeoutException tagged
+  ;; :optimistic/timeout.
+  (let [conn (<! (setup))
+        never-release (a/chan)]
+    (opt/register! conn {:ttl-ms 1500})
+    (let [{:keys [result]}
+          (opt/transact! conn [{:name "ghost"}]
+                         {:dispatch-fn (gated-dispatch
+                                        never-release
+                                        (fn [] {:reply :unused :max-tx 0}))})
+          reply (<! result)]
+      (is (instance? #?(:clj Throwable :cljs js/Error) reply))
+      (is (= :optimistic/timeout (:type (ex-data reply))) "tagged as timeout"))
+    (is (= 0 (count (opt/pending conn))) "overlay drained after TTL")
+    (is (= ["alice"] (names (opt/effective-db conn)))
+        "effective-db drops the timed-out entry")
+    (a/close! never-release)
     (opt/unregister! conn)))

--- a/test/datahike/test/optimistic_smoke_test.cljc
+++ b/test/datahike/test/optimistic_smoke_test.cljc
@@ -207,26 +207,41 @@
         (is (= 0 (count (opt/pending conn))) "overlay drained after dispatch resolved")))
     (opt/unregister! conn)))
 
-;; A dispatch-fn that resolves only when an external `release-ch` closes
-;; or yields a value. Used to hold an optimistic entry in flight while
-;; the test asserts intermediate state. The resolver thunk is called
-;; *after* release; its return must conform to {:reply :max-tx} or be
-;; a Throwable / js/Error (the wrapper normalizes both).
+;; A dispatch-fn that resolves only when an external `release-ch`
+;; closes or yields a value. Used to hold an optimistic entry in
+;; flight while the test asserts intermediate state.
+;;
+;; `resolver` may return either:
+;;   - a plain value (delivered as-is when release fires), or
+;;   - a `core.async` channel (whose value, when taken, is delivered).
+;;
+;; Channel-return is necessary when the resolver wants to do its own
+;; `<!` takes (e.g. waiting on `(d/transact! ...)`), because `<!` is
+;; a macro that's rewritten by the *lexically enclosing* `go` form —
+;; a thunk body containing `<!` compiled outside any `go` expands to
+;; the assert-nil fallback regardless of where it's later called.
+;; Having the resolver build its own `go` and hand back the channel
+;; sidesteps that pitfall. The plain-value form is for resolvers that
+;; have no async work to do.
 (defn- gated-dispatch [release-ch resolver]
   (fn []
     #?(:clj
        (let [p (promise)]
-         (a/thread
-           (a/<!! release-ch)
-           (deliver p (try (resolver)
-                           (catch Throwable e e))))
+         (go
+           (a/<! release-ch)
+           (let [r (resolver)]
+             (deliver p (if (satisfies? clojure.core.async.impl.protocols/ReadPort r)
+                          (a/<! r)
+                          r))))
          p)
        :cljs
        (let [out (a/chan 1)]
          (go
            (a/<! release-ch)
-           (try (a/put! out (resolver))
-                (catch :default e (a/put! out e))))
+           (let [r (resolver)]
+             (a/put! out (if (satisfies? cljs.core.async.impl.protocols/ReadPort r)
+                           (a/<! r)
+                           r))))
          out))))
 
 (deftest-async conflict-surfaces-via-on-conflict
@@ -251,10 +266,13 @@
                                   (gated-dispatch
                                    release
                                    (fn []
-                                     (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
-                                       (if (instance? #?(:clj Throwable :cljs js/Error) r)
-                                         r
-                                         {:reply r :max-tx (:max-tx (:db-after r))}))))})]
+                                     (let [out (a/chan 1)]
+                                       (go (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
+                                             (a/put! out
+                                                     (if (instance? #?(:clj Throwable :cljs js/Error) r)
+                                                       r
+                                                       {:reply r :max-tx (:max-tx (:db-after r))}))))
+                                       out)))})]
       (<! (a/timeout 20))
       (is (contains?
            (set (->> (d/q '[:find ?w :where [?e :who ?w]] (opt/effective-db conn))
@@ -273,7 +291,9 @@
       (a/close! release)
       (let [reply (<! (:result opt-res))]
         (is (instance? #?(:clj Throwable :cljs js/Error) reply)
-            ":result yields the server's rejection")))
+            ":result yields the server's rejection")
+        (is (= :transact/unique (:error (ex-data reply)))
+            ":result carries the unique-constraint error (not an AssertionError from misused <!)")))
     (<! (a/timeout 50))
     (is (= 0 (count (opt/pending conn))) "overlay drained")
     (is (= [] (last @conflicts)) "on-conflict cleared once entry removed")
@@ -361,15 +381,20 @@
                                      (gated-dispatch
                                       release
                                       (fn []
-                                        (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
-                                          (if (instance? Throwable r)
-                                            r
-                                            {:reply r :max-tx (:max-tx (:db-after r))}))))})]
+                                        (let [out (a/chan 1)]
+                                          (go (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
+                                                (a/put! out
+                                                        (if (instance? Throwable r)
+                                                          r
+                                                          {:reply r :max-tx (:max-tx (:db-after r))}))))
+                                          out)))})]
          ;; Sneak in a conflicting durable write first.
          (<! (d/transact! conn [{:slot "S" :who "mallory"}]))
          (a/close! release)
          (let [reply (<! (:result opt-res))]
-           (is (instance? Throwable reply) "dispatch returned the rejection"))
+           (is (instance? Throwable reply) "dispatch returned the rejection")
+           (is (= :transact/unique (:error (ex-data reply)))
+               ":result carries the server's unique-constraint error"))
          (<! (a/timeout 50))
          (let [origins (mapv :origin @tx-events)]
            (is (some #{:overlay-add} origins) ":overlay-add was emitted")

--- a/test/datahike/test/optimistic_smoke_test.cljc
+++ b/test/datahike/test/optimistic_smoke_test.cljc
@@ -1,0 +1,102 @@
+(ns datahike.test.optimistic-smoke-test
+  "Cross-platform smoke test for `datahike.optimistic`.
+
+   Validates the core API on both CLJ and CLJS-Node:
+     - register! / unregister!
+     - listen! / unlisten!
+     - transact! happy path (channel delivers tx-report)
+     - transact! eager-validation rejection (synchronous throw)
+     - effective-db reduces overlay over @conn
+     - external @conn advances re-fire listeners with correct effective-db"
+  #?(:clj  (:require [clojure.test :refer [deftest is testing]]
+                     [datahike.api :as d]
+                     [datahike.optimistic :as opt]
+                     [datahike.test.async :refer [deftest-async]]
+                     [clojure.core.async :as a :refer [<! go]])
+     :cljs (:require [cljs.test :refer [deftest is testing] :include-macros true]
+                     [datahike.api :as d]
+                     [datahike.optimistic :as opt]
+                     [datahike.test.async :refer-macros [deftest-async]]
+                     [clojure.core.async :as a :refer [<!] :refer-macros [go]])))
+
+(defn- mk-cfg []
+  {:store {:backend :memory :id (random-uuid)}
+   :schema-flexibility :write
+   :keep-history? false})
+
+(defn- setup []
+  (go
+    (let [cfg (mk-cfg)
+          _    (<! #?(:clj  (go (d/create-database cfg))
+                      :cljs (d/create-database cfg)))
+          conn (<! #?(:clj  (go (d/connect cfg))
+                      :cljs (d/connect cfg {:sync? false})))
+          _    (<! (d/transact! conn
+                                [{:db/ident :name :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one
+                                  :db/unique :db.unique/identity}]))
+          _    (<! (d/transact! conn [{:name "alice"}]))]
+      conn)))
+
+(defn- names [db]
+  (->> (d/datoms db :avet :name) (mapv :v) sort vec))
+
+(deftest-async register-listen-transact
+  (let [conn (<! (setup))
+        events (atom [])]
+    (opt/register! conn)
+    (opt/listen! conn ::probe (fn [eff-db]
+                                (swap! events conj (names eff-db))))
+    (testing "happy path: optimistic transact delivers tx-report on result chan"
+      (let [{:keys [ov-id result]} (opt/transact! conn [{:name "bob"}])
+            reply (<! result)]
+        (is (some? ov-id) "ov-id is set")
+        (is (not (#?(:clj instance? :cljs instance?)
+                  #?(:clj Throwable :cljs js/Error)
+                  reply))
+            "reply is not an exception")
+        (is (some? (:db-after reply)) "reply is a tx-report")
+        (is (= 0 (count (opt/pending conn))) "pending drained after success")
+        (is (= ["alice" "bob"] (names @conn)) "base advanced")
+        (is (every? #(contains? (set %) "bob") @events)
+            "all listener events include the optimistic name")
+        (is (>= (count @events) 1) "at least one listener event fired")))
+    (opt/unlisten! conn ::probe)
+    (opt/unregister! conn)))
+
+(deftest-async eager-validation-throws
+  (let [conn (<! (setup))]
+    (opt/register! conn)
+    (testing "schema-violating tx-data throws synchronously and never enters overlay"
+      (let [caught (try
+                     (opt/transact! conn [{:name 42}])
+                     ::no-throw
+                     (catch #?(:clj Throwable :cljs :default) e
+                       e))]
+        (is (not= ::no-throw caught) "transact! threw")
+        (is (= 0 (count (opt/pending conn))) "overlay not polluted")))
+    (opt/unregister! conn)))
+
+(deftest-async external-advance-keeps-overlay
+  (let [conn (<! (setup))
+        events (atom [])]
+    (opt/register! conn)
+    (opt/listen! conn ::probe (fn [eff-db] (swap! events conj (names eff-db))))
+    (testing "manually-stacked overlay entries survive an external @conn advance"
+      ;; Manually inject an entry that bypasses transact!. Removal is
+      ;; only ever by `:ov-id` from transact! itself, so the watcher
+      ;; never drops it on its own.
+      (let [{:keys [overlay]} (#'opt/conn-state conn)
+            ov-id (random-uuid)]
+        (swap! overlay conj
+               {:ov-id   ov-id
+                :tx-data [{:name "carol"}]
+                :status  :pending})
+        ;; External transact (simulates konserve-sync echo / another peer)
+        (<! (d/transact! conn [{:name "dave"}]))
+        (is (= 1 (count (opt/pending conn)))
+            "manual entry survives external advance")
+        (is (= ["alice" "dave"] (names @conn)) "base has dave only")
+        (is (= ["alice" "carol" "dave"] (names (opt/effective-db conn)))
+            "effective-db includes carol via overlay")))
+    (opt/unregister! conn)))

--- a/test/datahike/test/optimistic_smoke_test.cljc
+++ b/test/datahike/test/optimistic_smoke_test.cljc
@@ -383,6 +383,38 @@
        (opt/unregister! conn))))
 
 #?(:clj
+   (deftest-async tx-report-rollback-of-retract-restores-baseline
+     ;; Regression: tx-data with retract-only operations must roll back
+     ;; correctly on failure. The :overlay-add ships a retract; the
+     ;; rollback must re-assert the retracted datom so the consumer
+     ;; view converges to @conn.
+     (let [conn (<! (setup))
+           tx-events (atom [])
+           never (a/chan)]
+       (opt/register! conn {:ttl-ms 800})
+       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (let [before (user-datoms @conn #{:name})
+             ;; The setup helper already transacted alice. Optimistically
+             ;; retract her name, then let the TTL fire (we never resolve
+             ;; the dispatch).
+             {:keys [result]}
+             (opt/transact! conn [[:db/retract [:name "alice"] :name "alice"]]
+                            {:dispatch-fn (gated-dispatch
+                                           never
+                                           (fn [] {:reply :unused :max-tx 0}))})
+             reply (<! result)]
+         (is (instance? Throwable reply))
+         (is (= :optimistic/timeout (:type (ex-data reply))))
+         (<! (a/timeout 50))
+         (let [consumer (apply-tx-events @tx-events before)
+               after (user-datoms @conn #{:name})]
+           (is (= consumer after)
+               "consumer view restores alice after retract was rolled back")))
+       (a/close! never)
+       (opt/unlisten-tx! conn ::probe)
+       (opt/unregister! conn))))
+
+#?(:clj
    (deftest-async tx-report-ttl-emits-ttl-event-with-retract
      ;; A TTL-expired entry must emit a :ttl tx-report retracting its
      ;; predicted additions, so the consumer's view rolls back to the

--- a/test/datahike/test/optimistic_smoke_test.cljc
+++ b/test/datahike/test/optimistic_smoke_test.cljc
@@ -16,11 +16,13 @@
      - TTL expiry yields TimeoutException on :result"
   #?(:clj  (:require [clojure.test :refer [deftest is testing]]
                      [datahike.api :as d]
+                     [datahike.datom :as dd]
                      [datahike.optimistic :as opt]
                      [datahike.test.async :refer [deftest-async]]
                      [clojure.core.async :as a :refer [<! go]])
      :cljs (:require [cljs.test :refer [deftest is testing] :include-macros true]
                      [datahike.api :as d]
+                     [datahike.datom :as dd]
                      [datahike.optimistic :as opt]
                      [datahike.test.async :refer-macros [deftest-async]]
                      [clojure.core.async :as a :refer [<!] :refer-macros [go]])))
@@ -276,6 +278,139 @@
     (is (= 0 (count (opt/pending conn))) "overlay drained")
     (is (= [] (last @conflicts)) "on-conflict cleared once entry removed")
     (opt/unregister! conn)))
+
+;; ============================================================================
+;; tx-report listeners
+;; ============================================================================
+
+(defn- key-eav [d]
+  [(:e d) (:a d) (:v d)])
+
+(defn- apply-tx-events
+  "Walk events in order; build the consumer's view as a set of [e a v]
+  tuples. Each event's :tx-data adds or removes from the set based on
+  the datom's added? flag (via the IDatom protocol). Returns the
+  resulting set."
+  [events start-set]
+  (reduce (fn [view event]
+            (reduce (fn [v d]
+                      (if (dd/datom-added d)
+                        (conj v (key-eav d))
+                        (disj v (key-eav d))))
+                    view
+                    (:tx-data event)))
+          start-set
+          events))
+
+(defn- user-datoms
+  "Project @conn datoms to a set of [e a v] for the given attribute set."
+  [db attrs]
+  (->> (d/datoms db :eavt)
+       (filter (fn [d] (attrs (:a d))))
+       (mapv key-eav)
+       set))
+
+(deftest-async tx-report-happy-path-converges-to-conn
+  ;; The consumer's incremental tx-data application should arrive at
+  ;; exactly @conn's state for the attributes touched by the optimistic
+  ;; tx — proving the EID-shift handling works (predicted vs realized
+  ;; tx-data composition).
+  (let [conn (<! (setup))
+        tx-events (atom [])]
+    (opt/register! conn {:ttl-ms nil})
+    (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+    (testing "events fire and consumer view matches @conn"
+      (let [before (user-datoms @conn #{:name})
+            {:keys [result]} (opt/transact! conn [{:name "bob"}])]
+        (<! result)
+        (let [origins (mapv :origin @tx-events)]
+          (is (= :overlay-add (first origins))
+              "first event is :overlay-add")
+          (is (some #{:conn-advance} origins)
+              "a :conn-advance fires from the writer-listener")
+          (is (every? #{:overlay-add :conn-advance :overlay-realized}
+                      origins)
+              "only expected origins for happy path"))
+        (let [consumer (apply-tx-events @tx-events before)
+              after (user-datoms @conn #{:name})]
+          (is (= consumer after)
+              "consumer's incremental view matches @conn"))))
+    (opt/unlisten-tx! conn ::probe)
+    (opt/unregister! conn)))
+
+#?(:clj
+   (deftest-async tx-report-failure-emits-overlay-drop-with-retract
+     ;; A failed dispatch must emit an :overlay-drop tx-report whose
+     ;; :tx-data retracts the predicted additions, returning the
+     ;; consumer's view to the pre-submit baseline.
+     (let [cfg (mk-cfg)
+           _ (<! (go (d/create-database cfg)))
+           conn (<! (go (d/connect cfg)))
+           _ (<! (d/transact! conn [{:db/ident :slot :db/valueType :db.type/string
+                                     :db/cardinality :db.cardinality/one
+                                     :db/unique :db.unique/value}
+                                    {:db/ident :who :db/valueType :db.type/string
+                                     :db/cardinality :db.cardinality/one}]))
+           release (a/chan)
+           tx-events (atom [])]
+       (opt/register! conn {:ttl-ms 5000})
+       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (let [before-snap (user-datoms @conn #{:slot :who})
+             opt-res (opt/transact! conn [{:slot "S" :who "alice"}]
+                                    {:dispatch-fn
+                                     (gated-dispatch
+                                      release
+                                      (fn []
+                                        (let [r (<! (d/transact! conn [{:slot "S" :who "alice"}]))]
+                                          (if (instance? Throwable r)
+                                            r
+                                            {:reply r :max-tx (:max-tx (:db-after r))}))))})]
+         ;; Sneak in a conflicting durable write first.
+         (<! (d/transact! conn [{:slot "S" :who "mallory"}]))
+         (a/close! release)
+         (let [reply (<! (:result opt-res))]
+           (is (instance? Throwable reply) "dispatch returned the rejection"))
+         (<! (a/timeout 50))
+         (let [origins (mapv :origin @tx-events)]
+           (is (some #{:overlay-add} origins) ":overlay-add was emitted")
+           (is (some #{:overlay-drop :overlay-conflict} origins)
+               "either :overlay-drop (server-rejected) or :overlay-conflict (already conflicting before drop)"))
+         (let [consumer (apply-tx-events @tx-events before-snap)
+               after (user-datoms @conn #{:slot :who})]
+           (is (= consumer after)
+               "consumer view converges to @conn after failure path")))
+       (opt/unlisten-tx! conn ::probe)
+       (opt/unregister! conn))))
+
+#?(:clj
+   (deftest-async tx-report-ttl-emits-ttl-event-with-retract
+     ;; A TTL-expired entry must emit a :ttl tx-report retracting its
+     ;; predicted additions, so the consumer's view rolls back to the
+     ;; pre-submit baseline.
+     (let [conn (<! (setup))
+           never-release (a/chan)
+           tx-events (atom [])]
+       (opt/register! conn {:ttl-ms 1000})
+       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (let [before (user-datoms @conn #{:name})
+             {:keys [result]}
+             (opt/transact! conn [{:name "ghost"}]
+                            {:dispatch-fn (gated-dispatch
+                                           never-release
+                                           (fn [] {:reply :unused :max-tx 0}))})
+             reply (<! result)]
+         (is (instance? Throwable reply))
+         (is (= :optimistic/timeout (:type (ex-data reply))))
+         (<! (a/timeout 50))
+         (is (some #{:ttl} (mapv :origin @tx-events))
+             ":ttl tx-report was emitted")
+         (let [consumer (apply-tx-events @tx-events before)
+               after (user-datoms @conn #{:name})]
+           (is (= consumer after)
+               "consumer view returns to baseline after TTL")))
+       (a/close! never-release)
+       (opt/unlisten-tx! conn ::probe)
+       (opt/unregister! conn))))
 
 (deftest-async ttl-expires-then-fires-result
   ;; An entry whose dispatch never resolves expires after :ttl-ms and

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -2,10 +2,9 @@
   "Cross-platform tests for `datahike.optimistic`.
 
    Covers:
-     - API surface (register!, listen!, transact!, listen-tx!)
-     - Consistency invariants: default-dispatch closes the visibility
-       gap; custom dispatch with :max-tx does too; concurrent transacts
-       stay mutually visible
+     - API surface (register!, listen!, transact!, on-conflict!)
+     - Consistency invariants: durable transact closes the visibility
+       gap; concurrent transacts stay mutually visible
      - Case J (conflict): a conflicting entry hides from view, surfaces
        via :on-conflict, and drops cleanly on dispatch failure
      - TTL: expiry yields a tagged TimeoutException on :result and
@@ -57,8 +56,8 @@
   (let [conn (<! (setup))
         events (atom [])]
     (opt/register! conn)
-    (opt/listen! conn ::probe (fn [eff-db]
-                                (swap! events conj (names eff-db))))
+    (opt/listen! conn ::probe (fn [r]
+                                (swap! events conj (names (:db-after r)))))
     (testing "happy path: optimistic transact delivers tx-report on result chan"
       (let [{:keys [ov-id result]} (opt/transact! conn [{:name "bob"}])
             reply (<! result)]
@@ -69,7 +68,7 @@
         (is (= 0 (count (opt/pending conn))) "pending drained after success")
         (is (= ["alice" "bob"] (names @conn)) "base advanced")
         (is (every? #(contains? (set %) "bob") @events)
-            "all listener events include the optimistic name")
+            "every listener event's :db-after includes the optimistic name")
         (is (>= (count @events) 1) "at least one listener event fired")))
     (opt/unlisten! conn ::probe)
     (opt/unregister! conn)))
@@ -91,7 +90,7 @@
   (let [conn (<! (setup))
         events (atom [])]
     (opt/register! conn)
-    (opt/listen! conn ::probe (fn [eff-db] (swap! events conj (names eff-db))))
+    (opt/listen! conn ::probe (fn [r] (swap! events conj (names (:db-after r)))))
     (testing "manually-stacked overlay entries survive an external @conn advance"
       ;; Manual entry has no :expected-max-tx, so the watcher's
       ;; max-tx drop never removes it; it persists until unregister!.
@@ -109,11 +108,9 @@
     (opt/unregister! conn)))
 
 ;; A gate-as-dispatch lets us hold a transact!'s reply until we choose.
-;; The `:dispatch-fn` contract is "returns a `core.async` channel
-;; yielding a single value," so we use `promise-chan` on both
-;; platforms. The value is `{:reply ... :max-tx 0}` so the wrapper's
-;; sync drop check (`@conn :max-tx >= 0`) drops the entry immediately
-;; on resolution — no flapping while @conn marches on.
+;; Test-only hook (via the namespaced ::opt/dispatch-fn opt) — not part
+;; of the public API. Returns a `core.async` channel yielding a single
+;; value. `promise-chan` works on both platforms.
 (defn- make-gate []
   (a/promise-chan))
 
@@ -131,14 +128,14 @@
         gate1  (make-gate)
         gate2  (make-gate)]
     (opt/register! conn)
-    (opt/listen! conn ::probe (fn [eff-db] (swap! events conj (names eff-db))))
+    (opt/listen! conn ::probe (fn [r] (swap! events conj (names (:db-after r)))))
     (testing "an in-flight entry survives a concurrent transact!'s listener fire"
       (let [t1 (opt/transact! conn [{:name "bob"}]
-                              {:dispatch-fn (fn [] gate1)})]
+                              {::opt/dispatch-fn (fn [] gate1)})]
         (is (contains? (set (names (opt/effective-db conn))) "bob")
             "bob visible immediately after T1's optimistic transact!")
         (let [t2 (opt/transact! conn [{:name "carol"}]
-                                {:dispatch-fn (fn [] gate2)})]
+                                {::opt/dispatch-fn (fn [] gate2)})]
           (is (contains? (set (names (opt/effective-db conn))) "bob")
               "bob STILL visible after a concurrent transact!")
           (is (contains? (set (names (opt/effective-db conn))) "carol")
@@ -183,45 +180,16 @@
                  "snapshots are either pre-submit (alice-only) or post-submit (include bob)")))))
     (opt/unregister! conn)))
 
-(deftest-async custom-dispatch-with-max-tx-no-gap
-  ;; Custom dispatch-fns that honor the {:reply :max-tx} contract also
-  ;; close the gap — the watcher drops the entry only after @conn has
-  ;; demonstrably caught up.
-  (let [conn (<! (setup))]
-    (opt/register! conn {:ttl-ms nil})
-    (testing "good custom dispatch closes the gap"
-      (let [{:keys [result]}
-            (opt/transact! conn [{:name "carol"}]
-                           {:dispatch-fn
-                            (fn []
-                              (let [out (a/chan 1)]
-                                (go (let [r (<! (d/transact! conn [{:name "carol"}]))]
-                                      (a/put! out {:reply r
-                                                   :max-tx (:max-tx (:db-after r))})))
-                                out))})]
-        (<! result)
-        (is (contains? (set (names (opt/effective-db conn))) "carol"))
-        (is (= 0 (count (opt/pending conn))) "overlay drained after dispatch resolved")))
-    (opt/unregister! conn)))
-
-;; A dispatch-fn that resolves only when an external `release-ch`
+;; A dispatch hook that resolves only when an external `release-ch`
 ;; closes or yields a value. Used to hold an optimistic entry in
 ;; flight while the test asserts intermediate state.
 ;;
-;; Returns a `core.async` channel (the `:dispatch-fn` contract).
-;;
-;; `resolver` may return either:
-;;   - a plain value (placed on the channel as-is when release fires),
-;;   - or a `core.async` channel (whose value, when taken, is placed).
-;;
+;; Returns a `core.async` channel. `resolver` may return either a
+;; plain value or a `core.async` channel (whose value will be taken).
 ;; Channel-return is necessary when the resolver wants to do its own
-;; `<!` takes (e.g. waiting on `(d/transact! ...)`), because `<!` is
-;; a macro that's rewritten by the *lexically enclosing* `go` form —
-;; a thunk body containing `<!` compiled outside any `go` expands to
-;; the assert-nil fallback regardless of where it's later called.
-;; Having the resolver build its own `go` and hand back the channel
-;; sidesteps that pitfall. The plain-value form is for resolvers that
-;; have no async work to do.
+;; `<!` takes (e.g. waiting on `(d/transact! ...)`) — `<!` is a macro
+;; rewritten by the *lexically enclosing* `go`; a thunk body containing
+;; `<!` compiled outside a `go` expands to assert-nil.
 (defn- gated-dispatch [release-ch resolver]
   (fn []
     (let [out (a/chan 1)]
@@ -253,7 +221,7 @@
     (opt/register! conn {:ttl-ms 5000
                          :on-conflict (fn [cs] (swap! conflicts conj (mapv :ov-id cs)))})
     (let [opt-res (opt/transact! conn [{:slot "S" :who "alice"}]
-                                 {:dispatch-fn
+                                 {::opt/dispatch-fn
                                   (gated-dispatch
                                    release
                                    (fn []
@@ -331,7 +299,7 @@
   (let [conn (<! (setup))
         tx-events (atom [])]
     (opt/register! conn {:ttl-ms nil})
-    (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+    (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
     (testing "events fire and consumer view matches @conn"
       (let [before (user-datoms @conn #{:name})
             {:keys [result]} (opt/transact! conn [{:name "bob"}])]
@@ -348,7 +316,7 @@
               after (user-datoms @conn #{:name})]
           (is (= consumer after)
               "consumer's incremental view matches @conn"))))
-    (opt/unlisten-tx! conn ::probe)
+    (opt/unlisten! conn ::probe)
     (opt/unregister! conn)))
 
 #?(:clj
@@ -367,10 +335,10 @@
            release (a/chan)
            tx-events (atom [])]
        (opt/register! conn {:ttl-ms 5000})
-       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
        (let [before-snap (user-datoms @conn #{:slot :who})
              opt-res (opt/transact! conn [{:slot "S" :who "alice"}]
-                                    {:dispatch-fn
+                                    {::opt/dispatch-fn
                                      (gated-dispatch
                                       release
                                       (fn []
@@ -397,7 +365,7 @@
                after (user-datoms @conn #{:slot :who})]
            (is (= consumer after)
                "consumer view converges to @conn after failure path")))
-       (opt/unlisten-tx! conn ::probe)
+       (opt/unlisten! conn ::probe)
        (opt/unregister! conn))))
 
 #?(:clj
@@ -410,16 +378,16 @@
            tx-events (atom [])
            never (a/chan)]
        (opt/register! conn {:ttl-ms 800})
-       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
        (let [before (user-datoms @conn #{:name})
              ;; The setup helper already transacted alice. Optimistically
              ;; retract her name, then let the TTL fire (we never resolve
              ;; the dispatch).
              {:keys [result]}
              (opt/transact! conn [[:db/retract [:name "alice"] :name "alice"]]
-                            {:dispatch-fn (gated-dispatch
-                                           never
-                                           (fn [] {:reply :unused :max-tx 0}))})
+                            {::opt/dispatch-fn (gated-dispatch
+                                                never
+                                                (fn [] {:reply :unused :max-tx 0}))})
              reply (<! result)]
          (is (instance? Throwable reply))
          (is (= :optimistic/timeout (:type (ex-data reply))))
@@ -429,7 +397,7 @@
            (is (= consumer after)
                "consumer view restores alice after retract was rolled back")))
        (a/close! never)
-       (opt/unlisten-tx! conn ::probe)
+       (opt/unlisten! conn ::probe)
        (opt/unregister! conn))))
 
 #?(:clj
@@ -441,13 +409,13 @@
            never-release (a/chan)
            tx-events (atom [])]
        (opt/register! conn {:ttl-ms 1000})
-       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
        (let [before (user-datoms @conn #{:name})
              {:keys [result]}
              (opt/transact! conn [{:name "ghost"}]
-                            {:dispatch-fn (gated-dispatch
-                                           never-release
-                                           (fn [] {:reply :unused :max-tx 0}))})
+                            {::opt/dispatch-fn (gated-dispatch
+                                                never-release
+                                                (fn [] {:reply :unused :max-tx 0}))})
              reply (<! result)]
          (is (instance? Throwable reply))
          (is (= :optimistic/timeout (:type (ex-data reply))))
@@ -459,12 +427,12 @@
            (is (= consumer after)
                "consumer view returns to baseline after TTL")))
        (a/close! never-release)
-       (opt/unlisten-tx! conn ::probe)
+       (opt/unlisten! conn ::probe)
        (opt/unregister! conn))))
 
 #?(:clj
    (deftest-async tx-report-watcher-drop-emits-overlay-realized
-     ;; Regression for the case where a custom dispatch resolves with
+     ;; Regression for the case where a dispatch resolves with
      ;; `:max-tx` ahead of `@conn` — the entry can't sync-drop at
      ;; dispatch time, so the watcher drops it later when @conn
      ;; catches up. That watcher-drop path must also emit
@@ -475,19 +443,19 @@
            tx-events (atom [])
            predicted-max-tx (inc (:max-tx @conn))]
        (opt/register! conn {:ttl-ms 60000})
-       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
        (let [before (user-datoms @conn #{:name})
-             ;; Custom dispatch declares max-tx = (current+1) up front:
-             ;; the entry stays in overlay because @conn hasn't reached
-             ;; it. Open the gate immediately so the dispatch resolves
+             ;; Dispatch declares max-tx = (current+1) up front: the
+             ;; entry stays in overlay because @conn hasn't reached it.
+             ;; Open the gate immediately so the dispatch resolves
              ;; without doing any actual durable write.
              {:keys [result]}
              (opt/transact! conn [{:name "ghost-write"}]
-                            {:dispatch-fn (gated-dispatch
-                                           release
-                                           (fn []
-                                             {:reply :stub
-                                              :max-tx predicted-max-tx}))})]
+                            {::opt/dispatch-fn (gated-dispatch
+                                                release
+                                                (fn []
+                                                  {:reply :stub
+                                                   :max-tx predicted-max-tx}))})]
          (a/close! release)
          (<! result)
          (<! (a/timeout 30))
@@ -507,7 +475,7 @@
                after (user-datoms @conn #{:name})]
            (is (= consumer after)
                "consumer view converges to @conn after watcher-drop")))
-       (opt/unlisten-tx! conn ::probe)
+       (opt/unlisten! conn ::probe)
        (opt/unregister! conn))))
 
 #?(:clj
@@ -518,14 +486,14 @@
      ;; delivers N callbacks with N tx-reports that all share the same
      ;; `:max-tx` (it replaces `:db-after` with the batch's commit-db
      ;; on each — see writer.cljc commit-loop). Cache-keying by
-     ;; `:max-tx` would collide; we key by `:ov-id` via `::ov-id` in
-     ;; `:tx-meta`. This test pins that each batched entry's
-     ;; `:overlay-realized` follow-up still sees the right writer
-     ;; tx-data and the consumer view converges to @conn.
+     ;; `:max-tx` would collide; we key by `:ov-id` via each call's
+     ;; per-call promise resolution. This test pins that each batched
+     ;; entry's `:overlay-realized` follow-up still sees the right
+     ;; writer tx-data and the consumer view converges to @conn.
      (let [conn (<! (setup))
            tx-events (atom [])]
        (opt/register! conn {:ttl-ms nil})
-       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (opt/listen! conn ::probe (fn [r] (swap! tx-events conj r)))
        (let [before (user-datoms @conn #{:name})
              ;; Fire several optimistic transacts with no awaits
              ;; between them so they batch in the writer's commit-loop.
@@ -541,7 +509,7 @@
            (is (= consumer after)
                (str "consumer's incremental view matches @conn under batching "
                     "(no cross-entry cache collisions)"))))
-       (opt/unlisten-tx! conn ::probe)
+       (opt/unlisten! conn ::probe)
        (opt/unregister! conn))))
 
 (deftest-async ttl-expires-then-fires-result
@@ -553,9 +521,9 @@
     (opt/register! conn {:ttl-ms 1500})
     (let [{:keys [result]}
           (opt/transact! conn [{:name "ghost"}]
-                         {:dispatch-fn (gated-dispatch
-                                        never-release
-                                        (fn [] {:reply :unused :max-tx 0}))})
+                         {::opt/dispatch-fn (gated-dispatch
+                                             never-release
+                                             (fn [] {:reply :unused :max-tx 0}))})
           reply (<! result)]
       (is (instance? #?(:clj Throwable :cljs js/Error) reply))
       (is (= :optimistic/timeout (:type (ex-data reply))) "tagged as timeout"))

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -264,7 +264,9 @@
                                                        r
                                                        {:reply r :max-tx (:max-tx (:db-after r))}))))
                                        out)))})]
-      (<! (a/timeout 20))
+      ;; `opt/transact!` is synchronous through the overlay swap! and
+      ;; the :overlay-add fire — alice is in `effective-db` as soon
+      ;; as the call returns. No need to wait.
       (is (contains?
            (set (->> (d/q '[:find ?w :where [?e :who ?w]] (opt/effective-db conn))
                      (map first)))

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -508,6 +508,40 @@
        (opt/unlisten-tx! conn ::probe)
        (opt/unregister! conn))))
 
+#?(:clj
+   (deftest-async tx-report-batched-transacts-converge-to-conn
+     ;; Regression for writer batching: the writer's commit-loop drains
+     ;; `commit-queue` greedily, so several `opt/transact!`s submitted
+     ;; back-to-back can land in one durable commit. The writer then
+     ;; delivers N callbacks with N tx-reports that all share the same
+     ;; `:max-tx` (it replaces `:db-after` with the batch's commit-db
+     ;; on each — see writer.cljc commit-loop). Cache-keying by
+     ;; `:max-tx` would collide; we key by `:ov-id` via `::ov-id` in
+     ;; `:tx-meta`. This test pins that each batched entry's
+     ;; `:overlay-realized` follow-up still sees the right writer
+     ;; tx-data and the consumer view converges to @conn.
+     (let [conn (<! (setup))
+           tx-events (atom [])]
+       (opt/register! conn {:ttl-ms nil})
+       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (let [before (user-datoms @conn #{:name})
+             ;; Fire several optimistic transacts with no awaits
+             ;; between them so they batch in the writer's commit-loop.
+             results (mapv (fn [i]
+                             (opt/transact! conn [{:name (str "batched-" i)}]))
+                           (range 8))]
+         (doseq [r results] (<! (:result r)))
+         (<! (a/timeout 50))
+         (is (= 0 (count (opt/pending conn)))
+             "overlay drained — every batched entry's correlation succeeded")
+         (let [consumer (apply-tx-events @tx-events before)
+               after (user-datoms @conn #{:name})]
+           (is (= consumer after)
+               (str "consumer's incremental view matches @conn under batching "
+                    "(no cross-entry cache collisions)"))))
+       (opt/unlisten-tx! conn ::probe)
+       (opt/unregister! conn))))
+
 (deftest-async ttl-expires-then-fires-result
   ;; An entry whose dispatch never resolves expires after :ttl-ms and
   ;; the :result chan yields a TimeoutException tagged

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -34,10 +34,15 @@
 (defn- setup []
   (go
     (let [cfg (mk-cfg)
-          _    (<! #?(:clj  (go (d/create-database cfg))
-                      :cljs (d/create-database cfg)))
-          conn (<! #?(:clj  (go (d/connect cfg))
-                      :cljs (d/connect cfg {:sync? false})))
+          ;; CLJ: create/connect are synchronous — call them directly
+          ;; from inside the outer `go`. CLJS: async — `<!` the result.
+          ;; (Wrapping the CLJ calls in nested `go` blocks just to
+          ;; `<!` them would shunt blocking work onto core.async's
+          ;; dispatch threads for no reason.)
+          _    #?(:clj  (d/create-database cfg)
+                  :cljs (<! (d/create-database cfg)))
+          conn #?(:clj  (d/connect cfg)
+                  :cljs (<! (d/connect cfg {:sync? false})))
           _    (<! (d/transact! conn
                                 [{:db/ident :name :db/valueType :db.type/string
                                   :db/cardinality :db.cardinality/one
@@ -236,8 +241,8 @@
   ;; from the view, the :on-conflict callback fires, and once the gate
   ;; opens the server rejects → :result yields the throwable.
   (let [cfg (mk-cfg)
-        _ (<! #?(:clj (go (d/create-database cfg)) :cljs (d/create-database cfg)))
-        conn (<! #?(:clj (go (d/connect cfg)) :cljs (d/connect cfg {:sync? false})))
+        _ #?(:clj (d/create-database cfg) :cljs (<! (d/create-database cfg)))
+        conn #?(:clj (d/connect cfg) :cljs (<! (d/connect cfg {:sync? false})))
         _ (<! (d/transact! conn [{:db/ident :slot :db/valueType :db.type/string
                                   :db/cardinality :db.cardinality/one
                                   :db/unique :db.unique/value}
@@ -350,8 +355,8 @@
      ;; :tx-data retracts the predicted additions, returning the
      ;; consumer's view to the pre-submit baseline.
      (let [cfg (mk-cfg)
-           _ (<! (go (d/create-database cfg)))
-           conn (<! (go (d/connect cfg)))
+           _ (d/create-database cfg)
+           conn (d/connect cfg)
            _ (<! (d/transact! conn [{:db/ident :slot :db/valueType :db.type/string
                                      :db/cardinality :db.cardinality/one
                                      :db/unique :db.unique/value}
@@ -452,6 +457,54 @@
            (is (= consumer after)
                "consumer view returns to baseline after TTL")))
        (a/close! never-release)
+       (opt/unlisten-tx! conn ::probe)
+       (opt/unregister! conn))))
+
+#?(:clj
+   (deftest-async tx-report-watcher-drop-emits-overlay-realized
+     ;; Regression for the case where a custom dispatch resolves with
+     ;; `:max-tx` ahead of `@conn` — the entry can't sync-drop at
+     ;; dispatch time, so the watcher drops it later when @conn
+     ;; catches up. That watcher-drop path must also emit
+     ;; `:overlay-realized` (using the writer-tx-cache) so a tx-report
+     ;; consumer's incremental view still converges to @conn.
+     (let [conn (<! (setup))
+           release (a/chan)
+           tx-events (atom [])
+           predicted-max-tx (inc (:max-tx @conn))]
+       (opt/register! conn {:ttl-ms 60000})
+       (opt/listen-tx! conn ::probe (fn [r] (swap! tx-events conj r)))
+       (let [before (user-datoms @conn #{:name})
+             ;; Custom dispatch declares max-tx = (current+1) up front:
+             ;; the entry stays in overlay because @conn hasn't reached
+             ;; it. Open the gate immediately so the dispatch resolves
+             ;; without doing any actual durable write.
+             {:keys [result]}
+             (opt/transact! conn [{:name "ghost-write"}]
+                            {:dispatch-fn (gated-dispatch
+                                           release
+                                           (fn []
+                                             {:reply :stub
+                                              :max-tx predicted-max-tx}))})]
+         (a/close! release)
+         (<! result)
+         (<! (a/timeout 30))
+         (is (some #(= "ghost-write" %) (mapv :v (d/datoms (opt/effective-db conn) :avet :name)))
+             "before the watcher catches up, the optimistic value is still in view")
+         (is (= 1 (count (opt/pending conn)))
+             "entry still pending because @conn hasn't reached its expected-max-tx")
+         ;; Now do an unrelated durable write to advance @conn past
+         ;; the entry's expected-max-tx — triggers the watcher's drop
+         ;; and our `emit-overlay-realized!`.
+         (<! (d/transact! conn [{:name "real-bob"}]))
+         (<! (a/timeout 50))
+         (is (= 0 (count (opt/pending conn))) "watcher dropped the caught-up entry")
+         (is (some #{:overlay-realized} (mapv :origin @tx-events))
+             ":overlay-realized was emitted by the watcher-drop path")
+         (let [consumer (apply-tx-events @tx-events before)
+               after (user-datoms @conn #{:name})]
+           (is (= consumer after)
+               "consumer view converges to @conn after watcher-drop")))
        (opt/unlisten-tx! conn ::probe)
        (opt/unregister! conn))))
 

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -104,15 +104,16 @@
     (opt/unregister! conn)))
 
 ;; A gate-as-dispatch lets us hold a transact!'s reply until we choose.
-;; New contract: dispatch-fn yields {:reply X :max-tx N}. We set N = 0 so
-;; the wrapper's sync drop check (@conn :max-tx >= 0) drops the entry
-;; immediately on resolution — no flapping while @conn marches on.
+;; The `:dispatch-fn` contract is "returns a `core.async` channel
+;; yielding a single value," so we use `promise-chan` on both
+;; platforms. The value is `{:reply ... :max-tx 0}` so the wrapper's
+;; sync drop check (`@conn :max-tx >= 0`) drops the entry immediately
+;; on resolution — no flapping while @conn marches on.
 (defn- make-gate []
-  #?(:clj (promise) :cljs (a/chan 1)))
+  (a/promise-chan))
 
 (defn- open-gate! [gate]
-  #?(:clj (deliver gate {:reply {:ok true} :max-tx 0})
-     :cljs (a/put! gate {:reply {:ok true} :max-tx 0})))
+  (a/put! gate {:reply {:ok true} :max-tx 0}))
 
 (deftest-async concurrent-transacts-keep-each-other-visible
   ;; An in-flight optimistic entry must stay visible while another
@@ -188,19 +189,11 @@
             (opt/transact! conn [{:name "carol"}]
                            {:dispatch-fn
                             (fn []
-                              #?(:clj
-                                 (let [p (promise)]
-                                   (future
-                                     (let [r @(d/transact! conn [{:name "carol"}])]
-                                       (deliver p {:reply r
+                              (let [out (a/chan 1)]
+                                (go (let [r (<! (d/transact! conn [{:name "carol"}]))]
+                                      (a/put! out {:reply r
                                                    :max-tx (:max-tx (:db-after r))})))
-                                   p)
-                                 :cljs
-                                 (let [ch (a/chan 1)]
-                                   (go (let [r (<! (d/transact! conn [{:name "carol"}]))]
-                                         (a/put! ch {:reply r
-                                                     :max-tx (:max-tx (:db-after r))})))
-                                   ch)))})]
+                                out))})]
         (<! result)
         (is (contains? (set (names (opt/effective-db conn))) "carol"))
         (is (= 0 (count (opt/pending conn))) "overlay drained after dispatch resolved")))
@@ -210,9 +203,11 @@
 ;; closes or yields a value. Used to hold an optimistic entry in
 ;; flight while the test asserts intermediate state.
 ;;
+;; Returns a `core.async` channel (the `:dispatch-fn` contract).
+;;
 ;; `resolver` may return either:
-;;   - a plain value (delivered as-is when release fires), or
-;;   - a `core.async` channel (whose value, when taken, is delivered).
+;;   - a plain value (placed on the channel as-is when release fires),
+;;   - or a `core.async` channel (whose value, when taken, is placed).
 ;;
 ;; Channel-return is necessary when the resolver wants to do its own
 ;; `<!` takes (e.g. waiting on `(d/transact! ...)`), because `<!` is
@@ -224,24 +219,16 @@
 ;; have no async work to do.
 (defn- gated-dispatch [release-ch resolver]
   (fn []
-    #?(:clj
-       (let [p (promise)]
-         (go
-           (a/<! release-ch)
-           (let [r (resolver)]
-             (deliver p (if (satisfies? clojure.core.async.impl.protocols/ReadPort r)
-                          (a/<! r)
-                          r))))
-         p)
-       :cljs
-       (let [out (a/chan 1)]
-         (go
-           (a/<! release-ch)
-           (let [r (resolver)]
-             (a/put! out (if (satisfies? cljs.core.async.impl.protocols/ReadPort r)
-                           (a/<! r)
-                           r))))
-         out))))
+    (let [out (a/chan 1)]
+      (go
+        (a/<! release-ch)
+        (let [r (resolver)]
+          (a/put! out (if (satisfies? #?(:clj clojure.core.async.impl.protocols/ReadPort
+                                         :cljs cljs.core.async.impl.protocols/ReadPort)
+                                      r)
+                        (a/<! r)
+                        r))))
+      out)))
 
 (deftest-async conflict-surfaces-via-on-conflict
   ;; Case J: an in-flight overlay entry becomes un-applicable because a

--- a/test/datahike/test/optimistic_test.cljc
+++ b/test/datahike/test/optimistic_test.cljc
@@ -1,19 +1,18 @@
-(ns datahike.test.optimistic-smoke-test
-  "Cross-platform smoke + invariant tests for `datahike.optimistic`.
+(ns datahike.test.optimistic-test
+  "Cross-platform tests for `datahike.optimistic`.
 
    Covers:
-     - register! / unregister!
-     - listen! / unlisten!
-     - transact! happy path (channel delivers tx-report)
-     - transact! eager-validation rejection (synchronous throw)
-     - effective-db reduces overlay over @conn
-     - external @conn advances re-fire listeners with correct effective-db
-     - concurrent transacts: each entry stays visible while the other is in flight
-     - default-dispatch closes the visibility gap (hammered reads see no flicker)
-     - custom dispatch with :max-tx closes the gap likewise
-     - Case J (conflict): conflicting entry hides from view, surfaces via
-       :on-conflict, drops on dispatch failure
-     - TTL expiry yields TimeoutException on :result"
+     - API surface (register!, listen!, transact!, listen-tx!)
+     - Consistency invariants: default-dispatch closes the visibility
+       gap; custom dispatch with :max-tx does too; concurrent transacts
+       stay mutually visible
+     - Case J (conflict): a conflicting entry hides from view, surfaces
+       via :on-conflict, and drops cleanly on dispatch failure
+     - TTL: expiry yields a tagged TimeoutException on :result and
+       rolls the view back via the tx-report stream
+     - tx-report convergence: incremental application of tx-data through
+       :overlay-add / :conn-advance / :overlay-realized / :overlay-drop
+       / :overlay-conflict / :overlay-resolve / :ttl arrives at @conn"
   #?(:clj  (:require [clojure.test :refer [deftest is testing]]
                      [datahike.api :as d]
                      [datahike.datom :as dd]


### PR DESCRIPTION
## Summary

A small overlay primitive (`datahike.optimistic`) that lets UIs render
a transaction's effect immediately, before the underlying writer has
confirmed it. The entry stays visible until `@conn` has demonstrably
reflected its effect, the dispatch failed, or a TTL expires.

Most useful with a remote writer (e.g. Kabel over WebSockets) where
the round-trip — RPC → server transact → konserve-sync echo → `@conn`
advance — is on the user's interaction path.

**Status: Experimental.** API may still change; not yet exercised
under multi-writer / concurrent-peer load.

## Consistency model

One invariant:

> An entry is visible from `transact!` return until `@conn` has
> demonstrably reflected its effect (via the durable commit's
> `:max-tx`), the dispatch failed, or the entry's TTL expired.

The invariant holds independent of the writer. Soundness rests on
three structural facts of Datahike — monotonic `:max-tx` assignment,
snapshot completeness of each `:db` value, and the atomic `reset!` of
`@conn` — spelled out in `doc/optimistic-overlay.md`.

## API

```clojure
(opt/register! conn
  {:ttl-ms 30000                            ;; per-entry timeout, default 30s
   :on-conflict (fn [conflicts]             ;; fired when J-conflicts change
                  (toast "your edit may not save"))})

(opt/listen! conn ::ui (fn [eff-db] (rerender! eff-db)))

(let [{:keys [ov-id result]} (opt/transact! conn tx-data)]
  (let [reply (<! result)]
    (when (instance? Throwable reply) (notify-error reply))))

(opt/unlisten!   conn ::ui)
(opt/unregister! conn)
```

`(opt/transact! conn tx-data {:dispatch-fn …})` substitutes a custom
RPC. **Strict contract**: yields `{:reply X :max-tx N}` on success;
throws or yields a `Throwable`/`js/Error` on failure (wrapper
normalizes both).

## Mechanics

`effective-db` = `(reduce d/with @conn @overlay)`, excluding entries
that fail to apply on current `@conn` (Case J — surfaced via
`:on-conflict`, not silently swallowed). Eager `d/with` at submit
time validates tx-data synchronously so malformed input never enters
the overlay.

Each successful dispatch stamps the entry with `:expected-max-tx`; a
watcher drops entries whose expected `<= (:max-tx @conn)`. Sync-check
immediately after stamping catches the case where the writer
(`:self` / `:kabel`) already advanced `@conn` before the wrapper got
there. `:result` delivery is exactly-once via a `compare-and-set!`
gate — a late server reply after a TTL expiry can never block a
producer.

Identity assumption: callers should use stable attributes like
`:entity/uuid`, not EIDs — overlay and writer may resolve tempids to
different EIDs, and re-application after echo is idempotent upsert.

## Verified

- `bb test clj-pss` — 508 tests / 2434 assertions, 0 failures
- `bb test kabel`   — 14 / 73, 0 failures
- `bb node-cljs-test` — 15 / 88, 0 failures (incl. 8 cross-platform
  optimistic smoke tests covering default-dispatch / custom-dispatch
  no-gap, concurrent transacts, Case J conflict surfacing, TTL expiry)
- `bb format` — clean

See `doc/optimistic-overlay.md` for the full consistency-model
write-up, the `:dispatch-fn` contract, conflict semantics, TTL
semantics, and v1 limits.

## Companion change in the original commit

`deps.edn :paths` now includes `src-kabel` + `src-hitchhiker-tree` to
match what the published JAR already ships (per
`config.edn :build :clj :src-dirs`). `:local/root` downstreams testing
this branch directly now see the same namespaces as `:mvn/version`
consumers. Runtime deps for those dirs stay in the `:test` alias —
opt-in, same as for mvn consumers. Longer-term direction is a real
artifact split into `datahike-kabel` / `datahike-hitchhiker-tree`;
this is preparation.