### PR TITLE
audit: tamper-evident commit-ids + verify-chain

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -73,7 +73,7 @@
                                ;; secondary index integrations (for testing)
                                org.replikativ/proximum       {:mvn/version "0.1.24"}
                                org.replikativ/scriptum       {:mvn/version "0.1.25"}
-                               org.replikativ/stratum        {:mvn/version "0.2.51"}
+                               org.replikativ/stratum        {:mvn/version "0.2.67"}
 
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.94"}

--- a/deps.edn
+++ b/deps.edn
@@ -72,7 +72,7 @@
 
                                ;; secondary index integrations (for testing)
                                org.replikativ/proximum       {:mvn/version "0.1.24"}
-                               org.replikativ/scriptum       {:mvn/version "0.1.23"}
+                               org.replikativ/scriptum       {:mvn/version "0.1.25"}
                                org.replikativ/stratum        {:mvn/version "0.2.51"}
 
                                ;; kabel integration for distributed datahike

--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
                                org.replikativ/stratum        {:mvn/version "0.2.67"}
 
                                ;; kabel integration for distributed datahike
-                               org.replikativ/kabel          {:mvn/version "0.3.94"}
+                               org.replikativ/kabel          {:mvn/version "0.3.95"}
                                is.simm/distributed-scope     {:mvn/version "0.1.2"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.15"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -71,8 +71,8 @@
                                ring-cors/ring-cors           {:mvn/version "0.1.13"}
 
                                ;; secondary index integrations (for testing)
-                               org.replikativ/proximum       {:mvn/version "0.1.24"}
-                               org.replikativ/scriptum       {:mvn/version "0.1.25"}
+                               org.replikativ/proximum       {:mvn/version "0.1.25"}
+                               org.replikativ/scriptum       {:mvn/version "0.1.27"}
                                org.replikativ/stratum        {:mvn/version "0.2.67"}
 
                                ;; kabel integration for distributed datahike

--- a/src-hitchhiker-tree/datahike/index/hitchhiker_tree.cljc
+++ b/src-hitchhiker-tree/datahike/index/hitchhiker_tree.cljc
@@ -11,6 +11,7 @@
             [datahike.datom :as dd]
             [datahike.constants :refer [e0 tx0 emax txmax]]
             [clojure.spec.alpha :as s]
+            [datahike.index.audit :as audit :refer [IAuditable]]
             [datahike.index.interface :as di :refer [IIndex]])
   #?(:clj (:import [clojure.lang AMapEntry]
                    [hitchhiker.tree DataNode IndexNode]
@@ -177,6 +178,15 @@
     (identity tree))
   (-mark [tree]
     (mark tree)))
