### PR TITLE
fix(secondary/proximum): correct sync! call + surface :merkle-root

### DIFF
--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -15,9 +15,9 @@
    [datahike.index.entity-set :as es]
    [proximum.core :as prox]
    [proximum.crypto :as pcrypto]
+   [proximum.protocols :as pproto]
    [proximum.writing :as pwr]
    [proximum.versioning :as pver]
-   [proximum.vectors :as pvec]
    [proximum.hnsw.internal :as phi]
    [replikativ.logging :as log]
    [clojure.core.async :as async]))
@@ -65,15 +65,31 @@
 
       sec/IVersionedSecondaryIndex
       (-sec-flush [_ _store branch]
-        ;; Proximum manages its own konserve store internally.
-        ;; Sync writes pending data to its store. The merkle-root for
-        ;; audit is exposed via IAuditable below, computed from
-        ;; proximum's own commit-id.
-        (async/<!! (pvec/sync! prox-idx))
-        {:type :proximum
-         :branch (name branch)
-         :commit-id (phi/commit-id prox-idx)
-         :store-config (:store-config config)})
+        ;; Proximum manages its own konserve store internally. The
+        ;; protocol method `proximum.protocols/sync!` returns a chan
+        ;; that yields a NEW immutable index value carrying the post-
+        ;; sync commit-id; the live `prox-idx` field is the pre-sync
+        ;; value and stays that way (the bridge has nowhere to put the
+        ;; new one). So we wait, read commit-id off `synced`, and
+        ;; surface it under both :commit-id (for restore) and
+        ;; :merkle-root (for audit's key-map fallback path b in
+        ;; writing.cljc) — IAuditable below can't see the post-sync
+        ;; state on the live record.
+        ;;
+        ;; NOTE on the <!!: writing.cljc invokes -sec-flush from inside
+        ;; commit!'s go-try-, so blocking from here parks a core.async
+        ;; pool thread. Under load this can deadlock the writer. The
+        ;; correct fix is making -sec-flush async in the protocol;
+        ;; tracked separately. This call is the minimal fix to stop
+        ;; throwing NPE (which was caused by previously calling the
+        ;; wrong, VectorStore-shaped sync! against an HnswIndex).
+        (let [synced (async/<!! (pproto/sync! prox-idx))
+              cid    (phi/commit-id synced)]
+          {:type :proximum
+           :branch (name branch)
+           :commit-id cid
+           :merkle-root cid
+           :store-config (:store-config config)}))
 
       (-sec-restore [_ _store key-map]
         ;; Restore from proximum's own store using commit ID
@@ -150,10 +166,10 @@
 (defmethod sec/branch-from-key-map :proximum [key-map _store _from-branch new-branch]
   (let [idx (pwr/load-commit (:store-config key-map) (:commit-id key-map)
                              {:branch (keyword (:branch key-map))})
-        branched (pver/branch! idx (keyword new-branch))]
-    (async/<!! (pvec/sync! branched))
-    (let [new-commit-id (phi/commit-id branched)]
-      (pvec/close! branched)
-      (assoc key-map
-             :branch (name new-branch)
-             :commit-id new-commit-id))))
+        branched (pver/branch! idx (keyword new-branch))
+        synced (async/<!! (pproto/sync! branched))
+        new-commit-id (phi/commit-id synced)]
+    (pproto/close! synced)
+    (assoc key-map
+           :branch (name new-branch)
+           :commit-id new-commit-id)))

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -102,11 +102,14 @@
           ;;
           ;; Secondary indexes can produce their merkle root in two
           ;; ways: (a) extend IAuditable when their live instance has
-          ;; post-flush state (scriptum's Java writer; proximum's
-          ;; index handle); (b) surface `:merkle-root` in their
-          ;; -sec-flush return map when sync produces a new immutable
-          ;; value the live instance doesn't capture (stratum). The
-          ;; reader below tries (a) first, then (b).
+          ;; post-flush state visible to the bridge — scriptum, whose
+          ;; underlying Java writer is mutable so `(.getLastContentHash
+          ;; bw)` reflects the latest commit on the same handle; (b)
+          ;; surface `:merkle-root` in their -sec-flush return map when
+          ;; sync produces a new immutable value the bridge field
+          ;; doesn't capture — stratum and proximum, whose record-typed
+          ;; live values stay pinned to the pre-sync state. The reader
+          ;; below tries (a) first, then (b).
           safe-root      (fn [x]
                            (when x
                              (try (audit/-merkle-root x)

--- a/test/datahike/test/audit_verify_test.cljc
+++ b/test/datahike/test/audit_verify_test.cljc
@@ -240,6 +240,64 @@
              (finally (cleanup conn cfg))))))))
 
 ;; ============================================================================
