### PR TITLE
fix(query/planner): allow function-only base cases in recursive rules

### DIFF
--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -1552,18 +1552,25 @@
                                     :base-plans base-ps
                                     :rec-clause-versions rec-cvs}])))
                       scc-rule-names)
-                ;; Check if any base case lacks data patterns (e.g. [(identity ?a) ?c]).
-                ;; Such base cases can't be executed by the planned fixpoint engine
-                ;; because head vars have no data source — fall back to legacy.
-                has-scanless-base?
-                (some (fn [[_ {:keys [base-plans]}]]
-                        (some (fn [bp]
-                                (not (some #(#{:entity-group :pattern-scan} (:op %))
-                                           (:ops bp))))
-                              base-plans))
-                      scc-rule-plans)
-                ;; If scanless base cases, nil out scc-rule-plans to trigger legacy fallback
-                scc-rule-plans (when-not has-scanless-base? scc-rule-plans)
+                ;; Note: an earlier `has-scanless-base?` guard nilled out
+                ;; `scc-rule-plans` whenever a base case lacked an
+                ;; `:entity-group` / `:pattern-scan` op (e.g. SQL
+                ;; `WITH RECURSIVE … (SELECT 1 …)` anchor lowering to
+                ;; `[(identity 1) ?n]`, or a `[(ground […]) [?v ...]]`
+                ;; collection seed), routing such rules to `legacy/solve-rule`.
+                ;; Legacy can't evaluate recursive bodies that bind head vars
+                ;; through `:function` ops and then filter them with predicates
+                ;; — those queries hung or failed.
+                ;;
+                ;; The fixpoint executor already handles function-only base
+                ;; cases: `execute-branch-plans` runs the base plan against
+                ;; an empty ctx, `legacy/bind-by-fn` produces a single-tuple
+                ;; Relation, and the recursive branch's `rule-lookup` ops feed
+                ;; off the accumulator as usual. Magic sets are silently
+                ;; skipped when `base-scan-attr` is nil (the
+                ;; `and magic-demand base-scan-attr …` check in
+                ;; `execute-recursive-rule`). The guard was redundant and
+                ;; introduced a real regression for scanless-base recursion.
                 ;; Extract base scan attribute for magic set optimization
                 base-scan-attr
                 (when scc-rule-plans


### PR DESCRIPTION
## Summary

Removes the `has-scanless-base?` guard in `plan-rule-op` that routed any recursive rule whose base branch lacked an `:entity-group` / `:pattern-scan` op through `legacy/solve-rule`. Legacy can't evaluate recursive bodies that bind head vars through `:function` ops and then filter them with predicates — those queries raise `Cannot resolve any more clauses` or never terminate.

Two real shapes that hit this regression:

- **SQL `WITH RECURSIVE`**: anchors like `SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n < N` lower to a `[(identity 1) ?n]` base case. Surfaced via the SQL → Datalog translator in pg-datahike.
- **`[(ground […]) [?v ...]]` collection seeds**: rules whose entry point is a literal set rather than a scan.

The fixpoint executor already handles these: `execute-branch-plans` runs the base plan against an empty ctx, `legacy/bind-by-fn` produces a single-tuple Relation, and the recursive branch's `rule-lookup` ops feed off the accumulator as usual. Magic sets are silently skipped when `base-scan-attr` is nil (the existing `and magic-demand base-scan-attr …` check in `execute-recursive-rule`). The guard was redundant.

## Test plan

- [x] datahike `:clj-pss` suite under `DATAHIKE_QUERY_PLANNER=true`: 1510 tests, 7217 assertions, 0 failures
- [x] jobtech-taxonomy-api full suite under the patched datahike: 725 tests, 5416 assertions, 1 failure (timezone-only `mini-db-test` year boundary, unrelated)
- [x] jobtech-taxonomy-api's recursive `indirectly-replaced-by` rule (`replaced-concept-tracker-test/track-test`) — all sub-tests pass
- [x] End-to-end SQL `WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n < 5) SELECT n FROM t` returns `{1,2,3,4,5}`
- [x] End-to-end SQL tree traversal with `depth+1` returns correct levels