+
+;; HHT does not currently expose a content-addressed merkle root. Audit
+;; falls back to advisory mode when this index is in use.
+(let [unsupported (fn [_]
+                    (throw (ex-info "merkle-root not implemented for hitchhiker-tree"
+                                    {:type :audit/merkle-root-unsupported
+                                     :index :datahike.index/hitchhiker-tree})))]
+  (extend DataNode  IAuditable {:-merkle-root unsupported :-recompute-merkle-root unsupported})
+  (extend IndexNode IAuditable {:-merkle-root unsupported :-recompute-merkle-root unsupported}))
 
 (defn empty-tree [b-factor data-node-size log-size]
   (async/<?? (tree/b-tree (tree/->Config b-factor data-node-size log-size))))

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -93,22 +93,23 @@
       audit/IAuditable
       (-merkle-root [_]
         ;; Proximum's commit-id is a content hash of the HNSW graph
-        ;; + vectors state.
-        (or (phi/commit-id prox-idx)
-            (throw (ex-info "Proximum index has no commit-id yet"
-                            {:type :audit/merkle-root-unsupported
-                             :index :proximum}))))
+        ;; + vectors state. Returns nil pre-commit; never throws.
+        (phi/commit-id prox-idx))
       (-recompute-merkle-root [this]
         ;; Re-read vectors + edges from cold storage and verify each
-        ;; chunk's hash against the recorded commit chain.
+        ;; chunk's hash against the recorded commit chain. Returns the
+        ;; standardized result map instead of throwing.
         (let [store-config (:store-config config)
               branch (or (:branch config) :main)
-              result (pcrypto/verify-from-cold store-config branch)]
+              result (pcrypto/verify-from-cold store-config branch)
+              root (audit/-merkle-root this)]
           (if (:valid? result)
-            (audit/-merkle-root this)
-            (throw (ex-info "proximum: verify-from-cold failed"
-                            {:type :audit/merkle-mismatch
-                             :result result})))))
+            {:status :ok :root root}
+            {:status :mismatch :root nil
+             :errors [{:type :audit/merkle-mismatch
+                       :address root
+                       :expected root
+                       :details result}]})))
 
       (-transact [_ tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -96,20 +96,25 @@
         ;; + vectors state. Returns nil pre-commit; never throws.
         (phi/commit-id prox-idx))
       (-recompute-merkle-root [this]
-        ;; Re-read vectors + edges from cold storage and verify each
-        ;; chunk's hash against the recorded commit chain. Returns the
-        ;; standardized result map instead of throwing.
-        (let [store-config (:store-config config)
-              branch (or (:branch config) :main)
-              result (pcrypto/verify-from-cold store-config branch)
-              root (audit/-merkle-root this)]
-          (if (:valid? result)
-            {:status :ok :root root}
-            {:status :mismatch :root nil
-             :errors [{:type :audit/merkle-mismatch
-                       :address root
-                       :expected root
-                       :details result}]})))
+        ;; When proximum.audit (>= the audit-chain release) is on the
+        ;; classpath, delegate the live-index walk to it — that gives
+        ;; us actual chunk-level tamper detection (the older
+        ;; verify-from-cold only checked existence). Older proximum
+        ;; versions fall back to the local translation.
+        (or (when-let [recompute (try (requiring-resolve 'proximum.audit/-recompute-merkle-root)
+                                      (catch Throwable _ nil))]
+              (recompute prox-idx))
+            (let [store-config (:store-config config)
+                  branch (or (:branch config) :main)
+                  result (pcrypto/verify-from-cold store-config branch)
+                  root (audit/-merkle-root this)]
+              (if (:valid? result)
+                {:status :ok :root root}
+                {:status :mismatch :root nil
+                 :errors [{:type :audit/merkle-mismatch
+                           :address root
+                           :expected root
+                           :details result}]}))))
 
       (-transact [_ tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -10,9 +10,11 @@
                        :db.secondary/config {:dim 384 :distance :cosine
                                              :store-config {...}}}}"
   (:require
+   [datahike.index.audit :as audit]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
    [proximum.core :as prox]
+   [proximum.crypto :as pcrypto]
    [proximum.writing :as pwr]
    [proximum.versioning :as pver]
    [proximum.vectors :as pvec]
@@ -64,13 +66,14 @@
       sec/IVersionedSecondaryIndex
       (-sec-flush [_ _store branch]
         ;; Proximum manages its own konserve store internally.
-        ;; Sync writes pending data to its store.
+        ;; Sync writes pending data to its store. The merkle-root for
+        ;; audit is exposed via IAuditable below, computed from
+        ;; proximum's own commit-id.
         (async/<!! (pvec/sync! prox-idx))
-        (let [commit-id (phi/commit-id prox-idx)]
-          {:type :proximum
-           :branch (name branch)
-           :commit-id commit-id
-           :store-config (:store-config config)}))
+        {:type :proximum
+         :branch (name branch)
+         :commit-id (phi/commit-id prox-idx)
+         :store-config (:store-config config)})
 
       (-sec-restore [_ _store key-map]
         ;; Restore from proximum's own store using commit ID
@@ -86,6 +89,26 @@
       (-sec-mark [_]
         ;; Proximum uses its own konserve store, not datahike's
         #{})
+
+      audit/IAuditable
+      (-merkle-root [_]
+        ;; Proximum's commit-id is a content hash of the HNSW graph
+        ;; + vectors state.
+        (or (phi/commit-id prox-idx)
+            (throw (ex-info "Proximum index has no commit-id yet"
+                            {:type :audit/merkle-root-unsupported
+                             :index :proximum}))))
+      (-recompute-merkle-root [this]
+        ;; Re-read vectors + edges from cold storage and verify each
+        ;; chunk's hash against the recorded commit chain.
+        (let [store-config (:store-config config)
+              branch (or (:branch config) :main)
+              result (pcrypto/verify-from-cold store-config branch)]
+          (if (:valid? result)
+            (audit/-merkle-root this)
+            (throw (ex-info "proximum: verify-from-cold failed"
+                            {:type :audit/merkle-mismatch
+                             :result result})))))
 
       (-transact [_ tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -128,39 +128,36 @@
       audit/IAuditable
       ;; Scriptum's content-hash is the merkle root over its Lucene
       ;; segments. Available only when the writer was constructed with
-      ;; :crypto-hash? true. `writer` here is a ScriptumWriter record
-      ;; — unwrap to the Java BranchIndexWriter via sc/->writer.
-      ;; getLastContentHash returns a String; coerce to java.util.UUID
-      ;; for uniformity with the other audit roots.
+      ;; :crypto-hash? true.
       (-merkle-root [_]
-        ;; Returns nil when no commit has happened yet or :crypto-hash?
-        ;; was off; never throws.
+        ;; Returns nil pre-commit / pre-crypto-hash; never throws.
         (let [bw (sc/->writer writer)
               h (.getLastContentHash bw)]
           (when h (java.util.UUID/fromString h))))
       (-recompute-merkle-root [_]
-        ;; Once scriptum.audit ships its own IAuditable, we'll delegate
-        ;; via lazy resolve like the stratum bridge does. Until then
-        ;; this calls sc/verify-commit and translates the
-        ;; {:valid? :commit-id :errors} shape into the unified result
-        ;; map. Returns :unsupported when :crypto-hash? was off (no
-        ;; content-hash is available).
-        (let [bw (sc/->writer writer)
-              h (.getLastContentHash bw)]
-          (cond
-            (nil? h)
-            {:status :unsupported :reason :crypto-hash-disabled}
+        ;; When scriptum.audit (>= 0.1.x audit-chain release) is on the
+        ;; classpath we delegate the deep walk to it. Older scriptum
+        ;; versions degrade to a local translation of
+        ;; sc/verify-commit's {:valid? :commit-id :errors} shape.
+        (or (when-let [recompute (try (requiring-resolve 'scriptum.audit/-recompute-merkle-root)
+                                      (catch Throwable _ nil))]
+              (recompute writer))
+            (let [bw (sc/->writer writer)
+                  h (.getLastContentHash bw)]
+              (cond
+                (nil? h)
+                {:status :unsupported :reason :crypto-hash-disabled}
 
-            :else
-            (let [r (sc/verify-commit writer)
-                  root (java.util.UUID/fromString h)]
-              (if (:valid? r)
-                {:status :ok :root root}
-                {:status :mismatch :root nil
-                 :errors [{:type :audit/merkle-mismatch
-                           :address root
-                           :expected root
-                           :details (:errors r)}]})))))
+                :else
+                (let [r (sc/verify-commit writer)
+                      root (java.util.UUID/fromString h)]
+                  (if (:valid? r)
+                    {:status :ok :root root}
+                    {:status :mismatch :root nil
+                     :errors [{:type :audit/merkle-mismatch
+                               :address root
+                               :expected root
+                               :details (:errors r)}]}))))))
 
       (-transact [this tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -126,36 +126,41 @@
         #{})
 
       audit/IAuditable
+      ;; Scriptum's content-hash is the merkle root over its Lucene
+      ;; segments. Available only when the writer was constructed with
+      ;; :crypto-hash? true. `writer` here is a ScriptumWriter record
+      ;; — unwrap to the Java BranchIndexWriter via sc/->writer.
+      ;; getLastContentHash returns a String; coerce to java.util.UUID
+      ;; for uniformity with the other audit roots.
       (-merkle-root [_]
-        ;; Scriptum's content-hash is the merkle root over its Lucene
-        ;; segments. Available only when the writer was constructed with
-        ;; :crypto-hash? true. `writer` here is a ScriptumWriter record
-        ;; — unwrap to the Java BranchIndexWriter via sc/->writer.
-        ;; getLastContentHash returns a String; coerce to java.util.UUID
-        ;; for uniformity with the other audit roots.
+        ;; Returns nil when no commit has happened yet or :crypto-hash?
+        ;; was off; never throws.
         (let [bw (sc/->writer writer)
               h (.getLastContentHash bw)]
-          (if h
-            (java.util.UUID/fromString h)
-            (throw (ex-info "scriptum writer has no content-hash (was :crypto-hash? enabled?)"
-                            {:type :audit/merkle-root-unsupported
-                             :index :scriptum})))))
+          (when h (java.util.UUID/fromString h))))
       (-recompute-merkle-root [_]
-        ;; Walk the segment chain. sc/verify-commit returns
-        ;; {:valid? :commit-id :errors}. On success, return the current
-        ;; content-hash — the same merkle root the caller compares
-        ;; against.
-        (let [r (sc/verify-commit writer)]
-          (if (:valid? r)
-            (let [bw (sc/->writer writer)
-                  h (.getLastContentHash bw)]
-              (if h
-                (java.util.UUID/fromString h)
-                (throw (ex-info "verify ok but no content-hash"
-                                {:type :audit/merkle-root-unsupported}))))
-            (throw (ex-info "scriptum: verify-commit failed"
-                            {:type :audit/merkle-mismatch
-                             :errors (:errors r)})))))
+        ;; Once scriptum.audit ships its own IAuditable, we'll delegate
+        ;; via lazy resolve like the stratum bridge does. Until then
+        ;; this calls sc/verify-commit and translates the
+        ;; {:valid? :commit-id :errors} shape into the unified result
+        ;; map. Returns :unsupported when :crypto-hash? was off (no
+        ;; content-hash is available).
+        (let [bw (sc/->writer writer)
+              h (.getLastContentHash bw)]
+          (cond
+            (nil? h)
+            {:status :unsupported :reason :crypto-hash-disabled}
+
+            :else
+            (let [r (sc/verify-commit writer)
+                  root (java.util.UUID/fromString h)]
+              (if (:valid? r)
+                {:status :ok :root root}
+                {:status :mismatch :root nil
+                 :errors [{:type :audit/merkle-mismatch
+                           :address root
+                           :expected root
+                           :details (:errors r)}]})))))
 
       (-transact [this tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -9,6 +9,7 @@
                      :db.secondary/attrs [:person/name :person/bio]
                      :db.secondary/config {:path \"/tmp/idx\" :analyzer :standard}}}"
   (:require
+   [datahike.index.audit :as audit]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
    [scriptum.core :as sc]
@@ -98,7 +99,10 @@
       (-sec-flush [_ _store branch]
         ;; Scriptum manages its own storage (Lucene files), not konserve.
         ;; Commit the current state and return a key-map for restore.
-        (sc/commit! writer "datahike-flush" {"datahike.branch" (name branch)})
+        ;; The merkle-root for audit is exposed via IAuditable below,
+        ;; computed from the writer's most recent content-hash.
+        (sc/commit! writer "datahike-flush"
+                    {"datahike.branch" (name branch)})
         {:type :scriptum
          :path (:path config)
          :branch (or (:branch config) "main")})
@@ -120,6 +124,38 @@
       (-sec-mark [_]
         ;; Scriptum uses filesystem, not konserve — nothing to mark
         #{})
+
+      audit/IAuditable
+      (-merkle-root [_]
+        ;; Scriptum's content-hash is the merkle root over its Lucene
+        ;; segments. Available only when the writer was constructed with
+        ;; :crypto-hash? true. `writer` here is a ScriptumWriter record
+        ;; — unwrap to the Java BranchIndexWriter via sc/->writer.
+        ;; getLastContentHash returns a String; coerce to java.util.UUID
+        ;; for uniformity with the other audit roots.
+        (let [bw (sc/->writer writer)
+              h (.getLastContentHash bw)]
+          (if h
+            (java.util.UUID/fromString h)
+            (throw (ex-info "scriptum writer has no content-hash (was :crypto-hash? enabled?)"
+                            {:type :audit/merkle-root-unsupported
+                             :index :scriptum})))))
+      (-recompute-merkle-root [_]
+        ;; Walk the segment chain. sc/verify-commit returns
+        ;; {:valid? :commit-id :errors}. On success, return the current
+        ;; content-hash — the same merkle root the caller compares
+        ;; against.
+        (let [r (sc/verify-commit writer)]
+          (if (:valid? r)
+            (let [bw (sc/->writer writer)
+                  h (.getLastContentHash bw)]
+              (if h
+                (java.util.UUID/fromString h)
+                (throw (ex-info "verify ok but no content-hash"
+                                {:type :audit/merkle-root-unsupported}))))
+            (throw (ex-info "scriptum: verify-commit failed"
+                            {:type :audit/merkle-mismatch
+                             :errors (:errors r)})))))
 
       (-transact [this tx-report]
         ;; tx-report: {:datom datom :added? bool}

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -463,9 +463,20 @@
     ;; Returns nil when unsynced; never throws.
     (some-> dataset :commit-info :id))
   (-recompute-merkle-root [_]
-    ;; Stratum does not currently expose a from-cold verify function.
-    ;; Until stratum.audit ships, deep audit reports :unsupported.
-    {:status :unsupported :reason :no-deep-verify})
+    ;; Stratum's audit ns ships the same IAuditable shape, so when it's
+    ;; on the classpath we delegate the deep walk to it. Older stratum
+    ;; versions (pre-audit) make this resolve nil and we degrade to
+    ;; :unsupported. Resolved lazily so this bridge keeps loading
+    ;; against any stratum version.
+    (cond
+      (nil? dataset)
+      {:status :unsupported :reason :unsynced}
+
+      :else
+      (if-let [recompute (try (requiring-resolve 'stratum.audit/-recompute-merkle-root)
+                              (catch Throwable _ nil))]
+        (recompute dataset)
+        {:status :unsupported :reason :stratum-audit-unavailable})))
 
   sec/IColumnarAggregate
   (-columnar-aggregate [this query-spec]

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -19,6 +19,7 @@
    The secondary index path is preferred when available — it avoids the
    PSS scan + column extraction overhead entirely."
   (:require
+   [datahike.index.audit :as audit]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
    [datahike.db.interface :as dbi]
@@ -418,12 +419,18 @@
 
   sec/IVersionedSecondaryIndex
   (-sec-flush [_ store branch]
-    ;; Persist dataset to konserve via stratum's sync!
+    ;; Persist dataset to konserve via stratum's sync!. The dataset
+    ;; commit-id IS a content-addressed hash of the persisted state,
+    ;; so we surface it under both :dataset-commit-id (existing)
+    ;; and the standardized :merkle-root that datahike's audit-chain
+    ;; folds into the commit-id.
     (if dataset
-      (let [synced-ds (sd/sync! dataset store (name branch))]
+      (let [synced-ds (sd/sync! dataset store (name branch))
+            commit-id (get-in synced-ds [:commit-info :id])]
         {:type :stratum
          :branch (name branch)
-         :dataset-commit-id (get-in synced-ds [:commit-info :id])})
+         :dataset-commit-id commit-id
+         :merkle-root commit-id})
       {:type :stratum :branch (name branch) :dataset-commit-id nil}))
 
   (-sec-restore [_ store key-map]
@@ -446,6 +453,23 @@
     ;; doesn't have access to the store. GC uses mark-from-key-map instead,
     ;; which gets the key-map + store from the stored commit.
     #{})
+
+  audit/IAuditable
+  ;; The live instance's `dataset` field is immutable; the synced
+  ;; commit-id is only available locally inside -sec-flush. The
+  ;; flush-time merkle-root is captured via the :merkle-root key in
+  ;; -sec-flush's return map, and writing.cljc folds it into the cid.
+  (-merkle-root [_]
+    (or (some-> dataset :commit-info :id)
+        (throw (ex-info "Stratum dataset has no committed merkle-root yet"
+                        {:type :audit/merkle-root-unsupported
+                         :reason :unsynced}))))
+  (-recompute-merkle-root [_]
+    ;; Stratum does not currently expose a from-cold verify function.
+    ;; Deep audit treats this as :unsupported rather than :mismatch.
+    (throw (ex-info "stratum does not implement deep verify-from-cold"
+                    {:type :audit/recompute-unsupported
+                     :index :stratum})))
 
   sec/IColumnarAggregate
   (-columnar-aggregate [this query-spec]

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -460,16 +460,12 @@
   ;; flush-time merkle-root is captured via the :merkle-root key in
   ;; -sec-flush's return map, and writing.cljc folds it into the cid.
   (-merkle-root [_]
-    (or (some-> dataset :commit-info :id)
-        (throw (ex-info "Stratum dataset has no committed merkle-root yet"
-                        {:type :audit/merkle-root-unsupported
-                         :reason :unsynced}))))
+    ;; Returns nil when unsynced; never throws.
+    (some-> dataset :commit-info :id))
   (-recompute-merkle-root [_]
     ;; Stratum does not currently expose a from-cold verify function.
-    ;; Deep audit treats this as :unsupported rather than :mismatch.
-    (throw (ex-info "stratum does not implement deep verify-from-cold"
-                    {:type :audit/recompute-unsupported
-                     :index :stratum})))
+    ;; Until stratum.audit ships, deep audit reports :unsupported.
+    {:status :unsupported :reason :no-deep-verify})
 
   sec/IColumnarAggregate
   (-columnar-aggregate [this query-spec]

--- a/src/datahike/audit.cljc
+++ b/src/datahike/audit.cljc
@@ -1,0 +1,194 @@
+(ns datahike.audit
+  "Audit-chain verification for `:crypto-hash? true` databases.
+
+   `verify-chain` walks the commit DAG from a head cid backwards via
+   `:datahike/parents`, recomputes each cid from the stored merkle
+   roots, and reports any mismatch. Tampering with a stored commit
+   flips its recomputed cid (layer-1 detection).
+
+   With `:deep? true` the head commit is additionally cross-checked:
+   each live index in the snapshot is asked to `-recompute-merkle-root`
+   from its actual storage, and the result is compared with the root
+   that was hashed into the commit-id (layer-2: catches bytes-level
+   tampering on a secondary's external storage that doesn't change the
+   datahike commit itself)."
+  (:require [datahike.db.utils :as dbu]
+            [datahike.index.audit :as idx-audit]
+            [datahike.writing :as dw]
+            [konserve.core :as k]
+            [superv.async #?(:clj :refer :cljs :refer-macros) [go-try- <?-]]
+            [konserve.utils :refer [#?(:clj async+sync) *default-sync-translation*]
+             #?@(:cljs [:refer-macros [async+sync]])]))
+
+(defn- audit-grade-stored?
+  "Mirror of writing/audit-grade? but for already-stored commits we're
+   verifying. Looks at the stored merkle-roots map; legacy commits
+   that lack it (or have nil primary roots) get advisory."
+  [stored]
+  (let [config (:config stored)
+        roots (:merkle-roots stored)]
+    (and (:crypto-hash? config)
+         (not= :memory (get-in config [:store :backend]))
+         (every? some? (vals (select-keys roots [:eavt-key :aevt-key :avet-key]))))))
+
+(defn- classify [stored cid recomputed]
+  (let [config (:config stored)
+        roots (:merkle-roots stored)
+        sec-roots (:secondary roots)]
+    (cond
+      (not (:crypto-hash? config))
+      {:status :advisory :reason :crypto-hash-disabled}
+      (= :memory (get-in config [:store :backend]))
+      {:status :advisory :reason :memory-backend}
+      (not (audit-grade-stored? stored))
+      {:status :advisory :reason :primary-not-audit-grade}
+      (and (seq sec-roots) (not (every? some? (vals sec-roots))))
+      {:status :advisory :reason :secondary-not-audit-grade}
+      (= cid recomputed) {:status :ok}
+      :else              {:status :mismatch})))
+
+(defn- step
+  "Load `cid` from `store`, recompute, return a verification entry."
+  [store cid sync?]
+  (async+sync sync? *default-sync-translation*
+              (go-try-
+               (when-let [stored (<?- (k/get store cid nil {:sync? sync?}))]
+                 (let [recomputed (dw/create-commit-id stored stored)
+                       stored-cid (get-in stored [:meta :datahike/commit-id])
+                       parents    (get-in stored [:meta :datahike/parents] #{})
+                       {:keys [status reason]} (classify stored stored-cid recomputed)]
+                   (cond-> {:cid stored-cid :recomputed recomputed
+                            :parents parents :status status}
+                     reason (assoc :reason reason)))))))
+
+;; ============================================================================
+;; Deep verification — re-derive merkle roots from live storage for the
+;; head snapshot and compare with the cached roots.
+
+(defn- recompute-or-unsupported
+  "Try to recompute the merkle root for a live index. Returns
+   `[:ok uuid]` on success, `[:unsupported reason]` when the impl
+   doesn't support deep verification (e.g. live instance can't sync
+   without external state), or `[:mismatch errors]` if the impl
+   detected corruption."
+  [live]
+  (try
+    [:ok (idx-audit/-recompute-merkle-root live)]
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+      (case (:type (ex-data e))
+        :audit/merkle-mismatch [:mismatch (ex-data e)]
+        :audit/merkle-root-unsupported [:unsupported (:reason (ex-data e))]
+        :audit/recompute-unsupported [:unsupported :impl-not-supported]
+        [:unsupported (or (:type (ex-data e)) :unknown)]))))
+
+(defn- deep-verify-head
+  "Walk every live index in `db` and ask each to recompute its merkle
+   root. Compare against the stored roots. Returns
+   `{:status :ok|:mismatch, :diffs […], :unsupported […]}`.
+
+   Diffs are genuine mismatches (the impl recomputed something and it
+   didn't match). Unsupported entries flag indexes whose impl can't
+   deep-verify on the current snapshot — they're surfaced but don't
+   degrade the overall :ok status."
+  [db stored-head]
+  (let [stored-roots (:merkle-roots stored-head)
+        check (fn [idx-key live]
+                (let [stored (get stored-roots idx-key)
+                      [outcome v] (recompute-or-unsupported live)]
+                  (case outcome
+                    :ok (when (not= stored v)
+                          {:kind :diff :index idx-key :stored stored :recomputed v})
+                    :unsupported {:kind :unsupported :index idx-key :reason v}
+                    :mismatch {:kind :diff :index idx-key :stored stored :errors v})))
+        primary (keep identity
+                      [(check :eavt-key (:eavt db))
+                       (check :aevt-key (:aevt db))
+                       (check :avet-key (:avet db))
+                       (when (:keep-history? (:config db))
+                         (check :temporal-eavt-key (:temporal-eavt db)))
+                       (when (:keep-history? (:config db))
+                         (check :temporal-aevt-key (:temporal-aevt db)))
+                       (when (:keep-history? (:config db))
+                         (check :temporal-avet-key (:temporal-avet db)))])
+        sec-stored (:secondary stored-roots)
+        secondary (when (seq sec-stored)
+                    (keep (fn [[ident live]]
+                            (check ident live))
+                          (:secondary-indices db)))
+        all (concat primary secondary)
+        diffs (filterv (comp #{:diff} :kind) all)
+        unsupp (filterv (comp #{:unsupported} :kind) all)]
+    (cond-> {:status (if (seq diffs) :mismatch :ok)
+             :diffs diffs}
+      (seq unsupp) (assoc :unsupported unsupp))))
+
+(defn verify-chain
+  "Walk the commit DAG anchored at db snapshot `db` and return
+   `{:head, :status, :commits, :mismatches, :missing}`.
+
+   `db` must be a db value (from `d/db`). Defaults the head to the
+   snapshot's own `:datahike/commit-id`; pass an explicit `head-cid` to
+   verify from a different point.
+
+   Options:
+     :deep?   — when true, additionally re-derive merkle roots from
+                live storage for the head snapshot's indexes and confirm
+                they match the cached roots. Catches bytes-level tampering
+                that doesn't show up at the commit-pointer level. Adds a
+                `:deep` entry to the report with `{:status, :diffs}`.
+     :limit   — max commits to walk (default unlimited).
+     :sync?   — block (default true).
+
+   `:status` is `:ok | :mismatch | :advisory | :incomplete`. Each entry
+   in `:commits` is `{:cid :recomputed :parents :status [:reason]}`."
+  ([db] (verify-chain db nil {}))
+  ([db head-cid] (verify-chain db head-cid {}))
+  ([db head-cid {:keys [limit sync? deep?]
+                 :or {limit #?(:clj Long/MAX_VALUE :cljs (.-MAX_SAFE_INTEGER js/Number))
+                      sync? true
+                      deep? false}}]
+   (when-not (dbu/db? db)
+     (throw (ex-info "verify-chain: expected a db value (try (d/db conn))"
+                     {:type :audit/expected-db :got (type db)})))
+   (async+sync sync? *default-sync-translation*
+               (go-try-
+                (let [store   (:store db)
+                      head    (or head-cid (get-in db [:meta :datahike/commit-id]))
+                      _       (when-not head
+                                (throw (ex-info "verify-chain: no head cid on db"
+                                                {:type :audit/no-head})))
+                      commits (volatile! [])
+                      missing (volatile! [])
+                      visited (volatile! #{})]
+                  (loop [frontier [head] n 0]
+                    (when (and (seq frontier) (< n limit))
+                      (let [cid (first frontier) rest-f (rest frontier)]
+                        (if (contains? @visited cid)
+                          (recur rest-f n)
+                          (do (vswap! visited conj cid)
+                              (if-let [entry (<?- (step store cid sync?))]
+                                (do (vswap! commits conj entry)
+                                    (recur (into (vec rest-f)
+                                                 (remove @visited (:parents entry)))
+                                           (inc n)))
+                                (do (vswap! missing conj cid)
+                                    (recur rest-f n))))))))
+                  (let [es @commits
+                        mism (filterv (comp #{:mismatch} :status) es)
+                        miss @missing
+                        adv  (some (comp #{:advisory} :status) es)
+                        deep (when deep?
+                               (let [head-stored (<?- (k/get store head nil {:sync? sync?}))]
+                                 (when head-stored
+                                   (deep-verify-head db head-stored))))
+                        base-status (cond (seq mism) :mismatch
+                                          (seq miss) :incomplete
+                                          adv        :advisory
+                                          :else      :ok)
+                        deep-mismatch? (= :mismatch (:status deep))]
+                    (cond-> {:head head
+                             :status (if deep-mismatch? :mismatch base-status)
+                             :commits es :mismatches mism :missing miss}
+                      deep (assoc :deep deep))))))))
+
+(defn ok? [report] (= :ok (:status report)))

--- a/src/datahike/audit.cljc
+++ b/src/datahike/audit.cljc
@@ -65,22 +65,6 @@
 ;; Deep verification — re-derive merkle roots from live storage for the
 ;; head snapshot and compare with the cached roots.
 
-(defn- recompute-or-unsupported
-  "Try to recompute the merkle root for a live index. Returns
-   `[:ok uuid]` on success, `[:unsupported reason]` when the impl
-   doesn't support deep verification (e.g. live instance can't sync
-   without external state), or `[:mismatch errors]` if the impl
-   detected corruption."
-  [live]
-  (try
-    [:ok (idx-audit/-recompute-merkle-root live)]
-    (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
-      (case (:type (ex-data e))
-        :audit/merkle-mismatch [:mismatch (ex-data e)]
-        :audit/merkle-root-unsupported [:unsupported (:reason (ex-data e))]
-        :audit/recompute-unsupported [:unsupported :impl-not-supported]
-        [:unsupported (or (:type (ex-data e)) :unknown)]))))
-
 (defn- deep-verify-head
   "Walk every live index in `db` and ask each to recompute its merkle
    root. Compare against the stored roots. Returns
@@ -89,17 +73,24 @@
    Diffs are genuine mismatches (the impl recomputed something and it
    didn't match). Unsupported entries flag indexes whose impl can't
    deep-verify on the current snapshot — they're surfaced but don't
-   degrade the overall :ok status."
+   degrade the overall :ok status.
+
+   The protocol returns a result map (`{:status :ok|:mismatch|:unsupported …}`)
+   so this function only dispatches on :status."
   [db stored-head]
   (let [stored-roots (:merkle-roots stored-head)
         check (fn [idx-key live]
                 (let [stored (get stored-roots idx-key)
-                      [outcome v] (recompute-or-unsupported live)]
-                  (case outcome
-                    :ok (when (not= stored v)
-                          {:kind :diff :index idx-key :stored stored :recomputed v})
-                    :unsupported {:kind :unsupported :index idx-key :reason v}
-                    :mismatch {:kind :diff :index idx-key :stored stored :errors v})))
+                      result (idx-audit/-recompute-merkle-root live)]
+                  (case (:status result)
+                    :ok          (when (not= stored (:root result))
+                                   {:kind :diff :index idx-key
+                                    :stored stored :recomputed (:root result)})
+                    :unsupported {:kind :unsupported :index idx-key
+                                  :reason (:reason result)}
+                    :mismatch    {:kind :diff :index idx-key
+                                  :stored stored :errors (:errors result)
+                                  :recomputed (:root result)})))
         primary (keep identity
                       [(check :eavt-key (:eavt db))
                        (check :aevt-key (:aevt db))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -121,37 +121,51 @@
   (assoc db :rschema (dbu/rschema (:schema db))))
 
 #?(:clj
-   (defn- maybe-create-secondary-index
-     "When a secondary index schema entity is fully defined (has both
-      :db.secondary/type and :db.secondary/attrs) and no index instance exists
-      yet, create an empty index instance and wire it into the db.
-      Sets :db.secondary/status to :building and records :building-since-tx."
-     [db ^Datom datom]
-     (let [e (.-e datom)
-           schema (:schema db)
-           ;; The entity's ident is stored in schema[e] as a keyword
-           idx-ident (get schema e)
-           idx-schema (when (keyword? idx-ident) (get schema idx-ident))]
-       (if (and (map? idx-schema)
-                (:db.secondary/type idx-schema)
-                (:db.secondary/attrs idx-schema)
-                ;; Don't create if already exists
-                (not (get-in db [:secondary-indices idx-ident])))
-         (let [idx-type (:db.secondary/type idx-schema)
-               idx-attrs (set (:db.secondary/attrs idx-schema))
-               idx-config (merge (:db.secondary/config idx-schema)
-                                 {:attrs idx-attrs})
-               idx-config (cond-> idx-config
-                            (seq (:ident-ref-map db))
-                            (assoc :ident-ref-map (:ident-ref-map db)))
-               idx (sec/create-index idx-type idx-config nil)]
-           (-> db
-               (assoc-in [:secondary-indices idx-ident] idx)
-               (assoc-in [:schema idx-ident :db.secondary/status] :building)
-               (assoc-in [:schema idx-ident :db.secondary/building-since-tx] (:max-tx db))))
-         db)))
+   (defn- instantiate-secondary
+     "Create the secondary-index instance for `idx-ident` from a fully
+      populated schema entry. Used at end-of-tx so the factory sees the
+      complete config (including `:db.secondary/config`, which may have
+      been applied as a later datom within the same tx)."
+     [db idx-ident idx-schema]
+     (let [idx-type (:db.secondary/type idx-schema)
+           idx-attrs (set (:db.secondary/attrs idx-schema))
+           idx-config (cond-> (merge (:db.secondary/config idx-schema)
+                                     {:attrs idx-attrs})
+                        (seq (:ident-ref-map db))
+                        (assoc :ident-ref-map (:ident-ref-map db)))
+           idx (sec/create-index idx-type idx-config nil)]
+       (-> db
+           (assoc-in [:secondary-indices idx-ident] idx)
+           (assoc-in [:schema idx-ident :db.secondary/status] :building)
+           (assoc-in [:schema idx-ident :db.secondary/building-since-tx] (:max-tx db)))))
    :cljs
-   (defn- maybe-create-secondary-index [db _datom] db))
+   (defn- instantiate-secondary [db _idx-ident _idx-schema] db))
+
+#?(:clj
+   (defn finalize-secondary-indices
+     "Walk the post-tx schema for secondary-index entities that have
+      `:db.secondary/type` + `:db.secondary/attrs` but no instance yet,
+      and create them with their full config.
+
+      Called at the end of `transact-tx-data` so the factory sees a
+      complete schema entry — fixes the race where instantiating per-
+      datom would call the factory before `:db.secondary/config` had
+      been applied. The writer's auto-backfill (status :building →
+      `build-secondary-index!`) populates the new index from AEVT, so
+      data datoms applied in the same tx are picked up asynchronously."
+     [db]
+     (reduce-kv
+      (fn [d k entry]
+        (if (and (keyword? k)
+                 (map? entry)
+                 (:db.secondary/type entry)
+                 (:db.secondary/attrs entry)
+                 (not (get-in d [:secondary-indices k])))
+          (instantiate-secondary d k entry)
+          d))
+      db (:schema db)))
+   :cljs
+   (defn finalize-secondary-indices [db] db))
 
 (defn remove-schema [db ^Datom datom]
   (let [schema (dbi/-schema db)
@@ -228,8 +242,7 @@
         true (advance-max-eid (.-e datom))
         true (update :hash + (hash datom))
         schema? (-> (update-schema datom)
-                    update-rschema
-                    (maybe-create-secondary-index datom))
+                    update-rschema)
         true (update :op-count inc))
 
       (if-some [removing ^Datom (first (dbi/search db [(.-e datom) (.-a datom) (.-v datom)]))]
@@ -334,8 +347,7 @@
       true    (advance-max-eid (.-e datom))
       true    (update :hash + (hash datom))
       schema? (-> (update-schema datom)
-                  update-rschema
-                  (maybe-create-secondary-index datom)))))
+                  update-rschema))))
 
 (defn- transact-report
   ([report datom] (transact-report report datom false))
@@ -895,7 +907,8 @@
           (-> report
               (assoc-in [:tempids :db/current-tx] (current-tx report))
               (update-in [:db-after :max-tx] inc)
-              (update :db-after persistent!))
+              (update :db-after persistent!)
+              (update :db-after finalize-secondary-indices))
 
           (nil? entity)
           (recur report entities)
@@ -966,7 +979,8 @@
           (update-in [:db-after :migration] #(if %
                                                (merge % migration-state)
                                                migration-state))
-          (update :db-after persistent!))
+          (update :db-after persistent!)
+          (update :db-after finalize-secondary-indices))
       (let [[entity & entities] es
             {:keys [config] :as db} (:db-after report)
             [e a v t op] entity

--- a/src/datahike/index/audit.cljc
+++ b/src/datahike/index/audit.cljc
@@ -23,10 +23,13 @@
      content-address).")
 
   (-recompute-merkle-root [this]
-    "Walk storage and re-derive the merkle root. The caller compares
-     against `-merkle-root` to detect bytes-level tampering. May load
-     and walk all data — used only by deep audit. The default behavior
-     for storage layers that already content-address on read (e.g.
-     konserve in `:crypto-hash?` mode) is to return `(-merkle-root this)`.
+    "Walk every node from the underlying storage and re-derive the
+     merkle root, asserting that each address really is the content
+     hash of the bytes stored under it. Returns the recomputed root —
+     identical to `-merkle-root` on an intact tree. Detects bytes-level
+     tampering of storage that wouldn't otherwise change the in-memory
+     `_address` or the cached `:merkle-roots` on the commit (konserve
+     does not verify content on read; impls must do this themselves).
+     May load and walk all reachable nodes — used only by deep audit.
      Throws `{:type :audit/merkle-mismatch}` on detected corruption or
      `{:type :audit/recompute-unsupported}` when not implemented."))

--- a/src/datahike/index/audit.cljc
+++ b/src/datahike/index/audit.cljc
@@ -12,24 +12,34 @@
    New index implementations only need to extend `IAuditable` to opt
    in. Existing impls without the extension are flagged `:advisory` by
    the auditor (their state still gets folded into the commit, but
-   audit can't attest it).")
+   audit can't attest it).
+
+   Conventions across replikativ repos (datahike, stratum):
+   the protocol shape and result-map keys are intentionally identical so
+   bridges (e.g. datahike's stratum secondary) can pass results through
+   without translation.")
 
 (defprotocol IAuditable
   (-merkle-root [this]
-    "Content-addressed UUID of the index's current state. Cheap — post-
-     flush this returns a value the underlying library already computed.
-     Throws `{:type :audit/merkle-root-unsupported}` when the impl
-     can't provide one (e.g. unflushed, or the storage layer doesn't
-     content-address).")
+    "Cheap. Returns the cached/known content-addressed UUID of this
+     thing's current state — post-flush this is a value the underlying
+     library already computed. Returns `nil` when no root is available
+     (e.g. unflushed, or storage layer doesn't content-address). Never
+     throws.")
 
   (-recompute-merkle-root [this]
-    "Walk every node from the underlying storage and re-derive the
-     merkle root, asserting that each address really is the content
-     hash of the bytes stored under it. Returns the recomputed root —
-     identical to `-merkle-root` on an intact tree. Detects bytes-level
-     tampering of storage that wouldn't otherwise change the in-memory
-     `_address` or the cached `:merkle-roots` on the commit (konserve
-     does not verify content on read; impls must do this themselves).
-     May load and walk all reachable nodes — used only by deep audit.
-     Throws `{:type :audit/merkle-mismatch}` on detected corruption or
-     `{:type :audit/recompute-unsupported}` when not implemented."))
+    "Expensive. Walks the underlying storage and re-derives the merkle
+     root, asserting that every reachable node's bytes really hash back
+     to its address. Returns a result map; never throws on a detected
+     mismatch:
+
+       {:status :ok          :root <uuid>}
+       {:status :mismatch    :root <recomputed-uuid?>
+                             :errors [{:address, :expected, :recomputed,
+                                       :node-class, :type}]}
+       {:status :unsupported :reason <kw>}
+
+     Use `:status` for branching. `:errors` carries one entry per
+     anomaly the walker found (mismatch, missing node, or unexpected
+     node class). Konserve does not verify content on read, so impls
+     must do the walking themselves."))

--- a/src/datahike/index/audit.cljc
+++ b/src/datahike/index/audit.cljc
@@ -1,0 +1,32 @@
+(ns datahike.index.audit
+  "Shared `IAuditable` protocol for both primary and secondary indexes
+   that participate in datahike's audit chain.
+
+   An index that extends `IAuditable` exposes a content-addressed merkle
+   root for its current state. Datahike folds those roots into the
+   commit-id under `:crypto-hash?` so pointer tampering on stored
+   commits is detected by cid recomputation, and supports a deeper
+   `(verify-chain db {:deep? true})` mode that re-derives each index's
+   root from storage to detect bytes-level tampering.
+
+   New index implementations only need to extend `IAuditable` to opt
+   in. Existing impls without the extension are flagged `:advisory` by
+   the auditor (their state still gets folded into the commit, but
+   audit can't attest it).")
+
+(defprotocol IAuditable
+  (-merkle-root [this]
+    "Content-addressed UUID of the index's current state. Cheap — post-
+     flush this returns a value the underlying library already computed.
+     Throws `{:type :audit/merkle-root-unsupported}` when the impl
+     can't provide one (e.g. unflushed, or the storage layer doesn't
+     content-address).")
+
+  (-recompute-merkle-root [this]
+    "Walk storage and re-derive the merkle root. The caller compares
+     against `-merkle-root` to detect bytes-level tampering. May load
+     and walk all data — used only by deep audit. The default behavior
+     for storage layers that already content-address on read (e.g.
+     konserve in `:crypto-hash?` mode) is to return `(-merkle-root this)`.
+     Throws `{:type :audit/merkle-mismatch}` on detected corruption or
+     `{:type :audit/recompute-unsupported}` when not implemented."))

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -214,10 +214,62 @@
   (-mark [^PersistentSortedSet pset]
     (mark pset)))
 
+(defn- gen-address [^ANode node crypto-hash?]
+  (if crypto-hash?
+    (if (instance? Branch node)
+      (uuid (vec (.addresses ^Branch node)))
+      (uuid (mapv (comp vec seq) (.keys node))))
+    (squuid)))  ;; Sequential UUID for better index locality
+
+#?(:clj
+   (defn- recompute-pss-address!
+     "Read the node at `address` directly from konserve, recompute its
+      content-addressed UUID, and confirm it matches `address`. Recurses
+      into Branch children. Throws `:audit/merkle-mismatch` when the
+      bytes at `address` no longer hash back to it (tampering detected),
+      `:audit/node-missing` when the blob is gone.
+
+      `verified` is an atom holding the addresses already proven good in
+      this verification pass. Subtrees rooted at a verified address are
+      skipped — useful when the same cache is threaded across multiple
+      `-recompute-merkle-root` calls (e.g. parents in a chain walk).
+      Within a single tree the cache is a no-op, since B-tree nodes have
+      exactly one parent.
+
+      Reads go through `k/get store` directly, bypassing the live
+      `CachedStorage` LRU; otherwise a hot in-memory copy could mask a
+      tampered on-disk blob."
+     [store address verified]
+     (when-not (contains? @verified address)
+       (let [node (k/get store address nil {:sync? true})]
+         (when (nil? node)
+           (throw (ex-info "Node missing from store while recomputing merkle root"
+                           {:type :audit/node-missing
+                            :address address})))
+         (let [recomputed (cond
+                            (instance? Branch node)
+                            (uuid (vec (.addresses ^Branch node)))
+                            (instance? Leaf node)
+                            (uuid (mapv (comp vec seq) (.keys ^Leaf node)))
+                            :else
+                            (throw (ex-info "Unknown PSS node class while recomputing merkle root"
+                                            {:type :audit/recompute-unsupported
+                                             :node-class (some-> node class .getName)})))]
+           (when (not= address recomputed)
+             (throw (ex-info "Merkle root mismatch — content does not hash back to its address"
+                             {:type :audit/merkle-mismatch
+                              :expected address
+                              :recomputed recomputed
+                              :node-class (some-> node class .getName)})))
+           (when (instance? Branch node)
+             (doseq [child-addr (.addresses ^Branch node)]
+               (recompute-pss-address! store child-addr verified)))
+           (swap! verified conj address))))))
+
 (extend-type #?(:clj PersistentSortedSet :cljs BTSet)
   IAuditable
   (-merkle-root [^PersistentSortedSet pset]
-    ;; gen-address (above) makes every node UUID a recursive content
+    ;; gen-address (below) makes every node UUID a recursive content
     ;; hash of its datoms under :crypto-hash?, so the root _address
     ;; captures the whole tree. Set by psset/store during -flush.
     (or (.-_address pset)
@@ -225,17 +277,31 @@
                         {:type :audit/merkle-root-unsupported
                          :reason :unflushed}))))
   (-recompute-merkle-root [^PersistentSortedSet pset]
-    ;; Konserve's content-addressed read in :crypto-hash? mode already
-    ;; verifies each node's bytes match its address UUID on access —
-    ;; recomputation is implicit. Returning -merkle-root is correct here.
-    (audit/-merkle-root pset)))
-
-(defn- gen-address [^ANode node crypto-hash?]
-  (if crypto-hash?
-    (if (instance? Branch node)
-      (uuid (vec (.addresses ^Branch node)))
-      (uuid (mapv (comp vec seq) (.keys node))))
-    (squuid)))  ;; Sequential UUID for better index locality
+    ;; Walk the tree from konserve, deserialize each node, and confirm
+    ;; its bytes hash back to its address. Konserve does NOT verify
+    ;; content on read, so without this walk a tampered .ksv file would
+    ;; round-trip undetected — only the in-memory `_address` would still
+    ;; look correct.
+    #?(:clj
+       (let [address (.-_address pset)
+             storage (.-_storage pset)
+             store   (some-> storage :store)]
+         (cond
+           (nil? address)
+           (throw (ex-info "PersistentSortedSet must be flushed before merkle-root"
+                           {:type :audit/merkle-root-unsupported
+                            :reason :unflushed}))
+           (nil? store)
+           (throw (ex-info "PersistentSortedSet has no konserve store; cannot recompute merkle root"
+                           {:type :audit/recompute-unsupported
+                            :reason :no-store}))
+           :else
+           (do (recompute-pss-address! store address (atom #{}))
+               address)))
+       :cljs
+       (throw (ex-info "Deep recompute not implemented for cljs PSS"
+                       {:type :audit/recompute-unsupported
+                        :reason :cljs-not-implemented})))))
 
 (defn- freelist-pop!
   "Atomically pop an address from the freelist. Returns nil if empty."

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -222,49 +222,58 @@
     (squuid)))  ;; Sequential UUID for better index locality
 
 #?(:clj
-   (defn- recompute-pss-address!
+   (defn- walk-pss-address!
      "Read the node at `address` directly from konserve, recompute its
       content-addressed UUID, and confirm it matches `address`. Recurses
-      into Branch children. Throws `:audit/merkle-mismatch` when the
-      bytes at `address` no longer hash back to it (tampering detected),
-      `:audit/node-missing` when the blob is gone.
+      into Branch children, accumulating any anomalies into the
+      `errors` atom (instead of throwing).
 
-      `verified` is an atom holding the addresses already proven good in
-      this verification pass. Subtrees rooted at a verified address are
-      skipped — useful when the same cache is threaded across multiple
-      `-recompute-merkle-root` calls (e.g. parents in a chain walk).
-      Within a single tree the cache is a no-op, since B-tree nodes have
-      exactly one parent.
+      Each error has shape:
+        {:type :audit/merkle-mismatch | :audit/node-missing | :audit/unknown-node-class
+         :address <expected-address>
+         :recomputed <uuid?>           ;; only for :merkle-mismatch
+         :node-class <class-name?>}
+
+      `verified` holds addresses already proven good in this pass; the
+      walker prunes their subtrees. Within a single tree this is a
+      no-op (B-tree nodes have one parent) but it keeps the function
+      composable across multiple calls sharing the same atom.
 
       Reads go through `k/get store` directly, bypassing the live
       `CachedStorage` LRU; otherwise a hot in-memory copy could mask a
       tampered on-disk blob."
-     [store address verified]
+     [store address verified errors]
      (when-not (contains? @verified address)
        (let [node (k/get store address nil {:sync? true})]
-         (when (nil? node)
-           (throw (ex-info "Node missing from store while recomputing merkle root"
-                           {:type :audit/node-missing
-                            :address address})))
-         (let [recomputed (cond
-                            (instance? Branch node)
-                            (uuid (vec (.addresses ^Branch node)))
-                            (instance? Leaf node)
-                            (uuid (mapv (comp vec seq) (.keys ^Leaf node)))
-                            :else
-                            (throw (ex-info "Unknown PSS node class while recomputing merkle root"
-                                            {:type :audit/recompute-unsupported
-                                             :node-class (some-> node class .getName)})))]
-           (when (not= address recomputed)
-             (throw (ex-info "Merkle root mismatch — content does not hash back to its address"
-                             {:type :audit/merkle-mismatch
-                              :expected address
-                              :recomputed recomputed
-                              :node-class (some-> node class .getName)})))
-           (when (instance? Branch node)
-             (doseq [child-addr (.addresses ^Branch node)]
-               (recompute-pss-address! store child-addr verified)))
-           (swap! verified conj address))))))
+         (cond
+           (nil? node)
+           (swap! errors conj {:type :audit/node-missing :address address})
+
+           :else
+           (let [recomputed (cond
+                              (instance? Branch node)
+                              (uuid (vec (.addresses ^Branch node)))
+                              (instance? Leaf node)
+                              (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
+             (cond
+               (nil? recomputed)
+               (swap! errors conj {:type :audit/unknown-node-class
+                                   :address address
+                                   :node-class (some-> node class .getName)})
+
+               (not= address recomputed)
+               (swap! errors conj {:type :audit/merkle-mismatch
+                                   :address address
+                                   :expected address
+                                   :recomputed recomputed
+                                   :node-class (some-> node class .getName)})
+
+               :else
+               (do
+                 (when (instance? Branch node)
+                   (doseq [child-addr (.addresses ^Branch node)]
+                     (walk-pss-address! store child-addr verified errors)))
+                 (swap! verified conj address)))))))))
 
 (extend-type #?(:clj PersistentSortedSet :cljs BTSet)
   IAuditable
@@ -272,36 +281,32 @@
     ;; gen-address (below) makes every node UUID a recursive content
     ;; hash of its datoms under :crypto-hash?, so the root _address
     ;; captures the whole tree. Set by psset/store during -flush.
-    (or (.-_address pset)
-        (throw (ex-info "PersistentSortedSet must be flushed before merkle-root"
-                        {:type :audit/merkle-root-unsupported
-                         :reason :unflushed}))))
+    ;; Returns nil when unflushed; never throws.
+    (.-_address pset))
   (-recompute-merkle-root [^PersistentSortedSet pset]
     ;; Walk the tree from konserve, deserialize each node, and confirm
     ;; its bytes hash back to its address. Konserve does NOT verify
     ;; content on read, so without this walk a tampered .ksv file would
     ;; round-trip undetected — only the in-memory `_address` would still
-    ;; look correct.
+    ;; look correct. Returns a result map; never throws on mismatch.
     #?(:clj
        (let [address (.-_address pset)
              storage (.-_storage pset)
              store   (some-> storage :store)]
          (cond
            (nil? address)
-           (throw (ex-info "PersistentSortedSet must be flushed before merkle-root"
-                           {:type :audit/merkle-root-unsupported
-                            :reason :unflushed}))
+           {:status :unsupported :reason :unflushed}
            (nil? store)
-           (throw (ex-info "PersistentSortedSet has no konserve store; cannot recompute merkle root"
-                           {:type :audit/recompute-unsupported
-                            :reason :no-store}))
+           {:status :unsupported :reason :no-store}
            :else
-           (do (recompute-pss-address! store address (atom #{}))
-               address)))
+           (let [verified (atom #{})
+                 errors   (atom [])]
+             (walk-pss-address! store address verified errors)
+             (if (seq @errors)
+               {:status :mismatch :root nil :errors @errors}
+               {:status :ok :root address}))))
        :cljs
-       (throw (ex-info "Deep recompute not implemented for cljs PSS"
-                       {:type :audit/recompute-unsupported
-                        :reason :cljs-not-implemented})))))
+       {:status :unsupported :reason :cljs-not-implemented})))
 
 (defn- freelist-pop!
   "Atomically pop an address from the freelist. Returns nil if empty."

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -12,6 +12,7 @@
                        [cljs.cache.wrapped :as wrapped]])
             [datahike.datom :as dd :refer [index-type->cmp-quick]]
             [datahike.constants :refer [tx0 txmax]]
+            [datahike.index.audit :as audit :refer [IAuditable]]
             [datahike.index.interface :as di :refer [IIndex]]
             [datahike.tools :as dt]
             [konserve.core :as k]
@@ -212,6 +213,22 @@
     (persistent! pset))
   (-mark [^PersistentSortedSet pset]
     (mark pset)))
+
+(extend-type #?(:clj PersistentSortedSet :cljs BTSet)
+  IAuditable
+  (-merkle-root [^PersistentSortedSet pset]
+    ;; gen-address (above) makes every node UUID a recursive content
+    ;; hash of its datoms under :crypto-hash?, so the root _address
+    ;; captures the whole tree. Set by psset/store during -flush.
+    (or (.-_address pset)
+        (throw (ex-info "PersistentSortedSet must be flushed before merkle-root"
+                        {:type :audit/merkle-root-unsupported
+                         :reason :unflushed}))))
+  (-recompute-merkle-root [^PersistentSortedSet pset]
+    ;; Konserve's content-addressed read in :crypto-hash? mode already
+    ;; verifies each node's bytes match its address UUID on access —
+    ;; recomputation is implicit. Returning -merkle-root is correct here.
+    (audit/-merkle-root pset)))
 
 (defn- gen-address [^ANode node crypto-hash?]
   (if crypto-hash?

--- a/src/datahike/versioning.cljc
+++ b/src/datahike/versioning.cljc
@@ -165,12 +165,17 @@
      (async+sync sync? *default-sync-translation*
                  (go-try-
                   (let [store (:store db)
-                        cid (create-commit-id db)
-                        db-with-meta (-> db
-                                         (assoc-in [:config :branch] branch)
-                                         (assoc-in [:meta :datahike/parents] parents)
-                                         (assoc-in [:meta :datahike/commit-id] cid))
-                        [schema-meta-kv-to-write db-to-store] (db->stored db-with-meta true)
+                        ;; Flush first, then compute the audit-grade cid
+                        ;; from the post-flush stored form (true merkle
+                        ;; root). Same pattern as datahike.writing/commit!.
+                        db-with-parents (-> db
+                                            (assoc-in [:config :branch] branch)
+                                            (assoc-in [:meta :datahike/parents] parents))
+                        [schema-meta-kv-to-write pre-cid-store]
+                        (db->stored db-with-parents true)
+                        cid (create-commit-id db-with-parents pre-cid-store)
+                        db-to-store (assoc-in pre-cid-store
+                                              [:meta :datahike/commit-id] cid)
                         pending-kvs (get-and-clear-pending-kvs! store)]
 
                   ;; Update the set of known branches

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -5,6 +5,7 @@
             [datahike.db.utils :as dbu]
             [datahike.db.interface :as dbi]
             [datahike.index :as di]
+            [datahike.index.audit :as audit]
             [datahike.index.secondary :as sec]
             [datahike.store :as ds]
             [datahike.tools :as dt]
@@ -68,35 +69,84 @@
                                   [schema-meta-key schema-meta])]
     (when-not (sc/cache-has? schema-meta-key)
       (sc/cache-miss schema-meta-key schema-meta))
-    [schema-meta-kv-to-write ;; Return [key value] pair or nil
-     (merge
-      {:schema-meta-key  schema-meta-key
-       :config          config
-       :meta            meta
-       :hash            hash
-       :max-tx          max-tx
-       :max-eid         max-eid
-       :op-count        op-count
-       ;; di/-flush will now add [k v] to pending-writes via CachedStorage
-       :eavt-key        (cond-> eavt flush! (di/-flush backend))
-       :aevt-key        (cond-> aevt flush! (di/-flush backend))
-       :avet-key        (cond-> avet flush! (di/-flush backend))}
-      (when (:keep-history? config)
-        {:temporal-eavt-key (cond-> temporal-eavt flush! (di/-flush backend))
-         :temporal-aevt-key (cond-> temporal-aevt flush! (di/-flush backend))
-         :temporal-avet-key (cond-> temporal-avet flush! (di/-flush backend))})
-      ;; Secondary indices manage their own storage (Lucene files, konserve, mmap)
-      ;; so they must always be flushed regardless of the primary store backend.
-      #?(:clj
-         (when (and flush? (seq (:secondary-indices db)))
-           {:secondary-index-keys
-            (reduce-kv
-             (fn [acc idx-ident idx]
-               (if (satisfies? sec/IVersionedSecondaryIndex idx)
-                 (assoc acc idx-ident (sec/-sec-flush idx store (:branch config)))
-                 acc))
-             {} (:secondary-indices db))})
-         :cljs nil))]))
+    (let [;; Flush primary indices, capturing the post-flush instances so
+          ;; we can both serialize their storage keys and ask each for a
+          ;; merkle-root via the IAuditable protocol.
+          eavt'          (cond-> eavt flush! (di/-flush backend))
+          aevt'          (cond-> aevt flush! (di/-flush backend))
+          avet'          (cond-> avet flush! (di/-flush backend))
+          temporal-eavt' (when (:keep-history? config)
+                           (cond-> temporal-eavt flush! (di/-flush backend)))
+          temporal-aevt' (when (:keep-history? config)
+                           (cond-> temporal-aevt flush! (di/-flush backend)))
+          temporal-avet' (when (:keep-history? config)
+                           (cond-> temporal-avet flush! (di/-flush backend)))
+          ;; Secondary indices manage their own storage (Lucene files,
+          ;; konserve, mmap) so they must always be flushed regardless of
+          ;; the primary store backend.
+          secondary-index-keys
+          #?(:clj
+             (when (and flush? (seq (:secondary-indices db)))
+               (reduce-kv
+                (fn [acc idx-ident idx]
+                  (if (satisfies? sec/IVersionedSecondaryIndex idx)
+                    (assoc acc idx-ident (sec/-sec-flush idx store (:branch config)))
+                    acc))
+                {} (:secondary-indices db)))
+             :cljs nil)
+          ;; Audit roots: per-index content-addressed UUIDs that feed
+          ;; into the commit-id via merkle-leaves.
+          ;;
+          ;; Primary indexes implement IAuditable: their flushed instance
+          ;; carries the merkle root (e.g. PSS `_address` is post-flush).
+          ;;
+          ;; Secondary indexes can produce their merkle root in two
+          ;; ways: (a) extend IAuditable when their live instance has
+          ;; post-flush state (scriptum's Java writer; proximum's
+          ;; index handle); (b) surface `:merkle-root` in their
+          ;; -sec-flush return map when sync produces a new immutable
+          ;; value the live instance doesn't capture (stratum). The
+          ;; reader below tries (a) first, then (b).
+          safe-root      (fn [x]
+                           (when x
+                             (try (audit/-merkle-root x)
+                                  (catch #?(:clj Throwable :cljs js/Error) _ nil))))
+          sec-roots      (when (seq (:secondary-indices db))
+                           (reduce-kv
+                            (fn [acc idx-ident idx]
+                              (assoc acc idx-ident
+                                     (or (safe-root idx)
+                                         (:merkle-root (get secondary-index-keys idx-ident)))))
+                            {} (:secondary-indices db)))
+          merkle-roots
+          (cond-> {:eavt-key (safe-root eavt')
+                   :aevt-key (safe-root aevt')
+                   :avet-key (safe-root avet')}
+            (:keep-history? config)
+            (assoc :temporal-eavt-key (safe-root temporal-eavt')
+                   :temporal-aevt-key (safe-root temporal-aevt')
+                   :temporal-avet-key (safe-root temporal-avet'))
+            sec-roots
+            (assoc :secondary sec-roots))]
+      [schema-meta-kv-to-write
+       (merge
+        {:schema-meta-key  schema-meta-key
+         :config          config
+         :meta            meta
+         :hash            hash
+         :max-tx          max-tx
+         :max-eid         max-eid
+         :op-count        op-count
+         :merkle-roots    merkle-roots
+         :eavt-key        eavt'
+         :aevt-key        aevt'
+         :avet-key        avet'}
+        (when (:keep-history? config)
+          {:temporal-eavt-key temporal-eavt'
+           :temporal-aevt-key temporal-aevt'
+           :temporal-avet-key temporal-avet'})
+        (when secondary-index-keys
+          {:secondary-index-keys secondary-index-keys}))])))
 
 (defn- restore-secondary-indices
   "Restore secondary index instances from stored key-maps.
@@ -109,17 +159,30 @@
         (if (and (map? entry) (:db.secondary/type entry))
           (let [idx-type (:db.secondary/type entry)
                 idx-attrs (set (:db.secondary/attrs entry))
-                idx-config (merge (:db.secondary/config entry)
-                                  {:attrs idx-attrs})
-                idx-config (cond-> idx-config
+                key-map (get secondary-index-keys ident)
+                idx-config (cond-> (merge (:db.secondary/config entry)
+                                          {:attrs idx-attrs})
                              (seq ident-ref-map)
-                             (assoc :ident-ref-map ident-ref-map))
-                key-map (get secondary-index-keys ident)]
+                             (assoc :ident-ref-map ident-ref-map)
+                             ;; When a key-map carries a branch, route the
+                             ;; skeleton into that branch too — otherwise
+                             ;; the factory defaults to "main" and a non-
+                             ;; main connection re-opens the main writer,
+                             ;; contending for its per-branch lock.
+                             (:branch key-map)
+                             (assoc :branch (:branch key-map)))]
             (try
               (let [skeleton (sec/create-index idx-type idx-config nil)]
                 (if (and key-map (satisfies? sec/IVersionedSecondaryIndex skeleton))
-                  ;; Restore from durable storage
-                  (assoc acc ident (sec/-sec-restore skeleton store key-map))
+                  ;; Restore from durable storage. The skeleton existed
+                  ;; only to satisfy the protocol check; close its native
+                  ;; resources (e.g. Lucene's per-branch write lock)
+                  ;; before `-sec-restore` opens its own writer at the
+                  ;; same path/branch — otherwise the two contend.
+                  (do (when (instance? java.io.Closeable skeleton)
+                        (try (.close ^java.io.Closeable skeleton)
+                             (catch Exception _)))
+                      (assoc acc ident (sec/-sec-restore skeleton store key-map)))
                   ;; No stored keys — empty index, needs backfill
                   (assoc acc ident skeleton)))
               (catch Exception e
@@ -187,12 +250,39 @@
                                           :parent p}))
                             commit-id)))))))
 
-(defn create-commit-id [db]
-  (let [{:keys [hash max-tx max-eid meta config]} db
-        content-uuid (uuid [hash max-tx max-eid meta])]
-    (if (:crypto-hash? config)
-      content-uuid
-      (squuid content-uuid))))  ;; Sequential UUID for better index locality
+(defn- audit-grade?
+  "Audit-grade cids require :crypto-hash? on a persistent backend,
+   plus a `:merkle-roots` map computed during `db->stored` whose
+   primary entries (eavt-key/aevt-key/avet-key) are non-nil — i.e.
+   the primary index impl extends `IAuditable`."
+  [config stored-db]
+  (and (:crypto-hash? config)
+       (not= :memory (get-in config [:store :backend]))
+       (some? stored-db)
+       (every? some?
+               (vals (select-keys (:merkle-roots stored-db)
+                                  [:eavt-key :aevt-key :avet-key])))))
+
+(defn create-commit-id
+  "Compute the commit-id for `db`.
+
+   In audit-grade mode, returns a content-addressed UUID-5 over the
+   stored `:merkle-roots` map + schema-meta-key + max-tx + max-eid +
+   meta. Otherwise falls back to `[hash max-tx max-eid meta]`, wrapped
+   in `squuid` when `:crypto-hash?` is off."
+  ([db] (create-commit-id db nil))
+  ([db stored-db]
+   (let [{:keys [hash max-tx max-eid meta config]} db
+         content (if (audit-grade? config stored-db)
+                   [(:merkle-roots stored-db)
+                    (:schema-meta-key stored-db)
+                    max-tx max-eid
+                    (dissoc meta :datahike/commit-id)]
+                   [hash max-tx max-eid meta])
+         content-uuid (uuid content)]
+     (if (:crypto-hash? config)
+       content-uuid
+       (squuid content-uuid)))))
 
 (defn write-pending-kvs!
   "Writes a collection of key-value pairs to the store.
@@ -214,14 +304,17 @@
                 (let [{:keys [store config]} db
                       parents       (or parents #{(get config :branch)})
                       parents       (branch-heads-as-commits store parents)
-                      cid           (create-commit-id db)
-                      db            (-> db
-                                        (assoc-in [:meta :datahike/commit-id] cid)
-                                        (assoc-in [:meta :datahike/parents] parents))
-                      ;; db->stored now returns [schema-meta-kv-to-write db-to-store]
-                      ;; and index flushes will have populated pending-writes
-                      [schema-meta-kv-to-write db-to-store] (db->stored db true)
-                      ;; Get all pending [k v] pairs (e.g., from index flushes)
+                      ;; Stamp parents BEFORE flushing so they're in the
+                      ;; stored form the cid will be derived from.
+                      db            (assoc-in db [:meta :datahike/parents] parents)
+                      ;; Flush first → cid sees post-flush storage
+                      ;; addresses (true merkle leaves under crypto-hash?).
+                      [schema-meta-kv-to-write db-to-store-pre]
+                      (db->stored db true)
+                      cid           (create-commit-id db db-to-store-pre)
+                      db            (assoc-in db [:meta :datahike/commit-id] cid)
+                      db-to-store   (assoc-in db-to-store-pre
+                                              [:meta :datahike/commit-id] cid)
                       pending-kvs   (get-and-clear-pending-kvs! store)]
 
                   (if (multi-key-capable? store)
@@ -312,29 +405,49 @@
                  config max-tx max-eid op-count hash meta] :as db}
          (db/empty-db nil config store)
          backend (di/konserve-backend (:index config) store)
-         cid (create-commit-id db)
-         meta (assoc meta :datahike/commit-id cid)
          schema-meta {:schema schema
                       :rschema rschema
                       :system-entities system-entities
                       :ident-ref-map ident-ref-map
                       :ref-ident-map ref-ident-map}
          schema-meta-key (uuid schema-meta)
-         ;; di/-flush calls will populate pending-writes via CachedStorage
-         db-to-store (merge {:max-tx          max-tx
-                             :max-eid         max-eid
-                             :op-count        op-count
-                             :hash            hash
-                             :schema-meta-key schema-meta-key
-                             :config          (update config :initial-tx (comp not empty?))
-                             :meta            meta
-                             :eavt-key        (di/-flush eavt backend)
-                             :aevt-key        (di/-flush aevt backend)
-                             :avet-key        (di/-flush avet backend)}
-                            (when keep-history?
-                              {:temporal-eavt-key (di/-flush temporal-eavt backend)
-                               :temporal-aevt-key (di/-flush temporal-aevt backend)
-                               :temporal-avet-key (di/-flush temporal-avet backend)}))]
+         ;; Flush first → cid sees post-flush storage addresses.
+         eavt'          (di/-flush eavt backend)
+         aevt'          (di/-flush aevt backend)
+         avet'          (di/-flush avet backend)
+         temporal-eavt' (when keep-history? (di/-flush temporal-eavt backend))
+         temporal-aevt' (when keep-history? (di/-flush temporal-aevt backend))
+         temporal-avet' (when keep-history? (di/-flush temporal-avet backend))
+         safe-root      (fn [x]
+                          (when x
+                            (try (audit/-merkle-root x)
+                                 (catch Throwable _ nil))))
+         merkle-roots   (cond-> {:eavt-key (safe-root eavt')
+                                 :aevt-key (safe-root aevt')
+                                 :avet-key (safe-root avet')}
+                          keep-history?
+                          (assoc :temporal-eavt-key (safe-root temporal-eavt')
+                                 :temporal-aevt-key (safe-root temporal-aevt')
+                                 :temporal-avet-key (safe-root temporal-avet')))
+         pre-cid-stored
+         (merge {:max-tx          max-tx
+                 :max-eid         max-eid
+                 :op-count        op-count
+                 :hash            hash
+                 :merkle-roots    merkle-roots
+                 :schema-meta-key schema-meta-key
+                 :config          (update config :initial-tx (comp not empty?))
+                 :meta            meta
+                 :eavt-key        eavt'
+                 :aevt-key        aevt'
+                 :avet-key        avet'}
+                (when keep-history?
+                  {:temporal-eavt-key temporal-eavt'
+                   :temporal-aevt-key temporal-aevt'
+                   :temporal-avet-key temporal-avet'}))
+         cid (create-commit-id db pre-cid-stored)
+         meta (assoc meta :datahike/commit-id cid)
+         db-to-store (assoc pre-cid-stored :meta meta)]
      ;;we just created the first data base in this store, so the write cache is empty
      (<?- (k/assoc store schema-meta-key schema-meta opts))
      (sc/add-to-write-cache (:store config) schema-meta-key)

--- a/test/datahike/test/audit_verify_test.cljc
+++ b/test/datahike/test/audit_verify_test.cljc
@@ -175,17 +175,28 @@
              (finally (cleanup conn cfg))))))
 
      (deftest stratum-deep-verify-ok
-       (testing ":deep? true succeeds when primary storage is intact;
-                 stratum's secondary deep-verify is flagged unsupported
-                 (no verify-from-cold in stratum yet)"
+       (testing ":deep? true succeeds when primary storage is intact.
+                 Stratum's secondary delegates the deep walk to
+                 stratum.audit when it's on the classpath; otherwise
+                 (older published stratum) it degrades to :unsupported
+                 with reason :stratum-audit-unavailable. Either way the
+                 overall report stays :ok and the secondary lives in
+                 :deep :unsupported."
          (let [[conn cfg] (bootstrap-stratum)]
            (try
-             (let [r (audit/verify-chain (d/db conn) nil {:deep? true})]
+             (let [r (audit/verify-chain (d/db conn) nil {:deep? true})
+                   strat-uns (first (filter #(= :idx/strat (:index %))
+                                            (-> r :deep :unsupported)))]
                (is (= :ok (:status r)) "overall :ok — no mismatches")
                (is (= :ok (-> r :deep :status)))
                (is (empty? (-> r :deep :diffs)) "no diffs")
-               (is (some #(= :idx/strat (:index %)) (-> r :deep :unsupported))
-                   "stratum surfaces unsupported via :audit/recompute-unsupported"))
+               (is (some? strat-uns)
+                   "stratum surfaces under :unsupported")
+               (is (contains? #{:advisory :stratum-audit-unavailable
+                                :no-store :unsynced}
+                              (:reason strat-uns))
+                   "reason depends on whether stratum.audit is loaded
+                    and whether the dataset opted into :crypto-hash?"))
              (finally (cleanup conn cfg))))))
 
      (deftest stratum-secondary-root-tampering-detected

--- a/test/datahike/test/audit_verify_test.cljc
+++ b/test/datahike/test/audit_verify_test.cljc
@@ -244,22 +244,23 @@
 ;; ============================================================================
 
 (deftest deep-verify-mismatch-from-fake-index
-  (testing ":deep? reports :mismatch when an IAuditable impl signals
-            :audit/merkle-mismatch from -recompute-merkle-root"
+  (testing ":deep? reports :mismatch when an IAuditable impl returns
+            :status :mismatch from -recompute-merkle-root"
     (let [[conn cfg] (bootstrap true)]
       (try
         (let [db (d/db conn)
               fake-stored-root #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid))
               ;; Splice a fake secondary index into the live db + stored
               ;; commit so the auditor walks it. The fake's
-              ;; -recompute-merkle-root throws :audit/merkle-mismatch.
+              ;; -recompute-merkle-root returns a :mismatch result map.
               fake-index (reify
                            idx-audit/IAuditable
                            (-merkle-root [_] fake-stored-root)
                            (-recompute-merkle-root [_]
-                             (throw (ex-info "fake: bytes tampered"
-                                             {:type :audit/merkle-mismatch
-                                              :details :fake}))))
+                             {:status :mismatch
+                              :root nil
+                              :errors [{:type :audit/merkle-mismatch
+                                        :details :fake}]}))
               db-with-fake (assoc db :secondary-indices {:idx/fake fake-index})
               head (get-in db [:meta :datahike/commit-id])
               head-stored (k/get (:store db) head nil {:sync? true})
@@ -348,16 +349,17 @@
              (let [conn2 (d/connect cfg)
                    r     (audit/verify-chain (d/db conn2) nil {:deep? true})
                    diffs (-> r :deep :diffs)
-                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))]
+                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))
+                   first-err (-> eavt-diff :errors first)]
                (is (= :mismatch (:status r))
                    "deep tampering must surface as overall :mismatch")
                (is (= :mismatch (-> r :deep :status)))
                (is (some? eavt-diff)
                    ":eavt-key (the index we tampered through) must appear in :diffs")
-               (is (= :audit/merkle-mismatch (-> eavt-diff :errors :type)))
-               (is (= leaf-addr (-> eavt-diff :errors :expected))
+               (is (= :audit/merkle-mismatch (:type first-err)))
+               (is (= leaf-addr (:expected first-err))
                    "the mismatch points at the actual tampered address")
-               (is (every? #(= leaf-addr (-> % :errors :expected)) diffs)
+               (is (every? #(= leaf-addr (-> % :errors first :expected)) diffs)
                    "all diffs (e.g. temporal-eavt sharing the same leaf
                     by content-address) point at the same physical leaf")
                (d/release conn2)))
@@ -393,11 +395,12 @@
              (let [conn2 (d/connect cfg)
                    r     (audit/verify-chain (d/db conn2) nil {:deep? true})
                    diffs (-> r :deep :diffs)
-                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))]
+                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))
+                   first-err (-> eavt-diff :errors first)]
                (is (= :mismatch (:status r)))
                (is (some? eavt-diff))
-               (is (= :audit/merkle-mismatch (-> eavt-diff :errors :type)))
-               (is (= root-addr (-> eavt-diff :errors :expected))
+               (is (= :audit/merkle-mismatch (:type first-err)))
+               (is (= root-addr (:expected first-err))
                    "we tampered the root branch itself; mismatch is at root")
                (d/release conn2)))
            (finally (try (d/delete-database cfg) (catch Throwable _))))))))

--- a/test/datahike/test/audit_verify_test.cljc
+++ b/test/datahike/test/audit_verify_test.cljc
@@ -19,6 +19,7 @@
                      [clojure.test :as t :refer [is deftest testing]]
                      [datahike.api :as d]
                      [datahike.audit :as audit]
+                     [datahike.datom :as dd]
                      [datahike.index.audit :as idx-audit]
                      [konserve.core :as k])))
 
@@ -271,6 +272,135 @@
           (is (some #(= :idx/fake (:index %)) (-> r :deep :diffs))
               "the fake index is flagged in :diffs"))
         (finally (cleanup conn cfg))))))
+
+;; ============================================================================
+;; PSS deep-verify — actual walk of konserve nodes, with tampering directly
+;; at the underlying store. These exercise the per-index
+;; `-recompute-merkle-root` walker in datahike.index.persistent-set, not just
+;; the protocol contract.
+;; ============================================================================
+
+#?(:clj
+   (defn- tamper-leaf!
+     "Overwrite one leaf in `pset`'s konserve store: read the leaf at
+      `leaf-addr`, perturb its first datom's :v, and write the modified
+      Leaf back at the SAME address — so the address no longer matches
+      the content. Returns the leaf address that was tampered."
+     [store leaf-addr]
+     (let [orig          (k/get store leaf-addr nil {:sync? true})
+           keys-list     (vec (.keys ^org.replikativ.persistent_sorted_set.Leaf orig))
+           first-d       (first keys-list)
+           tampered-d    (dd/datom (:e first-d) (:a first-d)
+                                   (str (:v first-d) "-TAMPERED")
+                                   (:tx first-d) (:added first-d))
+           tampered-keys (java.util.Arrays/asList
+                          (into-array Object (cons tampered-d (rest keys-list))))
+           settings      (.-_settings ^org.replikativ.persistent_sorted_set.Leaf orig)
+           tampered-leaf (org.replikativ.persistent_sorted_set.Leaf.
+                          tampered-keys settings)]
+       (k/assoc store leaf-addr tampered-leaf {:sync? true})
+       leaf-addr)))
+
+#?(:clj
+   (defn- bootstrap-pss-deep
+     "Build a file-backed db with enough datoms to force a multi-level
+      PSS B-tree (root Branch + child Leaves) under :crypto-hash?.
+      Returns [conn cfg]."
+     []
+     (let [cfg (file-cfg true)]
+       (d/create-database cfg)
+       (let [conn (d/connect cfg)]
+         (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                            :db/cardinality :db.cardinality/one}])
+         ;; ~5000 datoms across batches → branching factor 512 forces a Branch root
+         (doseq [batch (partition-all 1000 (range 5000))]
+           (d/transact conn (vec (for [i batch] {:name (str "u" i)}))))
+         [conn cfg]))))
+
+#?(:clj
+   (deftest pss-deep-verify-clean-is-ok
+     (testing ":deep? true on an untampered PSS-backed db reports :ok"
+       (let [[conn cfg] (bootstrap-pss-deep)]
+         (try
+           (let [r (audit/verify-chain (d/db conn) nil {:deep? true})]
+             (is (= :ok (:status r)))
+             (is (= :ok (-> r :deep :status)))
+             (is (empty? (-> r :deep :diffs))))
+           (finally (cleanup conn cfg)))))))
+
+#?(:clj
+   (deftest pss-deep-verify-detects-leaf-tampering
+     (testing "rewriting a single PSS leaf at the konserve store level
+               makes :deep? true report :mismatch with the affected
+               primary index in :diffs"
+       (let [[conn cfg] (bootstrap-pss-deep)]
+         (try
+           (let [db        (d/db conn)
+                 store     (:store db)
+                 root-addr (idx-audit/-merkle-root (:eavt db))
+                 ^org.replikativ.persistent_sorted_set.Branch root-node
+                 (k/get store root-addr nil {:sync? true})
+                 leaf-addr (first (.addresses root-node))
+                 _ (tamper-leaf! store leaf-addr)]
+             ;; Drop the live conn so subsequent reads cannot serve a hot,
+             ;; pre-tamper copy from the writer's in-memory CachedStorage.
+             (d/release conn)
+             (let [conn2 (d/connect cfg)
+                   r     (audit/verify-chain (d/db conn2) nil {:deep? true})
+                   diffs (-> r :deep :diffs)
+                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))]
+               (is (= :mismatch (:status r))
+                   "deep tampering must surface as overall :mismatch")
+               (is (= :mismatch (-> r :deep :status)))
+               (is (some? eavt-diff)
+                   ":eavt-key (the index we tampered through) must appear in :diffs")
+               (is (= :audit/merkle-mismatch (-> eavt-diff :errors :type)))
+               (is (= leaf-addr (-> eavt-diff :errors :expected))
+                   "the mismatch points at the actual tampered address")
+               (is (every? #(= leaf-addr (-> % :errors :expected)) diffs)
+                   "all diffs (e.g. temporal-eavt sharing the same leaf
+                    by content-address) point at the same physical leaf")
+               (d/release conn2)))
+           (finally (try (d/delete-database cfg) (catch Throwable _))))))))
+
+#?(:clj
+   (deftest pss-deep-verify-detects-branch-tampering
+     (testing "rewriting a PSS branch (changing one of its child
+               addresses to a bogus uuid) is also detected"
+       (let [[conn cfg] (bootstrap-pss-deep)]
+         (try
+           (let [db        (d/db conn)
+                 store     (:store db)
+                 root-addr (idx-audit/-merkle-root (:eavt db))
+                 ^org.replikativ.persistent_sorted_set.Branch root-node
+                 (k/get store root-addr nil {:sync? true})
+                 keys-list (.keys root-node)
+                 keys-arr  (.toArray keys-list (make-array Object 0))
+                 addrs     (.addresses root-node)
+                 new-addrs-arr (into-array Object
+                                           (cons (java.util.UUID/randomUUID)
+                                                 (rest addrs)))
+                 settings  (.-_settings root-node)
+                 tampered  (org.replikativ.persistent_sorted_set.Branch.
+                            (.level root-node)
+                            (count keys-list)
+                            keys-arr
+                            new-addrs-arr
+                            nil
+                            settings)
+                 _ (k/assoc store root-addr tampered {:sync? true})]
+             (d/release conn)
+             (let [conn2 (d/connect cfg)
+                   r     (audit/verify-chain (d/db conn2) nil {:deep? true})
+                   diffs (-> r :deep :diffs)
+                   eavt-diff (first (filter #(= :eavt-key (:index %)) diffs))]
+               (is (= :mismatch (:status r)))
+               (is (some? eavt-diff))
+               (is (= :audit/merkle-mismatch (-> eavt-diff :errors :type)))
+               (is (= root-addr (-> eavt-diff :errors :expected))
+                   "we tampered the root branch itself; mismatch is at root")
+               (d/release conn2)))
+           (finally (try (d/delete-database cfg) (catch Throwable _))))))))
 
 #?(:clj
    (def ^:private scriptum-available?

--- a/test/datahike/test/audit_verify_test.cljc
+++ b/test/datahike/test/audit_verify_test.cljc
@@ -1,0 +1,338 @@
+(ns datahike.test.audit-verify-test
+  "End-to-end test for `datahike.audit/verify-chain`.
+
+   Sets up a real :file-backend db with `:crypto-hash? true`, transacts
+   a few commits, then exercises:
+
+     - clean walk: verify-chain reports :status :ok
+     - tamper detection: rewriting a non-head stored commit (e.g. its
+       :max-tx) makes that commit's cid mismatch on recompute
+     - advisory mode: when :crypto-hash? is off, walk completes but
+       per-commit status is :advisory and overall status is :advisory
+     - explicit head-cid: caller can pass a specific cid to start from"
+  #?(:cljs (:require [cljs.test :as t :refer-macros [is deftest testing]]
+                     [datahike.api :as d]
+                     [datahike.audit :as audit]
+                     [datahike.index.audit :as idx-audit]
+                     [konserve.core :as k])
+     :clj  (:require [datahike.index.hitchhiker-tree]
+                     [clojure.test :as t :refer [is deftest testing]]
+                     [datahike.api :as d]
+                     [datahike.audit :as audit]
+                     [datahike.index.audit :as idx-audit]
+                     [konserve.core :as k])))
+
+#?(:clj
+   (defn- temp-store-path []
+     (str (System/getProperty "java.io.tmpdir") "/datahike-audit-verify-"
+          (java.util.UUID/randomUUID))))
+
+(defn- file-cfg
+  "Persistent file-store config — required, since :crypto-hash? is a
+   no-op on the memory backend."
+  [crypto-hash?]
+  {:store              {:backend :file
+                        :path    #?(:clj (temp-store-path) :cljs nil)
+                        :id      #?(:clj (java.util.UUID/randomUUID)
+                                    :cljs (random-uuid))}
+   :crypto-hash?       crypto-hash?
+   :keep-history?      true
+   :schema-flexibility :write
+   :index              :datahike.index/persistent-set})
+
+(defn- bootstrap [crypto?]
+  (let [cfg (file-cfg crypto?)]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                         :db/cardinality :db.cardinality/one}])
+      (d/transact conn [{:name "alice"}])
+      (d/transact conn [{:name "bob"}])
+      [conn cfg])))
+
+(defn- cleanup [conn cfg]
+  (d/release conn)
+  (d/delete-database cfg))
+
+;; ============================================================================
+
+(deftest clean-chain-verifies-ok
+  (let [[conn cfg] (bootstrap true)]
+    (try
+      (let [report (audit/verify-chain (d/db conn))]
+        (is (= :ok (:status report)))
+        (is (audit/ok? report))
+        (is (zero? (count (:mismatches report))))
+        (is (zero? (count (:missing report))))
+        (is (every? #{:ok} (map :status (:commits report))))
+        (is (>= (count (:commits report)) 4)
+            "genesis + schema + alice + bob = 4 commits at least"))
+      (finally (cleanup conn cfg)))))
+
+(deftest tamper-on-non-head-commit-is-detected
+  (let [[conn cfg] (bootstrap true)]
+    (try
+      (let [db (d/db conn)
+            head (get-in db [:meta :datahike/commit-id])
+            head-stored (k/get (:store db) head nil {:sync? true})
+            ;; Pick the immediate parent and rewrite its :max-tx field
+            target-cid (first (-> head-stored :meta :datahike/parents))
+            target-stored (k/get (:store db) target-cid nil {:sync? true})
+            tampered (assoc target-stored :max-tx 999999)
+            _ (k/assoc (:store db) target-cid tampered {:sync? true})
+            report (audit/verify-chain db)]
+        (is (= :mismatch (:status report)))
+        (is (false? (audit/ok? report)))
+        (is (= 1 (count (:mismatches report))))
+        (is (= target-cid (-> report :mismatches first :cid)))
+        (is (not= target-cid (-> report :mismatches first :recomputed))
+            "recomputed cid differs from stored cid (the tamper signal)"))
+      (finally (cleanup conn cfg)))))
+
+(deftest non-crypto-hash-mode-is-advisory
+  (let [[conn cfg] (bootstrap false)]
+    (try
+      (let [report (audit/verify-chain (d/db conn))]
+        (is (= :advisory (:status report))
+            "without :crypto-hash?, the chain can be walked but not verified")
+        (is (every? #{:advisory} (map :status (:commits report))))
+        (is (every? #{:crypto-hash-disabled} (map :reason (:commits report)))))
+      (finally (cleanup conn cfg)))))
+
+(deftest verify-from-explicit-head-cid
+  (let [[conn cfg] (bootstrap true)]
+    (try
+      (let [db (d/db conn)
+            head (get-in db [:meta :datahike/commit-id])
+            ;; Use a known earlier cid (the immediate parent) as the head
+            prev-cid (first (-> db :meta :datahike/parents))
+            report (audit/verify-chain db prev-cid)]
+        (is (= :ok (:status report)))
+        (is (= prev-cid (:head report)))
+        (is (every? (fn [e] (not= head (:cid e))) (:commits report))
+            "walking from prev-cid never visits head"))
+      (finally (cleanup conn cfg)))))
+
+(deftest non-db-input-throws
+  (testing "verify-chain refuses anything that isn't a db value"
+    (let [[conn cfg] (bootstrap true)]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"expected a db value"
+                              (audit/verify-chain conn)))
+        (finally (cleanup conn cfg))))))
+
+;; ============================================================================
+;; Secondary-index integration — only run when stratum is on the classpath.
+;; Stratum is the cleanest test target: its dataset commit-id is content-
+;; addressed and is bridged into the standardized :merkle-root field of
+;; the secondary key-map, so audit picks it up automatically.
+;; ============================================================================
+
+#?(:clj
+   (def ^:private stratum-available?
+     (try (require '[datahike.index.secondary.stratum]) true
+          (catch Throwable _ false))))
+
+#?(:clj
+   (when stratum-available?
+     (defn- bootstrap-stratum []
+       (let [cfg (file-cfg true)]
+         (d/create-database cfg)
+         (let [conn (d/connect cfg)]
+           (d/transact conn [{:db/ident :p/name :db/valueType :db.type/string
+                              :db/cardinality :db.cardinality/one}
+                             {:db/ident :p/age :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}])
+           (d/transact conn [{:db/ident :idx/strat
+                              :db.secondary/type :stratum
+                              :db.secondary/attrs [:p/name :p/age]}])
+           (d/transact conn [{:p/name "Alice" :p/age 30}
+                             {:p/name "Bob" :p/age 25}])
+           [conn cfg])))))
+
+#?(:clj
+   (when stratum-available?
+     (deftest stratum-secondary-contributes-merkle-root
+       (testing "stratum's dataset commit-id surfaces under
+                 :merkle-roots :secondary; audit walks clean"
+         (let [[conn cfg] (bootstrap-stratum)]
+           (try
+             (let [db (d/db conn)
+                   head (get-in db [:meta :datahike/commit-id])
+                   stored (k/get (:store db) head nil {:sync? true})
+                   strat-root (get-in stored [:merkle-roots :secondary :idx/strat])
+                   strat-key (get-in stored [:secondary-index-keys :idx/strat])
+                   report (audit/verify-chain db)]
+               (is (some? strat-root)
+                   "stratum should provide a merkle-root via IAuditable")
+               (is (uuid? strat-root))
+               (is (= (:dataset-commit-id strat-key) strat-root)
+                   "merkle-root equals the dataset commit-id")
+               (is (= :ok (:status report))
+                   "every commit verifies cleanly with audit-grade secondary"))
+             (finally (cleanup conn cfg))))))
+
+     (deftest stratum-deep-verify-ok
+       (testing ":deep? true succeeds when primary storage is intact;
+                 stratum's secondary deep-verify is flagged unsupported
+                 (no verify-from-cold in stratum yet)"
+         (let [[conn cfg] (bootstrap-stratum)]
+           (try
+             (let [r (audit/verify-chain (d/db conn) nil {:deep? true})]
+               (is (= :ok (:status r)) "overall :ok — no mismatches")
+               (is (= :ok (-> r :deep :status)))
+               (is (empty? (-> r :deep :diffs)) "no diffs")
+               (is (some #(= :idx/strat (:index %)) (-> r :deep :unsupported))
+                   "stratum surfaces unsupported via :audit/recompute-unsupported"))
+             (finally (cleanup conn cfg))))))
+
+     (deftest stratum-secondary-root-tampering-detected
+       (testing "rewriting the stored :merkle-roots :secondary entry
+                 makes the recomputed cid diverge (layer-1 catches it)"
+         (let [[conn cfg] (bootstrap-stratum)]
+           (try
+             (let [db (d/db conn)
+                   head (get-in db [:meta :datahike/commit-id])
+                   head-stored (k/get (:store db) head nil {:sync? true})
+                   tampered (assoc-in head-stored
+                                      [:merkle-roots :secondary :idx/strat]
+                                      #?(:clj  (java.util.UUID/randomUUID)
+                                         :cljs (random-uuid)))
+                   _ (k/assoc (:store db) head tampered {:sync? true})
+                   ;; verify-chain starts from db's in-memory head cid; the
+                   ;; recompute now reads the tampered stored commit and
+                   ;; will produce a different cid.
+                   report (audit/verify-chain db)]
+               (is (= :mismatch (:status report)))
+               (is (= 1 (count (:mismatches report))))
+               (is (= head (-> report :mismatches first :cid))))
+             (finally (cleanup conn cfg))))))
+
+     (deftest stratum-tamper-detected
+       (testing "rewriting a non-head commit makes the chain mismatch
+                 even when the commit referenced a secondary index"
+         (let [[conn cfg] (bootstrap-stratum)]
+           (try
+             (let [db (d/db conn)
+                   head (get-in db [:meta :datahike/commit-id])
+                   head-stored (k/get (:store db) head nil {:sync? true})
+                   target-cid (first (-> head-stored :meta :datahike/parents))
+                   target-stored (k/get (:store db) target-cid nil {:sync? true})
+                   tampered (assoc target-stored :max-tx 999999)
+                   _ (k/assoc (:store db) target-cid tampered {:sync? true})
+                   report (audit/verify-chain db)]
+               (is (= :mismatch (:status report)))
+               (is (= 1 (count (:mismatches report))))
+               (is (= target-cid (-> report :mismatches first :cid))))
+             (finally (cleanup conn cfg))))))))
+
+;; ============================================================================
+;; Scriptum without crypto-hash → advisory.
+;; (Scriptum WITH crypto-hash is blocked by a pre-existing upstream bug:
+;;  maybe-create-secondary-index instantiates as soon as :type+:attrs are
+;;  present, before :db.secondary/config arrives, so the writer is created
+;;  with default config — :crypto-hash? never reaches the bridge.)
+;; ============================================================================
+
+;; ============================================================================
+;; Deep-verify mismatch path via a fake IAuditable index.
+;; This exercises `audit/verify-chain :deep? true`'s handling of a
+;; library-side `:audit/merkle-mismatch` signal without depending on a
+;; specific backend's working crypto-hash path through datahike.
+;; ============================================================================
+
+(deftest deep-verify-mismatch-from-fake-index
+  (testing ":deep? reports :mismatch when an IAuditable impl signals
+            :audit/merkle-mismatch from -recompute-merkle-root"
+    (let [[conn cfg] (bootstrap true)]
+      (try
+        (let [db (d/db conn)
+              fake-stored-root #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid))
+              ;; Splice a fake secondary index into the live db + stored
+              ;; commit so the auditor walks it. The fake's
+              ;; -recompute-merkle-root throws :audit/merkle-mismatch.
+              fake-index (reify
+                           idx-audit/IAuditable
+                           (-merkle-root [_] fake-stored-root)
+                           (-recompute-merkle-root [_]
+                             (throw (ex-info "fake: bytes tampered"
+                                             {:type :audit/merkle-mismatch
+                                              :details :fake}))))
+              db-with-fake (assoc db :secondary-indices {:idx/fake fake-index})
+              head (get-in db [:meta :datahike/commit-id])
+              head-stored (k/get (:store db) head nil {:sync? true})
+              stored-with-fake (assoc-in head-stored [:merkle-roots :secondary :idx/fake]
+                                         fake-stored-root)
+              _ (k/assoc (:store db) head stored-with-fake {:sync? true})
+              r (audit/verify-chain db-with-fake nil {:deep? true})]
+          (is (= :mismatch (:status r)))
+          (is (= :mismatch (-> r :deep :status)))
+          (is (some #(= :idx/fake (:index %)) (-> r :deep :diffs))
+              "the fake index is flagged in :diffs"))
+        (finally (cleanup conn cfg))))))
+
+#?(:clj
+   (def ^:private scriptum-available?
+     (try (require '[datahike.index.secondary.scriptum]) true
+          (catch Throwable _ false))))
+
+#?(:clj
+   (when scriptum-available?
+     (deftest scriptum-without-crypto-hash-is-advisory
+       (testing "scriptum that didn't opt into crypto-hash leaves :merkle-root
+                 absent → audit downgrades affected commits to advisory"
+         (let [cfg (file-cfg true)]
+           (d/create-database cfg)
+           (let [conn (d/connect cfg)]
+             (try
+               (d/transact conn [{:db/ident :p/name :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one}])
+               (d/transact conn [{:db/ident :idx/sc :db.secondary/type :scriptum
+                                  :db.secondary/attrs [:p/name]}])
+               (d/transact conn [{:p/name "Alice"}])
+               (let [db (d/db conn)
+                     stored-head (k/get (:store db)
+                                        (get-in db [:meta :datahike/commit-id])
+                                        nil {:sync? true})
+                     sc-root (get-in stored-head [:merkle-roots :secondary :idx/sc])
+                     report (audit/verify-chain db)]
+                 (is (nil? sc-root)
+                     "scriptum without crypto-hash should fail to produce a merkle-root")
+                 (is (= :advisory (:status report)))
+                 (is (some #{:secondary-not-audit-grade}
+                           (map :reason (:commits report)))
+                     "at least one commit should be flagged with the secondary reason"))
+               (finally (cleanup conn cfg)))))))))
+
+#?(:clj
+   (when scriptum-available?
+     (deftest scriptum-with-crypto-hash-is-audit-grade
+       (testing "scriptum opted into :crypto-hash? exposes :merkle-root
+                 via -sec-flush, and audit walks :ok end-to-end"
+         (let [cfg (file-cfg true)
+               scriptum-path (str (System/getProperty "java.io.tmpdir")
+                                  "/scriptum-audit-"
+                                  (java.util.UUID/randomUUID))]
+           (d/create-database cfg)
+           (let [conn (d/connect cfg)]
+             (try
+               (d/transact conn [{:db/ident :p/name :db/valueType :db.type/string
+                                  :db/cardinality :db.cardinality/one}])
+               (d/transact conn [{:db/ident :idx/sc :db.secondary/type :scriptum
+                                  :db.secondary/attrs [:p/name]
+                                  :db.secondary/config {:path scriptum-path
+                                                        :crypto-hash? true}}])
+               (d/transact conn [{:p/name "Alice"}])
+               (let [db (d/db conn)
+                     stored-head (k/get (:store db)
+                                        (get-in db [:meta :datahike/commit-id])
+                                        nil {:sync? true})
+                     sc-root (get-in stored-head [:merkle-roots :secondary :idx/sc])
+                     report (audit/verify-chain db)]
+                 (is (some? sc-root)
+                     "scriptum's :content-hash should reach merkle-roots")
+                 (is (uuid? sc-root))
+                 (is (= :ok (:status report))
+                     "every commit verifies cleanly with audit-grade scriptum"))
+               (finally (cleanup conn cfg)))))))))


### PR DESCRIPTION
## Summary

- Under `:crypto-hash? true` on a persistent backend, `create-commit-id` now hashes the post-flush merkle leaves of the DB (index storage addresses + schema-meta-key + max-tx + max-eid + meta) instead of `[hash max-tx max-eid meta]`. Konserve already content-addresses the index nodes themselves under `:crypto-hash?`, so the cid becomes a true merkle root: any datom change flips a leaf address and propagates up.
- Adds `datahike.audit/verify-chain` — walks parents from a head cid, recomputes each cid, returns `{:status :commits :mismatches :missing}`.

## Why

The current `:hash` field is a sum of JVM `hashCode`s of the datoms (`db.cljc`):
```clojure
:hash (reduce #(+ %1 (hash %2)) 0 datoms)
```
That's not collision-resistant. With `:crypto-hash? true` enabled, the cid input was `[hash max-tx max-eid meta]` — so two materially different states with the same JVM-hash sum would produce the same cid. Tampering with stored data could go undetected even in audit mode.

The fix wires the actual content-addressed index roots (which konserve+hasch already produce) into the cid input. Now any change to underlying datoms surfaces as a different cid.

## Mechanics

`commit!`, `-create-database*`, and `versioning/branch!` are reordered to flush indexes **first** (materializing the storage addresses), then compute the cid from the resulting `stored-db`.

The memory backend keeps the legacy weak input — no audit value to lose, and HHT-on-memory holds unresolved `core.async` channels that hasch can't encode. Memory + `:crypto-hash? true` still produces a deterministic UUID; it just isn't merkle-rooted.

## verify-chain

```clojure
(audit/verify-chain conn)
;; => {:head <cid>
;;     :status :ok | :mismatch | :advisory | :incomplete
;;     :commits [{:cid :recomputed :parents :status …} …]
;;     :mismatches [<entry> …]
;;     :missing [<cid> …]}
```

Tampering with a stored commit's `:max-tx` (or any other field) flips its recomputed cid, surfacing as a `:status :mismatch` entry. Commits written without `:crypto-hash?` (or on memory) are flagged `:advisory` — they pass through but don't contribute integrity.

External anchoring (OpenTimestamps, transparency log, etc.) is one line via the existing `d/listen!` — no new hook needed:
```clojure
(d/listen! conn ::audit-anchor
  (fn [report] (anchor! (-> report :tx-meta :db/commitId))))
```

## Test plan
- [x] `clj -M:test -m kaocha.runner clj-pss` — 489 tests / 2362 assertions / 0 failures
- [x] `clj -M:format` clean
- [x] `audit_verify_test` covers: clean walk, tamper detection on a non-head commit, advisory mode, explicit head-cid