+;; Proximum end-to-end through commit!. The whole point of this test is to
+;; drive `d/transact` so it goes through `commit!` → `db->stored` → the
+;; proximum bridge's `-sec-flush`. If the bridge calls the wrong sync! (an
+;; earlier regression invoked the low-level VectorStore sync! against the
+;; HnswIndex, NPE'd, and got past CI because no existing test exercised
+;; this path), we catch it here.
+;;
+;; We don't transact any embedding values — registering the secondary alone
+;; is enough to exercise the flush. Transacting actual float-array values
+;; would require either type=bytes (won't hash for the merkle leaf) or
+;; schema-flexibility :read with a hasch coercion for [F (separate issue).
+;; ============================================================================
+
+#?(:clj
+   (def ^:private proximum-available?
+     (try (require 'datahike.index.secondary.proximum) true
+          (catch Throwable _ false))))
+
+#?(:clj
+   (when proximum-available?
+     (deftest proximum-secondary-contributes-merkle-root
+       (testing "proximum's commit-id surfaces under
+                 :merkle-roots :secondary via the -sec-flush key-map
+                 (path b); audit walks clean. Regression guard for the
+                 NPE caused by calling the wrong (VectorStore-shaped)
+                 sync! against the HnswIndex from -sec-flush."
+         (let [cfg (file-cfg true)]
+           (d/create-database cfg)
+           (let [conn (d/connect cfg)]
+             (try
+               (d/transact conn
+                           [{:db/ident :idx/vectors
+                             :db.secondary/type :proximum
+                             :db.secondary/attrs [:person/embedding]
+                             :db.secondary/config
+                             {:dim 4 :distance :cosine
+                              :store-config {:backend :memory
+                                             :id (java.util.UUID/randomUUID)}
+                              :crypto-hash? true}}])
+               (let [db (d/db conn)
+                     head (get-in db [:meta :datahike/commit-id])
+                     stored (k/get (:store db) head nil {:sync? true})
+                     prox-root (get-in stored [:merkle-roots :secondary :idx/vectors])
+                     prox-key (get-in stored [:secondary-index-keys :idx/vectors])
+                     report (audit/verify-chain db)]
+                 (is (some? prox-root)
+                     "proximum must contribute a non-nil merkle-root")
+                 (is (uuid? prox-root))
+                 (is (= prox-root (:merkle-root prox-key))
+                     "the key-map's :merkle-root and the folded root must match")
+                 (is (= prox-root (:commit-id prox-key))
+                     "key-map :commit-id stays the post-sync cid (was previously
+                      reading the pre-sync value off the bridge's discarded sync result)")
+                 (is (= :ok (:status report))
+                     "with proximum contributing a real root, audit walks clean"))
+               (finally (cleanup conn cfg)))))))))
+
+;; ============================================================================
 ;; Scriptum without crypto-hash → advisory.
 ;; (Scriptum WITH crypto-hash is blocked by a pre-existing upstream bug:
 ;;  maybe-create-secondary-index instantiates as soon as :type+:attrs are


### PR DESCRIPTION
## Summary

The proximum secondary bridge was throwing NPE on every commit and (when not throwing) silently contributing a nil merkle-root to the audit chain. Root causes were never caught by existing tests because no proximum test exercised the persistent writer path — they all poke the secondary impl directly via \`-transact\`/\`-search\`.

### Two latent bugs

1. **NPE on every commit**. \`-sec-flush\` called \`proximum.vectors/sync!\` (the low-level VectorStore sync) against an HnswIndex. HnswIndex's \`ILookup\` interprets every keyword as an external-ID lookup, so \`(:pending-writes hnsw)\` returned nil; \`sync!\` then \`@nil\` and raised \"Cannot invoke Future.get because fut is null\". Switched to \`proximum.protocols/sync!\` (the IndexLifecycle method) which returns a chan yielding the post-sync HnswIndex.

2. **Stale commit-id in key-map**. proximum's \`sync!\` returns a NEW immutable index value with the post-sync \`:commit-id\`; the bridge discarded that and read \`commit-id\` off the pre-sync \`prox-idx\` field, so \`-sec-flush\`'s key-map carried a stale (or nil) \`:commit-id\` and no \`:merkle-root\` at all — meaning writing.cljc's path-b reader folded nothing into the audit chain.

Bind the synced result; surface its commit-id under both \`:commit-id\` (for restore) and \`:merkle-root\` (for audit). Same fix applied to \`branch-from-key-map\`.

### Why tests missed this

Three reasons:

1. No proximum test exercises the persistent writer path. \`test-proximum-lifecycle\` and \`test-in-transaction-proximum\` both poke the impl directly. \`d/db-with\` is in-memory and skips \`commit!\`.
2. \`audit_verify_test.cljc\` had stratum coverage but no proximum analogue.
3. The NPE propagated as \`:datahike/writer-shutdown\` ExceptionInfo with an opaque async-internals message — easy to dismiss.

Added \`proximum-secondary-contributes-merkle-root\` to \`audit_verify_test.cljc\`. It drives a proximum secondary through \`d/transact\` on a connected db so future regressions are caught.

### Doc fix

Updated the writing.cljc comment so proximum is listed under path (b) (\`:merkle-root\` in -sec-flush key-map) alongside stratum. Both have record-typed live values that don't capture post-sync state, so neither can use path (a).

### Known follow-up (not in this PR)

The bridge still uses \`async/<!!\` to wait on the sync chan, and \`-sec-flush\` runs inside the writer's \`go-try-\` block — that's a deadlock risk under load (parks a core.async pool thread). Stratum's \`sd/sync!\` has the same hidden \`<!!\` one layer down via \`cstorage/flush-writes!\`. The proper fix is making \`IVersionedSecondaryIndex/-sec-flush\` chan-returning so writing.cljc can park via \`<?-\` instead. That's a protocol bump and a separate PR.

## Test plan

- [x] \`audit_verify_test\`: 16 tests / 60 assertions (was 15/55), all pass
- [x] New proximum test confirms \`:merkle-root\` is surfaced and audit walks clean
- [x] Verified NPE reproduces on \`origin/main\` (stash + retry) and is gone on this branch