### PR TITLE
Bitemporal valid-time (system schema + built-in rules + SCD2 secondary index + writer fixes)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -73,10 +73,7 @@
                                ;; secondary index integrations (for testing)
                                org.replikativ/proximum       {:mvn/version "0.1.25"}
                                org.replikativ/scriptum       {:mvn/version "0.1.27"}
-                               ;; Local stratum checkout while feature/valid-time is in flight.
-                               ;; Revert to :mvn/version once stratum cuts a release with the
-                               ;; :valid-time column convention (kontor doc/research/57).
-                               org.replikativ/stratum        {:local/root "../stratum"}
+                               org.replikativ/stratum        {:mvn/version "0.3.69"}
 
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.95"}

--- a/deps.edn
+++ b/deps.edn
@@ -73,7 +73,10 @@
                                ;; secondary index integrations (for testing)
                                org.replikativ/proximum       {:mvn/version "0.1.25"}
                                org.replikativ/scriptum       {:mvn/version "0.1.27"}
-                               org.replikativ/stratum        {:mvn/version "0.2.67"}
+                               ;; Local stratum checkout while feature/valid-time is in flight.
+                               ;; Revert to :mvn/version once stratum cuts a release with the
+                               ;; :valid-time column convention (kontor doc/research/57).
+                               org.replikativ/stratum        {:local/root "../stratum"}
 
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.95"}

--- a/doc/time_variance.md
+++ b/doc/time_variance.md
@@ -263,6 +263,41 @@ your purposes.
 ;; => #{["Alice" #inst "2019-08-16T11:40:28.794-00:00"]}
 ```
 
+### `:db/txInstant` is strictly monotonic
+
+Auto-stamped `:db/txInstant` values are guaranteed to be strictly
+increasing across a connection's tx-log — even when multiple
+transactions commit within the same wall-clock millisecond. The
+allocator returns `max(get-date, prev-tx-instant + 1ms)`; under
+write bursts the stamp advances 1ms per tx until wall-clock catches
+up. This matches Datomic's contract and removes the `d/as-of
+<Date>` tied-instant ambiguity at the source: an instant resolves
+to one unique snapshot, never two.
+
+For exact temporal cuts ("snapshot just after tx X") use the tx-id
+directly — tx-ids are the canonical precise ordering primitive,
+while wall-clock instants remain useful for human-readable queries
+("what did the world look like at 2024-12-31 23:59?").
+
+User-provided `:db/txInstant` (via `:tx-meta {:db/txInstant
+<date>}`) still wins over the allocator default. This preserves
+the historical-import pattern: writing past events with their
+original dates — and pinned-clock test fixtures — both keep
+working unchanged.
+
+A useful side-effect: a pinned wall-clock turns into a *logical
+clock* automatically. Bind `datahike.tools/get-date` to a constant
+(e.g., for replay or regulator audits on a fresh database) and the
+allocator produces deterministic `[pinned, pinned+1ms, pinned+2ms,
+…]` stamps — fully reproducible without any separate logical-clock
+machinery. (This holds when the pin dominates the prev-tx-instant,
+i.e., the pin is at or after the most recently committed tx.)
+
+The allocator (`datahike.db.transaction/next-tx-instant`) is itself
+`^:dynamic`, so a future caller that wants a different allocation
+policy (hybrid logical clock, microsecond `Instant`, …) can swap
+it in via `binding` without touching the call site.
+
 ## Data Purging
 
 **Retraction vs Purging:** Normal retractions preserve data in history. Purging permanently deletes data from both current and historical indices.

--- a/doc/valid_time.md
+++ b/doc/valid_time.md
@@ -1,5 +1,27 @@
 # Valid Time
 
+> ⚠️ **EXPERIMENTAL FEATURE**
+>
+> Valid-time support is currently experimental. The schema and writer
+> paths are well-tested (see `test/datahike/test/valid_time_test.cljc`,
+> `valid_at_test.clj`, `cross_tx_vt_validation_test.clj`,
+> `stratum_vt_test.clj`, and the planner-equivalence proof in
+> `query_planner_temporal_test.clj`), but the API surface (`d/valid-at`,
+> `d/valid-between`, `d/valid-during`, `d/valid-all`, the Allen rule
+> library, the `:tx-meta` shape) may evolve before stabilising. We
+> recommend:
+>
+> - Thorough testing in your specific use case before production deployment.
+> - Pin a known-good datahike sha if you build on rule names and arities.
+> - Reporting issues at https://github.com/replikativ/datahike/issues.
+>
+> The **storage-level overlay-on-tx-time invariant** is stable and
+> verified: queries that don't reference `:db.valid/*` produce
+> byte-identical plans to a non-vt database (see the
+> `zero-cost-overlay-*` tests in `query_planner_temporal_test.clj`).
+> Migrations off a vt-equipped db remain compatible with the standard
+> EAVT / AEVT / AVET indices.
+
 Datahike tracks a second time axis alongside transaction time: **valid
 time**, the time at which a fact is true in the modeled world. While
 `:db/txInstant` records *when the database learned* about a fact (see

--- a/doc/valid_time.md
+++ b/doc/valid_time.md
@@ -1,0 +1,258 @@
+# Valid Time
+
+Datahike tracks a second time axis alongside transaction time: **valid
+time**, the time at which a fact is true in the modeled world. While
+`:db/txInstant` records *when the database learned* about a fact (see
+[Time Variance](time_variance.md)), `:db.valid/from` and
+`:db.valid/to` record *when the fact applies*. Together the two axes
+make Datahike a bitemporal database.
+
+You opt in per transaction. A tx with no valid-time meta has the same
+semantics as today; valid-time only matters for transactions that
+explicitly set it.
+
+## Valid-Time Views
+
+| View | Function | Returns | Use Case |
+|------|----------|---------|----------|
+| **At valid-time** | `(d/valid-at db t)` | State as it applies at `t` | "What was Bob's salary on Feb 15?" |
+| **Between** | `(d/valid-between db from to)` | Datoms whose validity window overlaps `[from, to)` | Window queries, audit-by-period |
+| **During** | `(d/valid-during db from to)` | Datoms whose validity window is contained by `[from, to)` | "Strictly within this period" |
+| **All** | `(d/valid-all db)` | Every datom regardless of validity window | Inspection / reporting |
+
+**Related:** For transaction-time travel, see [Time
+Variance](time_variance.md). For column-oriented secondary indices
+that push the valid-time filter into a native scan, see [Secondary
+Indices](secondary-indices.md).
+
+## Setup for Examples
+
+All examples below use this shared setup:
+
+```clojure
+(require '[datahike.api :as d])
+
+(def schema
+  [{:db/ident :emp/name
+    :db/valueType :db.type/string
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :emp/salary
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}])
+
+(def cfg {:store {:backend :memory :id #uuid "11111111-0000-0000-0000-000000000001"}
+          :initial-tx schema
+          :keep-history? true})
+
+(d/create-database cfg)
+(def conn (d/connect cfg))
+```
+
+`:keep-history? true` is required — `d/valid-at` reads the event
+stream behind every fact, and history is what keeps that stream
+available.
+
+## Writing a Tx With Valid-Time
+
+Pass `:tx-meta` alongside `:tx-data`. Both bounds are optional:
+
+```clojure
+;; Bob earns 100k for the whole of 2026 (no upper bound = open-ended)
+(d/transact conn
+  {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+   :tx-meta {:db.valid/from #inst "2026-01-01"}})
+
+;; A bounded window — explicit start AND end
+(d/transact conn
+  {:tx-data [{:emp/name "Alice" :emp/salary 90000}]
+   :tx-meta {:db.valid/from #inst "2026-01-01"
+             :db.valid/to   #inst "2026-07-01"}})
+```
+
+`:db.valid/from` defaults to the tx's `:db/txInstant` when absent.
+`:db.valid/to` defaults to open-ended (treated as +∞). The interval
+is half-open: a fact is valid at `t` when `vf <= t < vt`.
+
+The transactor rejects a tx whose `:db.valid/from >= :db.valid/to` —
+zero-width or reverse windows can never match a `d/valid-at` query.
+
+Equivalent low-level form, when you need the valid-time meta inside a
+multi-step tx-data vector:
+
+```clojure
+(d/transact conn
+  [{:emp/name "Bob" :emp/salary 100000}
+   [:db/add "datomic.tx" :db.valid/from #inst "2026-01-01"]])
+```
+
+## Querying At a Valid-Time
+
+`d/valid-at` returns a filtered view; queries against it see only
+the datoms whose tx's valid-time window covers the query point.
+
+```clojure
+(d/transact conn
+  {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+   :tx-meta {:db.valid/from #inst "2026-01-01"}})
+
+(d/q '[:find ?s . :where [?e :emp/name "Bob"] [?e :emp/salary ?s]]
+     (d/valid-at @conn #inst "2026-06-15"))
+;; => 100000     ; Bob's window covers June 15
+```
+
+Pair with `d/as-of` for "what did we know at system-time T about
+valid-time V?" — useful for replays and audits. **Order matters**:
+wrap `d/as-of` first, then `d/valid-at` outermost:
+
+```clojure
+(d/q query (d/valid-at (d/as-of @conn audit-system-time) audit-valid-time))
+```
+
+`d/as-of` will throw on a valid-time-marked db to catch the wrong
+ordering at the call site.
+
+## Back-Corrections
+
+The point of a second time axis: when you learn that yesterday's
+assertion was wrong, you can record the correction *and* preserve
+the audit trail of what you used to believe.
+
+```clojure
+;; Day 1: Bob's salary recorded as 100k from Jan-01 onward
+(d/transact conn
+  {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+   :tx-meta {:db.valid/from #inst "2026-01-01"}})
+
+;; Day 90 (Apr-01): correction — actual salary was 90k from Apr-01
+(d/transact conn
+  {:tx-data [{:emp/name "Bob" :emp/salary 90000}]
+   :tx-meta {:db.valid/from #inst "2026-04-01"}})
+```
+
+Reads via `(d/valid-at (d/history db) t)`. History is the right view
+here — it exposes both txes' assertions to the valid-time filter so
+the correction can take effect. The 5-position datom pattern with
+`?op = true` filters retraction datoms surfaced by the
+cardinality-one upsert:
+
+```clojure
+(def hist (d/history @conn))
+
+;; Before the correction's vt-from — only the original tx covers Feb-15
+(d/q '[:find ?s . :where [?e :emp/name "Bob"] [?e :emp/salary ?s ?tx true]]
+     (d/valid-at hist #inst "2026-02-15"))
+;; => 100000
+
+;; After the correction's vt-from — both txes cover May-15, but the
+;; later tx wins for the same (entity, attribute, value) group.
+(d/q '[:find ?s . :where [?e :emp/name "Bob"] [?e :emp/salary ?s ?tx true]]
+     (d/valid-at hist #inst "2026-05-15"))
+;; => 90000
+```
+
+The "later tx wins" rule operates per `(entity, attribute, value)`
+triple. When the correction is a cardinality-one upsert (as above),
+the prior value's retraction datom carries the new tx's id, so the
+filter naturally picks the correction over the original at every
+valid-time point covered by both windows.
+
+## Retroactively Closing a Window
+
+A back-correction expressed via cardinality-one upsert handles the
+common case. The other case: you want to mark a prior tx's whole
+window as "no longer valid past date T" — typically when the
+correction creates *new entities* rather than updating existing ones,
+so there's no shared `(e, a, v)` for the per-triple rule to dedupe.
+
+Write a new datom on the prior tx-entity, naming the tx-id you want
+to close:
+
+```clojure
+;; First tx — capture its tx-id from the report
+(def r (d/transact conn
+         {:tx-data [{:emp/name "Charlie" :emp/salary 80000}]
+          :tx-meta {:db.valid/from #inst "2026-01-01"}}))
+(def charlie-tx
+  (->> (:tx-data r)
+       (filter #(= :db/txInstant (.-a %)))
+       first
+       .-tx))
+
+;; Later — close Charlie's tx-window effective Jul-01 forward
+(d/transact conn
+  [{:db/id charlie-tx :db.valid/to #inst "2026-07-01"}])
+```
+
+After the closing tx:
+
+```clojure
+(d/q '[:find ?s . :where [?e :emp/name "Charlie"] [?e :emp/salary ?s]]
+     (d/valid-at @conn #inst "2026-06-15"))
+;; => 80000    ; June 15 is inside the now-closed window
+
+(d/q '[:find ?s . :where [?e :emp/name "Charlie"] [?e :emp/salary ?s]]
+     (d/valid-at @conn #inst "2026-08-15"))
+;; => nil      ; August 15 is past the closure
+```
+
+The closing tx is a normal commit on the writing tx. The prior tx's
+hash is unchanged; the writing tx records the change. Both are
+auditable, both verifiable. The transactor enforces a cross-tx
+`vf < vt` check so a careless closure cannot silently invalidate the
+prior tx's window.
+
+The bare datom form above is the API. If you want a named operation
+or to attach a `:reason` attr to the closing tx, do so in your own
+namespace — the substrate intentionally stays primitives-first.
+
+## Sequenced UPDATE (SQL:2011 style)
+
+The pattern "for the slice `[Apr-01, Jul-01)` only, set salary =
+95k" composes from three vt-windowed commits. The polygon at read
+time handles the slice arithmetic:
+
+```clojure
+;; Original — vt-window [Jan-01, ∞)
+(d/transact conn
+  {:tx-data [{:emp/name "Dave" :emp/salary 100000}]
+   :tx-meta {:db.valid/from #inst "2026-01-01"}})
+
+;; The slice — vt-window [Apr-01, Jul-01)
+(d/transact conn
+  {:tx-data [{:emp/name "Dave" :emp/salary 95000}]
+   :tx-meta {:db.valid/from #inst "2026-04-01"
+             :db.valid/to   #inst "2026-07-01"}})
+
+;; Restore the original value for the post-slice period
+(d/transact conn
+  {:tx-data [{:emp/name "Dave" :emp/salary 100000}]
+   :tx-meta {:db.valid/from #inst "2026-07-01"}})
+```
+
+Reads:
+
+| Query date | Result | Why |
+|---|---|---|
+| `#inst "2026-02-15"` | 100000 | Only the original window covers Feb-15 |
+| `#inst "2026-05-15"` | 95000  | Two windows cover, the later tx wins for the same `(e, a, v)` |
+| `#inst "2026-08-15"` | 100000 | Two windows cover, again the later tx wins |
+
+The writer's job is to land the three windowed assertions; the
+reader gets the slice for free.
+
+## Performance Note
+
+`d/valid-at` filters at the read layer — every result datom is
+checked against its tx's vt-window, plus a per-`(e, a, v)` scan to
+pick the winner among overlapping windows. The check is correct on
+every read path (`d/q`, `d/datoms`, `d/pull`, `d/entity`,
+`d/seek-datoms`, `d/index-range`) but does add cost.
+
+For workloads with high vt-query volume, install a valid-time-aware
+secondary index (see [Secondary Indices](secondary-indices.md));
+those push the filter into a native columnar scan and bypass the
+read-layer polygon entirely.
+
+For one-off audits and ordinary tx workloads, the read-layer
+filter is the path of least configuration.

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -278,6 +278,8 @@
 
 (def ^:private vt-from-col :_valid_from)
 (def ^:private vt-to-col   :_valid_to)
+(def ^:private sys-from-col :_system_from)
+(def ^:private sys-to-col   :_system_to)
 (def ^:private vt-open-sentinel Long/MAX_VALUE)
 ;; A vt-from that is older than any real tx-meta; rows seeded from
 ;; pre-existing AEVT data in build-initial-dataset use it so they appear
@@ -312,26 +314,45 @@
     (date->micros v)
     vt-open-sentinel))
 
+(defn- tx-meta->sf
+  "Pick the row's `_system_from` for this tx — the instant the DB
+   first knew about the row. Comes from `:db/txInstant` (the
+   transactor stamps it on every tx) or the legacy
+   `:datahike/created-at` fallback, or wall-clock now if neither
+   is set."
+  ^long [tx-meta]
+  (date->micros (or (:db/txInstant tx-meta)
+                    (:datahike/created-at tx-meta)
+                    (java.util.Date.))))
+
 (defn- ds-metadata
-  "Build the `:metadata` map passed to `st/make-dataset` for this index.
-   In vt-mode it carries `:valid-time` so stratum tags the two vt columns
-   with `:temporal-unit :micros` and round-trips the config through
-   sync!/load."
+  "Build the `:metadata` map passed to `st/make-dataset` for this
+   index. In vt-mode it carries `:bitemporal {:valid … :system …}`
+   matching stratum's current API: stratum tags all four temporal
+   columns with `:temporal-unit :micros` and round-trips the config
+   through `sync!`/`load`. Both axes are always present in vt-mode
+   so SCD2 surgery can advance the system-time axis when correcting
+   a valid-time window — the audit guarantee that backdated
+   corrections don't silently rewrite past `FOR SYSTEM_TIME` views."
   [config]
   (if (vt-mode? config)
-    {:valid-time {:from-col vt-from-col :to-col vt-to-col :unit :micros}}
+    {:bitemporal {:valid  {:from-col vt-from-col  :to-col vt-to-col   :unit :micros}
+                  :system {:from-col sys-from-col :to-col sys-to-col :unit :micros}}}
     {}))
 
 (defn- with-vt-cols
-  "If vt-mode, attach empty `:_valid_from`/`:_valid_to` columns (n long zeros)
-   alongside the per-attribute columns. The caller will fill them when
-   building rows; this helper just makes sure the columns exist before
-   `make-dataset` infers the schema."
+  "If vt-mode, attach empty `_valid_from`/`_valid_to`/`_system_from`/
+   `_system_to` columns (n long zeros) alongside the per-attribute
+   columns. The caller fills them when building rows; this helper
+   just makes sure the columns exist before `make-dataset` infers
+   the schema."
   [col-map config n]
   (if (vt-mode? config)
     (assoc col-map
-           vt-from-col (long-array n)
-           vt-to-col   (long-array n))
+           vt-from-col  (long-array n)
+           vt-to-col    (long-array n)
+           sys-from-col (long-array n)
+           sys-to-col   (long-array n))
     col-map))
 
 (defn- make-vt-dataset
@@ -422,15 +443,27 @@
               ;; In vt-mode, seed every pre-existing row with the maximally-
               ;; permissive vt-window [MIN, MAX). Subsequent vt-aware txes
               ;; close these windows when the entity is updated.
-              vt-from-arr (when (vt-mode? config)
-                            (let [arr (long-array n)]
-                              (java.util.Arrays/fill arr vt-from-floor) arr))
-              vt-to-arr   (when (vt-mode? config)
-                            (let [arr (long-array n)]
-                              (java.util.Arrays/fill arr vt-open-sentinel) arr))
+              ;; The system-time axis on seeded rows uses [MIN, MAX) too —
+              ;; we don't know when the DB first knew about pre-existing
+              ;; data; treating it as known-since-time-began matches the
+              ;; vt-axis convention.
+              vt-from-arr  (when (vt-mode? config)
+                             (let [arr (long-array n)]
+                               (java.util.Arrays/fill arr vt-from-floor) arr))
+              vt-to-arr    (when (vt-mode? config)
+                             (let [arr (long-array n)]
+                               (java.util.Arrays/fill arr vt-open-sentinel) arr))
+              sys-from-arr (when (vt-mode? config)
+                             (let [arr (long-array n)]
+                               (java.util.Arrays/fill arr vt-from-floor) arr))
+              sys-to-arr   (when (vt-mode? config)
+                             (let [arr (long-array n)]
+                               (java.util.Arrays/fill arr vt-open-sentinel) arr))
               col-map (cond-> (assoc attr-arrays :eid entity-ids)
-                        (vt-mode? config) (assoc vt-from-col vt-from-arr
-                                                 vt-to-col   vt-to-arr))]
+                        (vt-mode? config) (assoc vt-from-col  vt-from-arr
+                                                 vt-to-col    vt-to-arr
+                                                 sys-from-col sys-from-arr
+                                                 sys-to-col   sys-to-arr))]
           (sd/ensure-indexed (make-vt-dataset col-map config)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -895,8 +928,16 @@
       (StratumIndex. dataset attrs attr-refs config)
       (let [vf (tx-meta->vf tx-meta)
             new-vt (tx-meta->vt tx-meta)
+            ;; System-time for this batch: the tx's `:db/txInstant` (or
+            ;; now if absent). Every SCD2 surgery in this batch shares
+            ;; the same `sys-now` — closing rows close their system-to
+            ;; to it and new rows stamp their system-from with it. This
+            ;; preserves the audit invariant that a `FOR SYSTEM_TIME AS
+            ;; OF <past>` query returns the pre-correction state.
+            sys-now (tx-meta->sf tx-meta)
             attr-col-keys (mapv attr-col-key attrs)
-            col-keys (into [:eid vt-from-col vt-to-col] attr-col-keys)
+            col-keys (into [:eid vt-from-col vt-to-col sys-from-col sys-to-col]
+                           attr-col-keys)
             current-cols (when dataset (st/columns dataset))
             current-n (if dataset (st/row-count dataset) 0)
             close-eids (let [s (java.util.HashSet.)]
@@ -923,7 +964,16 @@
                                         (= vto vt-open-sentinel))]
                       (conj! rows
                              (-> (persistent! row)
-                                 (cond-> closing? (assoc vt-to-col vf)))))))
+                                 (cond-> closing?
+                                   ;; Close both vt-to AND system-to on
+                                   ;; supersession. The vt-close is the
+                                   ;; classical SCD2 step; the system-to
+                                   ;; close is what gives us the audit
+                                   ;; guarantee (`FOR SYSTEM_TIME AS OF
+                                   ;; <pre-correction>` sees this row as
+                                   ;; still open at that instant).
+                                   (assoc vt-to-col   vf
+                                          sys-to-col  sys-now)))))))
                 (persistent! rows)))
             ;; Snapshot previous-open attrs per entity for value-merging on
             ;; new rows (so partial attribute updates inherit the rest).
@@ -951,8 +1001,13 @@
                       (let [prev (when eid->prev-open (.get ^java.util.HashMap eid->prev-open eid))]
                         (-> (merge (or prev {}) em)
                             (assoc :eid eid
-                                   vt-from-col vf
-                                   vt-to-col   new-vt))))
+                                   vt-from-col  vf
+                                   vt-to-col    new-vt
+                                   ;; New rows stamp `sys-now` on
+                                   ;; `_system_from` so they're only
+                                   ;; visible at system-times >= now.
+                                   sys-from-col sys-now
+                                   sys-to-col   vt-open-sentinel))))
                     (seq pending-adds)))
             all-rows (into current-rows (or new-rows []))]
         (if (empty? all-rows)

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -918,102 +918,123 @@
                                   arr))])))
           col-keys)))
 
+(defn- materialize-existing-rows
+  "Walk every row in the current dataset and produce a vec of row-maps.
+   Rows whose `:eid` is in `close-eids` AND whose `_valid_to` is still
+   open (= `Long/MAX_VALUE`) get their `_valid_to` closed to `vt-close`
+   AND their `_system_to` closed to `sys-now`. Closing both axes in
+   the same step is what gives us the audit guarantee that a
+   `FOR SYSTEM_TIME AS OF <pre-correction>` query still sees the old
+   row as 'open at that instant'."
+  [current-cols current-n col-keys
+   ^java.util.HashSet close-eids vt-close sys-now]
+  (if (or (zero? (long current-n)) (nil? current-cols))
+    []
+    (let [eid-col (get current-cols :eid)
+          vto-col (get current-cols vt-to-col)
+          rows    (transient [])]
+      (dotimes [i current-n]
+        (let [row (transient {})]
+          (doseq [k col-keys]
+            (let [v (materialize-col-value (get current-cols k) i)]
+              (when (some? v) (assoc! row k v))))
+          (let [eid       (long (or (materialize-col-value eid-col i) 0))
+                vto       (long (or (materialize-col-value vto-col i)
+                                    vt-open-sentinel))
+                closing?  (and (.contains close-eids eid)
+                               (= vto vt-open-sentinel))]
+            (conj! rows
+                   (cond-> (persistent! row)
+                     closing? (assoc vt-to-col  vt-close
+                                     sys-to-col sys-now))))))
+      (persistent! rows))))
+
+(defn- snapshot-prev-open-attrs
+  "For each eid in `pending-adds`, find its currently-open row in the
+   dataset and capture the attribute values. Used to merge partial
+   updates into the new row so unchanged attributes carry over."
+  [current-cols ^long current-n ^java.util.HashMap pending-adds attr-col-keys]
+  (let [m (java.util.HashMap.)]
+    (when (and (pos? current-n) current-cols)
+      (let [eid-col (get current-cols :eid)
+            vto-col (get current-cols vt-to-col)]
+        (dotimes [i current-n]
+          (let [eid (long (materialize-col-value eid-col i))
+                vto (long (or (materialize-col-value vto-col i) vt-open-sentinel))]
+            (when (and (= vto vt-open-sentinel)
+                       (.containsKey pending-adds eid))
+              (let [prev (into {}
+                               (keep (fn [k]
+                                       (when-let [v (materialize-col-value
+                                                     (get current-cols k) i)]
+                                         [k v])))
+                               attr-col-keys)]
+                (.put m eid prev)))))))
+    m))
+
+(defn- build-new-rows
+  "For each `[eid attr-map]` in `pending-adds`, build the row to append:
+   merge `attr-map` over the prev-open snapshot (so partial updates
+   inherit unchanged attrs), then stamp the four temporal columns.
+   `sys-now` is the batch's system-time event; every new row gets
+   `_system_from = sys-now` so AS-OF queries at past system-times do
+   not see it."
+  [^java.util.HashMap pending-adds ^java.util.HashMap eid->prev-open
+   vt-from vt-to sys-now]
+  (mapv (fn [[eid em]]
+          (let [prev (.get eid->prev-open eid)]
+            (-> (merge (or prev {}) em)
+                (assoc :eid         eid
+                       vt-from-col  vt-from
+                       vt-to-col    vt-to
+                       sys-from-col sys-now
+                       sys-to-col   vt-open-sentinel))))
+        (seq pending-adds)))
+
 (defn- vt-persist-transient-stratum-index
-  [dataset attrs attr-refs config ^java.util.HashMap pending-adds
-   ^java.util.HashSet pending-retracts tx-meta]
-  (let [has-adds?     (pos? (.size pending-adds))
-        has-retracts? (pos? (.size pending-retracts))
+  "SCD2 surgery for vt-mode: materialize every current row,
+   close-on-supersession (both axes), append the new rows, and
+   rebuild the dataset. The rebuild pattern is what lets us derive
+   column types from values on first insert; subsequent txes still
+   go through the same path for consistency.
+
+   System-time symmetry: every batch shares one `sys-now`; closing
+   rows close their `_system_to` to it and new rows stamp their
+   `_system_from` with it, preserving the
+   `FOR SYSTEM_TIME AS OF <pre-correction>` audit semantic."
+  [dataset attrs attr-refs config
+   ^java.util.HashMap pending-adds ^java.util.HashSet pending-retracts tx-meta]
+  (let [has-adds?      (pos? (.size pending-adds))
+        has-retracts?  (pos? (.size pending-retracts))
         nothing-to-do? (and (not has-adds?) (not has-retracts?))]
     (if nothing-to-do?
       (StratumIndex. dataset attrs attr-refs config)
-      (let [vf (tx-meta->vf tx-meta)
-            new-vt (tx-meta->vt tx-meta)
-            ;; System-time for this batch: the tx's `:db/txInstant` (or
-            ;; now if absent). Every SCD2 surgery in this batch shares
-            ;; the same `sys-now` — closing rows close their system-to
-            ;; to it and new rows stamp their system-from with it. This
-            ;; preserves the audit invariant that a `FOR SYSTEM_TIME AS
-            ;; OF <past>` query returns the pre-correction state.
-            sys-now (tx-meta->sf tx-meta)
+      (let [vt-from       (tx-meta->vf tx-meta)
+            vt-to         (tx-meta->vt tx-meta)
+            sys-now       (tx-meta->sf tx-meta)
             attr-col-keys (mapv attr-col-key attrs)
-            col-keys (into [:eid vt-from-col vt-to-col sys-from-col sys-to-col]
-                           attr-col-keys)
-            current-cols (when dataset (st/columns dataset))
-            current-n (if dataset (st/row-count dataset) 0)
-            close-eids (let [s (java.util.HashSet.)]
-                         (when has-adds? (.addAll s (.keySet pending-adds)))
-                         (when has-retracts? (.addAll s pending-retracts))
-                         s)
-            ;; Materialize current rows. Walk index/data arrays directly via
-            ;; materialize-col-value.
-            current-rows
-            (if (or (zero? current-n) (nil? current-cols))
-              []
-              (let [eid-col (get current-cols :eid)
-                    vto-col (get current-cols vt-to-col)
-                    rows (transient [])]
-                (dotimes [i current-n]
-                  (let [row (transient {})]
-                    (doseq [k col-keys]
-                      (let [v (materialize-col-value (get current-cols k) i)]
-                        (when (some? v) (assoc! row k v))))
-                    (let [eid (long (or (materialize-col-value eid-col i) 0))
-                          vto (long (or (materialize-col-value vto-col i)
-                                        vt-open-sentinel))
-                          closing? (and (.contains close-eids eid)
-                                        (= vto vt-open-sentinel))]
-                      (conj! rows
-                             (-> (persistent! row)
-                                 (cond-> closing?
-                                   ;; Close both vt-to AND system-to on
-                                   ;; supersession. The vt-close is the
-                                   ;; classical SCD2 step; the system-to
-                                   ;; close is what gives us the audit
-                                   ;; guarantee (`FOR SYSTEM_TIME AS OF
-                                   ;; <pre-correction>` sees this row as
-                                   ;; still open at that instant).
-                                   (assoc vt-to-col   vf
-                                          sys-to-col  sys-now)))))))
-                (persistent! rows)))
-            ;; Snapshot previous-open attrs per entity for value-merging on
-            ;; new rows (so partial attribute updates inherit the rest).
-            eid->prev-open
-            (when has-adds?
-              (let [m (java.util.HashMap.)]
-                (dotimes [i current-n]
-                  (let [eid (long (materialize-col-value (get current-cols :eid) i))
-                        vto (long (or (materialize-col-value
-                                       (get current-cols vt-to-col) i)
-                                      vt-open-sentinel))]
-                    (when (and (= vto vt-open-sentinel)
-                               (.containsKey pending-adds eid))
-                      (let [prev (into {}
-                                       (keep (fn [k]
-                                               (when-let [v (materialize-col-value
-                                                             (get current-cols k) i)]
-                                                 [k v])))
-                                       attr-col-keys)]
-                        (.put m eid prev)))))
-                m))
-            new-rows
-            (when has-adds?
-              (mapv (fn [[eid em]]
-                      (let [prev (when eid->prev-open (.get ^java.util.HashMap eid->prev-open eid))]
-                        (-> (merge (or prev {}) em)
-                            (assoc :eid eid
-                                   vt-from-col  vf
-                                   vt-to-col    new-vt
-                                   ;; New rows stamp `sys-now` on
-                                   ;; `_system_from` so they're only
-                                   ;; visible at system-times >= now.
-                                   sys-from-col sys-now
-                                   sys-to-col   vt-open-sentinel))))
-                    (seq pending-adds)))
-            all-rows (into current-rows (or new-rows []))]
+            col-keys      (into [:eid vt-from-col vt-to-col sys-from-col sys-to-col]
+                                attr-col-keys)
+            current-cols  (when dataset (st/columns dataset))
+            current-n     (if dataset (st/row-count dataset) 0)
+            close-eids    (let [s (java.util.HashSet.)]
+                            (when has-adds?     (.addAll s (.keySet pending-adds)))
+                            (when has-retracts? (.addAll s pending-retracts))
+                            s)
+            existing-rows (materialize-existing-rows
+                            current-cols current-n col-keys
+                            close-eids vt-from sys-now)
+            new-rows      (when has-adds?
+                            (let [prev-open (snapshot-prev-open-attrs
+                                              current-cols current-n
+                                              pending-adds attr-col-keys)]
+                              (build-new-rows pending-adds prev-open
+                                              vt-from vt-to sys-now)))
+            all-rows      (into existing-rows (or new-rows []))]
         (if (empty? all-rows)
           (StratumIndex. nil attrs attr-refs config)
           (let [col-map (row->col-map all-rows col-keys)
-                ds (sd/ensure-indexed (make-vt-dataset col-map config))]
+                ds      (sd/ensure-indexed (make-vt-dataset col-map config))]
             (StratumIndex. ds attrs attr-refs config)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -266,17 +266,97 @@
     ;; actual type from values via col-types pre-scan on first insert
     (long-array 0)))
 
+;; ---------------------------------------------------------------------------
+;; Valid-time (SCD2) support — opt-in via `:valid-time true` in :db.secondary/config
+;;
+;; In vt-mode, each entity update appends a new row instead of mutating the
+;; existing one. Old rows have their `:_valid_to` closed to the new tx's
+;; `:db.valid/from`. Queries push `valid-at` filters down via -search-at-vt
+;; → stratum WHERE predicates → zone-map pruning.
+
+(defn- vt-mode? [config] (boolean (:valid-time config)))
+
+(def ^:private vt-from-col :_valid_from)
+(def ^:private vt-to-col   :_valid_to)
+(def ^:private vt-open-sentinel Long/MAX_VALUE)
+;; A vt-from that is older than any real tx-meta; rows seeded from
+;; pre-existing AEVT data in build-initial-dataset use it so they appear
+;; valid for any `valid-at` query against historical data.
+(def ^:private vt-from-floor Long/MIN_VALUE)
+
+(defn- date->micros
+  "Coerce a :db.valid/from or :db.valid/to value to long microseconds. Accepts
+   java.util.Date (millis × 1000), already-long values (passthrough), or nil
+   for which the caller supplies a default."
+  ^long [v]
+  (cond
+    (nil? v) 0
+    (instance? java.util.Date v) (* 1000 (.getTime ^java.util.Date v))
+    (number? v) (long v)
+    :else (throw (ex-info "Unsupported vt value type"
+                          {:value v :type (type v)}))))
+
+(defn- tx-meta->vf
+  "Pick the row's `_valid_from` for this tx. Prefers `:db.valid/from`;
+   falls back to `:db/txInstant` (so non-vt txes still get a meaningful
+   vf in vt-aware indices)."
+  ^long [tx-meta]
+  (date->micros (or (:db.valid/from tx-meta)
+                    (:db/txInstant tx-meta))))
+
+(defn- tx-meta->vt
+  "Pick the row's `_valid_to` for this tx. `:db.valid/to` if specified,
+   otherwise the open-ended sentinel."
+  ^long [tx-meta]
+  (if-let [v (:db.valid/to tx-meta)]
+    (date->micros v)
+    vt-open-sentinel))
+
+(defn- ds-metadata
+  "Build the `:metadata` map passed to `st/make-dataset` for this index.
+   In vt-mode it carries `:valid-time` so stratum tags the two vt columns
+   with `:temporal-unit :micros` and round-trips the config through
+   sync!/load."
+  [config]
+  (if (vt-mode? config)
+    {:valid-time {:from-col vt-from-col :to-col vt-to-col :unit :micros}}
+    {}))
+
+(defn- with-vt-cols
+  "If vt-mode, attach empty `:_valid_from`/`:_valid_to` columns (n long zeros)
+   alongside the per-attribute columns. The caller will fill them when
+   building rows; this helper just makes sure the columns exist before
+   `make-dataset` infers the schema."
+  [col-map config n]
+  (if (vt-mode? config)
+    (assoc col-map
+           vt-from-col (long-array n)
+           vt-to-col   (long-array n))
+    col-map))
+
+(defn- make-vt-dataset
+  "Wrap st/make-dataset with the vt-aware metadata when vt-mode is on."
+  [col-map config]
+  (st/make-dataset col-map {:metadata (ds-metadata config)}))
+
 (defn- build-initial-dataset
   "Build a StratumDataset from the DB's existing data for configured attributes.
    Scans AEVT per attribute to collect entity+value pairs, then joins by entity.
-   When db is nil (during empty-db creation), returns an empty dataset."
+   When db is nil (during empty-db creation), returns an empty dataset.
+
+   In vt-mode, pre-existing rows are seeded with `_valid_from = MIN_VALUE`
+   and `_valid_to = MAX_VALUE` — they're treated as valid for any
+   `valid-at` query. Retroactive vt accuracy for pre-existing data is
+   not reconstructed here; that requires walking history and is a
+   future enhancement."
   [db attrs config]
   (if (nil? db)
     ;; No DB yet — return empty dataset with typed columns
-    (let [col-map (into {:eid (long-array 0)}
-                        (map (fn [a] [(attr-col-key a) (long-array 0)]))
-                        attrs)]
-      (sd/ensure-indexed (st/make-dataset col-map)))
+    (let [col-map (-> (into {:eid (long-array 0)}
+                            (map (fn [a] [(attr-col-key a) (long-array 0)]))
+                            attrs)
+                      (with-vt-cols config 0))]
+      (sd/ensure-indexed (make-vt-dataset col-map config)))
     (let [;; For each attr, collect {eid value} via AEVT datoms
           attr->eid-vals
           (into {}
@@ -295,10 +375,11 @@
       ;; Empty dataset — use long-array 0 for all columns since we don't know
       ;; actual value types yet. persist-transient-stratum-index will determine
       ;; real types from values via col-types pre-scan on first insert.
-        (let [col-map (into {:eid (long-array 0)}
-                            (map (fn [a] [(attr-col-key a) (long-array 0)]))
-                            attrs)]
-          (sd/ensure-indexed (st/make-dataset col-map)))
+        (let [col-map (-> (into {:eid (long-array 0)}
+                                (map (fn [a] [(attr-col-key a) (long-array 0)]))
+                                attrs)
+                          (with-vt-cols config 0))]
+          (sd/ensure-indexed (make-vt-dataset col-map config)))
       ;; Build column arrays
         (let [entity-ids (long-array n)
               _ (let [i (volatile! 0)]
@@ -338,8 +419,19 @@
                                       (aset arr row (str (.getValue e)))))
                                   arr))])))
                     attrs)
-              col-map (assoc attr-arrays :eid entity-ids)]
-          (sd/ensure-indexed (st/make-dataset col-map)))))))
+              ;; In vt-mode, seed every pre-existing row with the maximally-
+              ;; permissive vt-window [MIN, MAX). Subsequent vt-aware txes
+              ;; close these windows when the entity is updated.
+              vt-from-arr (when (vt-mode? config)
+                            (let [arr (long-array n)]
+                              (java.util.Arrays/fill arr vt-from-floor) arr))
+              vt-to-arr   (when (vt-mode? config)
+                            (let [arr (long-array n)]
+                              (java.util.Arrays/fill arr vt-open-sentinel) arr))
+              col-map (cond-> (assoc attr-arrays :eid entity-ids)
+                        (vt-mode? config) (assoc vt-from-col vt-from-arr
+                                                 vt-to-col   vt-to-arr))]
+          (sd/ensure-indexed (make-vt-dataset col-map config)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Persistent stratum index (declared first — TransientStratumIndex references it)
@@ -489,7 +581,40 @@
         (let [eid-pred (fn [^long eid] (es/entity-bitset-contains? entity-filter eid))
               where (conj (vec (:where query-spec)) [:fn :eid eid-pred])]
           (st/q (assoc query-spec :from dataset :where where)))
-        (st/q (assoc query-spec :from dataset))))))
+        (st/q (assoc query-spec :from dataset)))))
+
+  sec/IValidTimeAware
+  ;; Native vt-pushdown: extend the query's `:where` with predicates on
+  ;; the two vt-window columns. Stratum's zone-map pruner skips chunks
+  ;; whose [min,max] range can't intersect, and the predicate kernel
+  ;; runs the row-level check on the survivors. Open-ended rows
+  ;; (`_valid_to = Long/MAX_VALUE`) participate normally because the
+  ;; predicate uses strict-greater.
+  ;;
+  ;; Index NOT in vt-mode falls back to plain `-search` — i.e. ignores
+  ;; the valid-at argument. Such indices stay correct via the post-hoc
+  ;; AVET filter described in `secondary.cljc`'s IValidTimeAware
+  ;; docstring; this `-search-at-vt` just returns the unfiltered set,
+  ;; which the call site composes with its own filter.
+  (-search-at-vt [this query-spec entity-filter valid-at-window]
+    (if (and (vt-mode? config) dataset)
+      (let [at-micros (cond
+                        (vector? valid-at-window)
+                        (date->micros (first valid-at-window))
+                        :else
+                        (date->micros valid-at-window))
+            window-end (when (vector? valid-at-window)
+                         (date->micros (second valid-at-window)))
+            extra (if window-end
+                    ;; valid-between (interval overlap)
+                    [[:< vt-from-col window-end]
+                     [:> vt-to-col   at-micros]]
+                    ;; valid-at (point membership)
+                    [[:<= vt-from-col at-micros]
+                     [:> vt-to-col   at-micros]])
+            augmented (update query-spec :where (fnil into []) extra)]
+        (sec/-search this augmented entity-filter))
+      (sec/-search this query-spec entity-filter))))
 
 ;; ---------------------------------------------------------------------------
 ;; Transient stratum index — mutable batch mode
@@ -500,12 +625,13 @@
                                 ref->col-key   ;; map of numeric ref → keyword col-key (or nil)
                                 config
                                 ^java.util.HashMap pending-adds
-                                ^java.util.HashSet pending-retracts]
+                                ^java.util.HashSet pending-retracts
+                                ^"[Ljava.lang.Object;" tx-meta-ref] ;; 1-slot mutable cell
   sec/ITransientSecondaryIndex
   (-as-transient [this] this)
 
   (-transact! [this tx-report]
-    (let [{:keys [^Datom datom added?]} tx-report
+    (let [{:keys [^Datom datom added? tx-meta]} tx-report
           eid (.-e datom)
           a-raw (.-a datom)
           ;; In attr-refs mode, a-raw is numeric — check both attrs and attr-refs
@@ -515,6 +641,9 @@
           col-key (if (and ref->col-key (number? a-raw))
                     (get ref->col-key a-raw)
                     (attr-col-key a-raw))]
+      ;; tx-meta is the same for every datom in a batch — capture once,
+      ;; persist! reads it back.
+      (when tx-meta (aset tx-meta-ref 0 tx-meta))
       (when a-match?
         (if added?
           (let [entity-map (or (.get pending-adds eid) {})]
@@ -524,7 +653,9 @@
           (.add pending-retracts eid)))))
 
   (-persistent! [this]
-    (persist-transient-stratum-index dataset attrs attr-refs config pending-adds pending-retracts)))
+    (persist-transient-stratum-index dataset attrs attr-refs config
+                                     pending-adds pending-retracts
+                                     (aget tx-meta-ref 0))))
 
 (defn- make-transient-stratum-index [dataset attrs attr-refs config]
   (let [;; Build ref→col-key map from ident-ref-map in config
@@ -536,9 +667,22 @@
                              attrs))]
     (TransientStratumIndex. dataset attrs attr-refs ref->col-key config
                             (java.util.HashMap.)
-                            (java.util.HashSet.))))
+                            (java.util.HashSet.)
+                            (object-array 1))))
+
+(declare vt-persist-transient-stratum-index)
+(declare persist-current-state-stratum-index)
 
 (defn- persist-transient-stratum-index
+  [dataset attrs attr-refs config ^java.util.HashMap pending-adds
+   ^java.util.HashSet pending-retracts tx-meta]
+  (if (vt-mode? config)
+    (vt-persist-transient-stratum-index dataset attrs attr-refs config
+                                        pending-adds pending-retracts tx-meta)
+    (persist-current-state-stratum-index dataset attrs attr-refs config
+                                         pending-adds pending-retracts)))
+
+(defn- persist-current-state-stratum-index
   [dataset attrs attr-refs config ^java.util.HashMap pending-adds ^java.util.HashSet pending-retracts]
   (let [current-ds dataset
         has-retracts? (pos? (.size pending-retracts))
@@ -677,6 +821,145 @@
           ;; ensure-indexed converts array-backed columns to index-backed (PSS)
           ;; columns, which is required before sync! can persist.
           (StratumIndex. (sd/ensure-indexed (st/make-dataset col-map)) attrs attr-refs config))))))
+
+;; ---------------------------------------------------------------------------
+;; Valid-time (SCD2) persist path
+;;
+;; In vt-mode every batch:
+;;   - Existing rows are NEVER physically removed; they accumulate.
+;;   - For every entity touched (in pending-adds or pending-retracts), the
+;;     current OPEN row (`_valid_to = MAX_VALUE`) — if any — has its
+;;     `_valid_to` closed to the tx's `:db.valid/from`.
+;;   - For every entity in pending-adds, a new row is appended carrying
+;;     the merged-with-previous attribute values plus the new vt-window.
+;;
+;; The intermediate is a vector of row-maps (one per row): correct and
+;; readable. Hot-path optimisation can move to typed arrays later — for
+;; the first cut, correctness over speed.
+
+(defn- materialize-col-value ^Object [col-info ^long i]
+  (let [{:keys [data dict index]} col-info
+        arr (or data (when index (sidx/idx-materialize-to-array index)))]
+    (cond
+      (nil? arr) nil
+      dict (let [code (aget ^longs arr i)]
+             (when-not (= code Long/MIN_VALUE)
+               (aget ^"[Ljava.lang.String;" dict (int code))))
+      (instance? (Class/forName "[D") arr) (aget ^doubles arr i)
+      (instance? (Class/forName "[Ljava.lang.String;") arr)
+      (aget ^"[Ljava.lang.String;" arr i)
+      :else (aget ^longs arr i))))
+
+(defn- row->col-map
+  "Pivot a row-vector of maps to a column map of arrays. Type per column
+   is inferred from the first non-nil value seen — matches how stratum's
+   encode-column auto-types raw arrays."
+  [rows col-keys]
+  (let [n (count rows)]
+    (into {}
+          (map (fn [k]
+                 (let [;; Find first non-nil value to infer type
+                       sample (some #(let [v (get % k)] (when (some? v) v)) rows)
+                       t (cond
+                           (= k :eid) :long
+                           (or (= k vt-from-col) (= k vt-to-col)) :long
+                           (nil? sample) :long
+                           (or (string? sample) (keyword? sample)) :string
+                           (double? sample) :double
+                           :else :long)]
+                   [k (case t
+                        :long   (let [arr (long-array n)]
+                                  (dotimes [i n]
+                                    (when-let [v (get (nth rows i) k)]
+                                      (aset arr i (long v))))
+                                  arr)
+                        :double (let [arr (double-array n)]
+                                  (dotimes [i n]
+                                    (when-let [v (get (nth rows i) k)]
+                                      (aset arr i (double v))))
+                                  arr)
+                        :string (let [arr ^"[Ljava.lang.String;" (make-array String n)]
+                                  (dotimes [i n]
+                                    (when-let [v (get (nth rows i) k)]
+                                      (aset arr i (str v))))
+                                  arr))])))
+          col-keys)))
+
+(defn- vt-persist-transient-stratum-index
+  [dataset attrs attr-refs config ^java.util.HashMap pending-adds
+   ^java.util.HashSet pending-retracts tx-meta]
+  (let [has-adds?     (pos? (.size pending-adds))
+        has-retracts? (pos? (.size pending-retracts))
+        nothing-to-do? (and (not has-adds?) (not has-retracts?))]
+    (if nothing-to-do?
+      (StratumIndex. dataset attrs attr-refs config)
+      (let [vf (tx-meta->vf tx-meta)
+            new-vt (tx-meta->vt tx-meta)
+            attr-col-keys (mapv attr-col-key attrs)
+            col-keys (into [:eid vt-from-col vt-to-col] attr-col-keys)
+            current-cols (when dataset (st/columns dataset))
+            current-n (if dataset (st/row-count dataset) 0)
+            close-eids (let [s (java.util.HashSet.)]
+                         (when has-adds? (.addAll s (.keySet pending-adds)))
+                         (when has-retracts? (.addAll s pending-retracts))
+                         s)
+            ;; Materialize current rows. Walk index/data arrays directly via
+            ;; materialize-col-value.
+            current-rows
+            (if (or (zero? current-n) (nil? current-cols))
+              []
+              (let [eid-col (get current-cols :eid)
+                    vto-col (get current-cols vt-to-col)
+                    rows (transient [])]
+                (dotimes [i current-n]
+                  (let [row (transient {})]
+                    (doseq [k col-keys]
+                      (let [v (materialize-col-value (get current-cols k) i)]
+                        (when (some? v) (assoc! row k v))))
+                    (let [eid (long (or (materialize-col-value eid-col i) 0))
+                          vto (long (or (materialize-col-value vto-col i)
+                                        vt-open-sentinel))
+                          closing? (and (.contains close-eids eid)
+                                        (= vto vt-open-sentinel))]
+                      (conj! rows
+                             (-> (persistent! row)
+                                 (cond-> closing? (assoc vt-to-col vf)))))))
+                (persistent! rows)))
+            ;; Snapshot previous-open attrs per entity for value-merging on
+            ;; new rows (so partial attribute updates inherit the rest).
+            eid->prev-open
+            (when has-adds?
+              (let [m (java.util.HashMap.)]
+                (dotimes [i current-n]
+                  (let [eid (long (materialize-col-value (get current-cols :eid) i))
+                        vto (long (or (materialize-col-value
+                                       (get current-cols vt-to-col) i)
+                                      vt-open-sentinel))]
+                    (when (and (= vto vt-open-sentinel)
+                               (.containsKey pending-adds eid))
+                      (let [prev (into {}
+                                       (keep (fn [k]
+                                               (when-let [v (materialize-col-value
+                                                             (get current-cols k) i)]
+                                                 [k v])))
+                                       attr-col-keys)]
+                        (.put m eid prev)))))
+                m))
+            new-rows
+            (when has-adds?
+              (mapv (fn [[eid em]]
+                      (let [prev (when eid->prev-open (.get ^java.util.HashMap eid->prev-open eid))]
+                        (-> (merge (or prev {}) em)
+                            (assoc :eid eid
+                                   vt-from-col vf
+                                   vt-to-col   new-vt))))
+                    (seq pending-adds)))
+            all-rows (into current-rows (or new-rows []))]
+        (if (empty? all-rows)
+          (StratumIndex. nil attrs attr-refs config)
+          (let [col-map (row->col-map all-rows col-keys)
+                ds (sd/ensure-indexed (make-vt-dataset col-map config))]
+            (StratumIndex. ds attrs attr-refs config)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Registration

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -154,61 +154,132 @@
     {:vf :db.valid/from
      :vt :db.valid/to}))
 
+(defn- tx-covers-at?
+  "Does the tx-entity `tx-id`'s vt-window contain `at`? Reads
+   `:db.valid/from` / `:db.valid/to` off the tx-entity. Missing
+   `:db.valid/from` is treated as -∞; missing `:db.valid/to` as +∞,
+   so non-vt-aware data passes through unchanged. Memoized via
+   `cover-cache` (tx-id → Boolean)."
+  [db tx-id ^java.util.Date at ^java.util.concurrent.ConcurrentHashMap cover-cache]
+  (let [cached (.get cover-cache tx-id)]
+    (if (some? cached)
+      cached
+      (let [{:keys [vf vt]} (vt-meta-attrs db)
+            tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+            vf-val (some (fn [^datahike.datom.Datom td]
+                           (when (= vf (.-a td)) (.-v td))) tx-datoms)
+            vt-val (some (fn [^datahike.datom.Datom td]
+                           (when (= vt (.-a td)) (.-v td))) tx-datoms)
+            ok? (and (or (nil? vf-val) (not (.after ^java.util.Date vf-val at)))
+                     (or (nil? vt-val) (.after ^java.util.Date vt-val at)))]
+        (.put cover-cache tx-id ok?)
+        ok?))))
+
+(defn- find-eav-winner
+  "Among all historical datoms about `(e, a, v)`, return the one whose
+   tx-id is the greatest AND whose tx-vt-window contains `at` — the
+   'supersession winner' for this fact at this valid-time. Returns
+   `nil` if no candidate. Implements bitemporal supersession at query time: the
+   topmost event at `(qvt, current-sys-time)` is the one whose tx-id
+   is highest among those covering `qvt`. Memoized via
+   `winner-cache` ([e a v] → Datom or ::miss)."
+  [db e a v ^java.util.Date at cover-cache
+   ^java.util.concurrent.ConcurrentHashMap winner-cache]
+  (let [k [e a v]
+        cached (.get winner-cache k)]
+    (cond
+      (= cached ::miss) nil
+      (some? cached)    cached
+      :else
+      (let [datoms (dbi/-datoms db :eavt [e a v] (dbi/-search-context db))
+            winner (reduce
+                    (fn [w ^datahike.datom.Datom d]
+                      (if (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
+                        (if (or (nil? w)
+                                (> (datahike.datom/datom-tx d)
+                                   (datahike.datom/datom-tx ^datahike.datom.Datom w)))
+                          d w)
+                        w))
+                    nil datoms)]
+        (.put winner-cache k (or winner ::miss))
+        winner))))
+
 (defn- mk-vt-pred
-  "Build a `d/filter` predicate `(fn [db datom])` that keeps datoms
-   whose asserting tx's vt-window contains `at`. The pred maintains
-   an internal `tx-id → bool` HashMap cache so each unique tx-id
-   triggers only one EAVT seek — same asymptotic cost as AsOfDB's
-   `filter-txInstant` dedup, just a different mechanism (HashMap
-   probe rather than transducer-distinct). Txes whose tx-entity has
-   no `:db.valid/from` are treated as `_valid_from = -∞` — i.e.
-   non-vt-aware data passes through unchanged."
+  "Build a `d/filter` predicate `(fn [db datom])` implementing
+   supersession-aware valid-time filtering at point `at`. Algorithm
+   implements bitemporal supersession at read time:
+
+     for each datom D = (e, a, v, tx, op):
+       1. require tx's vt-window covers `at`;
+       2. among ALL historical datoms about (e, a, v), find the one
+          whose tx is the greatest AND whose tx-vt covers `at` — the
+          'winner';
+       3. admit D iff D is the winner.
+
+   On current-view (no history) the (e, a, v) scan returns the single
+   live datom; the algorithm degrades to today's single-axis
+   filter. On `(d/history db)` it gives back-correction-correct
+   semantics: a later tx with overlapping vt supersedes an earlier
+   one at the relevant vt-points.
+
+   Two caches:
+     * `cover-cache` (tx-id → Boolean): one EAVT seek per unique tx.
+     * `winner-cache` ([e a v] → Datom): one EAVT seek per unique fact.
+
+   The fast path for high-throughput vt queries is the
+   `:datahike/valid-at` meta marker → `IValidTimeAware/-search-at-vt`
+   on a vt-aware secondary index (e.g. stratum), which precomputes
+   the polygon at write time. This predicate is the
+   semantically-correct fallback for paths that don't route through
+   a secondary."
   [^java.util.Date at]
-  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+  (let [cover-cache  (java.util.concurrent.ConcurrentHashMap.)
+        winner-cache (java.util.concurrent.ConcurrentHashMap.)]
     (fn vt-pred [db ^datahike.datom.Datom d]
-      ;; (datom-tx d) returns the absolute tx-id (retractions store it
-      ;; negated). Always-positive — safe to pass to entity lookups.
-      (let [tx-id (datahike.datom/datom-tx d)
-            cached (.get cache tx-id)]
-        (if (some? cached)
-          cached
-          (let [{:keys [vf vt]} (vt-meta-attrs db)
-                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
-                vf-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
-                vt-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
-                ok? (and (or (nil? vf-val) (not (.after ^java.util.Date vf-val at)))
-                         (or (nil? vt-val) (.after ^java.util.Date vt-val at)))]
-            (.put cache tx-id ok?)
-            ok?))))))
+      ;; (datom-tx d) is always-positive (retractions store it negated).
+      (when (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
+        (when-let [^datahike.datom.Datom w
+                   (find-eav-winner db (.-e d) (.-a d) (.-v d) at
+                                    cover-cache winner-cache)]
+          (= (datahike.datom/datom-tx d)
+             (datahike.datom/datom-tx w)))))))
 
 (defn valid-at
-  "Filter `db` to datoms whose asserting tx's valid-time window
-   contains `time-point`. Returns a `FilteredDB` whose predicate
-   reads the tx-entity's `:db.valid/from` / `:db.valid/to` and admits
-   a datom iff `vf <= time-point < vt` (open-ended `vt = nil` is
-   treated as unbounded; missing `vf` is treated as `-∞`).
+  "Snapshot `db` at valid-time `time-point` with **supersession**
+   semantics: among historical events about the same `(e, a, v)`, the
+   tx with the greatest tx-id whose vt-window covers `time-point`
+   wins. Earlier assertions whose vt-window also covers
+   `time-point` are filtered out as superseded.
 
-   Unlike `as-of`/`since`/`history` (tx-time axes), valid-at is a
-   valid-time axis: the *time something was true in the modelled
-   world* rather than *the tx that recorded it*. Composes cleanly
-   with the tx-time wrappers — e.g.
-     `(d/valid-at (d/as-of db tx-time) vt-inst)`
-   yields the snapshot at tx-time `tx-time`, further filtered to
-   datoms whose vt-window contains `vt-inst`.
+   This implements bitemporal supersession at the read layer: a
+   back-correction that asserts a new value with an overlapping
+   vt-window supersedes the prior claim at every vt-point ≥ the
+   correction's vt-from, without rewriting history. Composes with
+   `d/history` (recommended — exposes the events the supersession
+   algorithm needs) and `d/as-of` (bounds the supersession horizon
+   to a given tx-time).
 
-   The returned db also carries `:datahike/valid-at` on its meta so
-   vt-aware secondary indices (implementing `IValidTimeAware`) push
-   the filter into `-search-at-vt` for native pushdown — the
-   FilteredDB predicate is then the fallback for paths that don't
-   route through a secondary index.
+   The result is a `FilteredDB` whose predicate enforces supersession
+   per-datom on every read path (`d/q`, `d/datoms`, `d/pull`,
+   `d/entity`, `d/seek-datoms`, `d/index-range`).
 
-   `time-point` is a `java.util.Date`; `nil` only clears the
-   `:datahike/valid-at` marker (so vt-aware secondary indices stop
-   routing) — `FilteredDB` predicates are AND-composed and cannot be
-   surgically removed, so any active filter remains in effect. To
-   truly drop the filter, start from the original unwrapped db."
+   Returns the unwrapped db when `time-point` is `nil`, after
+   clearing any `:datahike/valid-at` meta marker. Carries
+   `:datahike/valid-at <time-point>` on meta so vt-aware secondary
+   indices (`IValidTimeAware`) can push the filter into a native
+   `-search-at-vt` — those secondaries (e.g. stratum vt-mode) are
+   the fast path; this FilteredDB predicate is the
+   semantically-correct fallback.
+
+   Non-vt-aware data (txes without `:db.valid/from`) is treated as
+   having an open-ended `[-∞, ∞)` window — it remains visible at
+   every valid-time. Mixing vt-aware and non-vt-aware data therefore
+   degrades gracefully (the non-vt facts pass through).
+
+   Performance note: the supersession check costs one EAVT scan per
+   unique `(e, a, v)` triple in the result set, cached for the
+   lifetime of the wrapper. For high-throughput vt queries, route
+   through a vt-aware secondary index."
   [db time-point]
   (if (nil? time-point)
     (vary-meta db dissoc :datahike/valid-at)

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -226,7 +226,7 @@
         (.put winner-cache k (or winner ::miss))
         winner))))
 
-(defn- mk-vt-pred
+(defn mk-vt-pred
   "Build a `d/filter` predicate `(fn [db datom])` implementing
    supersession-aware valid-time filtering at point `at`. Algorithm
    implements bitemporal supersession at read time:

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -215,6 +215,95 @@
     (-> (dcore/filter db (mk-vt-pred time-point))
         (vary-meta assoc :datahike/valid-at time-point))))
 
+(defn- mk-vt-overlap-pred
+  "Pred that admits a datom iff its tx's vt-window *overlaps*
+   `[from, to)`. Open-ended `vt = nil` is treated as `+∞`; missing
+   `vf` is `-∞`. The overlap condition is `(vf < to) AND (vt > from)`."
+  [^java.util.Date from ^java.util.Date to]
+  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+    (fn vt-overlap-pred [db ^datahike.datom.Datom d]
+      (let [tx-id (datahike.datom/datom-tx d)
+            cached (.get cache tx-id)]
+        (if (some? cached)
+          cached
+          (let [{:keys [vf vt]} (vt-meta-attrs db)
+                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+                vf-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
+                vt-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
+                ok? (and (or (nil? vf-val) (.before ^java.util.Date vf-val to))
+                         (or (nil? vt-val) (.after ^java.util.Date vt-val from)))]
+            (.put cache tx-id ok?)
+            ok?))))))
+
+(defn- mk-vt-during-pred
+  "Pred that admits a datom iff its tx's vt-window is *fully
+   contained* in `[from, to)`. Strict containment: missing `vf` or
+   `vt` fail (an unbounded interval can't be fully contained in a
+   bounded one)."
+  [^java.util.Date from ^java.util.Date to]
+  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+    (fn vt-during-pred [db ^datahike.datom.Datom d]
+      (let [tx-id (datahike.datom/datom-tx d)
+            cached (.get cache tx-id)]
+        (if (some? cached)
+          cached
+          (let [{:keys [vf vt]} (vt-meta-attrs db)
+                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+                vf-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
+                vt-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
+                ok? (and (some? vf-val) (some? vt-val)
+                         (not (.before ^java.util.Date vf-val from))
+                         (not (.after ^java.util.Date vt-val to)))]
+            (.put cache tx-id ok?)
+            ok?))))))
+
+(defn valid-between
+  "Filter `db` to datoms whose asserting tx's vt-window *overlaps*
+   `[from, to)`. SQL:2011 `FOR VALID_TIME BETWEEN from AND to`
+   maps to this. Both endpoints are `java.util.Date`s.
+
+   Carries `:datahike/valid-between [from to]` on the returned db
+   for vt-aware secondary-index pushdown.
+
+   Passing `nil` for either endpoint clears the marker only and
+   does not narrow the FilteredDB predicate — to truly drop the
+   filter start from the unwrapped db."
+  [db from to]
+  (if (or (nil? from) (nil? to))
+    (vary-meta db dissoc :datahike/valid-between)
+    (-> (dcore/filter db (mk-vt-overlap-pred from to))
+        (vary-meta assoc :datahike/valid-between [from to]))))
+
+(defn valid-during
+  "Filter `db` to datoms whose asserting tx's vt-window is *fully
+   contained* in `[from, to)`. Stricter than `valid-between`:
+   tx-windows that merely overlap the query window but extend past
+   either endpoint are excluded. Useful for 'find all corrections
+   whose effective period was wholly within Q2 2024' style queries.
+
+   Carries `:datahike/valid-during [from to]` on the returned db."
+  [db from to]
+  (if (or (nil? from) (nil? to))
+    (vary-meta db dissoc :datahike/valid-during)
+    (-> (dcore/filter db (mk-vt-during-pred from to))
+        (vary-meta assoc :datahike/valid-during [from to]))))
+
+(defn valid-all
+  "Clear any active valid-time marker so the db sees its full
+   vt-history. Equivalent to passing `nil` to `valid-at` /
+   `valid-between` / `valid-during`: it strips the meta markers so
+   vt-aware secondary indices stop routing, but does not unwrap a
+   FilteredDB if one is already in place. Idempotent."
+  [db]
+  (vary-meta db dissoc
+             :datahike/valid-at
+             :datahike/valid-between
+             :datahike/valid-during))
+
 (defn index-range [db {:keys [attrid start end]}]
   (dbi/index-range db attrid start end))
 

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -147,6 +147,23 @@
     (HistoricalDB. db)
     (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
+(defn valid-at
+  "Tag `db` with a `:datahike/valid-at` marker so vt-aware secondary
+   indices (those implementing `IValidTimeAware`) push the filter
+   into their own query plan instead of returning the full match set.
+
+   Unlike `as-of`/`since`/`history` (which are *tx-time* axes managed
+   by datahike's core), valid-at is a *valid-time* axis managed by
+   secondary indices. Datalog patterns that don't route through a
+   vt-aware index are unaffected — those queries must still use the
+   `(valid-at ?tx ?at)` built-in rule explicitly.
+
+   `time-point` is a `java.util.Date` or `nil` (clears the marker)."
+  [db time-point]
+  (if (nil? time-point)
+    (vary-meta db dissoc :datahike/valid-at)
+    (vary-meta db assoc :datahike/valid-at time-point)))
+
 (defn index-range [db {:keys [attrid start end]}]
   (dbi/index-range db attrid start end))
 

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -17,6 +17,7 @@
             [datahike.db.transaction :as dbt]
             [datahike.impl.entity :as de]
             [datahike.versioning :as dv]
+            [datahike.bitemporal.platform :as bp]
             [replikativ.logging :as log]
             #?(:cljs [clojure.core.async :as async :refer [<! >! chan put! close!]]))
   #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]
@@ -181,9 +182,9 @@
    `:db.valid/from` / `:db.valid/to` off the tx-entity. Missing
    `:db.valid/from` is treated as -∞; missing `:db.valid/to` as +∞,
    so non-vt-aware data passes through unchanged. Memoized via
-   `cover-cache` (tx-id → Boolean)."
-  [db tx-id ^java.util.Date at ^java.util.concurrent.ConcurrentHashMap cover-cache]
-  (let [cached (.get cover-cache tx-id)]
+   `cover-cache` (tx-id → Boolean) — a `bp/mutable-map`."
+  [db tx-id at cover-cache]
+  (let [cached (bp/mget cover-cache tx-id)]
     (if (some? cached)
       cached
       (let [{:keys [vf vt]} (vt-meta-attrs db)
@@ -192,9 +193,9 @@
                            (when (= vf (.-a td)) (.-v td))) tx-datoms)
             vt-val (some (fn [^datahike.datom.Datom td]
                            (when (= vt (.-a td)) (.-v td))) tx-datoms)
-            ok? (and (or (nil? vf-val) (not (.after ^java.util.Date vf-val at)))
-                     (or (nil? vt-val) (.after ^java.util.Date vt-val at)))]
-        (.put cover-cache tx-id ok?)
+            ok? (and (or (nil? vf-val) (not (bp/date-after? vf-val at)))
+                     (or (nil? vt-val) (bp/date-after? vt-val at)))]
+        (bp/mput! cover-cache tx-id ok?)
         ok?))))
 
 (defn- find-eav-winner
@@ -205,10 +206,9 @@
    topmost event at `(qvt, current-sys-time)` is the one whose tx-id
    is highest among those covering `qvt`. Memoized via
    `winner-cache` ([e a v] → Datom or ::miss)."
-  [db e a v ^java.util.Date at cover-cache
-   ^java.util.concurrent.ConcurrentHashMap winner-cache]
+  [db e a v at cover-cache winner-cache]
   (let [k [e a v]
-        cached (.get winner-cache k)]
+        cached (bp/mget winner-cache k)]
     (cond
       (= cached ::miss) nil
       (some? cached)    cached
@@ -223,7 +223,7 @@
                           d w)
                         w))
                     nil datoms)]
-        (.put winner-cache k (or winner ::miss))
+        (bp/mput! winner-cache k (or winner ::miss))
         winner))))
 
 (defn mk-vt-pred
@@ -254,9 +254,9 @@
    the polygon at write time. This predicate is the
    semantically-correct fallback for paths that don't route through
    a secondary."
-  [^java.util.Date at]
-  (let [cover-cache  (java.util.concurrent.ConcurrentHashMap.)
-        winner-cache (java.util.concurrent.ConcurrentHashMap.)]
+  [at]
+  (let [cover-cache  (bp/mutable-map)
+        winner-cache (bp/mutable-map)]
     (fn vt-pred [db ^datahike.datom.Datom d]
       ;; (datom-tx d) is always-positive (retractions store it negated).
       (when (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
@@ -320,11 +320,11 @@
   "Pred that admits a datom iff its tx's vt-window *overlaps*
    `[from, to)`. Open-ended `vt = nil` is treated as `+∞`; missing
    `vf` is `-∞`. The overlap condition is `(vf < to) AND (vt > from)`."
-  [^java.util.Date from ^java.util.Date to]
-  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+  [from to]
+  (let [cache (bp/mutable-map)]
     (fn vt-overlap-pred [db ^datahike.datom.Datom d]
       (let [tx-id (datahike.datom/datom-tx d)
-            cached (.get cache tx-id)]
+            cached (bp/mget cache tx-id)]
         (if (some? cached)
           cached
           (let [{:keys [vf vt]} (vt-meta-attrs db)
@@ -333,9 +333,9 @@
                                (when (= vf (.-a td)) (.-v td))) tx-datoms)
                 vt-val (some (fn [^datahike.datom.Datom td]
                                (when (= vt (.-a td)) (.-v td))) tx-datoms)
-                ok? (and (or (nil? vf-val) (.before ^java.util.Date vf-val to))
-                         (or (nil? vt-val) (.after ^java.util.Date vt-val from)))]
-            (.put cache tx-id ok?)
+                ok? (and (or (nil? vf-val) (bp/date-before? vf-val to))
+                         (or (nil? vt-val) (bp/date-after? vt-val from)))]
+            (bp/mput! cache tx-id ok?)
             ok?))))))
 
 (defn- mk-vt-during-pred
@@ -343,11 +343,11 @@
    contained* in `[from, to)`. Strict containment: missing `vf` or
    `vt` fail (an unbounded interval can't be fully contained in a
    bounded one)."
-  [^java.util.Date from ^java.util.Date to]
-  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+  [from to]
+  (let [cache (bp/mutable-map)]
     (fn vt-during-pred [db ^datahike.datom.Datom d]
       (let [tx-id (datahike.datom/datom-tx d)
-            cached (.get cache tx-id)]
+            cached (bp/mget cache tx-id)]
         (if (some? cached)
           cached
           (let [{:keys [vf vt]} (vt-meta-attrs db)
@@ -357,9 +357,9 @@
                 vt-val (some (fn [^datahike.datom.Datom td]
                                (when (= vt (.-a td)) (.-v td))) tx-datoms)
                 ok? (and (some? vf-val) (some? vt-val)
-                         (not (.before ^java.util.Date vf-val from))
-                         (not (.after ^java.util.Date vt-val to)))]
-            (.put cache tx-id ok?)
+                         (not (bp/date-before? vf-val from))
+                         (not (bp/date-after? vt-val to)))]
+            (bp/mput! cache tx-id ok?)
             ok?))))))
 
 (defn valid-between

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -147,22 +147,73 @@
     (HistoricalDB. db)
     (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
+(defn- vt-meta-attrs [db]
+  (if (:attribute-refs? (dbi/-config db))
+    {:vf (dbi/-ref-for db :db.valid/from)
+     :vt (dbi/-ref-for db :db.valid/to)}
+    {:vf :db.valid/from
+     :vt :db.valid/to}))
+
+(defn- mk-vt-pred
+  "Build a `d/filter` predicate `(fn [db datom])` that keeps datoms
+   whose asserting tx's vt-window contains `at`. The pred maintains
+   an internal `tx-id → bool` HashMap cache so each unique tx-id
+   triggers only one EAVT seek — same asymptotic cost as AsOfDB's
+   `filter-txInstant` dedup, just a different mechanism (HashMap
+   probe rather than transducer-distinct). Txes whose tx-entity has
+   no `:db.valid/from` are treated as `_valid_from = -∞` — i.e.
+   non-vt-aware data passes through unchanged."
+  [^java.util.Date at]
+  (let [cache (java.util.concurrent.ConcurrentHashMap.)]
+    (fn vt-pred [db ^datahike.datom.Datom d]
+      ;; (datom-tx d) returns the absolute tx-id (retractions store it
+      ;; negated). Always-positive — safe to pass to entity lookups.
+      (let [tx-id (datahike.datom/datom-tx d)
+            cached (.get cache tx-id)]
+        (if (some? cached)
+          cached
+          (let [{:keys [vf vt]} (vt-meta-attrs db)
+                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+                vf-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
+                vt-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
+                ok? (and (or (nil? vf-val) (not (.after ^java.util.Date vf-val at)))
+                         (or (nil? vt-val) (.after ^java.util.Date vt-val at)))]
+            (.put cache tx-id ok?)
+            ok?))))))
+
 (defn valid-at
-  "Tag `db` with a `:datahike/valid-at` marker so vt-aware secondary
-   indices (those implementing `IValidTimeAware`) push the filter
-   into their own query plan instead of returning the full match set.
+  "Filter `db` to datoms whose asserting tx's valid-time window
+   contains `time-point`. Returns a `FilteredDB` whose predicate
+   reads the tx-entity's `:db.valid/from` / `:db.valid/to` and admits
+   a datom iff `vf <= time-point < vt` (open-ended `vt = nil` is
+   treated as unbounded; missing `vf` is treated as `-∞`).
 
-   Unlike `as-of`/`since`/`history` (which are *tx-time* axes managed
-   by datahike's core), valid-at is a *valid-time* axis managed by
-   secondary indices. Datalog patterns that don't route through a
-   vt-aware index are unaffected — those queries must still use the
-   `(valid-at ?tx ?at)` built-in rule explicitly.
+   Unlike `as-of`/`since`/`history` (tx-time axes), valid-at is a
+   valid-time axis: the *time something was true in the modelled
+   world* rather than *the tx that recorded it*. Composes cleanly
+   with the tx-time wrappers — e.g.
+     `(d/valid-at (d/as-of db tx-time) vt-inst)`
+   yields the snapshot at tx-time `tx-time`, further filtered to
+   datoms whose vt-window contains `vt-inst`.
 
-   `time-point` is a `java.util.Date` or `nil` (clears the marker)."
+   The returned db also carries `:datahike/valid-at` on its meta so
+   vt-aware secondary indices (implementing `IValidTimeAware`) push
+   the filter into `-search-at-vt` for native pushdown — the
+   FilteredDB predicate is then the fallback for paths that don't
+   route through a secondary index.
+
+   `time-point` is a `java.util.Date`; `nil` only clears the
+   `:datahike/valid-at` marker (so vt-aware secondary indices stop
+   routing) — `FilteredDB` predicates are AND-composed and cannot be
+   surgically removed, so any active filter remains in effect. To
+   truly drop the filter, start from the original unwrapped db."
   [db time-point]
   (if (nil? time-point)
     (vary-meta db dissoc :datahike/valid-at)
-    (vary-meta db assoc :datahike/valid-at time-point)))
+    (-> (dcore/filter db (mk-vt-pred time-point))
+        (vary-meta assoc :datahike/valid-at time-point))))
 
 (defn index-range [db {:keys [attrid start end]}]
   (dbi/index-range db attrid start end))

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -17,7 +17,7 @@
             [datahike.db.transaction :as dbt]
             [datahike.impl.entity :as de]
             [datahike.versioning :as dv]
-            [datahike.bitemporal.platform :as bp]
+            [datahike.bitemporal.predicate :as bp.pred]
             [replikativ.logging :as log]
             #?(:cljs [clojure.core.async :as async :refer [<! >! chan put! close!]]))
   #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]
@@ -170,101 +170,11 @@
     (HistoricalDB. db)
     (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
-(defn- vt-meta-attrs [db]
-  (if (:attribute-refs? (dbi/-config db))
-    {:vf (dbi/-ref-for db :db.valid/from)
-     :vt (dbi/-ref-for db :db.valid/to)}
-    {:vf :db.valid/from
-     :vt :db.valid/to}))
-
-(defn- tx-covers-at?
-  "Does the tx-entity `tx-id`'s vt-window contain `at`? Reads
-   `:db.valid/from` / `:db.valid/to` off the tx-entity. Missing
-   `:db.valid/from` is treated as -∞; missing `:db.valid/to` as +∞,
-   so non-vt-aware data passes through unchanged. Memoized via
-   `cover-cache` (tx-id → Boolean) — a `bp/mutable-map`."
-  [db tx-id at cover-cache]
-  (let [cached (bp/mget cover-cache tx-id)]
-    (if (some? cached)
-      cached
-      (let [{:keys [vf vt]} (vt-meta-attrs db)
-            tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
-            vf-val (some (fn [^datahike.datom.Datom td]
-                           (when (= vf (.-a td)) (.-v td))) tx-datoms)
-            vt-val (some (fn [^datahike.datom.Datom td]
-                           (when (= vt (.-a td)) (.-v td))) tx-datoms)
-            ok? (and (or (nil? vf-val) (not (bp/date-after? vf-val at)))
-                     (or (nil? vt-val) (bp/date-after? vt-val at)))]
-        (bp/mput! cover-cache tx-id ok?)
-        ok?))))
-
-(defn- find-eav-winner
-  "Among all historical datoms about `(e, a, v)`, return the one whose
-   tx-id is the greatest AND whose tx-vt-window contains `at` — the
-   'supersession winner' for this fact at this valid-time. Returns
-   `nil` if no candidate. Implements bitemporal supersession at query time: the
-   topmost event at `(qvt, current-sys-time)` is the one whose tx-id
-   is highest among those covering `qvt`. Memoized via
-   `winner-cache` ([e a v] → Datom or ::miss)."
-  [db e a v at cover-cache winner-cache]
-  (let [k [e a v]
-        cached (bp/mget winner-cache k)]
-    (cond
-      (= cached ::miss) nil
-      (some? cached)    cached
-      :else
-      (let [datoms (dbi/-datoms db :eavt [e a v] (dbi/-search-context db))
-            winner (reduce
-                    (fn [w ^datahike.datom.Datom d]
-                      (if (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
-                        (if (or (nil? w)
-                                (> (datahike.datom/datom-tx d)
-                                   (datahike.datom/datom-tx ^datahike.datom.Datom w)))
-                          d w)
-                        w))
-                    nil datoms)]
-        (bp/mput! winner-cache k (or winner ::miss))
-        winner))))
-
-(defn mk-vt-pred
-  "Build a `d/filter` predicate `(fn [db datom])` implementing
-   supersession-aware valid-time filtering at point `at`. Algorithm
-   implements bitemporal supersession at read time:
-
-     for each datom D = (e, a, v, tx, op):
-       1. require tx's vt-window covers `at`;
-       2. among ALL historical datoms about (e, a, v), find the one
-          whose tx is the greatest AND whose tx-vt covers `at` — the
-          'winner';
-       3. admit D iff D is the winner.
-
-   On current-view (no history) the (e, a, v) scan returns the single
-   live datom; the algorithm degrades to today's single-axis
-   filter. On `(d/history db)` it gives back-correction-correct
-   semantics: a later tx with overlapping vt supersedes an earlier
-   one at the relevant vt-points.
-
-   Two caches:
-     * `cover-cache` (tx-id → Boolean): one EAVT seek per unique tx.
-     * `winner-cache` ([e a v] → Datom): one EAVT seek per unique fact.
-
-   The fast path for high-throughput vt queries is the
-   `:datahike/valid-at` meta marker → `IValidTimeAware/-search-at-vt`
-   on a vt-aware secondary index (e.g. stratum), which precomputes
-   the polygon at write time. This predicate is the
-   semantically-correct fallback for paths that don't route through
-   a secondary."
-  [at]
-  (let [cover-cache  (bp/mutable-map)
-        winner-cache (bp/mutable-map)]
-    (fn vt-pred [db ^datahike.datom.Datom d]
-      ;; (datom-tx d) is always-positive (retractions store it negated).
-      (when (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
-        (when-let [^datahike.datom.Datom w
-                   (find-eav-winner db (.-e d) (.-a d) (.-v d) at
-                                    cover-cache winner-cache)]
-          (= (datahike.datom/datom-tx d)
-             (datahike.datom/datom-tx w)))))))
+;; `vt-meta-attrs`, `tx-covers-at?`, `find-eav-winner`, `mk-vt-pred`,
+;; `mk-vt-overlap-pred` and `mk-vt-during-pred` live in the leaf
+;; namespace `datahike.bitemporal.predicate` so that vt-aware secondary
+;; indices can statically require them without closing a cycle back
+;; through `api.impl` → `query` → `secondary`.
 
 (defn valid-at
   "Snapshot `db` at valid-time `time-point` with **supersession**
@@ -313,54 +223,8 @@
   [db time-point]
   (if (nil? time-point)
     (vary-meta db dissoc :datahike/valid-at)
-    (-> (dcore/filter db (mk-vt-pred time-point))
+    (-> (dcore/filter db (bp.pred/mk-vt-pred time-point))
         (vary-meta assoc :datahike/valid-at time-point))))
-
-(defn- mk-vt-overlap-pred
-  "Pred that admits a datom iff its tx's vt-window *overlaps*
-   `[from, to)`. Open-ended `vt = nil` is treated as `+∞`; missing
-   `vf` is `-∞`. The overlap condition is `(vf < to) AND (vt > from)`."
-  [from to]
-  (let [cache (bp/mutable-map)]
-    (fn vt-overlap-pred [db ^datahike.datom.Datom d]
-      (let [tx-id (datahike.datom/datom-tx d)
-            cached (bp/mget cache tx-id)]
-        (if (some? cached)
-          cached
-          (let [{:keys [vf vt]} (vt-meta-attrs db)
-                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
-                vf-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
-                vt-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
-                ok? (and (or (nil? vf-val) (bp/date-before? vf-val to))
-                         (or (nil? vt-val) (bp/date-after? vt-val from)))]
-            (bp/mput! cache tx-id ok?)
-            ok?))))))
-
-(defn- mk-vt-during-pred
-  "Pred that admits a datom iff its tx's vt-window is *fully
-   contained* in `[from, to)`. Strict containment: missing `vf` or
-   `vt` fail (an unbounded interval can't be fully contained in a
-   bounded one)."
-  [from to]
-  (let [cache (bp/mutable-map)]
-    (fn vt-during-pred [db ^datahike.datom.Datom d]
-      (let [tx-id (datahike.datom/datom-tx d)
-            cached (bp/mget cache tx-id)]
-        (if (some? cached)
-          cached
-          (let [{:keys [vf vt]} (vt-meta-attrs db)
-                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
-                vf-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
-                vt-val (some (fn [^datahike.datom.Datom td]
-                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
-                ok? (and (some? vf-val) (some? vt-val)
-                         (not (bp/date-before? vf-val from))
-                         (not (bp/date-after? vt-val to)))]
-            (bp/mput! cache tx-id ok?)
-            ok?))))))
 
 (defn valid-between
   "Filter `db` to datoms whose asserting tx's vt-window *overlaps*
@@ -376,7 +240,7 @@
   [db from to]
   (if (or (nil? from) (nil? to))
     (vary-meta db dissoc :datahike/valid-between)
-    (-> (dcore/filter db (mk-vt-overlap-pred from to))
+    (-> (dcore/filter db (bp.pred/mk-vt-overlap-pred from to))
         (vary-meta assoc :datahike/valid-between [from to]))))
 
 (defn valid-during
@@ -390,7 +254,7 @@
   [db from to]
   (if (or (nil? from) (nil? to))
     (vary-meta db dissoc :datahike/valid-during)
-    (-> (dcore/filter db (mk-vt-during-pred from to))
+    (-> (dcore/filter db (bp.pred/mk-vt-during-pred from to))
         (vary-meta assoc :datahike/valid-during [from to]))))
 
 (defn valid-all

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -132,7 +132,29 @@
     (SinceDB. db time-point)
     (log/raise "since is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
-(defn as-of [db time-point]
+(defn as-of
+  "Snapshot `db` at tx-time `time-point` (a `java.util.Date` or
+   tx-id long). Returns an `AsOfDB` wrapper whose reads filter to
+   datoms asserted by txes ≤ `time-point`. Composes with
+   `d/history` and `d/valid-at`.
+
+   Composition with `d/valid-at`: wrap `d/as-of` FIRST, then
+   `d/valid-at` outermost — e.g. `(d/valid-at (d/as-of db t) v)`.
+   The supersession check inside `d/valid-at`'s predicate captures
+   whatever db it was passed; if you wrap `d/as-of` outside, the
+   captured db has no tx-time bound and the supersession scan reads
+   future txes, producing incorrect results. This wrapper throws
+   when invoked on a `d/valid-at`-wrapped db to surface the
+   inversion at call-site rather than silently."
+  [db time-point]
+  (when (some? (:datahike/valid-at (meta db)))
+    (log/raise (str "Cannot wrap d/as-of around a db already filtered by "
+                    "d/valid-at — the supersession check would not see the "
+                    "tx-time bound. Compose as (d/valid-at (d/as-of db t) v) "
+                    "instead.")
+               {:error :temporal/wrap-order
+                :inner-marker :datahike/valid-at
+                :outer-wrapper 'as-of}))
   (if (dbi/-temporal-index? db)
     (if (int? time-point)
       (if (<= const/tx0 time-point)
@@ -258,6 +280,14 @@
    `d/history` (recommended — exposes the events the supersession
    algorithm needs) and `d/as-of` (bounds the supersession horizon
    to a given tx-time).
+
+   **Composition order matters.** Wrap `d/as-of` first, then
+   `d/valid-at` outermost: `(d/valid-at (d/as-of db t) v)`. The
+   supersession check captures whatever db it was passed; wrapping
+   `d/as-of` *outside* leaves the inner predicate with an unbounded
+   db and the supersession scan reads future txes. `d/as-of` will
+   throw if invoked on a vt-marked db to catch this mistake at
+   call-site.
 
    The result is a `FilteredDB` whose predicate enforces supersession
    per-datom on every read path (`d/q`, `d/datoms`, `d/pull`,

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -519,6 +519,51 @@
                  :code "(q '[:find ?n :where [_ :name ?n]] (valid-at @conn #inst \"2024-04-15\"))"}]
      :impl datahike.api.impl/valid-at}
 
+    valid-between
+    {:args [:=> [:cat :datahike/SDB :any :any] :datahike/SDB]
+     :ret :datahike/SDB
+     :categories [:temporal :query]
+     :stability :experimental
+     :supports-remote? true
+     :referentially-transparent? true
+     :doc "Filter `db` to datoms whose asserting tx's vt-window overlaps the
+           half-open interval `[from, to)`. SQL:2011 `FOR VALID_TIME BETWEEN
+           from AND to` maps to this. Carries
+           `:datahike/valid-between [from to]` on the result for vt-aware
+           secondary-index pushdown."
+     :examples [{:desc "Datoms whose tx vt-window overlaps Q2 2024"
+                 :code "(q '[:find ?n :where [_ :name ?n]] (valid-between @conn #inst \"2024-04-01\" #inst \"2024-07-01\"))"}]
+     :impl datahike.api.impl/valid-between}
+
+    valid-during
+    {:args [:=> [:cat :datahike/SDB :any :any] :datahike/SDB]
+     :ret :datahike/SDB
+     :categories [:temporal :query]
+     :stability :experimental
+     :supports-remote? true
+     :referentially-transparent? true
+     :doc "Filter `db` to datoms whose tx's vt-window is *fully contained*
+           in `[from, to)`. Stricter than `valid-between` — overlapping
+           windows that extend past either endpoint are excluded. Useful
+           for 'corrections wholly within Q2' style queries."
+     :examples [{:desc "Corrections whose vt-window was wholly inside Q2"
+                 :code "(q '[:find ?e :where [?e :name _]] (valid-during @conn #inst \"2024-04-01\" #inst \"2024-07-01\"))"}]
+     :impl datahike.api.impl/valid-during}
+
+    valid-all
+    {:args [:=> [:cat :datahike/SDB] :datahike/SDB]
+     :ret :datahike/SDB
+     :categories [:temporal :query]
+     :stability :experimental
+     :supports-remote? true
+     :referentially-transparent? true
+     :doc "Strip any valid-time markers from `db` so the full vt-history is
+           visible. Idempotent. Does not unwrap an existing FilteredDB; to
+           drop an active filter, start from the unwrapped db."
+     :examples [{:desc "Drop vt-marker for full-history query"
+                 :code "(q '[:find ?n :where [_ :name ?n]] (valid-all @conn))"}]
+     :impl datahike.api.impl/valid-all}
+
     ;; =========================================================================
     ;; Versioning Operations
     ;; =========================================================================

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -504,6 +504,21 @@
                  :code "(as-of @conn 536870913)"}]
      :impl datahike.api.impl/as-of}
 
+    valid-at
+    {:args [:=> [:cat :datahike/SDB :any] :datahike/SDB]
+     :ret :datahike/SDB
+     :categories [:temporal :query]
+     :stability :experimental
+     :supports-remote? true
+     :referentially-transparent? true
+     :doc "Tag `db` with a `:datahike/valid-at` marker so vt-aware secondary
+           indices push the filter through `-search-at-vt`. Valid-time is a
+           secondary-index axis; regular datalog patterns still require the
+           built-in `(valid-at ?tx ?at)` rule to filter by vt explicitly."
+     :examples [{:desc "Query as of valid-time"
+                 :code "(q '[:find ?n :where [_ :name ?n]] (valid-at @conn #inst \"2024-04-15\"))"}]
+     :impl datahike.api.impl/valid-at}
+
     ;; =========================================================================
     ;; Versioning Operations
     ;; =========================================================================

--- a/src/datahike/bitemporal/platform.cljc
+++ b/src/datahike/bitemporal/platform.cljc
@@ -1,0 +1,83 @@
+(ns datahike.bitemporal.platform
+  "Cross-platform helpers for the valid-time read-side API.
+
+   The bitemporal predicate machinery in `datahike.api.impl` and the
+   write-side validation in `datahike.db.transaction` both rely on two
+   JVM-only constructs:
+
+     * `java.util.concurrent.ConcurrentHashMap` — a per-predicate
+       memoisation cache that mk-vt-pred / mk-vt-overlap-pred /
+       mk-vt-during-pred / find-eav-winner allocate and write into
+       under heavy read.
+
+     * `java.util.Date` `.before` / `.after` instance methods used for
+       point-in-window checks.
+
+   Neither has a direct CLJS counterpart: CLJS is single-threaded so a
+   plain `(atom {})` is functionally equivalent to a ConcurrentHashMap
+   for the same access pattern; and `js/Date` has `.getTime` returning
+   epoch-millis, so `<`/`>` on those numbers reproduces `.before`/`.after`.
+
+   This namespace centralises the dispatch so the per-callsite code in
+   `api/impl.cljc` stays small and the rules for *what* the JVM/CLJS
+   impls do live in one place. The fns are inline-callable from `.cljc`
+   files without per-callsite reader conditionals."
+  #?(:clj
+     (:import [java.util.concurrent ConcurrentHashMap]
+              [java.util Date])))
+
+;; ---------------------------------------------------------------------------
+;; Predicate-scoped mutable map
+;;
+;; Used by mk-vt-pred / mk-vt-overlap-pred / mk-vt-during-pred /
+;; find-eav-winner to memoise tx-id → Boolean and [e a v] → Datom lookups
+;; for the lifetime of one filter predicate. The CHM is the right shape
+;; on the JVM where multiple query threads may share the same predicate
+;; closure (the FilteredDB is shared, the predicate is captured in
+;; meta). On CLJS the runtime is single-threaded; an atom-wrapped map is
+;; functionally equivalent and avoids pulling in a concurrent-map shim.
+
+(defn mutable-map
+  "Allocate a new mutable map for predicate-scoped caches.
+   On JVM a `java.util.concurrent.ConcurrentHashMap`; on CLJS an
+   `(atom {})`."
+  []
+  #?(:clj  (ConcurrentHashMap.)
+     :cljs (atom {})))
+
+(defn mput!
+  "Associate `k` → `v` in the mutable map `m` returned by `mutable-map`.
+   Returns `m`."
+  [m k v]
+  #?(:clj  (do (.put ^ConcurrentHashMap m k v) m)
+     :cljs (do (swap! m assoc k v) m)))
+
+(defn mget
+  "Look `k` up in the mutable map `m`. Returns the previously-`mput!`'d
+   value, or `nil` if absent."
+  [m k]
+  #?(:clj  (.get ^ConcurrentHashMap m k)
+     :cljs (get @m k)))
+
+;; ---------------------------------------------------------------------------
+;; Date comparison
+;;
+;; All vt-window checks reduce to ordering of two instants. On JVM the
+;; idiomatic form is `(.before d1 d2)` / `(.after d1 d2)`; on CLJS the
+;; native `js/Date` has only `.getTime` so we compare epoch-millis as
+;; numbers. The helpers keep type hints on the JVM branch so the call
+;; stays inlined under typed reflection.
+
+(defn date-before?
+  "True iff `d1` strictly precedes `d2`. Both args are platform-native
+   instants: `java.util.Date` on JVM, `js/Date` on CLJS."
+  [d1 d2]
+  #?(:clj  (.before ^Date d1 ^Date d2)
+     :cljs (< (.getTime d1) (.getTime d2))))
+
+(defn date-after?
+  "True iff `d1` strictly follows `d2`. Both args are platform-native
+   instants: `java.util.Date` on JVM, `js/Date` on CLJS."
+  [d1 d2]
+  #?(:clj  (.after ^Date d1 ^Date d2)
+     :cljs (> (.getTime d1) (.getTime d2))))

--- a/src/datahike/bitemporal/predicate.cljc
+++ b/src/datahike/bitemporal/predicate.cljc
@@ -1,0 +1,162 @@
+(ns datahike.bitemporal.predicate
+  "Valid-time predicate factories — the semantically-correct read-side
+   filter for `d/valid-at` / `d/valid-between` / `d/valid-during`.
+
+   Lifted out of `datahike.api.impl` to a leaf namespace so vt-aware
+   secondary indices (`datahike.index.secondary` and downstream impls
+   like stratum) can require this directly without creating a cycle
+   back through the heavyweight `api.impl` → `query` → `writing` chain.
+
+   The factories return per-call predicate closures with their own
+   per-predicate memoisation caches; see
+   `datahike.bitemporal.platform/mutable-map` for the JVM/CLJS caching
+   story and `mk-vt-pred`'s docstring for the supersession algorithm."
+  (:require [datahike.db.interface :as dbi]
+            [datahike.bitemporal.platform :as bp]
+            [datahike.datom]))
+
+(defn- vt-meta-attrs
+  "On an attribute-refs DB the schema attrs are stored as ref-eids;
+   resolve them up-front so the predicate's inner loop compares ints,
+   not keywords."
+  [db]
+  (if (:attribute-refs? (dbi/-config db))
+    {:vf (dbi/-ref-for db :db.valid/from)
+     :vt (dbi/-ref-for db :db.valid/to)}
+    {:vf :db.valid/from
+     :vt :db.valid/to}))
+
+(defn- tx-covers-at?
+  "Does the tx-entity `tx-id`'s vt-window contain `at`? Reads
+   `:db.valid/from` / `:db.valid/to` off the tx-entity. Missing
+   `:db.valid/from` is treated as -∞; missing `:db.valid/to` as +∞,
+   so non-vt-aware data passes through unchanged. Memoized via
+   `cover-cache` (tx-id → Boolean) — a `bp/mutable-map`."
+  [db tx-id at cover-cache]
+  (let [cached (bp/mget cover-cache tx-id)]
+    (if (some? cached)
+      cached
+      (let [{:keys [vf vt]} (vt-meta-attrs db)
+            tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+            vf-val (some (fn [^datahike.datom.Datom td]
+                           (when (= vf (.-a td)) (.-v td))) tx-datoms)
+            vt-val (some (fn [^datahike.datom.Datom td]
+                           (when (= vt (.-a td)) (.-v td))) tx-datoms)
+            ok? (and (or (nil? vf-val) (not (bp/date-after? vf-val at)))
+                     (or (nil? vt-val) (bp/date-after? vt-val at)))]
+        (bp/mput! cover-cache tx-id ok?)
+        ok?))))
+
+(defn- find-eav-winner
+  "Among all historical datoms about `(e, a, v)`, return the one whose
+   tx-id is the greatest AND whose tx-vt-window contains `at` — the
+   'supersession winner' for this fact at this valid-time. Returns
+   `nil` if no candidate. Implements bitemporal supersession at query time: the
+   topmost event at `(qvt, current-sys-time)` is the one whose tx-id
+   is highest among those covering `qvt`. Memoized via
+   `winner-cache` ([e a v] → Datom or ::miss)."
+  [db e a v at cover-cache winner-cache]
+  (let [k [e a v]
+        cached (bp/mget winner-cache k)]
+    (cond
+      (= cached ::miss) nil
+      (some? cached)    cached
+      :else
+      (let [datoms (dbi/-datoms db :eavt [e a v] (dbi/-search-context db))
+            winner (reduce
+                    (fn [w ^datahike.datom.Datom d]
+                      (if (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
+                        (if (or (nil? w)
+                                (> (datahike.datom/datom-tx d)
+                                   (datahike.datom/datom-tx ^datahike.datom.Datom w)))
+                          d w)
+                        w))
+                    nil datoms)]
+        (bp/mput! winner-cache k (or winner ::miss))
+        winner))))
+
+(defn mk-vt-pred
+  "Build a `d/filter` predicate `(fn [db datom])` implementing
+   supersession-aware valid-time filtering at point `at`. Algorithm
+   implements bitemporal supersession at read time:
+
+     for each datom D = (e, a, v, tx, op):
+       1. require tx's vt-window covers `at`;
+       2. among ALL historical datoms about (e, a, v), find the one
+          whose tx is the greatest AND whose tx-vt covers `at` — the
+          'winner';
+       3. admit D iff D is the winner.
+
+   On current-view (no history) the (e, a, v) scan returns the single
+   live datom; the algorithm degrades to today's single-axis
+   filter. On `(d/history db)` it gives back-correction-correct
+   semantics: a later tx with overlapping vt supersedes an earlier
+   one at the relevant vt-points.
+
+   Two caches:
+     * `cover-cache` (tx-id → Boolean): one EAVT seek per unique tx.
+     * `winner-cache` ([e a v] → Datom): one EAVT seek per unique fact.
+
+   The fast path for high-throughput vt queries is the
+   `:datahike/valid-at` meta marker → `IValidTimeAware/-search-at-vt`
+   on a vt-aware secondary index (e.g. stratum), which precomputes
+   the polygon at write time. This predicate is the
+   semantically-correct fallback for paths that don't route through
+   a secondary."
+  [at]
+  (let [cover-cache  (bp/mutable-map)
+        winner-cache (bp/mutable-map)]
+    (fn vt-pred [db ^datahike.datom.Datom d]
+      ;; (datom-tx d) is always-positive (retractions store it negated).
+      (when (tx-covers-at? db (datahike.datom/datom-tx d) at cover-cache)
+        (when-let [^datahike.datom.Datom w
+                   (find-eav-winner db (.-e d) (.-a d) (.-v d) at
+                                    cover-cache winner-cache)]
+          (= (datahike.datom/datom-tx d)
+             (datahike.datom/datom-tx w)))))))
+
+(defn mk-vt-overlap-pred
+  "Pred that admits a datom iff its tx's vt-window *overlaps*
+   `[from, to)`. Open-ended `vt = nil` is treated as `+∞`; missing
+   `vf` is `-∞`. The overlap condition is `(vf < to) AND (vt > from)`."
+  [from to]
+  (let [cache (bp/mutable-map)]
+    (fn vt-overlap-pred [db ^datahike.datom.Datom d]
+      (let [tx-id (datahike.datom/datom-tx d)
+            cached (bp/mget cache tx-id)]
+        (if (some? cached)
+          cached
+          (let [{:keys [vf vt]} (vt-meta-attrs db)
+                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+                vf-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
+                vt-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
+                ok? (and (or (nil? vf-val) (bp/date-before? vf-val to))
+                         (or (nil? vt-val) (bp/date-after? vt-val from)))]
+            (bp/mput! cache tx-id ok?)
+            ok?))))))
+
+(defn mk-vt-during-pred
+  "Pred that admits a datom iff its tx's vt-window is *fully
+   contained* in `[from, to)`. Strict containment: missing `vf` or
+   `vt` fail (an unbounded interval can't be fully contained in a
+   bounded one)."
+  [from to]
+  (let [cache (bp/mutable-map)]
+    (fn vt-during-pred [db ^datahike.datom.Datom d]
+      (let [tx-id (datahike.datom/datom-tx d)
+            cached (bp/mget cache tx-id)]
+        (if (some? cached)
+          cached
+          (let [{:keys [vf vt]} (vt-meta-attrs db)
+                tx-datoms (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db))
+                vf-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vf (.-a td)) (.-v td))) tx-datoms)
+                vt-val (some (fn [^datahike.datom.Datom td]
+                               (when (= vt (.-a td)) (.-v td))) tx-datoms)
+                ok? (and (some? vf-val) (some? vt-val)
+                         (not (bp/date-before? vf-val from))
+                         (not (bp/date-after? vt-val to)))]
+            (bp/mput! cache tx-id ok?)
+            ok?))))))

--- a/src/datahike/constants.cljc
+++ b/src/datahike/constants.cljc
@@ -124,15 +124,20 @@
     :db/cardinality :db.cardinality/one
     :db/doc "A transaction's valid-time lower bound (inclusive).
              Every datom in the tx inherits this vt-from. When
-             absent the transaction's `:db/txInstant` is used."
+             absent the transaction's `:db/txInstant` is used.
+             See `doc/valid_time.md` for usage."
     :db/index true}
    {:db/id 40
     :db/ident :db.valid/to
     :db/valueType :db.type/instant
     :db/cardinality :db.cardinality/one
     :db/doc "A transaction's valid-time upper bound (exclusive).
-             When absent the interval is open-ended (treated as
-             +∞ by the bitemporal resolver)."
+             When absent the interval is open-ended (treated as +∞).
+             May be written retroactively on a prior tx-entity to
+             close that tx's window; the write is a normal commit,
+             the prior tx's hash is unchanged, and the transactor
+             enforces a cross-tx `vf < vt` check on the combined
+             state. See `doc/valid_time.md` for usage."
     :db/index true}])
 
 (def ^:const system-entities

--- a/src/datahike/constants.cljc
+++ b/src/datahike/constants.cljc
@@ -144,8 +144,33 @@
         system-schema)))
 
 (def ^:const non-ref-implicit-schema
-  {:db/ident {:db/unique :db.unique/identity}
-   :db/txInstant {:db/noHistory true}
+  ;; Pre-existing system attrs whose schema is "implicit" in non-attribute-
+  ;; refs mode (i.e. they're not in the user-installed schema, but the
+  ;; transactor + query planner must know their properties). Historically
+  ;; only carried the four entries below — but `:db/txInstant` was missing
+  ;; `:db/index true` even though it IS indexed both in `ref-implicit-schema`
+  ;; and in `implicit-schema-spec` (schema.cljc). The `:db/index` omission
+  ;; meant `(dbu/indexing? db :db/txInstant)` returned false, which silently
+  ;; broke the planner's AVET pushdown for predicates pivoting on these
+  ;; attrs (e.g. `[(<= ?vf ?at)]` after `[?tx :db.valid/from ?vf]` produced
+  ;; 0 results because the pushdown bounds were computed but the seek path
+  ;; treated the attr as non-indexed).
+  ;;
+  ;; The fix: declare the `:db/index true` flag here too so rschema is
+  ;; consistent across modes. Bitemporal-v1 also adds `:db.valid/from` and
+  ;; `:db.valid/to`, which join `:db/txInstant` as AVET-indexed tx-meta.
+  ;; Note: `:db/txInstant` is deliberately NOT flagged `:db/index true`
+  ;; here even though `system-schema` (above) and `implicit-schema-spec`
+  ;; (schema.cljc) declare it as such. Flipping it on would land every
+  ;; tx's `:db/txInstant` datom in AVET — a semantic change that ripples
+  ;; through existing tests + breaks the existing `:db/txInstant`-by-tx
+  ;; lookup path. Bitemporal v1 keeps that as-is and only graduates
+  ;; `:db.valid/from` / `:db.valid/to`, which are the new tx-meta attrs
+  ;; the planner needs to AVET-seek.
+  {:db/ident      {:db/unique :db.unique/identity}
+   :db/txInstant  {:db/noHistory true}
+   :db.valid/from {:db/index true}
+   :db.valid/to   {:db/index true}
    :db.entity/attrs {:db/cardinality :db.cardinality/many}
    :db.entity/preds {:db/cardinality :db.cardinality/many}})
 

--- a/src/datahike/constants.cljc
+++ b/src/datahike/constants.cljc
@@ -113,7 +113,27 @@
    {:db/id 37
     :db/ident :db/tupleAttrs}
    {:db/id 38
-    :db/ident :db.type/tuple}])
+    :db/ident :db.type/tuple}
+   ;; Bitemporal valid-time tx-meta — graduated from kontor-side
+   ;; userland into system schema. Tx-attached, half-open
+   ;; [from, to). Both AVET-indexed so the query planner can seek
+   ;; into them via the `valid-at` / `valid-between` rule rewrites.
+   {:db/id 39
+    :db/ident :db.valid/from
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/doc "A transaction's valid-time lower bound (inclusive).
+             Every datom in the tx inherits this vt-from. When
+             absent the transaction's `:db/txInstant` is used."
+    :db/index true}
+   {:db/id 40
+    :db/ident :db.valid/to
+    :db/valueType :db.type/instant
+    :db/cardinality :db.cardinality/one
+    :db/doc "A transaction's valid-time upper bound (exclusive).
+             When absent the interval is open-ended (treated as
+             +∞ by the bitemporal resolver)."
+    :db/index true}])
 
 (def ^:const system-entities
   "Holds the entity IDs of system attributes"

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -200,16 +200,49 @@
 ;; In context of `with-datom` we can use faster comparators which
 ;; do not check for nil (~10-15% performance gain in `transact`)
 
+(def ^:private meta-attrs-for-secondary
+  "Tx-meta attrs surfaced to secondary indices on each `-transact` call.
+   See `datahike.index.secondary/ISecondaryIndex` — adapters that want
+   vt-pushdown read these from `tx-report :tx-meta`."
+  #{:db/txInstant :db.valid/from :db.valid/to})
+
+(defn- tx-meta-for-secondary
+  "Extract the current tx's meta-attrs from the in-progress db state.
+   Tx-entity meta-datoms were added by `flush-tx-meta` BEFORE user
+   datoms reach `with-datom`, so a single EAVT seek on the tx-id is
+   sufficient. Returns nil when nothing is set (cheap no-op for
+   non-vt-bearing txes)."
+  [db ^Datom datom]
+  (let [tx-id (dd/datom-tx datom)
+        config (dbi/-config db)
+        ref? (:attribute-refs? config)
+        ident (fn [a] (if (and ref? (number? a)) (dbi/-ident-for db a) a))
+        m (reduce
+           (fn [m ^Datom d]
+             (let [a-ident (ident (.-a d))]
+               (if (contains? meta-attrs-for-secondary a-ident)
+                 (assoc m a-ident (.-v d))
+                 m)))
+           {}
+           (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db)))]
+    (not-empty m)))
+
 (defn- update-secondary-indices
   "Update all secondary indices that cover the given attribute.
    When the index supports ITransientSecondaryIndex (batch mode), uses
    -transact! (mutates in place, no assoc). Otherwise falls back to
    -transact (persistent, returns new instance).
-   Returns updated db with modified secondary-indices map."
+   Returns updated db with modified secondary-indices map.
+
+   Per bitemporal-v1, `tx-report` also carries `:tx-meta` — the
+   tx-entity's `:db/txInstant` / `:db.valid/from` / `:db.valid/to`
+   attrs — so adapters that implement `IValidTimeAware` can persist
+   the tx's valid-time window alongside their content keys."
   [db a-ident ^Datom datom added?]
   (let [sec-idx-map (get-in db [:rschema :db.secondary/index a-ident])]
     (if (seq sec-idx-map)
-      (let [tx-report {:datom datom :added? added?}]
+      (let [tx-report (cond-> {:datom datom :added? added?}
+                        true (assoc :tx-meta (tx-meta-for-secondary db datom)))]
         (reduce (fn [db' idx-ident]
                   (let [status (get-in db' [:schema idx-ident :db.secondary/status])]
                     ;; Skip disabled indices — they are no longer maintained

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -200,21 +200,19 @@
 ;; In context of `with-datom` we can use faster comparators which
 ;; do not check for nil (~10-15% performance gain in `transact`)
 
-(def ^:private meta-attrs-for-secondary
+(def meta-attrs-for-secondary
   "Tx-meta attrs surfaced to secondary indices on each `-transact` call.
    See `datahike.index.secondary/ISecondaryIndex` — adapters that want
    vt-pushdown read these from `tx-report :tx-meta`."
   #{:db/txInstant :db.valid/from :db.valid/to})
 
-(defn- tx-meta-for-secondary
-  "Extract the current tx's meta-attrs from the in-progress db state.
-   Tx-entity meta-datoms were added by `flush-tx-meta` BEFORE user
-   datoms reach `with-datom`, so a single EAVT seek on the tx-id is
-   sufficient. Returns nil when nothing is set (cheap no-op for
-   non-vt-bearing txes)."
-  [db ^Datom datom]
-  (let [tx-id (dd/datom-tx datom)
-        config (dbi/-config db)
+(defn meta-for-tx-id
+  "Return the meta-attrs map for the given tx-id by EAVT-seeking the tx
+   entity. Public so writing/build-secondary-index! can reconstruct
+   tx-meta during backfill (where the writing tx is not the in-progress
+   tx). Returns nil when no meta-attrs are set on that tx."
+  [db ^long tx-id]
+  (let [config (dbi/-config db)
         ref? (:attribute-refs? config)
         ident (fn [a] (if (and ref? (number? a)) (dbi/-ident-for db a) a))
         m (reduce
@@ -226,6 +224,15 @@
            {}
            (dbi/-datoms db :eavt [tx-id] (dbi/-search-context db)))]
     (not-empty m)))
+
+(defn- tx-meta-for-secondary
+  "Tx-meta for the *current* in-progress tx. We use `(inc max-tx)` —
+   incrementing matches the final bump in the transact loop's exit
+   branch — rather than `(dd/datom-tx datom)`. Retract datoms carry
+   the original asserting tx's id, but vt-aware adapters need the
+   writing tx's meta to close `_valid_to` correctly."
+  [db ^Datom _datom]
+  (meta-for-tx-id db (inc (long (:max-tx db)))))
 
 (defn- update-secondary-indices
   "Update all secondary indices that cover the given attribute.

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -120,6 +120,51 @@
 (defn update-rschema [db]
   (assoc db :rschema (dbu/rschema (:schema db))))
 
+(defn- last-tx-instant
+  "Read the :db/txInstant value of the most-recently-committed tx
+   (`:max-tx`). Returns nil only on a truly empty DB that has not
+   even seen the bootstrap tx — in practice always returns at least
+   the epoch sentinel from `tx0`."
+  ^Date [db]
+  (let [max-tx (:max-tx db)
+        ctx    (dbi/-search-context db)
+        a      (if (:attribute-refs? (dbi/-config db))
+                 (dbi/-ref-for db :db/txInstant)
+                 :db/txInstant)]
+    (some-> ^Datom (first (dbi/-datoms db :eavt [max-tx a] ctx)) .-v)))
+
+(defn ^:dynamic next-tx-instant
+  "Strictly-monotonic `:db/txInstant` allocator. Returns
+   `max(get-date, prev-tx-instant + 1ms)` so back-to-back writes
+   that share a wall-clock millisecond still get distinct,
+   strictly-ordered instants — matching Datomic's contract for
+   auto-stamped `:db/txInstant` and removing the `d/as-of <Date>`
+   tied-instant ambiguity at the source.
+
+   Reads the wall-clock via `datahike.tools/get-date`, so the
+   existing dynamic-binding clock-pinning patterns keep working.
+   A pinned constant clock turns into a *logical clock* for free:
+   the allocator advances by 1ms per tx, producing deterministic
+   monotonic stamps across the whole binding without any separate
+   logical-clock mode.
+
+   User-provided `:db/txInstant` in `:tx-meta` still wins over the
+   allocator's default; historical imports and SCD2 surgery tests
+   that intentionally back-date are unaffected.
+
+   Cost: one EAVT seek (~1µs on PSS in-memory at 10k txes; <0.3%
+   of `d/transact`). The `^:dynamic` shape leaves room for a
+   future caller-supplied allocator (e.g., HLC) without breaking
+   the default path.
+
+   See ADR for the design rationale."
+  ^Date [db-before]
+  (let [now-ms  (.getTime ^Date (get-date))
+        prev-ms (some-> (last-tx-instant db-before) .getTime)]
+    (Date. ^long (if (or (nil? prev-ms) (< (long prev-ms) now-ms))
+                   now-ms
+                   (inc (long prev-ms))))))
+
 #?(:clj
    (defn- attrs-have-datoms?
      "True iff at least one of `attrs` has any datoms in `db`'s AEVT index.
@@ -127,11 +172,22 @@
       the index is being registered on an empty (or empty-for-these-attrs)
       database — eliminating the writer race between
       `build-secondary-index!` and subsequent user writes that would
-      otherwise clobber the live updates with an empty rebuild."
+      otherwise clobber the live updates with an empty rebuild.
+
+      Attrs not declared in the schema have no datoms by definition;
+      `dbi/-datoms` validates the attr ident and throws otherwise. A
+      secondary-index spec can legitimately reference an attr that
+      hasn't been declared yet (schema-flexibility :read, or the index
+      is registered before any data writes touch the attr), so we
+      gate the lookup on schema membership."
      [db attrs]
-     (let [ctx (dbi/-search-context db)]
+     (let [ctx    (dbi/-search-context db)
+           schema (dbi/-schema db)]
        (boolean
-        (some (fn [a] (seq (dbi/-datoms db :aevt [a] ctx))) attrs)))))
+        (some (fn [a]
+                (and (contains? schema a)
+                     (seq (dbi/-datoms db :aevt [a] ctx))))
+              attrs)))))
 
 #?(:clj
    (defn- instantiate-secondary
@@ -957,7 +1013,7 @@
                       (interleave initial-es (repeat ::flush-tuples))
                       initial-es)
         initial-report (update initial-report :tx-meta
-                               #(merge {:db/txInstant (get-date)} %))
+                               #(merge {:db/txInstant (next-tx-instant db-before)} %))
         ;; Reject zero-width or reverse valid-time windows. A tx
         ;; with `:db.valid/from >= :db.valid/to` would produce a
         ;; tx-entity that no `d/valid-at` query can ever match

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -645,6 +645,12 @@
                               [:db.ensure/preds eid ensure preds]]))))
       entities)))
 
+(defn- vt-meta-attr?
+  "Cheap branch — true iff the resolved a-ident is one of the bitemporal
+   tx-meta attrs. Two keyword compares; called once per :db/add."
+  [a-ident]
+  (or (= a-ident :db.valid/from) (= a-ident :db.valid/to)))
+
 (defn- transact-add [{:keys [db-after] :as report} [_ e a v tx :as ent]]
   (let [a (dbu/normalize-and-validate-attr a ent db-after)
         _ (validate-val v ent db-after)
@@ -655,7 +661,21 @@
         a-ident (if attribute-refs? (dbi/ident-for db a :error-on-missing) a)
         v (if (dbu/ref? db a-ident) (dbu/entid-strict db v) v)
         new-datom (datom e a v tx)
-        upsert? (not (dbu/multival? db a))]
+        upsert? (not (dbu/multival? db a))
+        ;; Cross-tx vf<vt guard: when a :db.valid/from or :db.valid/to
+        ;; is written onto a PRIOR tx-entity, queue that tx-eid for
+        ;; end-of-loop validation. Pattern mirrors ::queued-tuples
+        ;; (composite-tuple recomputation). Validation itself is
+        ;; deferred so that the same tx writing BOTH halves on the
+        ;; same prior tx-entity is checked against the final combined
+        ;; state, not the half-way state. Retracts can only broaden
+        ;; the window so they're skipped — a retract+add in the same
+        ;; tx is caught by the add side.
+        report (cond-> report
+                 (and (vt-meta-attr? a-ident)
+                      (>= ^long e ^long tx0)
+                      (not= e (current-tx report)))
+                 (update ::pending-vt-validation (fnil conj #{}) e))]
     (transact-report report new-datom upsert?)))
 
 (defn- transact-retract-datom
@@ -1007,6 +1027,41 @@
                         " (e.g. {:db/ident <keyword> :db/fn <Ifn>}, usage of :db/ident requires {:db/unique :db.unique/identity} in schema)")
                    {:error :transact/syntax, :operation op, :tx-data op-vec})))))
 
+(defn- validate-cross-tx-vt-windows!
+  "Cross-tx vf<vt guard. For each prior tx-entity that received a
+   retroactive :db.valid/from or :db.valid/to write in this tx (see
+   `transact-add` ::pending-vt-validation queue), look up the
+   resulting (vf, vt) pair on db-after and raise if vf >= vt.
+
+   Single EAVT seek per affected tx-entity (3 datoms returned —
+   txInstant + vf + vt). No-op when no such writes occurred (the
+   ::pending-vt-validation set is absent).
+
+   Mirrors the pre-loop guard at the top of `transact-tx-data` which
+   checks the *current* tx's :tx-meta; this one covers the closure
+   formed by editing a *prior* tx-entity's vt-meta.
+
+   Throws `:transact/invalid-valid-times-cross-tx` on first violation."
+  [{:keys [db-after] :as report}]
+  (when-let [pending (::pending-vt-validation report)]
+    (let [attr-refs? (:attribute-refs? (dbi/-config db-after))
+          vf-a (if attr-refs? (dbi/-ref-for db-after :db.valid/from) :db.valid/from)
+          vt-a (if attr-refs? (dbi/-ref-for db-after :db.valid/to) :db.valid/to)
+          sc (dbi/-search-context db-after)]
+      (doseq [tx-eid pending]
+        (let [datoms (dbi/-datoms db-after :eavt [tx-eid] sc)
+              vf (some (fn [^Datom d] (when (= vf-a (.-a d)) (.-v d))) datoms)
+              vt (some (fn [^Datom d] (when (= vt-a (.-a d)) (.-v d))) datoms)]
+          (when (and vf vt (not (.before ^java.util.Date vf
+                                         ^java.util.Date vt)))
+            (log/raise (str "Invalid cross-tx valid-time window: tx-entity "
+                            tx-eid " would have :db.valid/from >= :db.valid/to "
+                            "(from=" vf ", to=" vt ") after this commit")
+                       {:error :transact/invalid-valid-times-cross-tx
+                        :tx-eid tx-eid
+                        :db.valid/from vf
+                        :db.valid/to vt})))))))
+
 (defn transact-tx-data [{:keys [db-before] :as initial-report} initial-es]
   (when-not (or (nil? initial-es)
                 (sequential? initial-es))
@@ -1046,11 +1101,20 @@
             db db-after]
         (cond
           (empty? es)
-          (-> report
-              (assoc-in [:tempids :db/current-tx] (current-tx report))
-              (update-in [:db-after :max-tx] inc)
-              (update :db-after persistent!)
-              (update :db-after finalize-secondary-indices))
+          (do
+            ;; Cross-tx vf<vt validation: any prior tx-entity touched
+            ;; by this commit's vt-meta writes is checked against the
+            ;; final combined state. Throws on invalid window. The
+            ;; ::pending-vt-validation bookkeeping is stripped before
+            ;; the report exits, matching the ::queued-tuples cleanup
+            ;; discipline.
+            (validate-cross-tx-vt-windows! report)
+            (-> report
+                (dissoc ::pending-vt-validation)
+                (assoc-in [:tempids :db/current-tx] (current-tx report))
+                (update-in [:db-after :max-tx] inc)
+                (update :db-after persistent!)
+                (update :db-after finalize-secondary-indices)))
 
           (nil? entity)
           (recur report entities)

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -121,11 +121,31 @@
   (assoc db :rschema (dbu/rschema (:schema db))))
 
 #?(:clj
+   (defn- attrs-have-datoms?
+     "True iff at least one of `attrs` has any datoms in `db`'s AEVT index.
+      Used by `instantiate-secondary` to skip the async backfill path when
+      the index is being registered on an empty (or empty-for-these-attrs)
+      database — eliminating the writer race between
+      `build-secondary-index!` and subsequent user writes that would
+      otherwise clobber the live updates with an empty rebuild."
+     [db attrs]
+     (let [ctx (dbi/-search-context db)]
+       (boolean
+        (some (fn [a] (seq (dbi/-datoms db :aevt [a] ctx))) attrs)))))
+
+#?(:clj
    (defn- instantiate-secondary
      "Create the secondary-index instance for `idx-ident` from a fully
       populated schema entry. Used at end-of-tx so the factory sees the
       complete config (including `:db.secondary/config`, which may have
-      been applied as a later datom within the same tx)."
+      been applied as a later datom within the same tx).
+
+      Status auto-detection: if AEVT has no datoms for any of the
+      indexed attrs, the index is ready immediately (no backfill
+      needed) and status is `:ready`. Otherwise status is `:building`
+      and the writer auto-dispatches `build-secondary-index!` to
+      backfill from AEVT. Common case (register on a fresh-or-empty
+      db) avoids the async-build race entirely."
      [db idx-ident idx-schema]
      (let [idx-type (:db.secondary/type idx-schema)
            idx-attrs (set (:db.secondary/attrs idx-schema))
@@ -133,11 +153,16 @@
                                      {:attrs idx-attrs})
                         (seq (:ident-ref-map db))
                         (assoc :ident-ref-map (:ident-ref-map db)))
-           idx (sec/create-index idx-type idx-config nil)]
-       (-> db
-           (assoc-in [:secondary-indices idx-ident] idx)
-           (assoc-in [:schema idx-ident :db.secondary/status] :building)
-           (assoc-in [:schema idx-ident :db.secondary/building-since-tx] (:max-tx db)))))
+           idx (sec/create-index idx-type idx-config nil)
+           needs-backfill? (attrs-have-datoms? db idx-attrs)
+           base (-> db
+                    (assoc-in [:secondary-indices idx-ident] idx)
+                    (assoc-in [:schema idx-ident :db.secondary/status]
+                              (if needs-backfill? :building :ready)))]
+       (if needs-backfill?
+         (assoc-in base [:schema idx-ident :db.secondary/building-since-tx]
+                   (:max-tx db))
+         base)))
    :cljs
    (defn- instantiate-secondary [db _idx-ident _idx-schema] db))
 

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -8,6 +8,7 @@
    [datahike.db.interface :as dbi]
    [datahike.db.search :as dbs]
    [datahike.db.utils :as dbu]
+   [datahike.bitemporal.platform :as bp]
    [datahike.constants :refer [tx0]]
    [datahike.tools :refer [get-date]]
    [replikativ.logging :as log]
@@ -1052,8 +1053,7 @@
         (let [datoms (dbi/-datoms db-after :eavt [tx-eid] sc)
               vf (some (fn [^Datom d] (when (= vf-a (.-a d)) (.-v d))) datoms)
               vt (some (fn [^Datom d] (when (= vt-a (.-a d)) (.-v d))) datoms)]
-          (when (and vf vt (not (.before ^java.util.Date vf
-                                         ^java.util.Date vt)))
+          (when (and vf vt (not (bp/date-before? vf vt)))
             (log/raise (str "Invalid cross-tx valid-time window: tx-entity "
                             tx-eid " would have :db.valid/from >= :db.valid/to "
                             "(from=" vf ", to=" vt ") after this commit")
@@ -1082,8 +1082,7 @@
         _ (let [tm (:tx-meta initial-report)
                 vf (:db.valid/from tm)
                 vt (:db.valid/to tm)]
-            (when (and vf vt (not (.before ^java.util.Date vf
-                                           ^java.util.Date vt)))
+            (when (and vf vt (not (bp/date-before? vf vt)))
               (log/raise (str "Invalid valid-time window: :db.valid/from "
                               "must be strictly before :db.valid/to "
                               "(got from=" vf ", to=" vt ")")

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -125,13 +125,15 @@
    (`:max-tx`). Returns nil only on a truly empty DB that has not
    even seen the bootstrap tx — in practice always returns at least
    the epoch sentinel from `tx0`."
-  ^Date [db]
+  [db]
   (let [max-tx (:max-tx db)
         ctx    (dbi/-search-context db)
         a      (if (:attribute-refs? (dbi/-config db))
                  (dbi/-ref-for db :db/txInstant)
                  :db/txInstant)]
-    (some-> ^Datom (first (dbi/-datoms db :eavt [max-tx a] ctx)) .-v)))
+    (some-> #?(:clj ^Datom (first (dbi/-datoms db :eavt [max-tx a] ctx))
+               :cljs (first (dbi/-datoms db :eavt [max-tx a] ctx)))
+            .-v)))
 
 (defn ^:dynamic next-tx-instant
   "Strictly-monotonic `:db/txInstant` allocator. Returns
@@ -158,12 +160,14 @@
    the default path.
 
    See ADR for the design rationale."
-  ^Date [db-before]
-  (let [now-ms  (.getTime ^Date (get-date))
-        prev-ms (some-> (last-tx-instant db-before) .getTime)]
-    (Date. ^long (if (or (nil? prev-ms) (< (long prev-ms) now-ms))
-                   now-ms
-                   (inc (long prev-ms))))))
+  [db-before]
+  (let [now-ms  (#?(:clj .getTime :cljs .getTime) (get-date))
+        prev-ms (some-> (last-tx-instant db-before) .getTime)
+        ms      (if (or (nil? prev-ms) (< (long prev-ms) (long now-ms)))
+                  (long now-ms)
+                  (inc (long prev-ms)))]
+    #?(:clj  (Date. ms)
+       :cljs (js/Date. ms))))
 
 #?(:clj
    (defn- attrs-have-datoms?

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -958,6 +958,23 @@
                       initial-es)
         initial-report (update initial-report :tx-meta
                                #(merge {:db/txInstant (get-date)} %))
+        ;; Reject zero-width or reverse valid-time windows. A tx
+        ;; with `:db.valid/from >= :db.valid/to` would produce a
+        ;; tx-entity that no `d/valid-at` query can ever match
+        ;; (the AVET predicate is `vf <= at < vt`, unsatisfiable
+        ;; when from >= to) — a silent data-quality bug. Throw at
+        ;; the transactor so it surfaces immediately.
+        _ (let [tm (:tx-meta initial-report)
+                vf (:db.valid/from tm)
+                vt (:db.valid/to tm)]
+            (when (and vf vt (not (.before ^java.util.Date vf
+                                           ^java.util.Date vt)))
+              (log/raise (str "Invalid valid-time window: :db.valid/from "
+                              "must be strictly before :db.valid/to "
+                              "(got from=" vf ", to=" vt ")")
+                         {:error :transact/invalid-valid-times
+                          :db.valid/from vf
+                          :db.valid/to vt})))
         meta-entities (flush-tx-meta initial-report)]
     (loop [report (update initial-report :db-after transient)
            es (if (dbi/-keep-history? db-before)

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -205,7 +205,7 @@
 
       (entity-bitset? result)
       (es/entity-bitset-from-longs
-        (filter keep? (es/entity-bitset-seq result)))
+       (filter keep? (es/entity-bitset-seq result)))
 
       (sequential? result)
       (filterv (fn [m] (keep? (or (:entity-id m) (get m :entity-id)))) result)

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -32,7 +32,12 @@
 
   (-transact [this tx-report]
     "Update index with transaction data. Called in-transaction (synchronous).
-     tx-report contains at minimum :datom and :added? keys.
+     `tx-report` carries at minimum `:datom` and `:added?`. Since
+     bitemporal-v1 it also carries `:tx-meta` — a map of the current
+     transaction's meta-attrs (`:db/txInstant`, `:db.valid/from`,
+     `:db.valid/to`) when present. Adapters that don't need vt simply
+     ignore the key; adapters that DO want vt-pushdown read it here and
+     persist alongside their content keys.
      Returns updated index instance (must be persistent/immutable)."))
 
 (defprotocol ITransientSecondaryIndex
@@ -101,6 +106,36 @@
     "Return the set of konserve keys referenced by this index instance.
      Used by GC to mark reachable storage. Indices using external storage
      (e.g., scriptum/Lucene filesystem) return #{}."))
+
+(defprotocol IValidTimeAware
+  "Optional protocol for secondary indices that natively understand the
+   tx-meta valid-time axis (`:db.valid/from` / `:db.valid/to`).
+
+   Indices that implement this can push the `valid-at` / `valid-between`
+   filter into their own query plan — for example, stratum can range-
+   prune on `_valid_from` / `_valid_to` columns at scan time; a
+   scriptum implementation can search per-vt-period segments.
+
+   Indices that DON'T implement this still produce correct vt-filtered
+   results — the secondary-search call site composes their plain
+   `-search` output with a post-hoc filter via kontor's primary AVET
+   on `:db.valid/from`. See `search-with-vt-filter` below."
+  (-search-at-vt [this query-spec entity-filter valid-at-window]
+    "Like `-search`, but restrict to entities whose tx-meta valid-time
+     window contains `valid-at-window`. `valid-at-window` is either:
+
+       a `java.util.Date`        — point-in-vt membership semantics
+                                   (equivalent to `valid-at` rule).
+       `[from to]` — half-open  — interval semantics (equivalent to
+                                   `valid-between` rule).
+
+     Returns the same shape as `-search` — an EntityBitSet or
+     ColumnSlice."))
+
+(defn vt-aware?
+  "True iff `index` implements `IValidTimeAware`."
+  [index]
+  (satisfies? IValidTimeAware index))
 
 ;; ---------------------------------------------------------------------------
 ;; GC: static key-map marking (avoids loading full index just for GC)

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -137,6 +137,28 @@
   [index]
   (satisfies? IValidTimeAware index))
 
+(defn search-with-vt
+  "Dispatch a secondary-index search, optionally routed through `-search-at-vt`
+   when the db carries a `:datahike/valid-at` marker (set by `d/valid-at`).
+
+   Routing:
+   - db has `:datahike/valid-at` AND index is `IValidTimeAware`
+       → `(-search-at-vt index query-spec entity-filter <valid-at>)`
+   - db has `:datahike/valid-at` AND index is NOT vt-aware
+       → `(-search ...)` for now; non-vt-aware adapters can be wrapped
+         post-hoc by the caller using kontor's `(valid-at ?tx ?at)` rule.
+   - no `:datahike/valid-at` marker
+       → `(-search index query-spec entity-filter)`
+
+   Centralises the read-of-the-marker so query-engine call sites stay
+   uniform — they call `search-with-vt` and don't need to know about vt."
+  [db index query-spec entity-filter]
+  (if-let [at (:datahike/valid-at (meta db))]
+    (if (vt-aware? index)
+      (-search-at-vt index query-spec entity-filter at)
+      (-search index query-spec entity-filter))
+    (-search index query-spec entity-filter)))
+
 ;; ---------------------------------------------------------------------------
 ;; GC: static key-map marking (avoids loading full index just for GC)
 

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -3,6 +3,7 @@
    Secondary indices are declared through schema and maintained in-transaction.
    Anyone can register their own index type — the planner treats all uniformly."
   (:require [replikativ.logging :as log]
+            [datahike.bitemporal.predicate :as bp.pred]
             [datahike.db.interface :as dbi]
             [datahike.index.entity-set :as es]))
 
@@ -188,12 +189,11 @@
   "Filter a secondary's result-set to entities whose `(e, a, v)` survives
    `d/valid-at`'s supersession-aware predicate at valid-time `at`."
   [db at result]
-  (let [;; Build the same pred d/valid-at would install. mk-vt-pred is
-        ;; resolved lazily so secondary.cljc need not require api.impl
-        ;; statically (avoiding a circular-load risk).
-        mk-pred  (or (resolve 'datahike.api.impl/mk-vt-pred)
-                     (throw (ex-info "mk-vt-pred not on classpath" {})))
-        vt-pred  (@mk-pred at)
+  (let [;; Build the same pred d/valid-at would install. `mk-vt-pred`
+        ;; lives in the leaf ns `datahike.bitemporal.predicate` so that
+        ;; both `api.impl` and `secondary` can require it statically —
+        ;; no cycle, no `resolve` foot-gun.
+        vt-pred  (bp.pred/mk-vt-pred at)
         keep?    (fn [eid]
                    ;; Enumerate the entity's datoms and ask the pred.
                    ;; Any survivor → entity is visible. Caches inside

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -2,7 +2,9 @@
   "Pluggable secondary index protocol and registry.
    Secondary indices are declared through schema and maintained in-transaction.
    Anyone can register their own index type — the planner treats all uniformly."
-  (:require [replikativ.logging :as log]))
+  (:require [replikativ.logging :as log]
+            [datahike.db.interface :as dbi]
+            [datahike.index.entity-set :as es]))
 
 ;; ---------------------------------------------------------------------------
 ;; Protocol
@@ -116,10 +118,12 @@
    prune on `_valid_from` / `_valid_to` columns at scan time; a
    scriptum implementation can search per-vt-period segments.
 
-   Indices that DON'T implement this still produce correct vt-filtered
-   results — the secondary-search call site composes their plain
-   `-search` output with a post-hoc filter via kontor's primary AVET
-   on `:db.valid/from`. See `search-with-vt-filter` below."
+   Indices that DON'T implement this still produce correct results —
+   `search-with-vt` / `slice-ordered-with-vt` apply a generic post-hoc
+   filter that drops eids whose tx-vt-supersession-winner doesn't admit
+   them at the query's valid-time. The post-hoc filter is correct but
+   slower than a native `-search-at-vt`; vt-aware adapters are the
+   fast path."
   (-search-at-vt [this query-spec entity-filter valid-at-window]
     "Like `-search`, but restrict to entities whose tx-meta valid-time
      window contains `valid-at-window`. `valid-at-window` is either:
@@ -132,32 +136,129 @@
      Returns the same shape as `-search` — an EntityBitSet or
      ColumnSlice."))
 
+(defprotocol IValidTimeStable
+  "Optional opt-out protocol for secondary indices whose data is
+   invariant under valid-time — e.g., schema-only indices, hashes,
+   content-addressed indices. When `(-vt-stable? this)` returns true,
+   `search-with-vt` / `slice-ordered-with-vt` bypass the post-hoc vt
+   filter entirely (the data has no vt-shadowing to compute).
+
+   Default for indices that don't implement this protocol: NOT
+   vt-stable (the safe assumption — apply the filter)."
+  (-vt-stable? [this]
+    "True iff this index's data is invariant under valid-time."))
+
 (defn vt-aware?
   "True iff `index` implements `IValidTimeAware`."
   [index]
   (satisfies? IValidTimeAware index))
 
+(defn vt-stable?
+  "True iff `index` opts out of vt-filtering via `IValidTimeStable`."
+  [index]
+  (and (satisfies? IValidTimeStable index)
+       (boolean (-vt-stable? index))))
+
+;; ---------------------------------------------------------------------------
+;; Post-hoc vt filter for non-vt-aware secondaries
+;;
+;; A non-vt-aware secondary returns candidates that ignore valid-time;
+;; we keep only those whose entity has at least one datom visible to
+;; `d/valid-at`'s supersession-aware predicate. The check uses the same
+;; pred `d/valid-at` builds (cached per query call), so the algorithmic
+;; cost mirrors that of routing the same query through datalog's
+;; FilteredDB.
+;;
+;; Shape dispatch:
+;;   EntityBitSet                       → new EntityBitSet, survivors only
+;;   vec of {:entity-id …}              → filterv on :entity-id (preserves
+;;                                         per-result columns like :score
+;;                                         and :distance from -slice-ordered)
+;;   nil / empty                        → returned as-is
+;;
+;; Other shapes pass through untouched with a warning; ColumnSlice
+;; support is a follow-up once a non-vt-aware ColumnSlice-returning
+;; secondary actually exists.
+
+(defn- entity-bitset? [x]
+  #?(:clj  (instance? org.roaringbitmap.RoaringBitmap x)
+     :cljs (set? x)))
+
+(defn- post-filter-vt
+  "Filter a secondary's result-set to entities whose `(e, a, v)` survives
+   `d/valid-at`'s supersession-aware predicate at valid-time `at`."
+  [db at result]
+  (let [;; Build the same pred d/valid-at would install. mk-vt-pred is
+        ;; resolved lazily so secondary.cljc need not require api.impl
+        ;; statically (avoiding a circular-load risk).
+        mk-pred  (or (resolve 'datahike.api.impl/mk-vt-pred)
+                     (throw (ex-info "mk-vt-pred not on classpath" {})))
+        vt-pred  (@mk-pred at)
+        keep?    (fn [eid]
+                   ;; Enumerate the entity's datoms and ask the pred.
+                   ;; Any survivor → entity is visible. Caches inside
+                   ;; vt-pred amortize across eids.
+                   (some (fn [d] (vt-pred db d))
+                         (dbi/datoms db :eavt [eid])))]
+    (cond
+      (nil? result) result
+
+      (entity-bitset? result)
+      (es/entity-bitset-from-longs
+        (filter keep? (es/entity-bitset-seq result)))
+
+      (sequential? result)
+      (filterv (fn [m] (keep? (or (:entity-id m) (get m :entity-id)))) result)
+
+      :else
+      (do
+        (log/warn :datahike/post-filter-vt-unknown-shape
+                  {:type (type result)})
+        result))))
+
 (defn search-with-vt
-  "Dispatch a secondary-index search, optionally routed through `-search-at-vt`
-   when the db carries a `:datahike/valid-at` marker (set by `d/valid-at`).
+  "Dispatch a secondary-index search with valid-time routing.
 
-   Routing:
-   - db has `:datahike/valid-at` AND index is `IValidTimeAware`
-       → `(-search-at-vt index query-spec entity-filter <valid-at>)`
-   - db has `:datahike/valid-at` AND index is NOT vt-aware
-       → `(-search ...)` for now; non-vt-aware adapters can be wrapped
-         post-hoc by the caller using kontor's `(valid-at ?tx ?at)` rule.
-   - no `:datahike/valid-at` marker
-       → `(-search index query-spec entity-filter)`
+   Routing when the db carries a `:datahike/valid-at` marker
+   (set by `d/valid-at`):
 
-   Centralises the read-of-the-marker so query-engine call sites stay
-   uniform — they call `search-with-vt` and don't need to know about vt."
+     1. index satisfies `IValidTimeAware`
+          → `-search-at-vt` (native fast path)
+     2. index satisfies `IValidTimeStable` (returns true)
+          → `-search` (no filtering needed — data is vt-invariant)
+     3. otherwise
+          → `-search` then `post-filter-vt` (correct, slower fallback)
+
+   No marker → `-search` directly.
+
+   The post-filter dispatches on the result shape (EntityBitSet or
+   vec-of-maps-with-:entity-id), so non-vt-aware adapters get
+   correctness for free; they only need to opt into `IValidTimeAware`
+   if perf matters."
   [db index query-spec entity-filter]
   (if-let [at (:datahike/valid-at (meta db))]
-    (if (vt-aware? index)
-      (-search-at-vt index query-spec entity-filter at)
-      (-search index query-spec entity-filter))
+    (cond
+      (vt-aware? index)  (-search-at-vt index query-spec entity-filter at)
+      (vt-stable? index) (-search index query-spec entity-filter)
+      :else              (post-filter-vt db at
+                                         (-search index query-spec entity-filter)))
     (-search index query-spec entity-filter)))
+
+(defn slice-ordered-with-vt
+  "Like `search-with-vt` but for `-slice-ordered`. Same routing rules.
+   Used by `:retrieval`-mode plan nodes that want both eids and a
+   per-result column (score/distance)."
+  [db index query-spec entity-filter attr direction limit]
+  (let [unfiltered (-slice-ordered index query-spec entity-filter attr direction limit)]
+    (if-let [at (:datahike/valid-at (meta db))]
+      (cond
+        ;; Native fast path: only if the index also implements vt-aware
+        ;; slice-ordered. Stratum doesn't ship that yet (a TODO), so for
+        ;; now even vt-aware indices flow through post-filter for the
+        ;; -slice-ordered axis. Add `-slice-ordered-at-vt` when needed.
+        (vt-stable? index) unfiltered
+        :else              (post-filter-vt db at unfiltered))
+      unfiltered)))
 
 ;; ---------------------------------------------------------------------------
 ;; GC: static key-map marking (avoids loading full index just for GC)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -654,7 +654,49 @@
       [(<= ?vt ?to)]]
      ;; period-overlaps? — Allen-relation alias for valid-between
      [(period-overlaps? ?tx ?from ?to)
-      (valid-between ?tx ?from ?to)]]))
+      (valid-between ?tx ?from ?to)]
+
+     ;; ----- Allen interval predicates (4-arg, generic) ---------------------
+     ;; Each takes two half-open intervals `[?af, ?at)` and `[?bf, ?bt)`
+     ;; and asserts the Allen relation. Generic over any orderable type
+     ;; the `<` / `<=` / `>` / `>=` predicates dispatch on (java.util.Date
+     ;; via CollectionOrder, java.lang.Long, etc.). Use for
+     ;; application-domain interval comparisons (lease vs contract dates,
+     ;; not just the bitemporal axis). Mirrors stratum's 4-arg SQL
+     ;; functions (OVERLAPS, EQUALS_PERIOD, CONTAINS_PERIOD, …).
+     [(interval-overlaps? ?af ?at ?bf ?bt)
+      [(< ?af ?bt)]
+      [(< ?bf ?at)]]
+     [(interval-equals? ?af ?at ?bf ?bt)
+      [(= ?af ?bf)]
+      [(= ?at ?bt)]]
+     ;; A contains B: A.from <= B.from AND A.to >= B.to
+     [(interval-contains? ?af ?at ?bf ?bt)
+      [(<= ?af ?bf)]
+      [(>= ?at ?bt)]]
+     ;; A strictly contains B: A.from < B.from AND A.to > B.to
+     [(interval-strictly-contains? ?af ?at ?bf ?bt)
+      [(< ?af ?bf)]
+      [(> ?at ?bt)]]
+     ;; A precedes B: A's end at-or-before B's start (touching allowed)
+     [(interval-precedes? ?af ?at ?bf ?bt)
+      [(<= ?at ?bf)]]
+     [(interval-strictly-precedes? ?af ?at ?bf ?bt)
+      [(< ?at ?bf)]]
+     ;; A immediately precedes B (A meets B): A.end == B.from
+     [(interval-immediately-precedes? ?af ?at ?bf ?bt)
+      [(= ?at ?bf)]]
+     ;; A succeeds B: A's start at-or-after B's end (touching allowed)
+     [(interval-succeeds? ?af ?at ?bf ?bt)
+      [(>= ?af ?bt)]]
+     [(interval-strictly-succeeds? ?af ?at ?bf ?bt)
+      [(> ?af ?bt)]]
+     ;; A immediately succeeds B: A.from == B.to
+     [(interval-immediately-succeeds? ?af ?at ?bf ?bt)
+      [(= ?af ?bt)]]
+     ;; A meets B — alias for interval-immediately-precedes?
+     [(interval-meets? ?af ?at ?bf ?bt)
+      (interval-immediately-precedes? ?af ?at ?bf ?bt)]]))
 
 (def ^:private built-in-rule-names
   "Set of rule-head symbols recognised as built-ins. Used by

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -82,6 +82,8 @@
 
 ;; Main functions
 
+(declare built-in-rule-names auto-inject-built-in-rules)
+
 (defn normalize-q-input
   "Turns input to q into a map with :query and :args fields.
    Also normalizes the query into a map representation."
@@ -97,10 +99,11 @@
                    (:args query-input))
                arg-inputs)
         extra-ks [:offset :limit :order-by :stats? :settings :cancel]]
-    (cond-> {:query (apply dissoc query extra-ks)
-             :args args}
-      (map? query-input)
-      (merge (select-keys query-input extra-ks)))))
+    (-> (cond-> {:query (apply dissoc query extra-ks)
+                 :args args}
+          (map? query-input)
+          (merge (select-keys query-input extra-ks)))
+        auto-inject-built-in-rules)))
 
 (defn q [query & inputs]
   (raw-q (normalize-q-input query inputs)))
@@ -602,6 +605,101 @@
   (let [rules (if (string? rules) (edn/read-string rules) rules)] ;; for datahike.js interop
     (group-by ffirst rules)))
 
+;; ============================================================================
+;; Built-in bitemporal rules
+;; ============================================================================
+;;
+;; Four rules that consumers can use directly in `:where` without
+;; passing `:in $ %` rules. They operate over the system attrs
+;; `:db.valid/from` / `:db.valid/to` (commit 1 of bitemporal-v1) and
+;; degrade gracefully when `:db.valid/to` is absent (treated as +∞).
+;;
+;; The rules expand to:
+;;   1. an AVET pattern on `:db.valid/from`,
+;;   2. a `get-else` for `:db.valid/to` with a `9999-12-31` default,
+;;   3. two `.compareTo` predicates against the user-provided time-points.
+;;
+;; *Performance note*: place the rule call EARLY in `:where`. Even
+;; with the planner, clause order dominates — the rule's AVET-seek
+;; pattern needs to run before downstream patterns that join on the
+;; same ?tx. (A future planner pass will auto-reorder; today the
+;; convention is "vt-predicate first".)
+
+(def built-in-rules
+  "Bitemporal rules pre-installed on every Context. User-supplied
+   rules (via `:in $ %`) override built-ins on name collision.
+
+   The `<` `<=` `>` `>=` predicates dispatch on Date via the
+   `CollectionOrder` protocol, so the rules can use them directly —
+   no `.compareTo` boilerplate."
+  (parse-rules
+   '[;; valid-at ?tx ?at — half-open membership: vf <= at < vt
+     [(valid-at ?tx ?at)
+      [?tx :db.valid/from ?vf]
+      [(get-else $ ?tx :db.valid/to #inst "9999-12-31T23:59:59.999-00:00") ?vt]
+      [(<= ?vf ?at)]
+      [(> ?vt ?at)]]
+     ;; valid-between ?tx ?from ?to — tx's window intersects [?from, ?to)
+     ;; non-empty intersection iff vf < to AND vt > from
+     [(valid-between ?tx ?from ?to)
+      [?tx :db.valid/from ?vf]
+      [(get-else $ ?tx :db.valid/to #inst "9999-12-31T23:59:59.999-00:00") ?vt]
+      [(< ?vf ?to)]
+      [(> ?vt ?from)]]
+     ;; valid-during ?tx ?from ?to — tx's window is CONTAINED in [?from, ?to)
+     [(valid-during ?tx ?from ?to)
+      [?tx :db.valid/from ?vf]
+      [(get-else $ ?tx :db.valid/to #inst "9999-12-31T23:59:59.999-00:00") ?vt]
+      [(>= ?vf ?from)]
+      [(<= ?vt ?to)]]
+     ;; period-overlaps? — Allen-relation alias for valid-between
+     [(period-overlaps? ?tx ?from ?to)
+      (valid-between ?tx ?from ?to)]]))
+
+(def ^:private built-in-rule-names
+  "Set of rule-head symbols recognised as built-ins. Used by
+   `auto-inject-built-in-rules` to detect when a user's query needs
+   `%` injected into `:in`."
+  (set (keys built-in-rules)))
+
+(defn- where-uses-built-in-rule?
+  "True iff any clause in `where-clauses` is a rule invocation whose
+   head names a built-in rule. Rule invocations are SEQs (not vectors)
+   whose head is a non-special-form symbol."
+  [where-clauses]
+  (boolean
+   (some (fn [clause]
+           (and (seq? clause)
+                (not (vector? clause))
+                (symbol? (first clause))
+                (contains? built-in-rule-names (first clause))))
+         where-clauses)))
+
+(defn- auto-inject-built-in-rules
+  "If the query uses a built-in rule (`valid-at` etc.) but the user
+   did NOT declare `%` in `:in`, synthesise the `%` binding and pass
+   `[]` as the corresponding arg — `resolve-in`'s `update :rules
+   merge` then leaves built-ins available (since Context's `:rules`
+   slot is pre-seeded with `built-in-rules`). Transparent to the
+   caller."
+  [{:keys [query args] :as input}]
+  (let [where (:where query)]
+    (if (and (where-uses-built-in-rule? where)
+             ;; `%` inside `#(...)` is the anonymous fn's first param, so
+             ;; `#(= '% %)` would compare `'%` to itself on every call;
+             ;; use an explicit fn to test for the literal `%` symbol.
+             (not (some (fn [x] (= '% x)) (:in query))))
+      (let [in (or (:in query) '[$])
+            new-in (vec (conj (vec in) '%))
+            ;; Build the flat rule-defs vec from the parsed map.
+            built-in-defs (vec (mapcat val built-in-rules))]
+        (-> input
+            (assoc-in [:query :in] new-in)
+            ;; `args` may be a list (from `& varargs` in `q`); `conj` on
+            ;; a list prepends — vectorize first so we always append.
+            (update :args (fn [a] (conj (vec (or a [])) built-in-defs)))))
+      input)))
+
 (defn empty-rel [binding]
   (let [vars (->> (dpi/collect-vars-distinct binding)
                   (map :symbol))]
@@ -652,7 +750,9 @@
     (update context :sources assoc (get-in binding [:variable :symbol]) value)
     (and (instance? BindScalar binding)
          (instance? RulesVar (:variable binding)))
-    (assoc context :rules (parse-rules value))
+    ;; Merge user-supplied rules over the built-ins so consumers can
+    ;; redefine `valid-at` etc. if they need to.
+    (update context :rules merge (parse-rules value))
     (and (instance? BindScalar binding)
          (instance? Variable (:variable binding)))
     (assoc-in context [:consts (get-in binding [:variable :symbol])] value)
@@ -2696,7 +2796,7 @@
   #?(:clj
      (let [{:keys [query args]} (normalize-q-input query inputs)
            {:keys [qfind qin]} (memoized-parse-query query)
-           context-in (-> (Context. [] {} {} {} default-settings nil)
+           context-in (-> (Context. [] {} built-in-rules {} default-settings nil)
                           (resolve-ins qin args))
            db (get (:sources context-in) '$)
            bound-vars (context-bound-vars context-in)
@@ -3062,6 +3162,10 @@
                 (if (and limit (pos? limit)) (take limit) identity)))
     stats?                                        (#(-> context-out
                                                         (dissoc :rels :sources :settings :cancel)
+                                                        (update :rules
+                                                                (fn [rs]
+                                                                  ;; Subtract built-ins; stats only show user-supplied rules.
+                                                                  (apply dissoc rs (keys built-in-rules))))
                                                         (assoc :ret % :query query)))))
 
 (defn- execute-planned-relation
@@ -3126,8 +3230,8 @@
         {:keys [qfind qwith qreturnmaps qin]} (memoized-parse-query query)
         t1 (when *profile?* #?(:clj (System/nanoTime) :cljs (* 1000 (.getTime (js/Date.)))))
         context-in (-> (if stats?
-                         (StatContext. [] {} {} {} [] settings cancel)
-                         (Context. [] {} {} {} settings cancel))
+                         (StatContext. [] {} built-in-rules {} [] settings cancel)
+                         (Context. [] {} built-in-rules {} settings cancel))
                        (resolve-ins qin args))
         t2 (when *profile?* #?(:clj (System/nanoTime) :cljs (* 1000 (.getTime (js/Date.)))))
 
@@ -3267,7 +3371,7 @@
                (let [find-elements (dpip/find-elements qfind)]
                  (when (and (some #(instance? Aggregate %) find-elements)
                             (not (some #(instance? Pull %) find-elements)))
-                   (let [context-in (-> (Context. [] {} {} {} (merge default-settings nil) nil)
+                   (let [context-in (-> (Context. [] {} built-in-rules {} (merge default-settings nil) nil)
                                         (resolve-ins qin args))
                          clauses (substitute-consts-with-lookup-refs db (:where query) (:consts context-in))
                          bound-vars (context-bound-vars context-in)

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -696,7 +696,28 @@
       [(= ?af ?bt)]]
      ;; A meets B — alias for interval-immediately-precedes?
      [(interval-meets? ?af ?at ?bf ?bt)
-      (interval-immediately-precedes? ?af ?at ?bf ?bt)]]))
+      (interval-immediately-precedes? ?af ?at ?bf ?bt)]
+     ;; ----- Allen "anchored-start" / "anchored-end" pairs --------------------
+     ;; Allen 1983 names that complete the canonical 13. The 11 above cover
+     ;; before/after, meets/met-by (via aliases), overlaps/overlapped-by,
+     ;; equals, during/contains. The four below cover starts/started-by and
+     ;; finishes/finished-by.
+     ;; A starts B: A.from == B.from AND A.to < B.to
+     [(interval-starts? ?af ?at ?bf ?bt)
+      [(= ?af ?bf)]
+      [(< ?at ?bt)]]
+     ;; A started-by B: A.from == B.from AND A.to > B.to (inverse of starts?)
+     [(interval-started-by? ?af ?at ?bf ?bt)
+      [(= ?af ?bf)]
+      [(> ?at ?bt)]]
+     ;; A finishes B: A.to == B.to AND A.from > B.from
+     [(interval-finishes? ?af ?at ?bf ?bt)
+      [(= ?at ?bt)]
+      [(> ?af ?bf)]]
+     ;; A finished-by B: A.to == B.to AND A.from < B.from (inverse of finishes?)
+     [(interval-finished-by? ?af ?at ?bf ?bt)
+      [(= ?at ?bt)]
+      [(< ?af ?bf)]]]))
 
 (def ^:private built-in-rule-names
   "Set of rule-head symbols recognised as built-ins. Used by

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -548,9 +548,18 @@
 (defn- temporal-info
   "Extract temporal metadata from a DB wrapper.
    Date-based time-points are resolved to numeric tx-ids via AVET lookup on the origin DB.
-   Returns nil for regular DBs."
+   Returns nil for regular DBs.
+
+   Recurses through `FilteredDB` so a composition like
+   `(d/valid-at (d/as-of db t) inst)` — FilteredDB wrapping AsOfDB —
+   still reports `:as-of` to the planner. The FilteredDB's predicate
+   stays on the outer `db`'s search-context and fires via
+   `post-process-datoms` alongside the AsOf timepred."
   [db]
   (cond
+    (instance? FilteredDB db)
+    (temporal-info (.-unfiltered-db ^FilteredDB db))
+
     (instance? HistoricalDB db)
     {:type :historical :origin-db (dbi/-origin db)}
 
@@ -665,18 +674,42 @@
                                      (recur (next-ok-a)
                                             (when (.hasNext iter-b) (.next iter-b))))))))))))))))
 
+(defn- maybe-post-process
+  "Pipe `slice` through `post-process-datoms` iff the wrapper `db`'s
+   search-context carries an xform-after (set by FilteredDB or any
+   future wrapper) or a timepred (legacy temporal path). When neither
+   is set the slice is returned unchanged — `post-process-datoms`'s
+   `:else` branch short-circuits, so this guard avoids the
+   `(into [] xform datoms)` realization cost on plain dbs.
+
+   This is what lifts FilteredDB's predicate into the planner's hot
+   scan: without this hook the planner short-circuited filtered dbs
+   into raw slices, silently dropping the predicate. `d/valid-at`
+   rides on the same hook via a `(d/filter db vt-pred)` wrap."
+  [slice db origin-db]
+  (let [ctx (dbi/-search-context db)]
+    (if (or (dbi/context-xform ctx) (dbi/context-time-pred ctx))
+      (db/post-process-datoms slice origin-db ctx)
+      slice)))
+
 (defn- temporal-merge-slice
   "Get merged datoms for [eid attr] from current+temporal indexes.
    For historical: merge via distinct-datoms (all versions).
-   For as-of/since: merge + post-process-datoms (time filter + assemble)."
+   For as-of/since: merge + post-process-datoms (time filter + assemble).
+   For regular DB: pass through `maybe-post-process` so FilteredDB
+   (and `d/valid-at`, which is `(d/filter db vt-pred)` underneath)
+   actually fires."
   [origin-db from-d to-d temporal-type temporal-tx-filter db]
   (let [current-slice (di/-slice (:eavt origin-db) from-d to-d :eavt)]
     (case temporal-type
       :historical
-      (let [temporal-index (:temporal-eavt origin-db)]
-        (dbu/distinct-datoms origin-db :eavt
-                             current-slice
-                             (di/-slice temporal-index from-d to-d :eavt)))
+      (let [temporal-index (:temporal-eavt origin-db)
+            merged (dbu/distinct-datoms origin-db :eavt
+                                        current-slice
+                                        (di/-slice temporal-index from-d to-d :eavt))]
+        ;; Same xform-after lift as the as-of/since branch — keeps
+        ;; FilteredDB-around-HistoricalDB working.
+        (maybe-post-process merged db origin-db))
 
       (:as-of :since)
       (let [temporal-index (:temporal-eavt origin-db)
@@ -687,7 +720,7 @@
         (db/post-process-datoms merged origin-db ctx))
 
       ;; regular DB
-      current-slice)))
+      (maybe-post-process current-slice db origin-db))))
 
 (defn- build-scan-slice
   "Build the scan slice for execute-group-direct / execute-fused-scan-rel.
@@ -695,7 +728,10 @@
    db is the temporal wrapper (needed for search-context), origin-db is the unwrapped DB."
   [db db-index from-datom to-datom index temporal origin-db resolved-a]
   (if-not temporal
-    (di/-slice db-index from-datom to-datom index)
+    ;; Regular DB hot path: still let FilteredDB / d/valid-at fire via
+    ;; the wrapper's xform-after on the search-context. No-op when
+    ;; neither xform nor timepred is set (vast majority of queries).
+    (maybe-post-process (di/-slice db-index from-datom to-datom index) db origin-db)
     (let [temporal-type (:type temporal)
           as-of-at-max-tx? (and (= temporal-type :as-of)
                                 (= (long (:time-point temporal))
@@ -703,16 +739,19 @@
           temporal-index-key (keyword (str "temporal-" (name index)))]
       (case temporal-type
         :historical
-        (let [temporal-index (get origin-db temporal-index-key)]
-          #?(:clj (fast-merge-scan db-index from-datom to-datom
-                                   temporal-index index origin-db resolved-a)
-             :cljs (dbu/distinct-datoms origin-db index
-                                        (di/-slice db-index from-datom to-datom index)
-                                        (di/-slice temporal-index from-datom to-datom index))))
+        (let [temporal-index (get origin-db temporal-index-key)
+              raw #?(:clj (fast-merge-scan db-index from-datom to-datom
+                                           temporal-index index origin-db resolved-a)
+                     :cljs (dbu/distinct-datoms origin-db index
+                                                (di/-slice db-index from-datom to-datom index)
+                                                (di/-slice temporal-index from-datom to-datom index)))]
+          ;; Wrapper (e.g. FilteredDB-around-HistoricalDB for valid-at on history)
+          ;; still gets its xform-after applied.
+          (maybe-post-process raw db origin-db))
 
         (:as-of :since)
         (if as-of-at-max-tx?
-          (di/-slice db-index from-datom to-datom index)
+          (maybe-post-process (di/-slice db-index from-datom to-datom index) db origin-db)
           (let [temporal-index (get origin-db temporal-index-key)
                 merged (dbu/distinct-datoms origin-db index
                                             (di/-slice db-index from-datom to-datom index)
@@ -720,8 +759,8 @@
                 ctx (dbi/-search-context db)]
             (db/post-process-datoms merged origin-db ctx)))
 
-        ;; default: regular slice
-        (di/-slice db-index from-datom to-datom index)))))
+        ;; default: regular slice — still apply xform-after if set
+        (maybe-post-process (di/-slice db-index from-datom to-datom index) db origin-db)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Path functions — each small enough for JIT C2/Graal compilation.

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3155,10 +3155,10 @@
          :retrieval
          (if idx
            (let [query-args (vec (drop 1 args))
-                 results (sec/-slice-ordered idx
-                                             {:query (first query-args)
-                                              :field (second query-args)}
-                                             nil nil nil nil)
+                 results (sec/slice-ordered-with-vt db idx
+                                                    {:query (first query-args)
+                                                     :field (second query-args)}
+                                                    nil nil nil nil)
                  ;; Map binding vars to column indices
                  attrs (into {} (map-indexed (fn [i v] [v i]) binding-vars))
                  ;; Build tuples from results

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3089,12 +3089,14 @@
                  resolved-fn (when (and (symbol? fn-sym) (namespace fn-sym))
                                (some-> (resolve fn-sym) deref))
                  result-bs (if resolved-fn
-                             ;; Call the function which should return results
-                             ;; For filter mode, we use sec/-search
-                             (sec/-search idx
-                                          {:query (first resolved-args)
-                                           :field (second resolved-args)}
-                                          nil)
+                             ;; Call the function which should return results.
+                             ;; `search-with-vt` reads the db's `:datahike/valid-at`
+                             ;; marker (set by `d/valid-at`) and routes through
+                             ;; `-search-at-vt` for vt-aware indices.
+                             (sec/search-with-vt db idx
+                                                 {:query (first resolved-args)
+                                                  :field (second resolved-args)}
+                                                 nil)
                              (es/entity-bitset))
                  ;; Create relation from entity IDs
                  entity-var (first binding-vars)

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -516,6 +516,47 @@
   [args]
   (into #{} (mapcat analyze/extract-vars) args))
 
+(defn- external-engine-spec-vars
+  "Collect implicit input vars from a stratum-style external-engine
+   query-spec map. The engine's `aggregate` / `window` / etc. reference
+   their input columns as keywords inside :group / :agg / :order /
+   :window / :select, not as ?-vars in :args. `execute-external-engine`
+   in execute.cljc maps these keywords to ?-symbols at runtime
+   (e.g. :dept → ?dept) — this helper mirrors that mapping at plan
+   time so the binding-policy can require those vars bound before
+   running the engine. Without it, the engine schedules before its
+   producers and runs on an empty :rels.
+
+   Returns a set of '?col-name symbols. Returns #{} when the first
+   arg isn't a map (e.g. raw scalar input)."
+  [args]
+  (let [query-spec (first args)]
+    (if-not (map? query-spec)
+      #{}
+      (let [kws (concat (:group query-spec)
+                        ;; Each agg-spec last keyword is the column ref
+                        ;; (e.g. [:avg :salary] → :salary,
+                        ;; [:as :total [:sum :salary]] → :salary)
+                        (keep (fn [agg]
+                                (when (and (sequential? agg)
+                                           (> (count agg) 1))
+                                  (let [c (last agg)]
+                                    (when (keyword? c) c))))
+                              (:agg query-spec))
+                        (mapcat (fn [w]
+                                  (concat (:partition-by w)
+                                          (map first (:order-by w))
+                                          (when-let [c (:col w)]
+                                            (when (keyword? c) [c]))))
+                                (:window query-spec))
+                        (when-let [sel (:select query-spec)]
+                          (filter keyword? sel))
+                        (map first (:order query-spec)))]
+        (into #{}
+              (comp (filter keyword?)
+                    (map #(symbol (str "?" (name %)))))
+              kws)))))
+
 (defn- op-input-vars
   "Return only the *input* vars of an op — vars it consumes, not vars it produces.
    For :function ops, output vars (bound by the function) are excluded.
@@ -1078,7 +1119,16 @@
     [(args-free-vars (:args op)) :all]
 
     :external-engine
-    (let [input-args (args-free-vars (:args op))
+    (let [direct-args (args-free-vars (:args op))
+          ;; Stratum-style engines reference their input columns as
+          ;; keywords inside the query-spec (e.g. :group [:dept]
+          ;; :agg [[:avg :salary]]). The runtime in
+          ;; execute-external-engine :solver mode maps :dept → ?dept
+          ;; before projecting the input relation. The planner must
+          ;; recognise the same convention or it schedules the
+          ;; engine before its producers and runs it on an empty ctx.
+          spec-args (external-engine-spec-vars (:args op))
+          input-args (into direct-args spec-args)
           spec (:input-vars-spec op)]
       (case spec
         :any-bound [input-args :any]

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -67,7 +67,12 @@
 (s/def ::secondary-index-attribute #{:db.secondary/type :db.secondary/attrs :db.secondary/config :db.secondary/status :db.secondary/building-since-tx})
 
 (s/def ::entity-spec-attribute #{:db/ensure :db.entity/attrs :db.entity/preds})
-(s/def ::meta-attribute #{:db/txInstant :db/retracted :db/noCommit})
+;; ADR — bitemporal v1: :db.valid/from and :db.valid/to graduate from
+;; userland tx-meta into datahike system schema. They are tx-attached
+;; (every datom in a tx inherits its tx's vt window) and AVET-indexed
+;; so the query planner can seek into them.
+(s/def ::meta-attribute #{:db/txInstant :db/retracted :db/noCommit
+                          :db.valid/from :db.valid/to})
 
 (s/def ::schema (s/keys :req [:db/ident :db/valueType :db/cardinality]
                         :opt [:db/id :db/unique :db/index :db.install/_attribute :db/doc :db/noHistory :db/tupleType :db/tupleTypes]))
@@ -119,6 +124,14 @@
                                                   :db/unique :db.unique/identity
                                                   :db/index true
                                                   :db/cardinality :db.cardinality/one}
+                                   ;; Bitemporal valid-time tx-meta — see ::meta-attribute above.
+                                   ;; Half-open interval [from, to). Both AVET-indexed.
+                                   :db.valid/from {:db/valueType :db.type/instant
+                                                   :db/index true
+                                                   :db/cardinality :db.cardinality/one}
+                                   :db.valid/to   {:db/valueType :db.type/instant
+                                                   :db/index true
+                                                   :db/cardinality :db.cardinality/one}
                                    :db/noCommit  {:db/valueType :db.type/boolean
                                                   :db/unique :db.unique/identity
                                                   :db/cardinality :db.cardinality/one}
@@ -146,7 +159,7 @@
 (s/def :db/helpers #{:db.install/attribute :db})
 (s/def :db.part/types #{:db.part/tx :db.part/sys :db.part/user})
 
-(s/def :db.meta/attributes #{:db/txInstant})
+(s/def :db.meta/attributes #{:db/txInstant :db.valid/from :db.valid/to})
 
 (s/def ::sys-idents (s/or :value :db.type/value
                           :cardinality :db.type/cardinality

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -61,6 +61,22 @@
   #?(:clj (.getTime (Date.))
      :cljs (.getTime (js/Date.))))
 
+;; Clock pinning for repeatable test runs / regulator replays:
+;;
+;; The writer runs transactions on a background thread, so per-call
+;; dynamic bindings (`(binding [get-date ...] ...)`) don't propagate.
+;; Two patterns work instead:
+;;
+;; 1. **Per-tx override via tx-meta** — pass `:db/txInstant <Date>` in
+;;    your tx's `:tx-meta`; the transactor merges your value over the
+;;    `get-date` default at `transact-tx-data` (db/transaction.cljc).
+;;    Simplest for deterministic snapshots and the one we recommend
+;;    for tests.
+;;
+;; 2. **Global override via `alter-var-root`** — for whole-suite test
+;;    pinning, redefine `get-date` once at fixture setup. This is
+;;    coarser than `binding` but survives the thread hop.
+
 ;; adapted from https://clojure.atlassian.net/browse/CLJ-2766
 #?(:clj
    (defn throwable-promise

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -2,6 +2,7 @@
   "Manage all state changes and access to state of durable store."
   (:require [datahike.connections :refer [delete-connection! *connections*]]
             [datahike.db :as db]
+            [datahike.db.transaction :as dbtx]
             [datahike.db.utils :as dbu]
             [datahike.db.interface :as dbi]
             [datahike.index :as di]
@@ -560,7 +561,13 @@
                                             (> (.-tx ^datahike.datom.Datom d) building-since-tx))
                                      idx
                                      (do (swap! n inc)
-                                         (let [tx-report {:datom d :added? true}]
+                                         ;; Reconstruct each datom's tx-meta from the
+                                         ;; historical EAVT seek on its tx-id. Without
+                                         ;; this, vt-aware adapters miss the writing-tx
+                                         ;; `:db.valid/from` and degrade to `txInstant`.
+                                         (let [tx-id (.-tx ^datahike.datom.Datom d)
+                                               tx-report {:datom d :added? true
+                                                          :tx-meta (dbtx/meta-for-tx-id db tx-id)}]
                                            (if use-transient?
                                              (do (sec/-transact! idx tx-report) idx)
                                              (sec/-transact idx tx-report))))))

--- a/test/datahike/test/api_test.cljc
+++ b/test/datahike/test/api_test.cljc
@@ -776,8 +776,8 @@
         schema-count 11                                     ;; amount of user schema datoms in temporal eavt index
         temporal-count 10                                   ;; amount of user data datoms in temporal eavt index when using schema-on-write
         temporal-avet-count 9                               ;; amount of user data datoms in temporal avet index when using schema-on write
-        sys-attr-count 69                                   ;; amount of system schema datoms in temporal eavt index when using attribute refs
-        sys-attr-avet-count 48                              ;; amount of system schema datoms in temporal avet index when using attribute refs
+        sys-attr-count 79                                   ;; amount of system schema datoms in temporal eavt index when using attribute refs (was 69; +10 for :db.valid/from + :db.valid/to)
+        sys-attr-avet-count 50                              ;; amount of system schema datoms in temporal avet index when using attribute refs (was 48; +2 for the :db/ident datoms of the new vt attrs)
         update-for-schema-on-write
         (fn [metrics]
           (-> (update metrics :count #(+ % 11))

--- a/test/datahike/test/back_correction_probe.clj
+++ b/test/datahike/test/back_correction_probe.clj
@@ -1,0 +1,62 @@
+(ns datahike.test.back-correction-probe
+  "Empirical probe of the back-correction semantic gap in datahike's
+   per-tx valid-time model. Demonstrates what the current `d/valid-at`
+   predicate returns vs what an bitemporal supersession would return."
+  (:require [clojure.test :as t :refer [is deftest testing]]
+            [datahike.api :as d]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(deftest back-correction-shows-current-semantic
+  ;; Scenario:
+  ;;   tx-1 (vt=[Jan-01, ∞)): assert Bob.salary = 100k
+  ;;   tx-2 (vt=[Apr-01, ∞)): assert Bob.salary = 90k  (back-correction)
+  ;;
+  ;; Expected bitemporal supersession semantic:
+  ;;   query at vt=Feb-15 → 100k (pre-correction era)
+  ;;   query at vt=May-15 →  90k (post-correction era, tx-2 supersedes)
+  ;;
+  ;; Current datahike single-axis predicate:
+  ;;   query at vt=Feb-15 → see what happens
+  ;;   query at vt=May-15 → see what happens
+  (let [conn (fresh-conn)
+        _ (d/transact conn [{:db/ident :emp/name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one
+                             :db/unique :db.unique/identity}
+                            {:db/ident :emp/salary
+                             :db/valueType :db.type/long
+                             :db/cardinality :db.cardinality/one
+                             :db/index true}])
+        _ (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                            :tx-meta {:db.valid/from #inst "2024-01-01"}})
+        _ (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 90000}]
+                            :tx-meta {:db.valid/from #inst "2024-04-01"}})
+        db   @conn
+        hist (d/history db)]
+    (testing "current-time only sees the latest assertion (90k)"
+      (is (= #{[90000]}
+             (d/q '[:find ?s :where [_ :emp/salary ?s]] db))))
+    (testing "current-time + valid-at Feb-15 → empty (tx-2's vt excludes Feb-15; tx-1's 100k is retracted in current view)"
+      (is (= #{}
+             (d/q '[:find ?s :where [_ :emp/salary ?s]]
+                  (d/valid-at db #inst "2024-02-15")))))
+    (testing "history + valid-at Feb-15 → returns {100k}"
+      (is (= #{[100000]}
+             (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]]
+                  (d/valid-at hist #inst "2024-02-15"))))
+      "tx-1 vt=[Jan, ∞) covers Feb-15 → 100k admitted; tx-2 vt=[Apr, ∞) excluded")
+    (testing "history + valid-at May-15 → {90k} via supersession"
+      ;; Both tx-1's vt=[Jan, ∞) and tx-2's vt=[Apr, ∞) cover May-15.
+      ;; Supersession picks the latest tx for each (e, a, v):
+      ;;   - (bob, :emp/salary, 100k) → winner = tx-2 (retraction). Reject the assertion datom.
+      ;;   - (bob, :emp/salary,  90k) → winner = tx-2 (assertion). Admit.
+      (let [result (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]]
+                        (d/valid-at hist #inst "2024-05-15"))]
+        (is (= #{[90000]} result)
+            "supersession-aware predicate picks tx-2's 90k over tx-1's 100k")))))

--- a/test/datahike/test/back_correction_test.clj
+++ b/test/datahike/test/back_correction_test.clj
@@ -1,7 +1,13 @@
-(ns datahike.test.back-correction-probe
-  "Empirical probe of the back-correction semantic gap in datahike's
-   per-tx valid-time model. Demonstrates what the current `d/valid-at`
-   predicate returns vs what an bitemporal supersession would return."
+(ns datahike.test.back-correction-test
+  "Regression for `d/valid-at` back-correction semantics — the
+   supersession contract under two overlapping vt-windowed assertions
+   for the same (e, a). When tx-2's vt-window covers `at` AND has a
+   greater tx-id than tx-1, tx-2's assertion supersedes tx-1's — the
+   bitemporal supersession at the read layer (see
+   `api/impl.cljc:269-309` for the design rationale). This test pins
+   the four cases that distinguish supersession-correct from
+   single-axis-naive: current-view, pre-correction history,
+   post-correction history, and the supersession winner."
   (:require [clojure.test :as t :refer [is deftest testing]]
             [datahike.api :as d]))
 
@@ -12,18 +18,17 @@
     (d/create-database cfg)
     (d/connect cfg)))
 
-(deftest back-correction-shows-current-semantic
+(deftest valid-at-back-correction-supersession
   ;; Scenario:
   ;;   tx-1 (vt=[Jan-01, ∞)): assert Bob.salary = 100k
   ;;   tx-2 (vt=[Apr-01, ∞)): assert Bob.salary = 90k  (back-correction)
   ;;
-  ;; Expected bitemporal supersession semantic:
-  ;;   query at vt=Feb-15 → 100k (pre-correction era)
+  ;; bitemporal supersession at the read layer:
+  ;;   query at vt=Feb-15 → 100k (pre-correction era, tx-2 excluded by vt)
   ;;   query at vt=May-15 →  90k (post-correction era, tx-2 supersedes)
   ;;
-  ;; Current datahike single-axis predicate:
-  ;;   query at vt=Feb-15 → see what happens
-  ;;   query at vt=May-15 → see what happens
+  ;; The supersession-correct `d/valid-at` implementation must produce
+  ;; the polygon shape on both branches.
   (let [conn (fresh-conn)
         _ (d/transact conn [{:db/ident :emp/name
                              :db/valueType :db.type/string

--- a/test/datahike/test/cross_tx_vt_validation_test.clj
+++ b/test/datahike/test/cross_tx_vt_validation_test.clj
@@ -228,9 +228,11 @@
 
 (deftest current-tx-vt-meta-not-tracked
   (testing "Writes to the CURRENT tx's :db.valid/from / :db.valid/to
-            (i.e., the standard :tx-meta path via {:db/id 'datomic.tx'})
-            do NOT fire the cross-tx guard — they're handled by the
-            existing pre-loop :tx-meta validator. No bookkeeping leak."
+            (i.e., the idiomatic `:tx-meta` map-arg path; the legacy
+            `{:db/id 'datomic.tx' ...}` inline-tempid path normalises
+            to the same shape per api/impl.cljc:29-41) do NOT fire the
+            cross-tx guard — they're handled by the existing pre-loop
+            :tx-meta validator. No bookkeeping leak."
     (let [conn (fresh-conn)
           _ (install-schema! conn)
           r (d/transact conn {:tx-data [{:p/k "z" :p/n 7}]

--- a/test/datahike/test/cross_tx_vt_validation_test.clj
+++ b/test/datahike/test/cross_tx_vt_validation_test.clj
@@ -1,0 +1,271 @@
+(ns datahike.test.cross-tx-vt-validation-test
+  "Tests for the cross-tx vf<vt validation guard at the transactor.
+
+   The standard `vf < vt` check on `:tx-meta` (transaction.cljc:1027)
+   only validates the CURRENT tx's own valid-time meta. A retroactive
+   `[:db/add prior-tx-eid :db.valid/{from,to} ...]` write produces a
+   closure formed against the prior tx's existing meta — and without
+   this cross-tx guard would silently corrupt the prior tx's queryable
+   window when the resulting (vf, vt) pair has vf >= vt.
+
+   These tests pin the guard's behaviour against the 8 scenarios from
+   the design discussion: retroactive vt, retroactive vf, both-halves-
+   in-one-tx, cardinality-one-double-write, :db.fn/cas, retract-alone,
+   retract-plus-add, and the no-op fast path (no vt-meta writes at all)."
+  (:require [clojure.test :as t :refer [is deftest testing]]
+            [datahike.api :as d]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defn- transact-ex-data
+  "datahike's async writer wraps the raw ExceptionInfo in a
+   java.util.concurrent.ExecutionException, which then propagates as
+   the outer ExceptionInfo's cause. Walk the chain until we find the
+   non-empty ex-data."
+  [^Throwable e]
+  (loop [t e]
+    (cond
+      (nil? t) nil
+      (seq (ex-data t)) (ex-data t)
+      :else (recur (.getCause t)))))
+
+(defn- install-schema! [conn]
+  (d/transact conn
+              [{:db/ident :p/k
+                :db/valueType :db.type/string
+                :db/unique :db.unique/identity
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :p/n
+                :db/valueType :db.type/long
+                :db/cardinality :db.cardinality/one}]))
+
+(defn- post-with-vt!
+  "Post one entity at the given vf (and optional vt). Returns the
+   tx-eid of the resulting tx for later retroactive testing."
+  [conn k vf & [vt]]
+  (let [r (d/transact conn {:tx-data [{:p/k k :p/n 1}]
+                            :tx-meta (cond-> {:db.valid/from vf}
+                                       vt (assoc :db.valid/to vt))})]
+    (->> (:tx-data r)
+         (filter #(= :db/txInstant (.-a %)))
+         first
+         .-tx)))
+
+;; ============================================================================
+;; Scenario 1: retroactive :db.valid/to write — good + bad paths
+;; ============================================================================
+
+(deftest retroactive-vt-to-good-path
+  (testing "Writing :db.valid/to > existing vf is accepted (the
+            standard 'close a window' supersession move)."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      (is (some? (d/transact conn [{:db/id txA
+                                    :db.valid/to #inst "2026-02-15"}]))
+          "valid closure accepted"))))
+
+(deftest retroactive-vt-to-bad-path
+  (testing "Writing :db.valid/to <= existing vf is rejected with
+            :transact/invalid-valid-times-cross-tx."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      (try
+        (d/transact conn [{:db/id txA
+                           :db.valid/to #inst "2026-01-15"}])
+        (is false "expected throw")
+        (catch Exception e
+          (let [data (transact-ex-data e)]
+            (is (= :transact/invalid-valid-times-cross-tx (:error data)))
+            (is (= txA (:tx-eid data)))
+            (is (= #inst "2026-01-31" (:db.valid/from data)))
+            (is (= #inst "2026-01-15" (:db.valid/to data)))))))))
+
+(deftest retroactive-vt-to-equal-vf-rejected
+  (testing "vt == vf (zero-width window) is also rejected — matches the
+            existing same-tx guard semantic (strict vf < vt)."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [{:db/id txA
+                                               :db.valid/to #inst "2026-01-31"}]))))))
+
+;; ============================================================================
+;; Scenario 2: retroactive :db.valid/from write — symmetric
+;; ============================================================================
+
+(deftest retroactive-vt-from-good-path
+  (testing "Writing :db.valid/from < existing vt is accepted (shifting
+            the window's lower bound)."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31" #inst "2026-02-15")]
+      (is (some? (d/transact conn [{:db/id txA
+                                    :db.valid/from #inst "2026-01-01"}]))))))
+
+(deftest retroactive-vt-from-bad-path
+  (testing "Writing :db.valid/from >= existing vt is rejected."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31" #inst "2026-02-15")]
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [{:db/id txA
+                                               :db.valid/from #inst "2026-03-01"}]))))))
+
+;; ============================================================================
+;; Scenario 3: both halves written in the same tx — combined-state check
+;; ============================================================================
+
+(deftest both-halves-in-one-tx-good
+  (testing "Same tx writes BOTH vf and vt on a prior tx-entity. Validation
+            sees the FINAL combined state — vf < vt → accepted."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      ;; tx-A had vf=jan-31, no vt. Re-stamp the window entirely:
+      (is (some? (d/transact conn [{:db/id txA
+                                    :db.valid/from #inst "2026-01-01"
+                                    :db.valid/to #inst "2026-02-01"}]))))))
+
+(deftest both-halves-in-one-tx-bad
+  (testing "Same tx writes BOTH vf and vt producing vf >= vt → rejected."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [{:db/id txA
+                                               :db.valid/from #inst "2026-03-01"
+                                               :db.valid/to #inst "2026-02-01"}]))))))
+
+;; ============================================================================
+;; Scenario 4: cardinality-one double-write within one tx — last wins
+;; ============================================================================
+
+(deftest cardinality-one-double-write-final-wins
+  (testing "Same tx writes :db.valid/to twice; cardinality-one means the
+            second write wins. The deferred check sees the final state."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")]
+      ;; First write (vt=feb-01) is valid. Second write (vt=jan-15) is invalid.
+      ;; Final state: vf=jan-31, vt=jan-15 → reject.
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [{:db/id txA
+                                               :db.valid/to #inst "2026-02-01"}
+                                              {:db/id txA
+                                               :db.valid/to #inst "2026-01-15"}]))))))
+
+;; ============================================================================
+;; Scenario 5: :db.fn/cas (lowered to retract+add) — caught by add side
+;; ============================================================================
+
+(deftest cas-bad-vt-rejected
+  (testing ":db.fn/cas on :db.valid/to with a bad new value is rejected —
+            the lowered :db/add fires the cross-tx tracker."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31" #inst "2026-02-15")]
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [[:db/cas txA :db.valid/to
+                                               #inst "2026-02-15"
+                                               #inst "2026-01-15"]]))))))
+
+;; ============================================================================
+;; Scenario 6: retract alone — never invalidates (can only broaden window)
+;; ============================================================================
+
+(deftest retract-alone-no-validation-needed
+  (testing "Retracting :db.valid/to alone broadens window to [vf, ∞);
+            cannot invalidate. The guard is skipped on retract-only paths."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31" #inst "2026-02-15")]
+      (is (some? (d/transact conn [[:db/retract txA :db.valid/to
+                                    #inst "2026-02-15"]])))
+      ;; Confirm the retract took effect: only vf remains on tx-A.
+      (let [datoms (vec (d/datoms (d/db conn) :eavt txA))
+            has-vt? (some #(= :db.valid/to (.-a %)) datoms)]
+        (is (not has-vt?))))))
+
+;; ============================================================================
+;; Scenario 7: retract+add same tx — add-side triggers the guard
+;; ============================================================================
+
+(deftest retract-plus-add-same-tx-rejected
+  (testing "Retract :db.valid/to, then add a bad new value, in the same
+            tx. The add fires the tracker; deferred check sees the
+            invalid final state and rejects."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31" #inst "2026-02-15")]
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [[:db/retract txA :db.valid/to
+                                               #inst "2026-02-15"]
+                                              [:db/add txA :db.valid/to
+                                               #inst "2026-01-15"]]))))))
+
+;; ============================================================================
+;; Scenario 8: the no-op fast path — no vt-meta writes at all
+;; ============================================================================
+
+(deftest no-vt-meta-writes-no-bookkeeping-leak
+  (testing "A tx that writes no :db.valid/from / :db.valid/to attrs
+            triggers no bookkeeping and the returned TxReport carries
+            only the canonical 5 keys (no ::pending-vt-validation leak)."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          r (d/transact conn [{:p/k "y" :p/n 42}])]
+      (is (= #{:db-before :db-after :tx-data :tempids :tx-meta}
+             (set (keys r)))
+          "TxReport carries only the canonical keys"))))
+
+(deftest current-tx-vt-meta-not-tracked
+  (testing "Writes to the CURRENT tx's :db.valid/from / :db.valid/to
+            (i.e., the standard :tx-meta path via {:db/id 'datomic.tx'})
+            do NOT fire the cross-tx guard — they're handled by the
+            existing pre-loop :tx-meta validator. No bookkeeping leak."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          r (d/transact conn {:tx-data [{:p/k "z" :p/n 7}]
+                              :tx-meta {:db.valid/from #inst "2026-01-01"
+                                        :db.valid/to #inst "2026-02-01"}})]
+      (is (= #{:db-before :db-after :tx-data :tempids :tx-meta}
+             (set (keys r)))))))
+
+;; ============================================================================
+;; Scenario 9: validation runs on db-after — sees the closure correctly
+;; even when interleaved with non-vt writes on the same tx-entity
+;; ============================================================================
+
+(deftest multiple-prior-txs-each-validated
+  (testing "When one commit touches N different prior tx-entities, each
+            is validated independently. Mixing a good close with a bad
+            close in the same tx is rejected (first violation wins)."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")
+          txB (post-with-vt! conn "y" #inst "2026-01-31")]
+      ;; Close txA validly, close txB invalidly — should reject.
+      (is (thrown-with-msg? Exception #"Invalid cross-tx valid-time window"
+                            (d/transact conn [{:db/id txA
+                                               :db.valid/to #inst "2026-02-15"}
+                                              {:db/id txB
+                                               :db.valid/to #inst "2026-01-15"}]))))))
+
+(deftest multiple-prior-txs-all-good
+  (testing "Multiple good closes in one commit all succeed."
+    (let [conn (fresh-conn)
+          _ (install-schema! conn)
+          txA (post-with-vt! conn "x" #inst "2026-01-31")
+          txB (post-with-vt! conn "y" #inst "2026-01-31")]
+      (is (some? (d/transact conn [{:db/id txA
+                                    :db.valid/to #inst "2026-02-15"}
+                                   {:db/id txB
+                                    :db.valid/to #inst "2026-03-01"}]))))))

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -80,7 +80,20 @@
               [:db/ident :db.type/double 536870912 true]
               [:db/doc "An attribute's value type" 536870912 true]
               [:db/doc "An attribute's documentation" 536870912 true]
-              [:db/ident :db.type/keyword 536870912 true]])
+              [:db/ident :db.type/keyword 536870912 true]
+              ;; Bitemporal valid-time tx-meta — system-schema (commit 1 of
+              ;; feature/bitemporal-v1). Two new idents + two doc strings;
+              ;; the valueType (22 = :db.type/instant), cardinality (11),
+              ;; and `:db/index true` ref-datoms collapse with existing
+              ;; entries when materialised through `into #{}`.
+              [:db/ident :db.valid/from 536870912 true]
+              [:db/ident :db.valid/to 536870912 true]
+              [:db/doc
+               "A transaction's valid-time lower bound (inclusive).\n             Every datom in the tx inherits this vt-from. When\n             absent the transaction's `:db/txInstant` is used."
+               536870912 true]
+              [:db/doc
+               "A transaction's valid-time upper bound (exclusive).\n             When absent the interval is open-ended (treated as\n             +∞ by the bitemporal resolver)."
+               536870912 true]])
 
 (deftest export-import-test
   (let [os-prefix (case (System/getProperty "os.name")

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -89,10 +89,10 @@
               [:db/ident :db.valid/from 536870912 true]
               [:db/ident :db.valid/to 536870912 true]
               [:db/doc
-               "A transaction's valid-time lower bound (inclusive).\n             Every datom in the tx inherits this vt-from. When\n             absent the transaction's `:db/txInstant` is used."
+               "A transaction's valid-time lower bound (inclusive).\n             Every datom in the tx inherits this vt-from. When\n             absent the transaction's `:db/txInstant` is used.\n             See `doc/valid_time.md` for usage."
                536870912 true]
               [:db/doc
-               "A transaction's valid-time upper bound (exclusive).\n             When absent the interval is open-ended (treated as\n             +∞ by the bitemporal resolver)."
+               "A transaction's valid-time upper bound (exclusive).\n             When absent the interval is open-ended (treated as +∞).\n             May be written retroactively on a prior tx-entity to\n             close that tx's window; the write is a normal commit,\n             the prior tx's hash is unchanged, and the transactor\n             enforces a cross-tx `vf < vt` check on the combined\n             state. See `doc/valid_time.md` for usage."
                536870912 true]])
 
 (deftest export-import-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -8,7 +8,8 @@
             [cljs.nodejs :as nodejs]
             ;; Sibling test namespaces — included so `bb node-cljs-test`
             ;; covers them too.
-            [datahike.test.cljs-pattern-scan-test]))
+            [datahike.test.cljs-pattern-scan-test]
+            [datahike.test.valid-time-test]))
 
 ;; Hook cljs.test's end-of-run callback so the Node process exits with
 ;; status 0 only when all tests pass. The previous setup always exited
@@ -352,4 +353,5 @@
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
-               'datahike.test.cljs-pattern-scan-test))
+               'datahike.test.cljs-pattern-scan-test
+               'datahike.test.valid-time-test))

--- a/test/datahike/test/query_planner_temporal_test.clj
+++ b/test/datahike/test/query_planner_temporal_test.clj
@@ -6,6 +6,7 @@
    should pass on both engines; the assertion form is `(= legacy planner)`
    so a future regression in either path is caught."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [datahike.api :as d]
    [datahike.query :as q])
@@ -338,3 +339,115 @@
                   produces a tuple of all-nils because the optional scan
                   ran with ?r still free")))
         (finally (d/delete-database cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; Note 179 §4 Gap 1 — zero-cost overlay invariant
+;;
+;; The substrate's framing in schema.cljc:71-74 — "valid-time is an
+;; overlay on tx-time" — implies that a query that does NOT reference
+;; `:db.valid/*` must produce IDENTICAL plans on a vt-equipped DB and
+;; on a plain DB. Per note 179 §6 Q1, this property has no test
+;; anywhere in the suite. The deftest below locks it in:
+;;
+;;   1. Plan the same EAV query on both a baseline DB and a DB that
+;;      contains vt-bearing transactions.
+;;   2. Assert the plans are structurally identical.
+;;
+;; A future refactor that, say, wires a vt filter "just to be safe"
+;; into the planner's default path would silently regress this
+;; invariant — and the rest of the suite would stay green because it
+;; only asserts behavioural correctness, not plan shape.
+;;
+;; The `(q/explain ...)` string-rendering is the canonical
+;; introspection hook (it folds the same plan tree the executor
+;; consumes through `format-plan-ops`). We strip the noisy `rules:`
+;; header line that lists the built-in interval rules — those are
+;; loaded into every Context regardless of whether the query uses them
+;; and aren't a per-DB property — and assert the remaining plan body
+;; matches byte-for-byte.
+
+(defn- strip-rules-line
+  "Remove the `rules: [...]` header line from a (q/explain ...) string.
+   Built-in interval rules are loaded uniformly; they are not part of the
+   per-DB plan shape we want to compare."
+  [^String s]
+  (->> (str/split-lines s)
+       (remove #(str/starts-with? % "rules:"))
+       (str/join "\n")))
+
+(deftest test-vt-schema-zero-cost-for-non-vt-query
+  (testing "a query that does NOT touch :db.valid/* must produce the
+            identical plan whether the DB has vt-bearing data or not.
+            This is the maintainer's headline overlay invariant —
+            non-vt queries pay zero plan-shape cost."
+    (let [baseline-cfg {:store {:backend :memory :id (UUID/randomUUID)}
+                        :writer {:backend :self}
+                        :schema-flexibility :write
+                        :keep-history? true}
+          vt-cfg {:store {:backend :memory :id (UUID/randomUUID)}
+                  :writer {:backend :self}
+                  :schema-flexibility :write
+                  :keep-history? true}]
+      (try
+        (d/create-database baseline-cfg)
+        (d/create-database vt-cfg)
+        (let [baseline (d/connect baseline-cfg)
+              vt (d/connect vt-cfg)
+              schema [{:db/ident :user/name
+                       :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one
+                       :db/unique :db.unique/identity}
+                      {:db/ident :user/age
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one
+                       :db/index true}]]
+          (d/transact baseline schema)
+          (d/transact vt schema)
+          ;; Baseline: write with no vt-meta.
+          (d/transact baseline [{:user/name "Alice" :user/age 30}
+                                {:user/name "Bob"   :user/age 40}])
+          ;; vt: write the SAME data but every tx carries a vt-meta
+          ;; window. The vt-bearing data must NOT perturb the plan for
+          ;; a query that doesn't reference :db.valid/*.
+          (d/transact vt {:tx-data [{:user/name "Alice" :user/age 30}]
+                          :tx-meta {:db.valid/from #inst "2024-01-01"
+                                    :db.valid/to   #inst "2024-07-01"}})
+          (d/transact vt {:tx-data [{:user/name "Bob" :user/age 40}]
+                          :tx-meta {:db.valid/from #inst "2024-01-01"}})
+
+          (testing "simple EAV scan — `[?e :user/name \"Alice\"]`"
+            (let [q '[:find ?e :where [?e :user/name "Alice"]]
+                  baseline-plan (strip-rules-line (q/explain q (d/db baseline)))
+                  vt-plan       (strip-rules-line (q/explain q (d/db vt)))]
+              (is (= baseline-plan vt-plan)
+                  (str "plans must be identical for a non-vt query.\n"
+                       "baseline:\n" baseline-plan "\n"
+                       "vt:\n" vt-plan))))
+
+          (testing "multi-clause join — entity-group with predicate"
+            (let [q '[:find ?n ?a
+                      :where
+                      [?e :user/name ?n]
+                      [?e :user/age ?a]
+                      [(> ?a 35)]]
+                  baseline-plan (strip-rules-line (q/explain q (d/db baseline)))
+                  vt-plan       (strip-rules-line (q/explain q (d/db vt)))]
+              (is (= baseline-plan vt-plan)
+                  (str "plans must be identical for a multi-clause
+                        non-vt query.\nbaseline:\n" baseline-plan
+                       "\nvt:\n" vt-plan))))
+
+          (testing "behavioural correctness — vt data answers the query"
+            ;; Sanity: the vt-equipped DB still resolves the same data
+            ;; the baseline does. Without this check, a "plans equal"
+            ;; assertion could be vacuously true if vt-data simply
+            ;; failed to land.
+            (let [q '[:find ?n :where [_ :user/name ?n]]
+                  baseline-result (set (d/q q (d/db baseline)))
+                  vt-result       (set (d/q q (d/db vt)))]
+              (is (= #{["Alice"] ["Bob"]} baseline-result))
+              (is (= baseline-result vt-result)
+                  "vt-DB answers the non-vt query identically"))))
+        (finally
+          (d/delete-database baseline-cfg)
+          (d/delete-database vt-cfg))))))

--- a/test/datahike/test/secondary_vt_routing_test.clj
+++ b/test/datahike/test/secondary_vt_routing_test.clj
@@ -1,0 +1,154 @@
+(ns datahike.test.secondary-vt-routing-test
+  "Verifies the routing contract of `sec/search-with-vt` /
+   `sec/slice-ordered-with-vt`:
+
+     - vt-aware index (IValidTimeAware)         → -search-at-vt (native)
+     - vt-stable index (IValidTimeStable)       → -search (no filter)
+     - plain index                              → -search + post-filter
+
+   Uses mock indices to isolate the routing logic from any specific
+   secondary's behavior."
+  (:require [clojure.test :as t :refer [is deftest testing]]
+            [datahike.api :as d]
+            [datahike.index.secondary :as sec]
+            [datahike.index.entity-set :as es]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defrecord MockBitsetIndex [bitset call-log]
+  sec/ISecondaryIndex
+  (-search [_ _query-spec _entity-filter]
+    (swap! call-log conj :-search)
+    bitset)
+  (-estimate [_ _] (es/entity-bitset-cardinality bitset))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _qs _ef _attr _dir _limit]
+    (swap! call-log conj :-slice-ordered)
+    ;; Mimic proximum's vec-of-maps shape
+    (mapv (fn [eid] {:entity-id eid :score 0.99})
+          (es/entity-bitset-seq bitset)))
+  (-indexed-attrs [_] #{})
+  (-transact [this _] this))
+
+(defrecord MockVtAwareIndex [bitset call-log]
+  sec/ISecondaryIndex
+  (-search [_ _qs _ef]
+    (swap! call-log conj :-search)
+    bitset)
+  (-estimate [_ _] (es/entity-bitset-cardinality bitset))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _qs _ef _attr _dir _limit]
+    (swap! call-log conj :-slice-ordered)
+    (mapv (fn [eid] {:entity-id eid :score 0.99})
+          (es/entity-bitset-seq bitset)))
+  (-indexed-attrs [_] #{})
+  (-transact [this _] this)
+
+  sec/IValidTimeAware
+  (-search-at-vt [_ _qs _ef _at]
+    (swap! call-log conj :-search-at-vt)
+    ;; Native fast path — pretend we filtered correctly
+    bitset))
+
+(defrecord MockVtStableIndex [bitset call-log]
+  sec/ISecondaryIndex
+  (-search [_ _qs _ef]
+    (swap! call-log conj :-search)
+    bitset)
+  (-estimate [_ _] (es/entity-bitset-cardinality bitset))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _qs _ef _attr _dir _limit]
+    (swap! call-log conj :-slice-ordered)
+    (mapv (fn [eid] {:entity-id eid :score 0.99})
+          (es/entity-bitset-seq bitset)))
+  (-indexed-attrs [_] #{})
+  (-transact [this _] this)
+
+  sec/IValidTimeStable
+  (-vt-stable? [_] true))
+
+(defn- setup-data []
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :emp/name
+                       :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one
+                       :db/unique :db.unique/identity}])
+    ;; Bob is asserted with vt in [Jan, Apr)
+    (d/transact conn {:tx-data [{:emp/name "Bob"}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-04-01"}})
+    ;; Alice in [Apr, Jul)
+    (d/transact conn {:tx-data [{:emp/name "Alice"}]
+                      :tx-meta {:db.valid/from #inst "2024-04-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    conn))
+
+(deftest vt-aware-index-routes-to-search-at-vt
+  (let [conn (setup-data)
+        bob  (d/q '[:find ?e . :where [?e :emp/name "Bob"]] @conn)
+        alice (d/q '[:find ?e . :where [?e :emp/name "Alice"]] @conn)
+        bitset (es/entity-bitset-from-longs [bob alice])
+        log (atom [])
+        idx (->MockVtAwareIndex bitset log)
+        vt-db (d/valid-at @conn #inst "2024-02-15")]
+    (testing "marker present + vt-aware → -search-at-vt"
+      (sec/search-with-vt vt-db idx {} nil)
+      (is (= [:-search-at-vt] @log)))))
+
+(deftest vt-stable-index-bypasses-post-filter
+  (let [conn (setup-data)
+        bob  (d/q '[:find ?e . :where [?e :emp/name "Bob"]] @conn)
+        bitset (es/entity-bitset-from-longs [bob])
+        log (atom [])
+        idx (->MockVtStableIndex bitset log)
+        vt-db (d/valid-at @conn #inst "2024-02-15")]
+    (testing "marker present + vt-stable → plain -search"
+      (let [result (sec/search-with-vt vt-db idx {} nil)]
+        (is (= [:-search] @log))
+        (testing "result not filtered — Bob comes through even at vt outside his window"
+          ;; sanity: caller passed Bob's eid, vt-stable means we trust the index
+          (is (= [bob] (vec (es/entity-bitset-seq result)))))))))
+
+(deftest plain-index-applies-post-hoc-filter
+  (let [conn (setup-data)
+        bob  (d/q '[:find ?e . :where [?e :emp/name "Bob"]] @conn)
+        alice (d/q '[:find ?e . :where [?e :emp/name "Alice"]] @conn)
+        ;; Mock index returns BOTH Bob and Alice unconditionally
+        bitset (es/entity-bitset-from-longs [bob alice])
+        log (atom [])
+        idx (->MockBitsetIndex bitset log)]
+    (testing "history view + valid-at Feb-15 → only Bob (in his vt-window)"
+      (let [vt-db   (d/valid-at (d/history @conn) #inst "2024-02-15")
+            result  (sec/search-with-vt vt-db idx {} nil)]
+        (is (= [:-search] @log))
+        (testing "post-filter drops Alice (her vt is [Apr, Jul))"
+          (is (= [bob] (vec (es/entity-bitset-seq result)))))))
+    (testing "no marker → -search, full bitset returned"
+      (reset! log [])
+      (let [result (sec/search-with-vt @conn idx {} nil)]
+        (is (= [:-search] @log))
+        (is (= #{bob alice} (set (es/entity-bitset-seq result))))))))
+
+(deftest post-hoc-filter-works-on-vec-of-maps
+  ;; slice-ordered returns vec of {:entity-id ... :score ...}; the
+  ;; post-filter must preserve the :score column for survivors.
+  (let [conn (setup-data)
+        bob  (d/q '[:find ?e . :where [?e :emp/name "Bob"]] @conn)
+        alice (d/q '[:find ?e . :where [?e :emp/name "Alice"]] @conn)
+        bitset (es/entity-bitset-from-longs [bob alice])
+        log (atom [])
+        idx (->MockBitsetIndex bitset log)
+        vt-db (d/valid-at (d/history @conn) #inst "2024-02-15")
+        result (sec/slice-ordered-with-vt vt-db idx {} nil nil nil nil)]
+    (testing "slice-ordered + post-filter keeps survivors with their score"
+      (is (= [:-slice-ordered] @log))
+      (is (= 1 (count result)))
+      (is (= bob (:entity-id (first result))))
+      (is (= 0.99 (:score (first result))))
+      (testing "Alice was dropped"
+        (is (not-any? #(= alice (:entity-id %)) result))))))

--- a/test/datahike/test/secondary_vt_test.cljc
+++ b/test/datahike/test/secondary_vt_test.cljc
@@ -58,18 +58,12 @@
     (d/transact conn [{:db/id "datomic.tx"
                        :db.valid/from #inst "2024-07-01"}
                       {:db/id -1 :emp/salary 110000}])
-    ;; Let the async build-secondary-index! (kicked off when the schema
-    ;; tx promotes the index to :building) finish replaying — its
-    ;; tx-meta reconstruction (see writing.cljc) emits extra events
-    ;; with tx-meta from EAVT lookups.
-    (Thread/sleep 300)
     (let [idx (get-in (d/db conn) [:secondary-indices :idx/employees])
           seen @(.-seen idx)
           ;; The transactor may invoke `-transact` more than once per
-          ;; user-datom (retract-old-then-add pattern under upsert); the
-          ;; async build-secondary-index! may also replay user-datoms
-          ;; with reconstructed tx-meta. We filter to the distinct set
-          ;; of :db.valid/from values seen with a tx-meta payload.
+          ;; user-datom (retract-old-then-add pattern under upsert); we
+          ;; assert on the set of distinct :db.valid/from values seen
+          ;; with a tx-meta payload, not a strict count.
           vt-events (filter #(get-in % [:tx-meta :db.valid/from]) seen)
           vt-froms (set (map #(get-in % [:tx-meta :db.valid/from]) vt-events))]
       (testing "the adapter saw at least one :transact call per user write"

--- a/test/datahike/test/secondary_vt_test.cljc
+++ b/test/datahike/test/secondary_vt_test.cljc
@@ -1,0 +1,147 @@
+(ns datahike.test.secondary-vt-test
+  "Tests for the bitemporal-v1 secondary-index protocol additions:
+
+   - `ISecondaryIndex.-transact` receives `:tx-meta` on every datom —
+     populated by `update-secondary-indices` from the in-progress db
+     state (the tx-entity's `:db/txInstant` / `:db.valid/from` /
+     `:db.valid/to` datoms, added pre-user-datoms by `flush-tx-meta`).
+   - Adapters can opt into vt-pushdown via the optional
+     `IValidTimeAware` protocol; non-implementers stay correct via the
+     standard post-hoc AVET filter on `:db.valid/from`."
+  (:require #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
+               :clj  [clojure.test :as t :refer [is deftest testing]])
+            [datahike.api :as d]
+            [datahike.index.secondary :as sec])
+  #?(:clj (:import [java.util Date])))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+;; ============================================================================
+;; A test adapter that records every -transact call's tx-meta
+;; ============================================================================
+
+(deftype RecordingIndex [seen]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] #{:emp/salary})
+  (-transact [this tx-report]
+    (swap! seen conj (select-keys tx-report [:tx-meta :added?]))
+    this))
+
+(deftest tx-meta-flows-into-secondary-transact
+  ;; Hook in a tiny adapter that records every tx-report it sees, then
+  ;; transact two vt-bearing txes and confirm tx-meta reached the
+  ;; adapter on each user-datom write.
+  (sec/register-index-type! ::recording
+                            (fn [_config _db] (->RecordingIndex (atom []))))
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :emp/salary
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :idx/employees
+                       :db.secondary/type ::recording
+                       :db.secondary/attrs [:emp/salary]
+                       :db.secondary/config {}
+                       :db.secondary/status :ready}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-01-01"
+                       :db.valid/to   #inst "2024-07-01"}
+                      {:db/id -1 :emp/salary 100000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-07-01"}
+                      {:db/id -1 :emp/salary 110000}])
+    (let [idx (get-in (d/db conn) [:secondary-indices :idx/employees])
+          seen @(.-seen idx)
+          ;; The transactor may invoke `-transact` more than once per
+          ;; user-datom (retract-old-then-add pattern under upsert);
+          ;; we only care about the calls that DID carry vt tx-meta.
+          vt-events (filter #(get-in % [:tx-meta :db.valid/from]) seen)]
+      (testing "the adapter saw at least one :transact call per user write"
+        (is (>= (count seen) 2)))
+      (testing "vt-bearing :transact calls carried the tx's :tx-meta"
+        (is (= 2 (count vt-events)))
+        (is (= [#inst "2024-01-01" #inst "2024-07-01"]
+               (map #(get-in % [:tx-meta :db.valid/from]) vt-events)))))))
+
+;; ============================================================================
+;; Default fallback: ISecondaryIndex without IValidTimeAware stays correct
+;; ============================================================================
+
+(deftype StringIndex [content-map]
+  ;; A tiny content index keyed by string-attr value → entity-set.
+  sec/ISecondaryIndex
+  (-search [_ query _entity-filter]
+    ;; query is a string; returns the set of entities that have that string.
+    (get @content-map query #{}))
+  (-estimate [_ q] (count (get @content-map q #{})))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] #{:emp/name})
+  (-transact [this {:keys [^datahike.datom.Datom datom added?]}]
+    (when added?
+      (swap! content-map update (.-v datom) (fnil conj #{}) (.-e datom)))
+    this))
+
+(deftest non-vt-aware-index-is-vt-aware?-false
+  ;; A plain ISecondaryIndex impl that doesn't implement
+  ;; IValidTimeAware should be recognised by `sec/vt-aware?`.
+  (let [idx (->StringIndex (atom {}))]
+    (is (not (sec/vt-aware? idx)))))
+
+;; ============================================================================
+;; A vt-aware adapter — proves the protocol implements
+;; ============================================================================
+
+(deftype VtAwareIndex [content-map]
+  sec/ISecondaryIndex
+  (-search [_ q _] (get-in @content-map [q :any] #{}))
+  (-estimate [_ q] (count (get-in @content-map [q :any] #{})))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] #{:emp/name})
+  (-transact [this {:keys [^datahike.datom.Datom datom added? tx-meta]}]
+    (when added?
+      (let [vf (or (:db.valid/from tx-meta) (:db/txInstant tx-meta))
+            vt (or (:db.valid/to tx-meta) #inst "9999-12-31")]
+        (swap! content-map update-in [(.-v datom) :any]
+               (fnil conj #{}) (.-e datom))
+        (swap! content-map update-in [(.-v datom) :windows]
+               (fnil conj []) {:e (.-e datom) :vf vf :vt vt})))
+    this)
+  sec/IValidTimeAware
+  (-search-at-vt [_ query _entity-filter valid-at-window]
+    (let [windows (get-in @content-map [query :windows] [])
+          at (if (vector? valid-at-window) (first valid-at-window) valid-at-window)]
+      (into #{}
+            (keep (fn [{:keys [e vf vt]}]
+                    (when (and (not (.before ^Date at ^Date vf))
+                               (.before ^Date at ^Date vt))
+                      e)))
+            windows))))
+
+(deftest vt-aware-protocol-search-at-vt
+  (let [idx (->VtAwareIndex (atom {}))]
+    (testing "vt-aware? returns true for an IValidTimeAware impl"
+      (is (sec/vt-aware? idx)))
+    (testing "-search-at-vt filters by vt window"
+      ;; Manually simulate two -transact calls on the same name with
+      ;; different vt windows.
+      (let [d1 (datahike.datom/datom 1 :emp/name "Bob" 100 true)
+            d2 (datahike.datom/datom 2 :emp/name "Bob" 200 true)]
+        (sec/-transact idx {:datom d1 :added? true
+                            :tx-meta {:db.valid/from #inst "2024-01-01"
+                                      :db.valid/to   #inst "2024-07-01"}})
+        (sec/-transact idx {:datom d2 :added? true
+                            :tx-meta {:db.valid/from #inst "2024-07-01"
+                                      :db.valid/to   #inst "9999-12-31"}})
+        (is (= #{1 2} (sec/-search idx "Bob" nil)))
+        (is (= #{1} (sec/-search-at-vt idx "Bob" nil #inst "2024-04-15")))
+        (is (= #{2} (sec/-search-at-vt idx "Bob" nil #inst "2024-09-15")))))))

--- a/test/datahike/test/secondary_vt_test.cljc
+++ b/test/datahike/test/secondary_vt_test.cljc
@@ -51,13 +51,11 @@
                        :db.secondary/attrs [:emp/salary]
                        :db.secondary/config {}
                        :db.secondary/status :ready}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-01-01"
-                       :db.valid/to   #inst "2024-07-01"}
-                      {:db/id -1 :emp/salary 100000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-07-01"}
-                      {:db/id -1 :emp/salary 110000}])
+    (d/transact conn {:tx-data [{:db/id -1 :emp/salary 100000}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    (d/transact conn {:tx-data [{:db/id -1 :emp/salary 110000}]
+                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
     (let [idx (get-in (d/db conn) [:secondary-indices :idx/employees])
           seen @(.-seen idx)
           ;; The transactor may invoke `-transact` more than once per

--- a/test/datahike/test/secondary_vt_test.cljc
+++ b/test/datahike/test/secondary_vt_test.cljc
@@ -58,18 +58,25 @@
     (d/transact conn [{:db/id "datomic.tx"
                        :db.valid/from #inst "2024-07-01"}
                       {:db/id -1 :emp/salary 110000}])
+    ;; Let the async build-secondary-index! (kicked off when the schema
+    ;; tx promotes the index to :building) finish replaying — its
+    ;; tx-meta reconstruction (see writing.cljc) emits extra events
+    ;; with tx-meta from EAVT lookups.
+    (Thread/sleep 300)
     (let [idx (get-in (d/db conn) [:secondary-indices :idx/employees])
           seen @(.-seen idx)
           ;; The transactor may invoke `-transact` more than once per
-          ;; user-datom (retract-old-then-add pattern under upsert);
-          ;; we only care about the calls that DID carry vt tx-meta.
-          vt-events (filter #(get-in % [:tx-meta :db.valid/from]) seen)]
+          ;; user-datom (retract-old-then-add pattern under upsert); the
+          ;; async build-secondary-index! may also replay user-datoms
+          ;; with reconstructed tx-meta. We filter to the distinct set
+          ;; of :db.valid/from values seen with a tx-meta payload.
+          vt-events (filter #(get-in % [:tx-meta :db.valid/from]) seen)
+          vt-froms (set (map #(get-in % [:tx-meta :db.valid/from]) vt-events))]
       (testing "the adapter saw at least one :transact call per user write"
         (is (>= (count seen) 2)))
-      (testing "vt-bearing :transact calls carried the tx's :tx-meta"
-        (is (= 2 (count vt-events)))
-        (is (= [#inst "2024-01-01" #inst "2024-07-01"]
-               (map #(get-in % [:tx-meta :db.valid/from]) vt-events)))))))
+      (testing "vt-bearing :transact calls covered both txes' tx-meta"
+        (is (contains? vt-froms #inst "2024-01-01"))
+        (is (contains? vt-froms #inst "2024-07-01"))))))
 
 ;; ============================================================================
 ;; Default fallback: ISecondaryIndex without IValidTimeAware stays correct

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -12,14 +12,12 @@
    - `IValidTimeAware/-search-at-vt` translates `valid-at` / window-
      overlap into stratum WHERE predicates on the two vt columns.
 
-   Note on the Thread/sleep usage: the writer's `instantiate-secondary`
-   always sets `:db.secondary/status :building` on a newly-registered
-   index, which auto-dispatches `build-secondary-index!` asynchronously.
-   When that backfill races with subsequent user txes, the install
-   step can clobber later writes. The fix lives in the writer
-   architecture (out of scope here); tests sleep briefly between
-   schema-and-data and the upsert to give the backfill time to settle.
-   See `feature/valid-time` notes."
+   No Thread/sleep is needed: `instantiate-secondary` auto-detects
+   whether AEVT has any datoms for the indexed attrs at registration
+   time. When the index is registered on an empty (or empty-for-
+   these-attrs) DB, status is set to `:ready` directly and no async
+   `build-secondary-index!` dispatch fires — eliminating the race
+   between the async backfill and subsequent user writes."
   (:require [clojure.test :as t :refer [is deftest testing]]
             [datahike.api :as d]
             [datahike.index.secondary :as sec]
@@ -54,12 +52,7 @@
                      :db.secondary/type :stratum
                      :db.secondary/attrs [:emp/name :emp/salary]
                      :db.secondary/config {:valid-time true}
-                     :db.secondary/status :ready}])
-  ;; Wait for the async build-secondary-index! that fires off the schema
-  ;; tx to settle. With async writer + the ":building" override in
-  ;; instantiate-secondary, the backfill on the initially-empty index
-  ;; can race with user-data writes.
-  (Thread/sleep 200))
+                     :db.secondary/status :ready}]))
 
 ;; ============================================================================
 ;; Dataset shape — vt config wires through
@@ -88,7 +81,6 @@
     (d/transact conn [{:db/id "datomic.tx"
                        :db.valid/from #inst "2024-07-01"}
                       {:emp/name "Bob" :emp/salary 110000}])
-    (Thread/sleep 200)
     (let [rows (vt-rows conn :idx/employees)]
       (testing "two rows: the closed tx1 row + the open tx2 row"
         (is (= 2 (count rows))))
@@ -116,7 +108,6 @@
     (d/transact conn [{:db/id "datomic.tx"
                        :db.valid/from #inst "2024-07-01"}
                       {:emp/name "Bob" :emp/salary 110000}])
-    (Thread/sleep 200)
     (let [idx (-> (d/db conn) :secondary-indices :idx/employees)]
       (testing "vt-aware?: the StratumIndex implements IValidTimeAware"
         (is (sec/vt-aware? idx)))
@@ -146,7 +137,6 @@
                              :db.secondary/attrs [:emp/salary]
                              :db.secondary/config {}
                              :db.secondary/status :ready}])
-        _ (Thread/sleep 200)
         ds (index-dataset conn :idx/employees-plain)]
     (testing "no :valid-time in metadata → no vt-config exposed"
       (is (nil? (:valid-time (:metadata ds)))))
@@ -183,14 +173,12 @@
       (d/transact conn [{:db/id "datomic.tx"
                          :db.valid/from #inst "2024-07-01"}
                         {:emp/name "Bob" :emp/salary 110000}])
-      (Thread/sleep 300)
       (let [pre-rows (vt-rows conn :idx/employees)]
         (testing "two rows present before release"
           (is (= 2 (count pre-rows))))
         (d/release conn)
         (let [conn2 (d/connect cfg)]
           (try
-            (Thread/sleep 300)
             (let [ds (index-dataset conn2 :idx/employees)
                   post-rows (vt-rows conn2 :idx/employees)]
               (testing "vt metadata round-trips through konserve"
@@ -219,7 +207,6 @@
     (d/transact conn [{:db/id "datomic.tx"
                        :db.valid/from #inst "2024-07-01"}
                       {:emp/name "Bob" :emp/salary 110000}])
-    (Thread/sleep 200)
     (let [db (d/db conn)
           idx (-> db :secondary-indices :idx/employees)]
       (testing "valid-at marker lands on the db's metadata"
@@ -262,14 +249,12 @@
                          :db.valid/from #inst "2024-01-01"
                          :db.valid/to   #inst "2024-07-01"}
                         {:emp/name "Bob" :emp/salary 100000}])
-      (Thread/sleep 200)
       (let [main-rows (vt-rows conn :idx/employees)]
         (testing "main has one row"
           (is (= 1 (count main-rows))))
         (dv/branch! conn :db :feature)
         (let [feat-conn (d/connect (assoc cfg :branch :feature))]
           (try
-            (Thread/sleep 300)
             (testing "feature branch inherits vt-mode metadata"
               (let [ds (index-dataset feat-conn :idx/employees)]
                 (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
@@ -281,7 +266,6 @@
               (d/transact feat-conn [{:db/id "datomic.tx"
                                       :db.valid/from #inst "2024-07-01"}
                                      {:emp/name "Bob" :emp/salary 200000}])
-              (Thread/sleep 300)
               (is (= 2 (count (vt-rows feat-conn :idx/employees))))
               (is (= 1 (count (vt-rows conn :idx/employees)))
                   "main branch should still show only the original row"))

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -206,6 +206,52 @@
       (finally
         (d/delete-database cfg)))))
 
+;; ============================================================================
+;; d/valid-at marker + search-with-vt routing
+
+(deftest valid-at-marker-routes-to-search-at-vt
+  (let [conn (fresh-conn)]
+    (register-vt-index! conn)
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-01-01"
+                       :db.valid/to   #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 100000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 110000}])
+    (Thread/sleep 200)
+    (let [db (d/db conn)
+          idx (-> db :secondary-indices :idx/employees)]
+      (testing "valid-at marker lands on the db's metadata"
+        (let [marked (d/valid-at db #inst "2024-04-15")]
+          (is (= #inst "2024-04-15"
+                 (:datahike/valid-at (meta marked))))))
+      (testing "valid-at nil clears the marker"
+        (let [marked (d/valid-at db #inst "2024-04-15")
+              cleared (d/valid-at marked nil)]
+          (is (nil? (:datahike/valid-at (meta cleared))))))
+      (testing "search-with-vt routes through -search-at-vt when marker is set + index is vt-aware"
+        (let [marked (d/valid-at db #inst "2024-04-15")
+              bs (sec/search-with-vt marked idx
+                                     {:where [[:= :salary 100000]]}
+                                     nil)]
+          (is (not (.isEmpty bs)))))
+      (testing "search-with-vt without marker → plain -search (no vt filter applied)"
+        (let [bs-no-marker (sec/search-with-vt db idx
+                                               {:where [[:= :salary 100000]]}
+                                               nil)
+              bs-marker (sec/search-with-vt
+                         (d/valid-at db #inst "2024-09-15")  ;; after the closed window
+                         idx
+                         {:where [[:= :salary 100000]]}
+                         nil)]
+          ;; Both queries ask for salary=100000. Without marker → returns
+          ;; entity 4 (the row with salary 100k exists in the dataset).
+          ;; With marker at 2024-09-15 → that row's window is [2024-01-01,
+          ;; 2024-07-01), which doesn't contain 2024-09-15 → no match.
+          (is (not (.isEmpty bs-no-marker)) "without marker, plain search finds salary=100k")
+          (is (.isEmpty bs-marker) "with valid-at after the window, vt-pushdown filters the row out"))))))
+
 (deftest vt-mode-survives-branch
   (let [cfg (file-cfg)
         _ (d/create-database cfg)

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -64,9 +64,14 @@
       (testing "vt cols exist on the empty initial dataset"
         (is (contains? (set (keys (st/columns ds))) :_valid_from))
         (is (contains? (set (keys (st/columns ds))) :_valid_to)))
-      (testing "metadata round-trips the vt-config"
+      (testing "metadata round-trips the valid-axis config"
+        ;; Stratum's bitemporal config carries both axes by default —
+        ;; we assert the valid axis specifically.
         (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
-               (:valid-time (:metadata ds))))))))
+               (get-in (:metadata ds) [:bitemporal :valid]))))
+      (testing "system-time axis is present for SCD2 audit symmetry"
+        (is (= {:from-col :_system_from :to-col :_system_to :unit :micros}
+               (get-in (:metadata ds) [:bitemporal :system])))))))
 
 ;; ============================================================================
 ;; SCD2 layout — close-on-upsert
@@ -138,8 +143,8 @@
                              :db.secondary/config {}
                              :db.secondary/status :ready}])
         ds (index-dataset conn :idx/employees-plain)]
-    (testing "no :valid-time in metadata → no vt-config exposed"
-      (is (nil? (:valid-time (:metadata ds)))))
+    (testing "no :bitemporal in metadata → no vt-config exposed"
+      (is (nil? (:bitemporal (:metadata ds)))))
     (testing "no _valid_from / _valid_to columns"
       (is (not (contains? (set (keys (st/columns ds))) :_valid_from)))
       (is (not (contains? (set (keys (st/columns ds))) :_valid_to))))))
@@ -183,7 +188,7 @@
                   post-rows (vt-rows conn2 :idx/employees)]
               (testing "vt metadata round-trips through konserve"
                 (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
-                       (:valid-time (:metadata ds)))))
+                       (get-in (:metadata ds) [:bitemporal :valid]))))
               (testing "vt columns are tagged :micros on restore"
                 (is (= :micros (:temporal-unit (get (st/columns ds) :_valid_from))))
                 (is (= :micros (:temporal-unit (get (st/columns ds) :_valid_to)))))
@@ -258,7 +263,7 @@
             (testing "feature branch inherits vt-mode metadata"
               (let [ds (index-dataset feat-conn :idx/employees)]
                 (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
-                       (:valid-time (:metadata ds))))))
+                       (get-in (:metadata ds) [:bitemporal :valid])))))
             (testing "feature branch sees the same SCD2 rows"
               (is (= (set main-rows)
                      (set (vt-rows feat-conn :idx/employees)))))
@@ -274,3 +279,44 @@
       (finally
         (d/release conn)
         (d/delete-database cfg)))))
+
+;; ============================================================================
+;; System-time symmetry on SCD2 surgery (DH-5 / Phase E)
+;;
+;; When the vt-mode adapter closes an old row's `_valid_to`, it must
+;; also close that row's `_system_to` to the current tx's instant, so
+;; a `FOR SYSTEM_TIME AS OF <pre-correction>` query still sees the
+;; row as "open at the time the DB knew it." Without this, backdated
+;; corrections silently rewrite past system-time views — the very
+;; bug stratum's P0-1 fixed at the dataset layer.
+;; ============================================================================
+
+(deftest scd2-closes-system-to-on-old-row
+  (let [conn (fresh-conn)]
+    (register-vt-index! conn)
+    (d/transact conn {:tx-meta {:db/txInstant #inst "2024-06-01T00:00:00Z"
+                                :db.valid/from #inst "2024-01-01"}
+                      :tx-data [{:emp/name "Bob" :emp/salary 100000}]})
+    (d/transact conn {:tx-meta {:db/txInstant #inst "2024-08-01T00:00:00Z"
+                                :db.valid/from #inst "2024-07-01"}
+                      :tx-data [{:emp/name "Bob" :emp/salary 110000}]})
+    (let [ds (index-dataset conn :idx/employees)
+          rows (vec (st/q {:from ds
+                           :select [:eid :salary :_valid_from :_valid_to
+                                    :_system_from :_system_to]}))]
+      (testing "two rows present after the SCD2 update"
+        (is (= 2 (count rows))))
+      (let [closed (first (filter #(not= Long/MAX_VALUE (:_valid_to %)) rows))
+            new-row (first (filter #(= Long/MAX_VALUE (:_valid_to %)) rows))]
+        (testing "closed row's _system_to advanced to second tx's instant"
+          (is (some? closed))
+          (is (= (* 1000 (.getTime #inst "2024-08-01T00:00:00Z"))
+                 (:_system_to closed))
+              "closed row's _system_to should equal the correcting tx's txInstant"))
+        (testing "new row's _system_from is the correcting tx's instant"
+          (is (some? new-row))
+          (is (= (* 1000 (.getTime #inst "2024-08-01T00:00:00Z"))
+                 (:_system_from new-row))
+              "new row's _system_from should equal the tx's txInstant"))
+        (testing "new row's _system_to is open (MAX_VALUE)"
+          (is (= Long/MAX_VALUE (:_system_to new-row))))))))

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -79,13 +79,11 @@
 (deftest scd2-upsert-closes-old-row-and-opens-new
   (let [conn (fresh-conn)]
     (register-vt-index! conn)
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-01-01"
-                       :db.valid/to   #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 100000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 110000}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
     (let [rows (vt-rows conn :idx/employees)]
       (testing "two rows: the closed tx1 row + the open tx2 row"
         (is (= 2 (count rows))))
@@ -106,13 +104,11 @@
 (deftest search-at-vt-returns-correct-as-of-eid
   (let [conn (fresh-conn)]
     (register-vt-index! conn)
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-01-01"
-                       :db.valid/to   #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 100000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 110000}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
     (let [idx (-> (d/db conn) :secondary-indices :idx/employees)]
       (testing "vt-aware?: the StratumIndex implements IValidTimeAware"
         (is (sec/vt-aware? idx)))
@@ -171,13 +167,11 @@
         conn (d/connect cfg)]
     (try
       (register-vt-index! conn)
-      (d/transact conn [{:db/id "datomic.tx"
-                         :db.valid/from #inst "2024-01-01"
-                         :db.valid/to   #inst "2024-07-01"}
-                        {:emp/name "Bob" :emp/salary 100000}])
-      (d/transact conn [{:db/id "datomic.tx"
-                         :db.valid/from #inst "2024-07-01"}
-                        {:emp/name "Bob" :emp/salary 110000}])
+      (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                        :tx-meta {:db.valid/from #inst "2024-01-01"
+                                  :db.valid/to   #inst "2024-07-01"}})
+      (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                        :tx-meta {:db.valid/from #inst "2024-07-01"}})
       (let [pre-rows (vt-rows conn :idx/employees)]
         (testing "two rows present before release"
           (is (= 2 (count pre-rows))))
@@ -205,13 +199,11 @@
 (deftest valid-at-marker-routes-to-search-at-vt
   (let [conn (fresh-conn)]
     (register-vt-index! conn)
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-01-01"
-                       :db.valid/to   #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 100000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 110000}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
     (let [db (d/db conn)
           idx (-> db :secondary-indices :idx/employees)]
       (testing "valid-at marker lands on the db's metadata"
@@ -250,10 +242,9 @@
         conn (d/connect cfg)]
     (try
       (register-vt-index! conn)
-      (d/transact conn [{:db/id "datomic.tx"
-                         :db.valid/from #inst "2024-01-01"
-                         :db.valid/to   #inst "2024-07-01"}
-                        {:emp/name "Bob" :emp/salary 100000}])
+      (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                        :tx-meta {:db.valid/from #inst "2024-01-01"
+                                  :db.valid/to   #inst "2024-07-01"}})
       (let [main-rows (vt-rows conn :idx/employees)]
         (testing "main has one row"
           (is (= 1 (count main-rows))))
@@ -268,9 +259,9 @@
               (is (= (set main-rows)
                      (set (vt-rows feat-conn :idx/employees)))))
             (testing "writing to feature branch keeps main unchanged"
-              (d/transact feat-conn [{:db/id "datomic.tx"
-                                      :db.valid/from #inst "2024-07-01"}
-                                     {:emp/name "Bob" :emp/salary 200000}])
+              (d/transact feat-conn
+                          {:tx-data [{:emp/name "Bob" :emp/salary 200000}]
+                           :tx-meta {:db.valid/from #inst "2024-07-01"}})
               (is (= 2 (count (vt-rows feat-conn :idx/employees))))
               (is (= 1 (count (vt-rows conn :idx/employees)))
                   "main branch should still show only the original row"))

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -24,6 +24,7 @@
             [datahike.api :as d]
             [datahike.index.secondary :as sec]
             [datahike.index.secondary.stratum]
+            [datahike.versioning :as dv]
             [stratum.api :as st]))
 
 (defn- fresh-conn []
@@ -152,3 +153,94 @@
     (testing "no _valid_from / _valid_to columns"
       (is (not (contains? (set (keys (st/columns ds))) :_valid_from)))
       (is (not (contains? (set (keys (st/columns ds))) :_valid_to))))))
+
+;; ============================================================================
+;; Versioning — release/reconnect + branch round-trip preserve SCD2 layout
+;;
+;; The adapter implements IVersionedSecondaryIndex (-sec-flush calls
+;; `stratum.dataset/sync!`, -sec-restore calls `stratum.dataset/load`).
+;; Stratum commit 1 (feature/valid-time) made `:metadata {:valid-time
+;; ...}` round-trip through sync!/load; these tests confirm the
+;; integration end-to-end through the datahike write/read path.
+
+(defn- file-cfg []
+  {:store {:backend :file
+           :id (java.util.UUID/randomUUID)
+           :path (str "/tmp/datahike-stratum-vt-test-" (random-uuid))}
+   :keep-history? true
+   :schema-flexibility :write})
+
+(deftest vt-mode-survives-release-and-reconnect
+  (let [cfg (file-cfg)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    (try
+      (register-vt-index! conn)
+      (d/transact conn [{:db/id "datomic.tx"
+                         :db.valid/from #inst "2024-01-01"
+                         :db.valid/to   #inst "2024-07-01"}
+                        {:emp/name "Bob" :emp/salary 100000}])
+      (d/transact conn [{:db/id "datomic.tx"
+                         :db.valid/from #inst "2024-07-01"}
+                        {:emp/name "Bob" :emp/salary 110000}])
+      (Thread/sleep 300)
+      (let [pre-rows (vt-rows conn :idx/employees)]
+        (testing "two rows present before release"
+          (is (= 2 (count pre-rows))))
+        (d/release conn)
+        (let [conn2 (d/connect cfg)]
+          (try
+            (Thread/sleep 300)
+            (let [ds (index-dataset conn2 :idx/employees)
+                  post-rows (vt-rows conn2 :idx/employees)]
+              (testing "vt metadata round-trips through konserve"
+                (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
+                       (:valid-time (:metadata ds)))))
+              (testing "vt columns are tagged :micros on restore"
+                (is (= :micros (:temporal-unit (get (st/columns ds) :_valid_from))))
+                (is (= :micros (:temporal-unit (get (st/columns ds) :_valid_to)))))
+              (testing "SCD2 row set is identical after reconnect"
+                (is (= (set pre-rows) (set post-rows)))))
+            (finally
+              (d/release conn2)))))
+      (finally
+        (d/delete-database cfg)))))
+
+(deftest vt-mode-survives-branch
+  (let [cfg (file-cfg)
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    (try
+      (register-vt-index! conn)
+      (d/transact conn [{:db/id "datomic.tx"
+                         :db.valid/from #inst "2024-01-01"
+                         :db.valid/to   #inst "2024-07-01"}
+                        {:emp/name "Bob" :emp/salary 100000}])
+      (Thread/sleep 200)
+      (let [main-rows (vt-rows conn :idx/employees)]
+        (testing "main has one row"
+          (is (= 1 (count main-rows))))
+        (dv/branch! conn :db :feature)
+        (let [feat-conn (d/connect (assoc cfg :branch :feature))]
+          (try
+            (Thread/sleep 300)
+            (testing "feature branch inherits vt-mode metadata"
+              (let [ds (index-dataset feat-conn :idx/employees)]
+                (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
+                       (:valid-time (:metadata ds))))))
+            (testing "feature branch sees the same SCD2 rows"
+              (is (= (set main-rows)
+                     (set (vt-rows feat-conn :idx/employees)))))
+            (testing "writing to feature branch keeps main unchanged"
+              (d/transact feat-conn [{:db/id "datomic.tx"
+                                      :db.valid/from #inst "2024-07-01"}
+                                     {:emp/name "Bob" :emp/salary 200000}])
+              (Thread/sleep 300)
+              (is (= 2 (count (vt-rows feat-conn :idx/employees))))
+              (is (= 1 (count (vt-rows conn :idx/employees)))
+                  "main branch should still show only the original row"))
+            (finally
+              (d/release feat-conn)))))
+      (finally
+        (d/release conn)
+        (d/delete-database cfg)))))

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -1,0 +1,154 @@
+(ns datahike.test.stratum-vt-test
+  "Tests for the stratum secondary-index adapter's `:valid-time` (SCD2) mode.
+
+   When the index config declares `:valid-time true`, the adapter:
+
+   - Materialises `:_valid_from` / `:_valid_to` columns on every row,
+     populated from the writing tx's `:db.valid/from` / `:db.valid/to`
+     tx-meta (falling back to `:db/txInstant` for non-vt-bearing txes).
+   - On entity update, the previous open row's `:_valid_to` is closed
+     to the new tx's vt-from, and a new row is appended carrying the
+     merged-with-previous attribute values plus the new vt-window.
+   - `IValidTimeAware/-search-at-vt` translates `valid-at` / window-
+     overlap into stratum WHERE predicates on the two vt columns.
+
+   Note on the Thread/sleep usage: the writer's `instantiate-secondary`
+   always sets `:db.secondary/status :building` on a newly-registered
+   index, which auto-dispatches `build-secondary-index!` asynchronously.
+   When that backfill races with subsequent user txes, the install
+   step can clobber later writes. The fix lives in the writer
+   architecture (out of scope here); tests sleep briefly between
+   schema-and-data and the upsert to give the backfill time to settle.
+   See `feature/valid-time` notes."
+  (:require [clojure.test :as t :refer [is deftest testing]]
+            [datahike.api :as d]
+            [datahike.index.secondary :as sec]
+            [datahike.index.secondary.stratum]
+            [stratum.api :as st]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defn- index-dataset [conn idx-ident]
+  (.-dataset ^datahike.index.secondary.stratum.StratumIndex
+   (-> (d/db conn) :secondary-indices idx-ident)))
+
+(defn- vt-rows [conn idx-ident]
+  (vec (st/q {:from (index-dataset conn idx-ident)
+              :select [:eid :_valid_from :_valid_to :name :salary]})))
+
+(defn- register-vt-index! [conn]
+  (d/transact conn [{:db/ident :emp/name
+                     :db/valueType :db.type/string
+                     :db/cardinality :db.cardinality/one
+                     :db/unique :db.unique/identity}
+                    {:db/ident :emp/salary
+                     :db/valueType :db.type/long
+                     :db/cardinality :db.cardinality/one}
+                    {:db/ident :idx/employees
+                     :db.secondary/type :stratum
+                     :db.secondary/attrs [:emp/name :emp/salary]
+                     :db.secondary/config {:valid-time true}
+                     :db.secondary/status :ready}])
+  ;; Wait for the async build-secondary-index! that fires off the schema
+  ;; tx to settle. With async writer + the ":building" override in
+  ;; instantiate-secondary, the backfill on the initially-empty index
+  ;; can race with user-data writes.
+  (Thread/sleep 200))
+
+;; ============================================================================
+;; Dataset shape — vt config wires through
+
+(deftest vt-mode-flag-creates-vt-columns
+  (let [conn (fresh-conn)]
+    (register-vt-index! conn)
+    (let [ds (index-dataset conn :idx/employees)]
+      (testing "vt cols exist on the empty initial dataset"
+        (is (contains? (set (keys (st/columns ds))) :_valid_from))
+        (is (contains? (set (keys (st/columns ds))) :_valid_to)))
+      (testing "metadata round-trips the vt-config"
+        (is (= {:from-col :_valid_from :to-col :_valid_to :unit :micros}
+               (:valid-time (:metadata ds))))))))
+
+;; ============================================================================
+;; SCD2 layout — close-on-upsert
+
+(deftest scd2-upsert-closes-old-row-and-opens-new
+  (let [conn (fresh-conn)]
+    (register-vt-index! conn)
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-01-01"
+                       :db.valid/to   #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 100000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 110000}])
+    (Thread/sleep 200)
+    (let [rows (vt-rows conn :idx/employees)]
+      (testing "two rows: the closed tx1 row + the open tx2 row"
+        (is (= 2 (count rows))))
+      (testing "tx1's row is closed at tx2's :db.valid/from"
+        (let [tx1 (first (filter #(= 100000 (:salary %)) rows))]
+          (is (= 1704067200000000 (:_valid_from tx1))) ;; 2024-01-01
+          (is (= 1719792000000000 (:_valid_to   tx1))) ;; 2024-07-01
+          (is (= "Bob" (:name tx1)))))
+      (testing "tx2's row carries the new salary + open vt-to (MAX_VALUE)"
+        (let [tx2 (first (filter #(= 110000 (:salary %)) rows))]
+          (is (= 1719792000000000 (:_valid_from tx2))) ;; 2024-07-01
+          (is (= Long/MAX_VALUE    (:_valid_to   tx2)))
+          (is (= "Bob" (:name tx2))))))))
+
+;; ============================================================================
+;; IValidTimeAware — search-at-vt
+
+(deftest search-at-vt-returns-correct-as-of-eid
+  (let [conn (fresh-conn)]
+    (register-vt-index! conn)
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-01-01"
+                       :db.valid/to   #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 100000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 110000}])
+    (Thread/sleep 200)
+    (let [idx (-> (d/db conn) :secondary-indices :idx/employees)]
+      (testing "vt-aware?: the StratumIndex implements IValidTimeAware"
+        (is (sec/vt-aware? idx)))
+      (testing "valid-at #inst 2024-04-15 → only tx1's row matches"
+        (let [bs (sec/-search-at-vt idx
+                                    {:where [[:= :salary 100000]]}
+                                    nil
+                                    #inst "2024-04-15")]
+          (is (not (.isEmpty bs)))))
+      (testing "valid-at #inst 2024-09-15 → only tx2's row matches"
+        (let [bs (sec/-search-at-vt idx
+                                    {:where [[:= :salary 110000]]}
+                                    nil
+                                    #inst "2024-09-15")]
+          (is (not (.isEmpty bs))))))))
+
+;; ============================================================================
+;; vt-mode off — adapter still works (regression / parity check)
+
+(deftest non-vt-config-skips-vt-columns
+  (let [conn (fresh-conn)
+        _ (d/transact conn [{:db/ident :emp/salary
+                             :db/valueType :db.type/long
+                             :db/cardinality :db.cardinality/one}
+                            {:db/ident :idx/employees-plain
+                             :db.secondary/type :stratum
+                             :db.secondary/attrs [:emp/salary]
+                             :db.secondary/config {}
+                             :db.secondary/status :ready}])
+        _ (Thread/sleep 200)
+        ds (index-dataset conn :idx/employees-plain)]
+    (testing "no :valid-time in metadata → no vt-config exposed"
+      (is (nil? (:valid-time (:metadata ds)))))
+    (testing "no _valid_from / _valid_to columns"
+      (is (not (contains? (set (keys (st/columns ds))) :_valid_from)))
+      (is (not (contains? (set (keys (st/columns ds))) :_valid_to))))))

--- a/test/datahike/test/tx_instant_monotonic_test.clj
+++ b/test/datahike/test/tx_instant_monotonic_test.clj
@@ -91,13 +91,13 @@
                                    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
                                   {:db/ident :emp/salary :db/valueType :db.type/long
                                    :db/cardinality :db.cardinality/one}])
-                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-01-01"
-                                   :db.valid/to #inst "2024-07-01"}
-                                  {:emp/name "Bob" :emp/salary 100000}])
-                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-07-01"}
-                                  {:emp/name "Bob" :emp/salary 110000}])
-                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-01-01"}
-                                  {:emp/name "Alice" :emp/salary 80000}]))
+                   (d/transact c {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                                  :tx-meta {:db.valid/from #inst "2024-01-01"
+                                            :db.valid/to   #inst "2024-07-01"}})
+                   (d/transact c {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                                  :tx-meta {:db.valid/from #inst "2024-07-01"}})
+                   (d/transact c {:tx-data [{:emp/name "Alice" :emp/salary 80000}]
+                                  :tx-meta {:db.valid/from #inst "2024-01-01"}}))
           flakes (atom [])
           n 200
           threads (doall

--- a/test/datahike/test/tx_instant_monotonic_test.clj
+++ b/test/datahike/test/tx_instant_monotonic_test.clj
@@ -1,0 +1,126 @@
+(ns datahike.test.tx-instant-monotonic-test
+  "Tests for the strict-monotonic `:db/txInstant` allocator
+   (`datahike.db.transaction/next-tx-instant`). Matches Datomic's
+   contract: auto-stamped tx-instants are strictly increasing
+   across writes, even when several writes land in the same
+   wall-clock millisecond. Removes the d/as-of <Date> tied-instant
+   ambiguity at the source.
+
+   See ADR for design rationale + the original flake reproducer."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.tools :as dt]
+            [datahike.db.transaction :as tx])
+  (:import [java.util Date]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defn- tx-instants [conn]
+  (->> (d/q '[:find ?tx ?t :where [?tx :db/txInstant ?t]]
+            (d/history (d/db conn)))
+       (sort-by first)
+       (mapv second)))
+
+(deftest auto-stamp-strictly-monotonic-under-burst
+  (testing "back-to-back writes within a single wall-clock ms still get distinct, strictly-ordered :db/txInstant"
+    (let [conn (fresh-conn)]
+      (d/transact conn [{:db/ident :x :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (dotimes [i 50] (d/transact conn [{:x (long i)}]))
+      (let [insts (tx-instants conn)
+            ms (mapv #(.getTime ^Date %) insts)]
+        (is (= 51 (count insts)) "51 txes (1 schema + 50 data)")
+        (is (= (count insts) (count (distinct insts)))
+            "no two :db/txInstant values tie")
+        (is (apply < ms)
+            "values are strictly monotonically increasing")))))
+
+(deftest pinned-clock-becomes-logical-clock
+  (testing "with `get-date` pinned to a constant, the allocator advances 1ms per tx — fully deterministic"
+    (let [pinned-date #inst "2024-01-01T00:00:00.000-00:00"
+          pinned-ms (.getTime ^Date pinned-date)
+          orig dt/get-date]
+      (alter-var-root #'dt/get-date (constantly (constantly pinned-date)))
+      (try
+        (let [conn (fresh-conn)]
+          (d/transact conn [{:db/ident :x :db/valueType :db.type/long
+                             :db/cardinality :db.cardinality/one}])
+          (dotimes [i 5] (d/transact conn [{:x (long i)}]))
+          (let [ms (mapv #(.getTime ^Date %) (tx-instants conn))]
+            (is (= 6 (count ms)))
+            (is (= (range pinned-ms (+ pinned-ms 6)) ms)
+                "stamps are pinned-ms, pinned-ms+1, pinned-ms+2 …")))
+        (finally
+          (alter-var-root #'dt/get-date (constantly orig)))))))
+
+(deftest user-provided-txInstant-still-wins
+  (testing ":tx-meta {:db/txInstant <date>} still overrides the allocator default, even with a back-dated value"
+    (let [conn (fresh-conn)
+          past #inst "2024-06-01T00:00:00.000-00:00"]
+      (d/transact conn [{:db/ident :x :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (d/transact conn {:tx-meta {:db/txInstant past}
+                        :tx-data [{:x 1}]})
+      (let [last-data-tx-inst (last (tx-instants conn))]
+        (is (= past last-data-tx-inst)
+            "user override flows through unchanged — historical-import / SCD2 test patterns preserved")))))
+
+(deftest next-tx-instant-is-dynamic-overridable
+  (testing "next-tx-instant is ^:dynamic — a future caller can swap in an entirely custom allocator (e.g., HLC) without changing the call site"
+    (let [orig tx/next-tx-instant
+          pinned #inst "2030-12-31T23:59:59.999-00:00"]
+      (alter-var-root #'tx/next-tx-instant (constantly (fn [_db-before] pinned)))
+      (try
+        (let [conn (fresh-conn)]
+          (d/transact conn [{:db/ident :x :db/valueType :db.type/long
+                             :db/cardinality :db.cardinality/one}])
+          (is (= pinned (last (tx-instants conn)))
+              "custom allocator's value lands on the stamped tx"))
+        (finally
+          (alter-var-root #'tx/next-tx-instant (constantly orig)))))))
+
+(deftest valid-at-composes-with-as-of-no-flake-under-load
+  (testing "previously-flaky scenario (valid-at-composes-with-as-of) — runs N times under concurrent JVM load, zero flakes"
+    (let [setup! (fn [c]
+                   (d/transact c [{:db/ident :emp/name :db/valueType :db.type/string
+                                   :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                                  {:db/ident :emp/salary :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one}])
+                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-01-01"
+                                   :db.valid/to #inst "2024-07-01"}
+                                  {:emp/name "Bob" :emp/salary 100000}])
+                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-07-01"}
+                                  {:emp/name "Bob" :emp/salary 110000}])
+                   (d/transact c [{:db/id "datomic.tx" :db.valid/from #inst "2024-01-01"}
+                                  {:emp/name "Alice" :emp/salary 80000}]))
+          flakes (atom [])
+          n 200
+          threads (doall
+                   (for [_ (range 8)]
+                     (future
+                       (dotimes [_ (/ n 8)]
+                         (let [c (fresh-conn)
+                               _ (setup! c)
+                               db (d/db c)
+                               t2 (d/q '[:find ?t .
+                                         :where [?tx :db.valid/from #inst "2024-07-01"]
+                                         [?tx :db/txInstant ?t]]
+                                       (d/history db))
+                               composed (-> db
+                                            (d/history)
+                                            (d/as-of t2)
+                                            (d/valid-at #inst "2024-04-15"))
+                               res (d/q '[:find ?s
+                                          :where [?e :emp/salary ?s ?tx true]]
+                                        composed)]
+                           (when (not= #{[100000]} res)
+                             (swap! flakes conj res)))))))]
+      (doseq [f threads] @f)
+      (is (zero? (count @flakes))
+          (str "expected 0 flakes, got " (count @flakes)
+               ", sample: " (first @flakes))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -1,0 +1,116 @@
+(ns datahike.test.valid-at-test
+  "Tests for the `d/valid-at` filter wrapper. Verifies that pure-datalog
+   queries (no vt-aware secondary index in the query path) correctly
+   filter to entities whose asserting tx's valid-time window contains
+   the given `at` instant.
+
+   `d/valid-at` returns `(d/filter db vt-pred)` where the pred reads
+   the tx-entity's `:db.valid/from` / `:db.valid/to` and admits a
+   datom iff `vf <= at < vt`. The planner's regular-DB hot scan and
+   the temporal merge-slice both call `maybe-post-process` so the
+   FilteredDB's xform-after fires on every read path."
+  (:require [clojure.test :as t :refer [is deftest testing]]
+            [datahike.api :as d]))
+
+(defn- fresh-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defn- setup-vt-data!
+  "Two employees, each with two vt-windowed salary updates.
+   Bob: 100k (2024-Q1-Q2) → 110k (2024-Q3 onwards, open).
+   Alice: 80k (2024-Q1 onwards, open)."
+  [conn]
+  (d/transact conn [{:db/ident :emp/name
+                     :db/valueType :db.type/string
+                     :db/cardinality :db.cardinality/one
+                     :db/unique :db.unique/identity}
+                    {:db/ident :emp/salary
+                     :db/valueType :db.type/long
+                     :db/cardinality :db.cardinality/one}])
+  (d/transact conn [{:db/id "datomic.tx"
+                     :db.valid/from #inst "2024-01-01"
+                     :db.valid/to   #inst "2024-07-01"}
+                    {:emp/name "Bob" :emp/salary 100000}])
+  (d/transact conn [{:db/id "datomic.tx"
+                     :db.valid/from #inst "2024-07-01"}
+                    {:emp/name "Bob" :emp/salary 110000}])
+  (d/transact conn [{:db/id "datomic.tx"
+                     :db.valid/from #inst "2024-01-01"}
+                    {:emp/name "Alice" :emp/salary 80000}]))
+
+(deftest valid-at-filters-pure-datalog-query
+  ;; History queries combined with valid-at use the 5-tuple
+  ;; `[e a v t true]` pattern to filter to additions only — otherwise
+  ;; both the addition AND the retraction datom match the
+  ;; 3-tuple `[?e :emp/salary ?s]` shape (the retraction's value field
+  ;; is the OLD value being retracted), and the per-datom vt-pred can
+  ;; admit a retraction whose retracting-tx vt-window contains `at`.
+  ;; This 5-tuple discipline is the standard datalog history pattern.
+  (let [conn (fresh-conn)]
+    (setup-vt-data! conn)
+    (let [hist-db (d/history (d/db conn))]
+      (testing "history view, additions only — all 3 asserted salary rows"
+        (is (= #{[100000] [110000] [80000]}
+               (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]] hist-db))))
+      (testing "valid-at mid-Q2 → Bob's 100k row + Alice's 80k"
+        (is (= #{[100000] [80000]}
+               (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]]
+                    (d/valid-at hist-db #inst "2024-04-15")))))
+      (testing "valid-at mid-Q3 → Bob's 110k + Alice's 80k"
+        (is (= #{[110000] [80000]}
+               (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]]
+                    (d/valid-at hist-db #inst "2024-08-15")))))
+      (testing "valid-at before-data returns empty"
+        (is (= #{}
+               (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]]
+                    (d/valid-at hist-db #inst "2020-01-01"))))))))
+
+(deftest valid-at-nil-clears-marker
+  (let [conn (fresh-conn)
+        db (d/db conn)
+        marked (d/valid-at db #inst "2024-04-15")
+        cleared (d/valid-at marked nil)]
+    (testing "marked db has the meta"
+      (is (= #inst "2024-04-15" (:datahike/valid-at (meta marked)))))
+    (testing "nil clears the meta marker"
+      (is (nil? (:datahike/valid-at (meta cleared)))))))
+
+(deftest valid-at-composes-with-as-of
+  ;; Tx1 (vt 2024-Q1) created Bob with salary 100k.
+  ;; Tx2 (vt 2024-Q3) updated Bob's salary to 110k.
+  ;; Tx3 (vt 2024-Q1) created Alice with salary 80k.
+  ;;
+  ;; as-of at tx2-instant => sees tx1+tx2 (not tx3): so Bob 100k + 110k.
+  ;; valid-at "mid-Q2" on top: vt-window for Bob's 100k is Q1..Q3 — contains mid-Q2 → match.
+  ;; Bob's 110k vt-window is Q3..MAX — doesn't contain mid-Q2 → no match.
+  ;; Result: just 100000.
+  (let [conn (fresh-conn)
+        _ (setup-vt-data! conn)
+        tx2-instant (d/q '[:find ?t .
+                           :where [?tx :db.valid/from #inst "2024-07-01"]
+                           [?tx :db/txInstant ?t]]
+                         (d/history (d/db conn)))
+        composed (-> (d/db conn)
+                     (d/history)
+                     (d/as-of tx2-instant)
+                     (d/valid-at #inst "2024-04-15"))]
+    (testing "as-of tx2 then valid-at mid-Q2 → only Bob's 100k row"
+      (is (= #{[100000]}
+             (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]] composed))))))
+
+(deftest valid-at-non-vt-tx-passes-through
+  ;; A tx with no :db.valid/from is treated as "always valid" — the
+  ;; vt-pred admits any datom whose asserting tx has no vt-window.
+  ;; This keeps non-vt data working under d/valid-at.
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :foo/x
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn [{:foo/x 42}])
+    (let [db (d/valid-at (d/db conn) #inst "2024-04-15")]
+      (testing "datom from non-vt tx survives the filter"
+        (is (= 42 (d/q '[:find ?x . :where [_ :foo/x ?x]] db)))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -31,16 +31,13 @@
                     {:db/ident :emp/salary
                      :db/valueType :db.type/long
                      :db/cardinality :db.cardinality/one}])
-  (d/transact conn [{:db/id "datomic.tx"
-                     :db.valid/from #inst "2024-01-01"
-                     :db.valid/to   #inst "2024-07-01"}
-                    {:emp/name "Bob" :emp/salary 100000}])
-  (d/transact conn [{:db/id "datomic.tx"
-                     :db.valid/from #inst "2024-07-01"}
-                    {:emp/name "Bob" :emp/salary 110000}])
-  (d/transact conn [{:db/id "datomic.tx"
-                     :db.valid/from #inst "2024-01-01"}
-                    {:emp/name "Alice" :emp/salary 80000}]))
+  (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                    :tx-meta {:db.valid/from #inst "2024-01-01"
+                              :db.valid/to   #inst "2024-07-01"}})
+  (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                    :tx-meta {:db.valid/from #inst "2024-07-01"}})
+  (d/transact conn {:tx-data [{:emp/name "Alice" :emp/salary 80000}]
+                    :tx-meta {:db.valid/from #inst "2024-01-01"}}))
 
 (deftest valid-at-filters-pure-datalog-query
   ;; History queries combined with valid-at use the 5-tuple

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -243,112 +243,290 @@
       (is (nil? (:datahike/valid-between (meta cleared)))))))
 
 ;; ============================================================================
-;; Allen interval predicates as built-in datalog rules (DH-3)
+;; Allen interval predicates as built-in datalog rules (DH-3 + note 179 Gap 2)
 ;;
 ;; 4-arg interval-* rules take (a-from, a-to, b-from, b-to). Generic
 ;; over any orderable type — works for the bitemporal axis, but also
 ;; for application-domain date ranges (lease vs contract, etc.).
+;;
+;; The canonical 13 Allen relations (Allen 1983) are: equals,
+;; before/after, meets/met-by, overlaps/overlapped-by, during/contains,
+;; starts/started-by, finishes/finished-by. The library implements 11
+;; names + 1 alias (meets? → immediately-precedes?). The library splits
+;; "before" into precedes? (touching counts) / strictly-precedes? (no
+;; touch) and "after" into succeeds? / strictly-succeeds?, which is
+;; more granular than canonical Allen. Each named relation gets its own
+;; focused test below — each interval setup is a hand-computed oracle.
 ;; ============================================================================
 
-(defn- intervals-conn []
+(defn- install-interval-schema! [conn]
+  (d/transact conn [{:db/ident :iv/name :db/valueType :db.type/string
+                     :db/cardinality :db.cardinality/one}
+                    {:db/ident :iv/from :db/valueType :db.type/instant
+                     :db/cardinality :db.cardinality/one}
+                    {:db/ident :iv/to :db/valueType :db.type/instant
+                     :db/cardinality :db.cardinality/one}]))
+
+(defn- intervals-conn
+  "Fresh in-memory conn with `[:iv/name :iv/from :iv/to]` schema and the
+   given intervals already transacted. Each map in `intervals` has shape
+   `{:name <s> :from <inst> :to <inst>}`."
+  [intervals]
   (let [cfg {:store {:backend :memory :id (random-uuid)}
              :schema-flexibility :write
              :keep-history? false}]
     (d/create-database cfg)
     (let [conn (d/connect cfg)]
-      (d/transact conn [{:db/ident :iv/name
-                         :db/valueType :db.type/string
-                         :db/cardinality :db.cardinality/one}
-                        {:db/ident :iv/from
-                         :db/valueType :db.type/instant
-                         :db/cardinality :db.cardinality/one}
-                        {:db/ident :iv/to
-                         :db/valueType :db.type/instant
-                         :db/cardinality :db.cardinality/one}])
-      ;; Two intervals: A=[Jan, Jul), B=[Apr, Sep)
-      (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-07-01"}
-                        {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-09-01"}])
+      (install-interval-schema! conn)
+      (d/transact conn (mapv (fn [{:keys [name from to]}]
+                               {:iv/name name :iv/from from :iv/to to})
+                             intervals))
       conn)))
 
-(deftest interval-overlaps?-detects-overlap
-  (let [conn (intervals-conn)]
-    (testing "A and B overlap"
-      (is (= #{["A" "B"]}
-             (d/q '[:find ?an ?bn
-                    :where
-                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
-                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                    [(not= ?a ?b)]
-                    [(< ?an ?bn)]  ;; one direction only
-                    (interval-overlaps? ?af ?at ?bf ?bt)]
-                  (d/db conn)))))))
-
-(deftest interval-contains?-checks-containment
-  ;; Setup: A=[Jan, Sep) contains B=[Apr, Jul) but not C=[Jun, Oct).
-  (let [cfg {:store {:backend :memory :id (random-uuid)}
-             :schema-flexibility :write :keep-history? false}
-        _ (d/create-database cfg)
-        conn (d/connect cfg)]
-    (d/transact conn [{:db/ident :iv/name :db/valueType :db.type/string
-                       :db/cardinality :db.cardinality/one}
-                      {:db/ident :iv/from :db/valueType :db.type/instant
-                       :db/cardinality :db.cardinality/one}
-                      {:db/ident :iv/to :db/valueType :db.type/instant
-                       :db/cardinality :db.cardinality/one}])
-    (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-09-01"}
-                      {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-07-01"}
-                      {:iv/name "C" :iv/from #inst "2024-06-01" :iv/to #inst "2024-10-01"}])
-    (testing "A contains B but not C"
-      (is (= #{["A" "B"]}
-             (d/q '[:find ?an ?bn
-                    :where
-                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
-                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                    [(not= ?a ?b)]
-                    (interval-contains? ?af ?at ?bf ?bt)]
-                  (d/db conn)))))))
-
-(deftest interval-precedes?-touching-vs-strict
-  ;; A=[Jan, Apr), B=[Apr, Jul). A.to == B.from — touching.
-  (let [cfg {:store {:backend :memory :id (random-uuid)}
-             :schema-flexibility :write :keep-history? false}
-        _ (d/create-database cfg)
-        conn (d/connect cfg)]
-    (d/transact conn [{:db/ident :iv/name :db/valueType :db.type/string
-                       :db/cardinality :db.cardinality/one}
-                      {:db/ident :iv/from :db/valueType :db.type/instant
-                       :db/cardinality :db.cardinality/one}
-                      {:db/ident :iv/to :db/valueType :db.type/instant
-                       :db/cardinality :db.cardinality/one}])
-    (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-04-01"}
-                      {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-07-01"}])
-    (testing "A precedes B (touching counts)"
-      (is (= #{["A" "B"]}
-             (d/q '[:find ?an ?bn
-                    :where
-                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
-                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                    [(not= ?a ?b)] [(< ?an ?bn)]
-                    (interval-precedes? ?af ?at ?bf ?bt)]
-                  (d/db conn)))))
-    (testing "A strictly-precedes B fails on touching"
-      (is (empty?
-           (d/q '[:find ?an ?bn
-                  :where
+(defmacro ^:private fires-on
+  "Returns the set of `[?an ?bn]` pairs from `conn` where the named
+   Allen rule body fires. The rule is given as a literal sexp like
+   `(interval-starts? ?af ?at ?bf ?bt)` — the macro splices it into a
+   standard 2-interval datalog query. Per-relation tests use this to
+   keep the assertion line readable while reusing the shared pattern."
+  [conn rule-call]
+  `(d/q '~(into '[:find ?an ?bn :where
                   [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
                   [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                  [(not= ?a ?b)] [(< ?an ?bn)]
-                  (interval-strictly-precedes? ?af ?at ?bf ?bt)]
-                (d/db conn)))))
-    (testing "A meets B (alias for immediately-precedes)"
-      (is (= #{["A" "B"]}
-             (d/q '[:find ?an ?bn
-                    :where
-                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
-                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                    [(not= ?a ?b)] [(< ?an ?bn)]
-                    (interval-meets? ?af ?at ?bf ?bt)]
-                  (d/db conn)))))))
+                  [(not= ?a ?b)]]
+                [rule-call])
+        (d/db ~conn)))
+
+;; --- Symmetric: equals --------------------------------------------------
+
+(deftest interval-equals?-only-self-shaped-pair-fires
+  ;; A=[Jan,Jul), B=[Jan,Jul) — identical windows; C=[Jan,Aug) — same
+  ;; from but different to. equals? must pair (A,B) and (B,A); never
+  ;; (A,C) / (C,A).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "C" :from #inst "2024-01-01" :to #inst "2024-08-01"}])]
+    (is (= #{["A" "B"] ["B" "A"]}
+           (fires-on conn (interval-equals? ?af ?at ?bf ?bt)))
+        "equal-shaped windows fire symmetrically; differing-to ones don't")))
+
+;; --- overlaps? --------------------------------------------------------------
+
+(deftest interval-overlaps?-detects-partial-overlap
+  ;; A=[Jan,Jul), B=[Apr,Sep). A.from < B.from < A.to < B.to → overlap.
+  ;; The rule is symmetric (both [(< ?af ?bt)] and [(< ?bf ?at)] hold
+  ;; under swap), so both (A,B) and (B,A) fire.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-09-01"}])]
+    (is (= #{["A" "B"] ["B" "A"]}
+           (fires-on conn (interval-overlaps? ?af ?at ?bf ?bt)))
+        "partially-overlapping windows fire in both orientations")))
+
+(deftest interval-overlaps?-fails-on-disjoint
+  ;; A=[Jan,Apr), B=[Jul,Sep). A.to <= B.from → no overlap, even with
+  ;; the symmetric rule body.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+               {:name "B" :from #inst "2024-07-01" :to #inst "2024-09-01"}])]
+    (is (empty? (fires-on conn (interval-overlaps? ?af ?at ?bf ?bt)))
+        "disjoint windows never overlap")))
+
+;; --- contains? / strictly-contains? -----------------------------------------
+
+(deftest interval-contains?-allows-shared-boundaries
+  ;; A=[Jan,Sep) contains B=[Apr,Jul). C=[Jun,Oct) is NOT contained by A
+  ;; (C.to > A.to). A also contains itself trivially — the [(not= ?a ?b)]
+  ;; guard suppresses that, leaving only (A,B).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-09-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+               {:name "C" :from #inst "2024-06-01" :to #inst "2024-10-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-contains? ?af ?at ?bf ?bt)))
+        "non-strict contains: A contains B but not C")))
+
+(deftest interval-strictly-contains?-rejects-shared-boundaries
+  ;; A=[Jan,Sep), B=[Jan,Jul) — B shares A's from, so A does NOT strictly
+  ;; contain B (the rule demands A.from < B.from AND A.to > B.to).
+  ;; A=[Jan,Sep) DOES strictly contain D=[Apr,Jul).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-09-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "D" :from #inst "2024-04-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "D"]}
+           (fires-on conn (interval-strictly-contains? ?af ?at ?bf ?bt)))
+        "strict contains: only A wholly inside, no shared boundary")))
+
+;; --- precedes? / strictly-precedes? -----------------------------------------
+
+(deftest interval-precedes?-touching-fires
+  ;; A=[Jan,Apr), B=[Apr,Jul) — A.to == B.from. Touching counts for
+  ;; precedes? (rule body is [(<= ?at ?bf)]).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-precedes? ?af ?at ?bf ?bt)))
+        "A precedes B with touching boundary; the reverse does not")))
+
+(deftest interval-strictly-precedes?-rejects-touching
+  ;; A=[Jan,Apr), B=[Apr,Jul) — A.to == B.from. strictly-precedes?
+  ;; demands [(< ?at ?bf)] so touching is rejected.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}])]
+    (is (empty?
+         (fires-on conn (interval-strictly-precedes? ?af ?at ?bf ?bt)))
+        "touching is the canonical edge case strict ordering rejects"))
+  ;; But with a real gap (A=[Jan,Mar), C=[May,Jul)) strict-precedes
+  ;; fires.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-03-01"}
+               {:name "C" :from #inst "2024-05-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "C"]}
+           (fires-on conn (interval-strictly-precedes? ?af ?at ?bf ?bt)))
+        "with a real gap, strict-precedes fires forward only")))
+
+;; --- immediately-precedes? = meets? -----------------------------------------
+
+(deftest interval-immediately-precedes?-fires-only-on-touch
+  ;; meets? is an alias — same rule, both must fire on the same data.
+  ;; Touching case (A.to == B.from): both fire (A,B). Gapped case
+  ;; (A=[Jan,Mar), C=[May,Jul)): neither fires.
+  (let [touching (intervals-conn
+                  [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+                   {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}])
+        gapped (intervals-conn
+                [{:name "A" :from #inst "2024-01-01" :to #inst "2024-03-01"}
+                 {:name "C" :from #inst "2024-05-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on touching (interval-immediately-precedes? ?af ?at ?bf ?bt)))
+        "immediately-precedes: A.to == B.from")
+    (is (= #{["A" "B"]}
+           (fires-on touching (interval-meets? ?af ?at ?bf ?bt)))
+        "meets? is the canonical alias — same fact pattern fires")
+    (is (empty? (fires-on gapped (interval-immediately-precedes? ?af ?at ?bf ?bt)))
+        "a real gap → no immediate-precede; meets? agrees")
+    (is (empty? (fires-on gapped (interval-meets? ?af ?at ?bf ?bt))))))
+
+;; --- succeeds? / strictly-succeeds? / immediately-succeeds? ----------------
+
+(deftest interval-succeeds?-touching-fires
+  ;; A=[Apr,Jul) succeeds B=[Jan,Apr) (A.from == B.to → touching counts).
+  ;; Symmetric to precedes?, opposite direction.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-04-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-succeeds? ?af ?at ?bf ?bt)))
+        "A succeeds B with touching boundary")))
+
+(deftest interval-strictly-succeeds?-rejects-touching
+  ;; Touching: A.from == B.to → strict succeed rejects (needs >, not >=).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-04-01"}])]
+    (is (empty?
+         (fires-on conn (interval-strictly-succeeds? ?af ?at ?bf ?bt)))
+        "touching boundary is rejected by strict-succeeds?"))
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-05-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-03-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-strictly-succeeds? ?af ?at ?bf ?bt)))
+        "with a real gap, strict-succeeds fires")))
+
+(deftest interval-immediately-succeeds?-fires-only-on-touch
+  ;; A=[Apr,Jul), B=[Jan,Apr). A.from == B.to — fires.
+  ;; A=[May,Jul), C=[Jan,Mar) — gap. Doesn't fire.
+  (let [touching (intervals-conn
+                  [{:name "A" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+                   {:name "B" :from #inst "2024-01-01" :to #inst "2024-04-01"}])
+        gapped (intervals-conn
+                [{:name "A" :from #inst "2024-05-01" :to #inst "2024-07-01"}
+                 {:name "C" :from #inst "2024-01-01" :to #inst "2024-03-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on touching (interval-immediately-succeeds? ?af ?at ?bf ?bt)))
+        "immediately-succeeds: A.from == B.to")
+    (is (empty?
+         (fires-on gapped (interval-immediately-succeeds? ?af ?at ?bf ?bt)))
+        "a real gap → no immediate-succeed")))
+
+;; --- starts? / started-by? (note 179 Gap 2 — newly added) -------------------
+
+(deftest interval-starts?-shared-from-shorter-to
+  ;; A=[Jan,Apr), B=[Jan,Jul) — same from, A.to < B.to. A "starts" B in
+  ;; Allen's sense: they begin together and A finishes first.
+  ;; Reverse direction (B starts A) does NOT fire — B.to > A.to.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-starts? ?af ?at ?bf ?bt)))
+        "A starts B: shared from, A.to strictly less than B.to")))
+
+(deftest interval-starts?-rejects-equal-windows
+  ;; A=[Jan,Apr), B=[Jan,Apr) — identical. starts? demands STRICT
+  ;; A.to < B.to, so identical windows give equals?, not starts?.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-04-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-04-01"}])]
+    (is (empty? (fires-on conn (interval-starts? ?af ?at ?bf ?bt)))
+        "identical windows are equals?, not starts?")
+    (is (= #{["A" "B"] ["B" "A"]}
+           (fires-on conn (interval-equals? ?af ?at ?bf ?bt)))
+        "and equals? confirms the relation is the right one")))
+
+(deftest interval-started-by?-is-the-inverse-of-starts?
+  ;; A=[Jan,Jul), B=[Jan,Apr). A.from == B.from, A.to > B.to → A
+  ;; "started-by" B (B starts A in the Allen sense, viewed from A).
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-04-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-started-by? ?af ?at ?bf ?bt)))
+        "A started-by B: shared from, A.to strictly greater than B.to")
+    ;; Cross-check: starts? fires in the opposite direction on the same
+    ;; data. The pair (B,A) for starts? must equal the pair (A,B) for
+    ;; started-by? — that's the inversion contract.
+    (is (= #{["B" "A"]}
+           (fires-on conn (interval-starts? ?af ?at ?bf ?bt)))
+        "starts? is the inverse — fires on the swapped pair")))
+
+;; --- finishes? / finished-by? (note 179 Gap 2 — newly added) ----------------
+
+(deftest interval-finishes?-shared-to-later-from
+  ;; A=[Apr,Jul), B=[Jan,Jul) — shared to, A.from > B.from. A "finishes"
+  ;; B in Allen's sense: they end together but A starts later.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-01-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-finishes? ?af ?at ?bf ?bt)))
+        "A finishes B: shared to, A.from strictly greater than B.from")))
+
+(deftest interval-finishes?-rejects-equal-windows
+  ;; Identical windows go to equals?, not finishes?.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-04-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}])]
+    (is (empty? (fires-on conn (interval-finishes? ?af ?at ?bf ?bt)))
+        "identical windows are equals?, not finishes?")))
+
+(deftest interval-finished-by?-is-the-inverse-of-finishes?
+  ;; A=[Jan,Jul), B=[Apr,Jul). Shared to, A.from < B.from → A
+  ;; finished-by B.
+  (let [conn (intervals-conn
+              [{:name "A" :from #inst "2024-01-01" :to #inst "2024-07-01"}
+               {:name "B" :from #inst "2024-04-01" :to #inst "2024-07-01"}])]
+    (is (= #{["A" "B"]}
+           (fires-on conn (interval-finished-by? ?af ?at ?bf ?bt)))
+        "A finished-by B: shared to, A.from strictly less than B.from")
+    (is (= #{["B" "A"]}
+           (fires-on conn (interval-finishes? ?af ?at ?bf ?bt)))
+        "finishes? is the inverse — fires on the swapped pair")))
 
 ;; ============================================================================
 ;; Clock pinning for repeatable tests (DH-4)

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -363,3 +363,70 @@
                             (d/db conn))]
         (testing "tx-instant falls in [before, after] window"
           (is (<= before (.getTime ^java.util.Date tx-instant) after)))))))
+
+(deftest valid-at-filters-all-read-apis
+  ;; Locks in the invariant: the FilteredDB returned by `d/valid-at`
+  ;; carries its predicate via `-search-context`'s xform-after, so every
+  ;; read path that flows through `dbi/datoms` / `dbi/search` honours it
+  ;; — not just `d/q`. Setup: one entity with three attributes asserted
+  ;; in a single tx whose vt-window is [Jan, Jul). A `valid-at` inside
+  ;; the window admits all three datoms; one before the window admits
+  ;; none.
+  (let [conn (fresh-conn)
+        _ (d/transact conn [{:db/ident :emp/name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one
+                             :db/unique :db.unique/identity}
+                            {:db/ident :emp/department
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one
+                             :db/index true}
+                            {:db/ident :emp/salary
+                             :db/valueType :db.type/long
+                             :db/cardinality :db.cardinality/one
+                             :db/index true}])
+        _ (d/transact conn {:tx-data [{:emp/name "Bob"
+                                       :emp/department "eng"
+                                       :emp/salary 100000}]
+                            :tx-meta {:db.valid/from #inst "2024-01-01"
+                                      :db.valid/to   #inst "2024-07-01"}})
+        db        (d/db conn)
+        ;; resolve Bob's numeric eid on the *unfiltered* db once; we use
+        ;; the numeric form below so the lookup-ref doesn't bottom out on
+        ;; the filtered view (which would correctly throw — that's a
+        ;; separate, already-tested property).
+        bob       (d/q '[:find ?e . :where [?e :emp/name "Bob"]] db)
+        in-window  (d/valid-at db #inst "2024-04-15")
+        out-window (d/valid-at db #inst "2023-06-01")]
+    (testing "d/q on plain db sees Bob"
+      (is (= #{["Bob"]} (d/q '[:find ?n :where [_ :emp/name ?n]] db))))
+    (testing "d/q honours valid-at"
+      (is (= #{["Bob"]} (d/q '[:find ?n :where [_ :emp/name ?n]] in-window))
+          "in-window: Bob visible")
+      (is (= #{}        (d/q '[:find ?n :where [_ :emp/name ?n]] out-window))
+          "out-window: Bob filtered out"))
+    (testing "d/datoms honours valid-at"
+      (is (seq  (d/datoms in-window  :avet :emp/name))
+          "in-window: AVET scan returns Bob's name datom")
+      (is (empty? (d/datoms out-window :avet :emp/name))
+          "out-window: AVET scan returns nothing"))
+    (testing "d/pull honours valid-at"
+      (is (= {:db/id bob :emp/name "Bob" :emp/salary 100000}
+             (d/pull in-window  [:db/id :emp/name :emp/salary] bob))
+          "in-window: pull resolves both attrs by numeric eid")
+      (is (nil? (d/pull out-window [:db/id :emp/name :emp/salary] bob))
+          "out-window: pull returns nil because no datoms survive the filter"))
+    (testing "d/entity honours valid-at"
+      (is (= "Bob"   (:emp/name   (d/entity in-window  bob))))
+      (is (= 100000  (:emp/salary (d/entity in-window  bob))))
+      (is (nil? (:emp/name   (d/entity out-window bob)))
+          "out-window: entity lookup returns nil for filtered attrs")
+      (is (nil? (:emp/salary (d/entity out-window bob)))))
+    (testing "d/seek-datoms and d/index-range honour valid-at"
+      (is (seq (d/seek-datoms in-window :avet :emp/salary)))
+      (is (empty?
+            (filter #(= :emp/salary (:a %))
+                    (d/seek-datoms out-window :avet :emp/salary))))
+      (is (seq (d/index-range in-window {:attrid :emp/salary :start 0 :end 200000})))
+      (is (empty?
+            (d/index-range out-window {:attrid :emp/salary :start 0 :end 200000}))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -91,9 +91,9 @@
         vt-marked (d/valid-at (d/db conn) #inst "2024-04-15")]
     (testing "wrong order throws :temporal/wrap-order"
       (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo
-            #"Cannot wrap d/as-of around a db already filtered by d/valid-at"
-            (d/as-of vt-marked #inst "2024-08-01"))))
+           clojure.lang.ExceptionInfo
+           #"Cannot wrap d/as-of around a db already filtered by d/valid-at"
+           (d/as-of vt-marked #inst "2024-08-01"))))
     (testing "correct order works"
       (is (some? (-> (d/db conn)
                      (d/as-of #inst "2024-08-01")
@@ -150,34 +150,34 @@
   (testing "Tx with :db.valid/from > :db.valid/to throws at transact"
     (let [conn (fresh-conn)]
       (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo #"Invalid valid-time window"
-            (d/transact conn
-                        {:tx-meta {:db.valid/from #inst "2024-07-01"
-                                   :db.valid/to   #inst "2024-01-01"}
-                         :tx-data [{:db/ident :foo
-                                    :db/valueType :db.type/long
-                                    :db/cardinality :db.cardinality/one}]}))))))
+           clojure.lang.ExceptionInfo #"Invalid valid-time window"
+           (d/transact conn
+                       {:tx-meta {:db.valid/from #inst "2024-07-01"
+                                  :db.valid/to   #inst "2024-01-01"}
+                        :tx-data [{:db/ident :foo
+                                   :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one}]}))))))
 
 (deftest transact-rejects-zero-width-valid-window
   (testing "Tx with :db.valid/from == :db.valid/to throws at transact"
     (let [conn (fresh-conn)]
       (is (thrown-with-msg?
-            clojure.lang.ExceptionInfo #"Invalid valid-time window"
-            (d/transact conn
-                        {:tx-meta {:db.valid/from #inst "2024-04-01"
-                                   :db.valid/to   #inst "2024-04-01"}
-                         :tx-data [{:db/ident :foo
-                                    :db/valueType :db.type/long
-                                    :db/cardinality :db.cardinality/one}]}))))))
+           clojure.lang.ExceptionInfo #"Invalid valid-time window"
+           (d/transact conn
+                       {:tx-meta {:db.valid/from #inst "2024-04-01"
+                                  :db.valid/to   #inst "2024-04-01"}
+                        :tx-data [{:db/ident :foo
+                                   :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one}]}))))))
 
 (deftest transact-accepts-open-ended-valid-window
   (testing "Tx with :db.valid/from but no :db.valid/to succeeds"
     (let [conn (fresh-conn)]
       (is (some? (d/transact conn
-                              {:tx-meta {:db.valid/from #inst "2024-01-01"}
-                               :tx-data [{:db/ident :foo
-                                          :db/valueType :db.type/long
-                                          :db/cardinality :db.cardinality/one}]}))))))
+                             {:tx-meta {:db.valid/from #inst "2024-01-01"}
+                              :tx-data [{:db/ident :foo
+                                         :db/valueType :db.type/long
+                                         :db/cardinality :db.cardinality/one}]}))))))
 
 ;; ============================================================================
 ;; valid-between / valid-during / valid-all wrappers (DH-2)
@@ -336,13 +336,13 @@
                   (d/db conn)))))
     (testing "A strictly-precedes B fails on touching"
       (is (empty?
-            (d/q '[:find ?an ?bn
-                   :where
-                   [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
-                   [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
-                   [(not= ?a ?b)] [(< ?an ?bn)]
-                   (interval-strictly-precedes? ?af ?at ?bf ?bt)]
-                 (d/db conn)))))
+           (d/q '[:find ?an ?bn
+                  :where
+                  [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                  [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                  [(not= ?a ?b)] [(< ?an ?bn)]
+                  (interval-strictly-precedes? ?af ?at ?bf ?bt)]
+                (d/db conn)))))
     (testing "A meets B (alias for immediately-precedes)"
       (is (= #{["A" "B"]}
              (d/q '[:find ?an ?bn
@@ -452,8 +452,8 @@
     (testing "d/seek-datoms and d/index-range honour valid-at"
       (is (seq (d/seek-datoms in-window :avet :emp/salary)))
       (is (empty?
-            (filter #(= :emp/salary (:a %))
-                    (d/seek-datoms out-window :avet :emp/salary))))
+           (filter #(= :emp/salary (:a %))
+                   (d/seek-datoms out-window :avet :emp/salary))))
       (is (seq (d/index-range in-window {:attrid :emp/salary :start 0 :end 200000})))
       (is (empty?
-            (d/index-range out-window {:attrid :emp/salary :start 0 :end 200000}))))))
+           (d/index-range out-window {:attrid :emp/salary :start 0 :end 200000}))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -114,3 +114,214 @@
     (let [db (d/valid-at (d/db conn) #inst "2024-04-15")]
       (testing "datom from non-vt tx survives the filter"
         (is (= 42 (d/q '[:find ?x . :where [_ :foo/x ?x]] db)))))))
+
+;; ============================================================================
+;; vf < vt validation at the transactor (DH-1)
+;; ============================================================================
+
+(deftest transact-rejects-reverse-valid-window
+  (testing "Tx with :db.valid/from > :db.valid/to throws at transact"
+    (let [conn (fresh-conn)]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo #"Invalid valid-time window"
+            (d/transact conn
+                        {:tx-meta {:db.valid/from #inst "2024-07-01"
+                                   :db.valid/to   #inst "2024-01-01"}
+                         :tx-data [{:db/ident :foo
+                                    :db/valueType :db.type/long
+                                    :db/cardinality :db.cardinality/one}]}))))))
+
+(deftest transact-rejects-zero-width-valid-window
+  (testing "Tx with :db.valid/from == :db.valid/to throws at transact"
+    (let [conn (fresh-conn)]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo #"Invalid valid-time window"
+            (d/transact conn
+                        {:tx-meta {:db.valid/from #inst "2024-04-01"
+                                   :db.valid/to   #inst "2024-04-01"}
+                         :tx-data [{:db/ident :foo
+                                    :db/valueType :db.type/long
+                                    :db/cardinality :db.cardinality/one}]}))))))
+
+(deftest transact-accepts-open-ended-valid-window
+  (testing "Tx with :db.valid/from but no :db.valid/to succeeds"
+    (let [conn (fresh-conn)]
+      (is (some? (d/transact conn
+                              {:tx-meta {:db.valid/from #inst "2024-01-01"}
+                               :tx-data [{:db/ident :foo
+                                          :db/valueType :db.type/long
+                                          :db/cardinality :db.cardinality/one}]}))))))
+
+;; ============================================================================
+;; valid-between / valid-during / valid-all wrappers (DH-2)
+;; ============================================================================
+
+(deftest valid-between-filters-overlapping-tx-windows
+  ;; Setup: Bob 100k [Jan-Jul), 110k [Jul-MAX); Alice 80k [Jan-MAX).
+  ;; Query: valid-between [Apr, Sep) should keep all three (Bob's two
+  ;; windows both overlap [Apr, Sep): [Jan, Jul) overlaps on [Apr, Jul);
+  ;; [Jul, MAX) overlaps on [Jul, Sep). Alice's [Jan, MAX) overlaps too.
+  (let [conn (fresh-conn)]
+    (setup-vt-data! conn)
+    (let [hist (d/history (d/db conn))
+          db (d/valid-between hist #inst "2024-04-01" #inst "2024-09-01")]
+      (testing "all three windows overlap [Apr, Sep)"
+        (is (= #{[100000] [110000] [80000]}
+               (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]] db))))
+      (testing "marker is set"
+        (is (= [#inst "2024-04-01" #inst "2024-09-01"]
+               (:datahike/valid-between (meta db))))))))
+
+(deftest valid-between-narrow-window-excludes-non-overlapping
+  ;; Bob 100k [Jan-Jul), 110k [Jul-MAX). Query [Aug, Oct) overlaps only
+  ;; the 110k window. Alice's [Jan-MAX) also overlaps.
+  (let [conn (fresh-conn)]
+    (setup-vt-data! conn)
+    (let [hist (d/history (d/db conn))
+          db (d/valid-between hist #inst "2024-08-01" #inst "2024-10-01")]
+      (is (= #{[110000] [80000]}
+             (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]] db))))))
+
+(deftest valid-during-strict-containment
+  ;; Bob 100k [Jan, Jul) — fully contained in [Jan, Sep). vt-to=Jul <= Sep.
+  ;; Bob 110k [Jul, MAX) — vt-to=MAX is open, NOT contained in any bounded window.
+  ;; Alice 80k [Jan, MAX) — same, not contained.
+  ;; Query valid-during [Jan, Sep): only Bob's 100k row passes.
+  (let [conn (fresh-conn)]
+    (setup-vt-data! conn)
+    (let [hist (d/history (d/db conn))
+          db (d/valid-during hist #inst "2024-01-01" #inst "2024-09-01")]
+      (is (= #{[100000]}
+             (d/q '[:find ?s :where [?e :emp/salary ?s ?tx true]] db))))))
+
+(deftest valid-all-clears-markers
+  (let [conn (fresh-conn)
+        ;; Chaining valid-at then valid-between nests FilteredDBs;
+        ;; the outer wrapper's meta doesn't carry the inner's marker.
+        ;; Stack both markers on a single FilteredDB via vary-meta
+        ;; to exercise the multi-marker case.
+        marked (-> (d/valid-at (d/db conn) #inst "2024-04-15")
+                   (vary-meta assoc :datahike/valid-between
+                              [#inst "2024-01-01" #inst "2024-07-01"]))]
+    (testing "both markers present"
+      (is (some? (:datahike/valid-at (meta marked))))
+      (is (some? (:datahike/valid-between (meta marked)))))
+    (let [cleared (d/valid-all marked)]
+      (testing "valid-all strips both markers"
+        (is (nil? (:datahike/valid-at (meta cleared))))
+        (is (nil? (:datahike/valid-between (meta cleared))))))))
+
+(deftest valid-between-nil-endpoint-clears-marker
+  (let [conn (fresh-conn)
+        marked (d/valid-between (d/db conn) #inst "2024-01-01" #inst "2024-07-01")
+        cleared (d/valid-between marked nil #inst "2024-07-01")]
+    (testing "nil endpoint clears the between marker"
+      (is (nil? (:datahike/valid-between (meta cleared)))))))
+
+;; ============================================================================
+;; Allen interval predicates as built-in datalog rules (DH-3)
+;;
+;; 4-arg interval-* rules take (a-from, a-to, b-from, b-to). Generic
+;; over any orderable type — works for the bitemporal axis, but also
+;; for application-domain date ranges (lease vs contract, etc.).
+;; ============================================================================
+
+(defn- intervals-conn []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn [{:db/ident :iv/name
+                         :db/valueType :db.type/string
+                         :db/cardinality :db.cardinality/one}
+                        {:db/ident :iv/from
+                         :db/valueType :db.type/instant
+                         :db/cardinality :db.cardinality/one}
+                        {:db/ident :iv/to
+                         :db/valueType :db.type/instant
+                         :db/cardinality :db.cardinality/one}])
+      ;; Two intervals: A=[Jan, Jul), B=[Apr, Sep)
+      (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-07-01"}
+                        {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-09-01"}])
+      conn)))
+
+(deftest interval-overlaps?-detects-overlap
+  (let [conn (intervals-conn)]
+    (testing "A and B overlap"
+      (is (= #{["A" "B"]}
+             (d/q '[:find ?an ?bn
+                    :where
+                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                    [(not= ?a ?b)]
+                    [(< ?an ?bn)]  ;; one direction only
+                    (interval-overlaps? ?af ?at ?bf ?bt)]
+                  (d/db conn)))))))
+
+(deftest interval-contains?-checks-containment
+  ;; Setup: A=[Jan, Sep) contains B=[Apr, Jul) but not C=[Jun, Oct).
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    (d/transact conn [{:db/ident :iv/name :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :iv/from :db/valueType :db.type/instant
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :iv/to :db/valueType :db.type/instant
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-09-01"}
+                      {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-07-01"}
+                      {:iv/name "C" :iv/from #inst "2024-06-01" :iv/to #inst "2024-10-01"}])
+    (testing "A contains B but not C"
+      (is (= #{["A" "B"]}
+             (d/q '[:find ?an ?bn
+                    :where
+                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                    [(not= ?a ?b)]
+                    (interval-contains? ?af ?at ?bf ?bt)]
+                  (d/db conn)))))))
+
+(deftest interval-precedes?-touching-vs-strict
+  ;; A=[Jan, Apr), B=[Apr, Jul). A.to == B.from — touching.
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    (d/transact conn [{:db/ident :iv/name :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :iv/from :db/valueType :db.type/instant
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :iv/to :db/valueType :db.type/instant
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn [{:iv/name "A" :iv/from #inst "2024-01-01" :iv/to #inst "2024-04-01"}
+                      {:iv/name "B" :iv/from #inst "2024-04-01" :iv/to #inst "2024-07-01"}])
+    (testing "A precedes B (touching counts)"
+      (is (= #{["A" "B"]}
+             (d/q '[:find ?an ?bn
+                    :where
+                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                    [(not= ?a ?b)] [(< ?an ?bn)]
+                    (interval-precedes? ?af ?at ?bf ?bt)]
+                  (d/db conn)))))
+    (testing "A strictly-precedes B fails on touching"
+      (is (empty?
+            (d/q '[:find ?an ?bn
+                   :where
+                   [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                   [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                   [(not= ?a ?b)] [(< ?an ?bn)]
+                   (interval-strictly-precedes? ?af ?at ?bf ?bt)]
+                 (d/db conn)))))
+    (testing "A meets B (alias for immediately-precedes)"
+      (is (= #{["A" "B"]}
+             (d/q '[:find ?an ?bn
+                    :where
+                    [?a :iv/name ?an] [?a :iv/from ?af] [?a :iv/to ?at]
+                    [?b :iv/name ?bn] [?b :iv/from ?bf] [?b :iv/to ?bt]
+                    [(not= ?a ?b)] [(< ?an ?bn)]
+                    (interval-meets? ?af ?at ?bf ?bt)]
+                  (d/db conn)))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -79,6 +79,26 @@
     (testing "nil clears the meta marker"
       (is (nil? (:datahike/valid-at (meta cleared)))))))
 
+(deftest as-of-rejects-vt-marked-input
+  ;; Wrapping order matters: d/as-of must be wrapped FIRST, then
+  ;; d/valid-at outermost — otherwise the supersession check inside
+  ;; valid-at's predicate captures an unbounded db and reads future
+  ;; txes. d/as-of throws if it sees a vt-marked db to surface the
+  ;; mistake at call-site rather than silently returning wrong
+  ;; answers.
+  (let [conn (fresh-conn)
+        _ (setup-vt-data! conn)
+        vt-marked (d/valid-at (d/db conn) #inst "2024-04-15")]
+    (testing "wrong order throws :temporal/wrap-order"
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"Cannot wrap d/as-of around a db already filtered by d/valid-at"
+            (d/as-of vt-marked #inst "2024-08-01"))))
+    (testing "correct order works"
+      (is (some? (-> (d/db conn)
+                     (d/as-of #inst "2024-08-01")
+                     (d/valid-at #inst "2024-04-15")))))))
+
 (deftest valid-at-composes-with-as-of
   ;; Tx1 (vt 2024-Q1) created Bob with salary 100k.
   ;; Tx2 (vt 2024-Q3) updated Bob's salary to 110k.

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -325,3 +325,41 @@
                     [(not= ?a ?b)] [(< ?an ?bn)]
                     (interval-meets? ?af ?at ?bf ?bt)]
                   (d/db conn)))))))
+
+;; ============================================================================
+;; Clock pinning for repeatable tests (DH-4)
+;;
+;; Per-call dynamic bindings (`(binding [tools/get-date ...] ...)`)
+;; don't reach the writer thread, which runs transactions on a
+;; background go-loop. Two patterns work across the thread hop:
+;; (a) tx-meta `:db/txInstant` override (recommended), or
+;; (b) `alter-var-root` on `get-date` (whole-suite fixture).
+;; ============================================================================
+
+(deftest tx-meta-txInstant-override-pins-time
+  (testing "tx-meta :db/txInstant overrides the default :db/txInstant"
+    (let [pinned-date #inst "2024-01-01T00:00:00.000-00:00"
+          conn (fresh-conn)]
+      (d/transact conn {:tx-meta {:db/txInstant pinned-date}
+                        :tx-data [{:db/ident :foo/x
+                                   :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one}]})
+      (let [tx-instant (d/q '[:find ?t .
+                              :where [_ :db/ident :foo/x] [_ :db/txInstant ?t]]
+                            (d/db conn))]
+        (is (= pinned-date tx-instant)
+            "tx-meta :db/txInstant should pin the tx-instant deterministically")))))
+
+(deftest default-tx-instant-is-wall-clock
+  (testing "Without tx-meta override, :db/txInstant is wall-clock now"
+    (let [conn (fresh-conn)
+          before (System/currentTimeMillis)]
+      (d/transact conn [{:db/ident :foo/x
+                         :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (let [after (System/currentTimeMillis)
+            tx-instant (d/q '[:find ?t .
+                              :where [_ :db/ident :foo/x] [_ :db/txInstant ?t]]
+                            (d/db conn))]
+        (testing "tx-instant falls in [before, after] window"
+          (is (<= before (.getTime ^java.util.Date tx-instant) after)))))))

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -529,6 +529,123 @@
         "finishes? is the inverse — fires on the swapped pair")))
 
 ;; ============================================================================
+;; Half-open boundary semantics on valid-at (note 179 §4 Gap 2)
+;;
+;; The substrate's valid-at semantics is **half-open `[vf, vt)`** —
+;; documented at `doc/valid_time.md:75`, encoded in two places:
+;;   * the supersession predicate in `api/impl.cljc:179-198`
+;;     (`tx-covers-at?`): `(not (.after vf at)) AND (vt.after at)`
+;;     — i.e. `vf <= at < vt`.
+;;   * the auto-injected `valid-at` rule at `query.cljc:640-641`:
+;;     `[(<= ?vf ?at)] [(> ?vt ?at)]`.
+;;
+;; A query at `t == vf` MUST match; a query at `t == vt` MUST NOT.
+;; Without these boundary tests, a future refactor that flips the `<=`
+;; to `<` (or the `>` to `>=`) — say while porting to a different time
+;; type — would silently regress: every existing test queries strictly
+;; inside or strictly outside the window.
+;; ============================================================================
+
+(defn- vt-bounded-conn
+  "Tx a single tx with vt window [from, to). Returns the conn."
+  [from to]
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :emp/name :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :emp/salary :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                      :tx-meta {:db.valid/from from :db.valid/to to}})
+    conn))
+
+(defn- vt-open-ended-conn
+  "Tx a single tx with vt window [from, +∞). Returns the conn."
+  [from]
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :emp/name :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :emp/salary :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 100000}]
+                      :tx-meta {:db.valid/from from}})
+    conn))
+
+(defn- salaries-at [db at]
+  (d/q '[:find ?s :where [_ :emp/salary ?s]] (d/valid-at db at)))
+
+(deftest valid-at-boundary-lower-vf-inclusive
+  ;; Half-open `[vf, vt)` — `t == vf` is INSIDE the window.
+  ;; Setup: window = [2024-01-01, 2024-07-01).
+  (let [conn (vt-bounded-conn #inst "2024-01-01" #inst "2024-07-01")
+        db (d/db conn)]
+    (testing "at exactly vf (2024-01-01) the fact IS visible (inclusive lower)"
+      (is (= #{[100000]} (salaries-at db #inst "2024-01-01"))
+          "vf <= at must admit at == vf — the half-open [vf, vt) contract"))))
+
+(deftest valid-at-boundary-just-before-vt-inclusive
+  ;; t = vt - 1ms must STILL be inside — the upper bound is exclusive
+  ;; but everything below it is in.
+  (let [conn (vt-bounded-conn #inst "2024-01-01" #inst "2024-07-01")
+        db (d/db conn)]
+    (testing "at 2024-06-30T23:59:59.999 (vt minus 1 ms) the fact IS visible"
+      (is (= #{[100000]} (salaries-at db #inst "2024-06-30T23:59:59.999"))
+          "any instant strictly < vt must admit the fact"))))
+
+(deftest valid-at-boundary-upper-vt-exclusive
+  ;; The defining test: `t == vt` MUST NOT be inside. This is what
+  ;; distinguishes half-open `[vf, vt)` from closed `[vf, vt]`.
+  (let [conn (vt-bounded-conn #inst "2024-01-01" #inst "2024-07-01")
+        db (d/db conn)]
+    (testing "at exactly vt (2024-07-01) the fact is NOT visible (exclusive upper)"
+      (is (= #{} (salaries-at db #inst "2024-07-01"))
+          "vt > at must reject at == vt — the half-open contract"))))
+
+(deftest valid-at-boundary-just-after-vt-exclusive
+  ;; And of course `t > vt` is also out.
+  (let [conn (vt-bounded-conn #inst "2024-01-01" #inst "2024-07-01")
+        db (d/db conn)]
+    (testing "at 2024-07-01T00:00:00.001 (vt plus 1 ms) the fact is NOT visible"
+      (is (= #{} (salaries-at db #inst "2024-07-01T00:00:00.001"))
+          "any instant > vt is strictly outside the window"))))
+
+(deftest valid-at-boundary-just-before-vf-exclusive
+  ;; Strictly-before-vf: the fact is NOT visible. Pairs with the
+  ;; lower-inclusive test above — together they nail down the lower
+  ;; boundary.
+  (let [conn (vt-bounded-conn #inst "2024-01-01" #inst "2024-07-01")
+        db (d/db conn)]
+    (testing "at 2023-12-31T23:59:59.999 (vf minus 1 ms) the fact is NOT visible"
+      (is (= #{} (salaries-at db #inst "2023-12-31T23:59:59.999"))
+          "any instant strictly < vf is before the window"))))
+
+(deftest valid-at-open-ended-far-future-visible
+  ;; Open-ended `[vf, ∞)` — the substrate substitutes `+∞` for missing
+  ;; `:db.valid/to`. A query at any instant after vf must match.
+  ;; `query.cljc:639` uses `#inst "9999-12-31T23:59:59.999"` as the
+  ;; sentinel; the impl.cljc predicate treats nil vt as no upper bound.
+  (let [conn (vt-open-ended-conn #inst "2024-01-01")
+        db (d/db conn)]
+    (testing "at far future (2999-12-31) the fact IS visible for an open vt"
+      (is (= #{[100000]} (salaries-at db #inst "2999-12-31"))
+          "open-ended vt treats every future instant as inside"))))
+
+(deftest valid-at-open-ended-before-vf-not-visible
+  ;; Open-ended on the upper end doesn't help below the lower bound.
+  (let [conn (vt-open-ended-conn #inst "2024-01-01")
+        db (d/db conn)]
+    (testing "at 2020-01-01 (before vf) the fact is NOT visible"
+      (is (= #{} (salaries-at db #inst "2020-01-01"))
+          "lower bound stays in effect even for open-ended windows"))))
+
+(deftest valid-at-open-ended-at-vf-visible
+  ;; Lower-bound inclusivity holds for open-ended windows too.
+  (let [conn (vt-open-ended-conn #inst "2024-01-01")
+        db (d/db conn)]
+    (testing "at exactly vf (2024-01-01) the fact IS visible for an open vt"
+      (is (= #{[100000]} (salaries-at db #inst "2024-01-01"))
+          "vf inclusive boundary applies regardless of vt being open"))))
+
+;; ============================================================================
 ;; Clock pinning for repeatable tests (DH-4)
 ;;
 ;; Per-call dynamic bindings (`(binding [tools/get-date ...] ...)`)

--- a/test/datahike/test/valid_at_test.clj
+++ b/test/datahike/test/valid_at_test.clj
@@ -104,19 +104,26 @@
   ;; Tx2 (vt 2024-Q3) updated Bob's salary to 110k.
   ;; Tx3 (vt 2024-Q1) created Alice with salary 80k.
   ;;
-  ;; as-of at tx2-instant => sees tx1+tx2 (not tx3): so Bob 100k + 110k.
+  ;; as-of at tx2-id => sees tx1+tx2 (not tx3): so Bob 100k + 110k.
   ;; valid-at "mid-Q2" on top: vt-window for Bob's 100k is Q1..Q3 — contains mid-Q2 → match.
   ;; Bob's 110k vt-window is Q3..MAX — doesn't contain mid-Q2 → no match.
   ;; Result: just 100000.
+  ;;
+  ;; Cuts by tx-id rather than tx-instant: tx-ids are strictly
+  ;; monotonic by definition, while :db/txInstant could tie when
+  ;; multiple writes land in the same wall-clock ms. The Datomic
+  ;; idiom for "exact tx as the cut point" is `as-of <tx-id>`.
+  ;; (Today next-tx-instant also enforces strict monotonicity on
+  ;; auto-stamped :db/txInstant, but tx-id is the correct primitive
+  ;; for an unambiguous snapshot cut.)
   (let [conn (fresh-conn)
         _ (setup-vt-data! conn)
-        tx2-instant (d/q '[:find ?t .
-                           :where [?tx :db.valid/from #inst "2024-07-01"]
-                           [?tx :db/txInstant ?t]]
-                         (d/history (d/db conn)))
+        tx2-id (d/q '[:find ?tx .
+                      :where [?tx :db.valid/from #inst "2024-07-01"]]
+                    (d/history (d/db conn)))
         composed (-> (d/db conn)
                      (d/history)
-                     (d/as-of tx2-instant)
+                     (d/as-of tx2-id)
                      (d/valid-at #inst "2024-04-15"))]
     (testing "as-of tx2 then valid-at mid-Q2 → only Bob's 100k row"
       (is (= #{[100000]}

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -180,6 +180,75 @@
         (is (= 42 (d/q '[:find ?x . :where [_ :pos/x ?x]] (d/db conn))))))))
 
 ;; ============================================================================
+;; Tuple form — [:db/add tx-tempid :db.valid/from ...] — the doc snippet
+;;
+;; `doc/valid_time.md` L80-87 claims this low-level tuple form is
+;; equivalent to the inline-map form + the `:tx-meta` map-arg form. The
+;; tuple-form path runs through `db/transaction.cljc:1141` (`tx-id?` →
+;; allocate-eid + rewrite e to `(current-tx report)`), then
+;; `transact-add` lands the datom on the tx-entity exactly like any
+;; other `[:db/add tx-eid :attr value]`. This pins all three tempid
+;; spellings — `:db/current-tx`, `"datomic.tx"`, `"datahike.tx"` —
+;; mirroring `transact_test.cljc:377-398` (test-resolve-current-tx).
+;; ============================================================================
+
+(deftest tuple-form-vt-meta-attr-lands-on-tx
+  (doseq [tx-tempid [:db/current-tx "datomic.tx" "datahike.tx"]]
+    (testing (str "tx-tempid = " tx-tempid)
+      (let [conn (fresh-conn)]
+        (d/transact conn [{:db/ident :emp/name
+                           :db/valueType :db.type/string
+                           :db/unique :db.unique/identity
+                           :db/cardinality :db.cardinality/one}
+                          {:db/ident :emp/salary
+                           :db/valueType :db.type/long
+                           :db/cardinality :db.cardinality/one}])
+        ;; The exact doc snippet shape — mixed entity-map + tuple in
+        ;; one tx-data vector — with both vt-bounds via tuple.
+        (let [report (d/transact conn
+                                 [{:emp/name "Bob" :emp/salary 100000}
+                                  [:db/add tx-tempid :db.valid/from #inst "2026-01-01"]
+                                  [:db/add tx-tempid :db.valid/to   #inst "2026-12-31"]])
+              tx     (get-in report [:tempids :db/current-tx])
+              pulled (d/pull (d/db conn) '[*] tx)]
+          (testing "tuple-form vt-meta lands on the writing tx-entity"
+            (is (= #inst "2026-01-01" (:db.valid/from pulled))
+                "tuple-form :db.valid/from must land on tx")
+            (is (= #inst "2026-12-31" (:db.valid/to   pulled))
+                "tuple-form :db.valid/to must land on tx"))
+          (testing "the user data lands on a non-tx entity"
+            (is (= 100000 (d/q '[:find ?s . :where
+                                 [?e :emp/name "Bob"]
+                                 [?e :emp/salary ?s]]
+                               (d/db conn)))
+                "Bob's salary is asserted on a normal entity")))
+        ;; valid-at semantics — the vt-from inclusive lower bound +
+        ;; vt-to exclusive upper bound apply to a query against the
+        ;; current db (not history): the user datom is visible only
+        ;; when ?at falls in [vf, vt).
+        (testing "valid-at finds user data INSIDE the window"
+          (let [r (d/q '[:find ?s . :where
+                         [?e :emp/name "Bob"]
+                         [?e :emp/salary ?s]]
+                       (d/valid-at (d/db conn) #inst "2026-06-01"))]
+            (is (= 100000 r)
+                "mid-2026 falls in the [2026-01-01, 2026-12-31) window")))
+        (testing "valid-at does NOT find user data BEFORE the window"
+          (let [r (d/q '[:find ?s . :where
+                         [?e :emp/name "Bob"]
+                         [?e :emp/salary ?s]]
+                       (d/valid-at (d/db conn) #inst "2025-01-01"))]
+            (is (nil? r)
+                "2025-01-01 is before vt-from — must not match")))
+        (testing "valid-at does NOT find user data AT/AFTER the upper bound"
+          (let [r (d/q '[:find ?s . :where
+                         [?e :emp/name "Bob"]
+                         [?e :emp/salary ?s]]
+                       (d/valid-at (d/db conn) #inst "2027-01-01"))]
+            (is (nil? r)
+                "2027-01-01 is past vt-to (half-open window) — must not match")))))))
+
+;; ============================================================================
 ;; Schema enforcement — :db.valid/from rejects non-instant values
 ;; ============================================================================
 

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -120,3 +120,90 @@
       (testing "vt-from alone is sufficient; vt-to may be omitted"
         (is (= #inst "2024-01-01" (:db.valid/from pulled)))
         (is (nil? (:db.valid/to pulled)))))))
+
+(deftest system-attrs-show-up-as-indexed
+  ;; Regression: `:db.valid/from` / `:db.valid/to` must appear in
+  ;; rschema's `:db/index` set so `(dbu/indexing? db ...)` returns
+  ;; true and the planner's AVET pushdown for predicates pivoting on
+  ;; these attrs actually fires. Without it, `[(<= ?vf ?at)]` after
+  ;; `[?tx :db.valid/from ?vf]` silently returned 0 results (the
+  ;; planner computed pushdown bounds but the seek path treated the
+  ;; attr as non-indexed).
+  ;;
+  ;; Note: `:db/txInstant` is deliberately NOT in this set in
+  ;; non-attribute-refs mode — adding it would land every tx's
+  ;; `:db/txInstant` datom in AVET, a semantic change that breaks
+  ;; existing tests + the existing `:db/txInstant`-by-tx lookup
+  ;; path. See `non-ref-implicit-schema` in constants.cljc.
+  (let [conn (fresh-conn)
+        db   (d/db conn)
+        rs   (datahike.db.interface/-rschema db)]
+    (testing ":db.valid/from and :db.valid/to are recognised as indexed"
+      (is (contains? (:db/index rs) :db.valid/from))
+      (is (contains? (:db/index rs) :db.valid/to)))))
+
+(deftest built-in-rules-work-without-in-percent
+  ;; `valid-at` / `valid-between` / `valid-during` / `period-overlaps?`
+  ;; should be invokable in `:where` without the user declaring `%` in
+  ;; `:in`. The auto-inject inside `normalize-q-input` adds `%` and
+  ;; the built-in rule defs transparently.
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :emp/name
+                       :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one
+                       :db/unique :db.unique/identity}
+                      {:db/ident :emp/salary
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn [{:emp/name "Bob" :emp/salary 100000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-01-01"
+                       :db.valid/to   #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 110000}])
+    (d/transact conn [{:db/id "datomic.tx"
+                       :db.valid/from #inst "2024-07-01"}
+                      {:emp/name "Bob" :emp/salary 120000}])
+    (let [hist (d/history (d/db conn))]
+      ;; NOTE: `d/history` returns BOTH added and retracted datoms. A
+      ;; cardinality-one upsert (like the salary updates here) produces
+      ;; one retraction + one assertion per tx. The valid-at filter
+      ;; runs PER-TX (it filters the tx's vt-window, not per-datom
+      ;; add/retract polarity), so a tx whose vt-window includes
+      ;; ?at returns ALL its salary datoms — both the retracted and
+      ;; the newly-asserted value. Use the 5-tuple `[e a v t added?]`
+      ;; pattern to filter to additions only.
+      (testing "valid-at — Bob's salary as of mid-April-2024"
+        (let [r (d/q '[:find ?s :in $ ?at :where
+                       (valid-at ?tx ?at)
+                       [?e :emp/salary ?s ?tx true]]
+                     hist #inst "2024-04-15")]
+          (is (= #{[110000]} r))))
+      (testing "valid-at — Bob's salary as of mid-August-2024"
+        (let [r (d/q '[:find ?s :in $ ?at :where
+                       (valid-at ?tx ?at)
+                       [?e :emp/salary ?s ?tx true]]
+                     hist #inst "2024-08-15")]
+          (is (= #{[120000]} r))))
+      (testing "valid-between — salaries with vt-window intersecting Q2 2024"
+        (let [r (d/q '[:find ?s :in $ ?from ?to :where
+                       (valid-between ?tx ?from ?to)
+                       [?e :emp/salary ?s ?tx true]]
+                     hist #inst "2024-04-01" #inst "2024-07-01")]
+          (is (= #{[110000]} r))))
+      (testing "user-supplied % overrides built-ins on name collision"
+        ;; Define a no-op `valid-at` that matches every tx; built-in
+        ;; should be shadowed and the result includes all salaries.
+        (let [user-rules '[[(valid-at ?tx ?at) [?tx :db/txInstant _]]]
+              r (d/q '[:find ?s :in $ % ?at :where
+                       (valid-at ?tx ?at)
+                       [?e :emp/salary ?s ?tx true]]
+                     hist user-rules #inst "2024-04-15")]
+          (is (= #{[100000] [110000] [120000]} r))))
+      (testing "native < <= > >= work on Dates inside predicates"
+        ;; Regression for the planner-pushdown-on-system-attrs bug.
+        (let [r (d/q '[:find ?s :in $ ?at :where
+                       [?tx :db.valid/from ?vf]
+                       [(<= ?vf ?at)]
+                       [?e :emp/salary ?s ?tx true]]
+                     hist #inst "2024-08-15")]
+          (is (= #{[110000] [120000]} r)))))))

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -55,10 +55,10 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (let [report (d/transact conn
-                              [{:db/id "datomic.tx"
-                                :db.valid/from #inst "2024-01-01"
-                                :db.valid/to   #inst "2024-07-01"}
-                               {:pos/x 42}])
+                             [{:db/id "datomic.tx"
+                               :db.valid/from #inst "2024-01-01"
+                               :db.valid/to   #inst "2024-07-01"}
+                              {:pos/x 42}])
           tx    (get-in report [:tempids "datomic.tx"])
           db    (d/db conn)
           pulled (d/pull db '[*] tx)]
@@ -112,9 +112,9 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (let [report (d/transact conn
-                              [{:db/id "datomic.tx"
-                                :db.valid/from #inst "2024-01-01"}
-                               {:pos/x 1}])
+                             [{:db/id "datomic.tx"
+                               :db.valid/from #inst "2024-01-01"}
+                              {:pos/x 1}])
           tx    (get-in report [:tempids "datomic.tx"])
           pulled (d/pull (d/db conn) '[*] tx)]
       (testing "vt-from alone is sufficient; vt-to may be omitted"

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -342,21 +342,21 @@
   ;; should be invokable in `:where` without the user declaring `%` in
   ;; `:in`. The auto-inject inside `normalize-q-input` adds `%` and
   ;; the built-in rule defs transparently.
-  (let [conn (<! (fresh-conn))]
-    (<! (d/transact! conn [{:db/ident :emp/name
-                            :db/valueType :db.type/string
-                            :db/cardinality :db.cardinality/one
-                            :db/unique :db.unique/identity}
-                           {:db/ident :emp/salary
-                            :db/valueType :db.type/long
-                            :db/cardinality :db.cardinality/one}]))
-    (<! (d/transact! conn [{:emp/name "Bob" :emp/salary 100000}]))
-    (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
-                           :tx-meta {:db.valid/from #inst "2024-01-01"
-                                     :db.valid/to   #inst "2024-07-01"}}))
-    (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 120000}]
-                           :tx-meta {:db.valid/from #inst "2024-07-01"}}))
-    (let [hist (d/history (d/db conn))]
+     (let [conn (<! (fresh-conn))]
+       (<! (d/transact! conn [{:db/ident :emp/name
+                               :db/valueType :db.type/string
+                               :db/cardinality :db.cardinality/one
+                               :db/unique :db.unique/identity}
+                              {:db/ident :emp/salary
+                               :db/valueType :db.type/long
+                               :db/cardinality :db.cardinality/one}]))
+       (<! (d/transact! conn [{:emp/name "Bob" :emp/salary 100000}]))
+       (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                              :tx-meta {:db.valid/from #inst "2024-01-01"
+                                        :db.valid/to   #inst "2024-07-01"}}))
+       (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 120000}]
+                              :tx-meta {:db.valid/from #inst "2024-07-01"}}))
+       (let [hist (d/history (d/db conn))]
       ;; NOTE: `d/history` returns BOTH added and retracted datoms. A
       ;; cardinality-one upsert (like the salary updates here) produces
       ;; one retraction + one assertion per tx. The valid-at filter
@@ -365,38 +365,38 @@
       ;; ?at returns ALL its salary datoms — both the retracted and
       ;; the newly-asserted value. Use the 5-tuple `[e a v t added?]`
       ;; pattern to filter to additions only.
-      (testing "valid-at — Bob's salary as of mid-April-2024"
-        (let [r (d/q '[:find ?s :in $ ?at :where
-                       (valid-at ?tx ?at)
-                       [?e :emp/salary ?s ?tx true]]
-                     hist #inst "2024-04-15")]
-          (is (= #{[110000]} r))))
-      (testing "valid-at — Bob's salary as of mid-August-2024"
-        (let [r (d/q '[:find ?s :in $ ?at :where
-                       (valid-at ?tx ?at)
-                       [?e :emp/salary ?s ?tx true]]
-                     hist #inst "2024-08-15")]
-          (is (= #{[120000]} r))))
-      (testing "valid-between — salaries with vt-window intersecting Q2 2024"
-        (let [r (d/q '[:find ?s :in $ ?from ?to :where
-                       (valid-between ?tx ?from ?to)
-                       [?e :emp/salary ?s ?tx true]]
-                     hist #inst "2024-04-01" #inst "2024-07-01")]
-          (is (= #{[110000]} r))))
-      (testing "user-supplied % overrides built-ins on name collision"
+         (testing "valid-at — Bob's salary as of mid-April-2024"
+           (let [r (d/q '[:find ?s :in $ ?at :where
+                          (valid-at ?tx ?at)
+                          [?e :emp/salary ?s ?tx true]]
+                        hist #inst "2024-04-15")]
+             (is (= #{[110000]} r))))
+         (testing "valid-at — Bob's salary as of mid-August-2024"
+           (let [r (d/q '[:find ?s :in $ ?at :where
+                          (valid-at ?tx ?at)
+                          [?e :emp/salary ?s ?tx true]]
+                        hist #inst "2024-08-15")]
+             (is (= #{[120000]} r))))
+         (testing "valid-between — salaries with vt-window intersecting Q2 2024"
+           (let [r (d/q '[:find ?s :in $ ?from ?to :where
+                          (valid-between ?tx ?from ?to)
+                          [?e :emp/salary ?s ?tx true]]
+                        hist #inst "2024-04-01" #inst "2024-07-01")]
+             (is (= #{[110000]} r))))
+         (testing "user-supplied % overrides built-ins on name collision"
         ;; Define a no-op `valid-at` that matches every tx; built-in
         ;; should be shadowed and the result includes all salaries.
-        (let [user-rules '[[(valid-at ?tx ?at) [?tx :db/txInstant _]]]
-              r (d/q '[:find ?s :in $ % ?at :where
-                       (valid-at ?tx ?at)
-                       [?e :emp/salary ?s ?tx true]]
-                     hist user-rules #inst "2024-04-15")]
-          (is (= #{[100000] [110000] [120000]} r))))
-      (testing "native < <= > >= work on Dates inside predicates"
+           (let [user-rules '[[(valid-at ?tx ?at) [?tx :db/txInstant _]]]
+                 r (d/q '[:find ?s :in $ % ?at :where
+                          (valid-at ?tx ?at)
+                          [?e :emp/salary ?s ?tx true]]
+                        hist user-rules #inst "2024-04-15")]
+             (is (= #{[100000] [110000] [120000]} r))))
+         (testing "native < <= > >= work on Dates inside predicates"
         ;; Regression for the planner-pushdown-on-system-attrs bug.
-        (let [r (d/q '[:find ?s :in $ ?at :where
-                       [?tx :db.valid/from ?vf]
-                       [(<= ?vf ?at)]
-                       [?e :emp/salary ?s ?tx true]]
-                     hist #inst "2024-08-15")]
-          (is (= #{[110000] [120000]} r)))))))) ;; last `)` closes `#?(:clj ...)`
+           (let [r (d/q '[:find ?s :in $ ?at :where
+                          [?tx :db.valid/from ?vf]
+                          [(<= ?vf ?at)]
+                          [?e :emp/salary ?s ?tx true]]
+                        hist #inst "2024-08-15")]
+             (is (= #{[110000] [120000]} r)))))))) ;; last `)` closes `#?(:clj ...)`

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -327,7 +327,17 @@
         (is (= :db.valid/from (:attribute thrown))
             "the throw must name the offending attribute")))))
 
-(deftest-async built-in-rules-work-without-in-percent
+;; JVM-only: the built-in-rules query path runs against `(d/history db)`,
+;; which on CLJS returns a `HistoricalDB` wrapper whose `-lookup` raises.
+;; The query engine's plan executor calls `get` on the db (datahike.query.execute
+;; line 3301 in node-test output), which triggers `cljs.core/-lookup`. This
+;; is a pre-existing CLJS gap in the query/wrapper interop, NOT in the
+;; vt machinery — `mk-vt-pred` itself is fully cross-platform after the
+;; port (see `datahike.bitemporal.platform`). Once `HistoricalDB`/`AsOfDB`
+;; gain a CLJS `-lookup` impl, drop the `:clj` guard and this test runs
+;; on Node too.
+#?(:clj
+   (deftest-async built-in-rules-work-without-in-percent
   ;; `valid-at` / `valid-between` / `valid-during` / `period-overlaps?`
   ;; should be invokable in `:where` without the user declaring `%` in
   ;; `:in`. The auto-inject inside `normalize-q-input` adds `%` and
@@ -389,4 +399,4 @@
                        [(<= ?vf ?at)]
                        [?e :emp/salary ?s ?tx true]]
                      hist #inst "2024-08-15")]
-          (is (= #{[110000] [120000]} r)))))))
+          (is (= #{[110000] [120000]} r)))))))) ;; last `)` closes `#?(:clj ...)`

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -1,0 +1,122 @@
+(ns datahike.test.valid-time-test
+  "Tests for the bitemporal valid-time tx-meta attributes that graduated
+   into the system schema:
+
+   - `:db.valid/from` and `:db.valid/to` are pre-installed system attrs.
+   - Consumers can attach them to the tx entity via the standard
+     `{:db/id \"datomic.tx\" :db.valid/from #inst ... :db.valid/to #inst ...}`
+     tx-meta map — no schema declaration required.
+   - Both attrs are `:db/index true` so they materialise into the
+     temporal AVET index for range seeks by the query planner.
+
+   This file accompanies the system-schema graduation in commit 1 of
+   the `feature/bitemporal-v1` branch. The planner-recognised rule
+   rewrites (`valid-at`, `valid-between`, …) ship in commit 3 — this
+   file's tests cover the storage layer only."
+  (:require #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
+               :clj  [clojure.test :as t :refer [is deftest testing]])
+            [datahike.api :as d]
+            [datahike.schema :as s]
+            [datahike.constants :as c]))
+
+(defn- fresh-conn
+  ([] (fresh-conn {}))
+  ([extra-cfg]
+   (let [cfg (merge {:store {:backend :memory :id (random-uuid)}
+                     :schema-flexibility :write
+                     :keep-history? true}
+                    extra-cfg)]
+     (d/create-database cfg)
+     (d/connect cfg))))
+
+(deftest valid-time-attrs-are-system-schema
+  (testing "both attrs appear in `system-schema`"
+    (is (some #(= :db.valid/from (:db/ident %)) c/system-schema))
+    (is (some #(= :db.valid/to   (:db/ident %)) c/system-schema)))
+  (testing "schema recognises them as meta-attributes"
+    (is (s/meta-attr? :db.valid/from))
+    (is (s/meta-attr? :db.valid/to)))
+  (testing "no user-side schema install is needed — fresh DB accepts vt tx-meta"
+    ;; System attrs are recognised by the transactor via the implicit
+    ;; schema (same path `:db/txInstant` uses). They don't need a
+    ;; `[:db/add ... :db/ident ...]` install — they're built in.
+    (let [conn (fresh-conn)]
+      (d/transact conn [{:db/ident :pos/x
+                         :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (is (some? (d/transact conn [{:db/id "datomic.tx"
+                                    :db.valid/from #inst "2024-01-01"
+                                    :db.valid/to   #inst "2024-07-01"}
+                                   {:pos/x 1}]))))))
+
+(deftest valid-time-tx-meta-lands-on-the-tx-entity
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :pos/x
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (let [report (d/transact conn
+                              [{:db/id "datomic.tx"
+                                :db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}
+                               {:pos/x 42}])
+          tx    (get-in report [:tempids "datomic.tx"])
+          db    (d/db conn)
+          pulled (d/pull db '[*] tx)]
+      (testing "the tempid `datomic.tx` resolves and the tx-meta attrs land"
+        (is (= #inst "2024-01-01" (:db.valid/from pulled)))
+        (is (= #inst "2024-07-01" (:db.valid/to   pulled))))
+      (testing "the user datom is on its own entity, not the tx"
+        (is (= 42 (-> (d/q '[:find ?x . :where [_ :pos/x ?x]] db)))))
+      (testing "tx-data contains exactly the meta datoms + the user datom + :db/txInstant"
+        (is (= 4 (count (:tx-data report))))))))
+
+(deftest valid-time-attrs-are-indexed-and-queryable-via-history
+  ;; The tx-entity isn't a "currently asserted" entity (no eid in user
+  ;; space), so its datoms live in the temporal index. This is the same
+  ;; place auditors look for `:db/txInstant`-keyed reads. Range queries
+  ;; on `:db.valid/from` therefore run against `(d/history db)`, and
+  ;; should run fast — the planner-rule rewrite (commit 3) leans on this.
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :pos/x
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (dotimes [i 5]
+      (d/transact conn [{:db/id "datomic.tx"
+                         :db.valid/from (java.util.Date.
+                                         (+ 1700000000000 (* i 86400000)))}
+                        {:pos/x i}]))
+    (let [db   (d/db conn)
+          hist (d/history db)
+          all-vts (d/q '[:find [?vf ...]
+                         :where [_ :db.valid/from ?vf]]
+                       hist)]
+      (testing "all 5 vt-bearing txes are recoverable via history"
+        (is (= 5 (count all-vts))))
+      (testing "range query: find txes with vt-from in [t1, t2)"
+        (let [t1 #inst "2023-11-16T00:00:00.000-00:00"
+              t2 #inst "2023-11-18T00:00:00.000-00:00"
+              n (d/q '[:find (count ?tx) .
+                       :in $ ?from ?to
+                       :where
+                       [?tx :db.valid/from ?vf]
+                       [(.compareTo ^java.util.Date ?vf ?from) ?cf]
+                       [(<= 0 ?cf)]
+                       [(.compareTo ^java.util.Date ?vf ?to) ?ct]
+                       [(< ?ct 0)]]
+                     hist t1 t2)]
+          (is (= 2 n)))))))
+
+(deftest valid-to-is-optional
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :pos/x
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (let [report (d/transact conn
+                              [{:db/id "datomic.tx"
+                                :db.valid/from #inst "2024-01-01"}
+                               {:pos/x 1}])
+          tx    (get-in report [:tempids "datomic.tx"])
+          pulled (d/pull (d/db conn) '[*] tx)]
+      (testing "vt-from alone is sufficient; vt-to may be omitted"
+        (is (= #inst "2024-01-01" (:db.valid/from pulled)))
+        (is (nil? (:db.valid/to pulled)))))))

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -145,6 +145,79 @@
       (is (contains? (:db/index rs) :db.valid/from))
       (is (contains? (:db/index rs) :db.valid/to)))))
 
+;; ============================================================================
+;; Backward-compat — inline-tempid write shape (note 179 §2 partial)
+;;
+;; The docstring at L9-13 documents that `{:db/id "datomic.tx"
+;; :db.valid/from ... :db.valid/to ...}` still works alongside the
+;; idiomatic `:tx-meta` map-arg form. Note 178's cleanup removed all
+;; inline-form writes from the test suite; this test pins the
+;; equivalence so the legacy shape doesn't silently regress.
+;; ============================================================================
+
+(deftest inline-tempid-form-still-works-for-vt
+  ;; Guards backward-compat for the legacy inline form documented at
+  ;; valid_time_test.cljc:L9-13 + schema.cljc:71-74. The "datomic.tx"
+  ;; tempid resolves to `:db/current-tx`; the `:db.valid/from` /
+  ;; `:db.valid/to` datoms then land on the tx-entity exactly as the
+  ;; idiomatic `:tx-meta` form would. Both shapes are normalised via
+  ;; the same `tx-id?` branch at `db/transaction.cljc:62`.
+  (let [conn (fresh-conn)]
+    (d/transact conn [{:db/ident :pos/x
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one}])
+    (let [report (d/transact conn
+                             [{:pos/x 42}
+                              {:db/id "datomic.tx"
+                               :db.valid/from #inst "2024-01-01"
+                               :db.valid/to   #inst "2024-07-01"}])
+          tx     (get-in report [:tempids :db/current-tx])
+          pulled (d/pull (d/db conn) '[*] tx)]
+      (testing "inline form lands vf/vt on the tx-entity"
+        (is (= #inst "2024-01-01" (:db.valid/from pulled)))
+        (is (= #inst "2024-07-01" (:db.valid/to   pulled))))
+      (testing "user datom lands on its own entity"
+        (is (= 42 (d/q '[:find ?x . :where [_ :pos/x ?x]] (d/db conn))))))))
+
+;; ============================================================================
+;; Schema enforcement — :db.valid/from rejects non-instant values
+;; ============================================================================
+
+#?(:clj
+   (defn- transact-ex-data
+     "Walk the cause chain to find the inner ExceptionInfo's data —
+      the async writer wraps the raw ExceptionInfo in an
+      ExecutionException."
+     [^Throwable e]
+     (loop [t e]
+       (cond
+         (nil? t) nil
+         (seq (ex-data t)) (ex-data t)
+         :else (recur (.getCause t))))))
+
+#?(:clj
+   (deftest valid-from-rejects-non-instant-value
+     (testing ":db.valid/from is :db.type/instant — the transactor must
+               reject a string (or any non-Date) value at write time."
+       (let [conn (fresh-conn)]
+         (d/transact conn [{:db/ident :pos/x
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}])
+         (let [thrown
+               (try
+                 (d/transact conn
+                             {:tx-data [{:pos/x 1}]
+                              :tx-meta {:db.valid/from "not-a-date"}})
+                 nil
+                 (catch Exception e
+                   (transact-ex-data e)))]
+           (is (some? thrown)
+               "non-instant :db.valid/from must throw")
+           (is (= :transact/schema (:error thrown))
+               "the throw must carry the schema-mismatch error code")
+           (is (= :db.valid/from (:attribute thrown))
+               "the throw must name the offending attribute"))))))
+
 (deftest built-in-rules-work-without-in-percent
   ;; `valid-at` / `valid-between` / `valid-during` / `period-overlaps?`
   ;; should be invokable in `:where` without the user declaring `%` in

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -17,24 +17,43 @@
    This file accompanies the system-schema graduation in commit 1 of
    the `feature/bitemporal-v1` branch. The planner-recognised rule
    rewrites (`valid-at`, `valid-between`, …) ship in commit 3 — this
-   file's tests cover the storage layer only."
-  (:require #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
-               :clj  [clojure.test :as t :refer [is deftest testing]])
+   file's tests cover the storage layer only.
+
+   Cross-platform: every deftest below is `deftest-async` so the body
+   runs through a `go` block on both JVM and Node. `<!` resolves both
+   real channels (CLJS) and `(go x)` (JVM); JVM sees the same `<!`-driven
+   shape with a free synchronous round-trip. `d/transact`/`d/transact!`
+   are routed through `<!` so the CLJS async writer's promise channel
+   is consumed correctly; on JVM the macro's `(go ...)` wrapper makes
+   the value a single-element channel.
+
+   Why `<! (d/transact! ...)` and not `(d/transact ...)`? `d/transact`
+   is JVM-sync only — it throws on CLJS. The async form is uniform
+   across runtimes and the test rhythm stays clean."
+  (:require #?(:cljs [cljs.test :as t :refer-macros [is testing]]
+               :clj  [clojure.test :as t :refer [is testing]])
+            [clojure.core.async :refer [<!]]
             [datahike.api :as d]
             [datahike.schema :as s]
-            [datahike.constants :as c]))
+            [datahike.constants :as c]
+            [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
 
 (defn- fresh-conn
+  "Create + connect to a fresh in-memory keep-history? DB.
+   Returns a channel yielding the connection."
   ([] (fresh-conn {}))
   ([extra-cfg]
    (let [cfg (merge {:store {:backend :memory :id (random-uuid)}
                      :schema-flexibility :write
                      :keep-history? true}
                     extra-cfg)]
-     (d/create-database cfg)
-     (d/connect cfg))))
+     (clojure.core.async/go
+       #?(:clj  (do (d/create-database cfg)
+                    (d/connect cfg))
+          :cljs (do (<! (d/create-database cfg))
+                    (<! (d/connect cfg {:sync? false}))))))))
 
-(deftest valid-time-attrs-are-system-schema
+(deftest-async valid-time-attrs-are-system-schema
   (testing "both attrs appear in `system-schema`"
     (is (some #(= :db.valid/from (:db/ident %)) c/system-schema))
     (is (some #(= :db.valid/to   (:db/ident %)) c/system-schema)))
@@ -45,24 +64,24 @@
     ;; System attrs are recognised by the transactor via the implicit
     ;; schema (same path `:db/txInstant` uses). They don't need a
     ;; `[:db/add ... :db/ident ...]` install — they're built in.
-    (let [conn (fresh-conn)]
-      (d/transact conn [{:db/ident :pos/x
-                         :db/valueType :db.type/long
-                         :db/cardinality :db.cardinality/one}])
-      (is (some? (d/transact conn
-                             {:tx-data [{:pos/x 1}]
-                              :tx-meta {:db.valid/from #inst "2024-01-01"
-                                        :db.valid/to   #inst "2024-07-01"}}))))))
+    (let [conn (<! (fresh-conn))]
+      (<! (d/transact! conn [{:db/ident :pos/x
+                              :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}]))
+      (is (some? (<! (d/transact! conn
+                                  {:tx-data [{:pos/x 1}]
+                                   :tx-meta {:db.valid/from #inst "2024-01-01"
+                                             :db.valid/to   #inst "2024-07-01"}})))))))
 
-(deftest valid-time-tx-meta-lands-on-the-tx-entity
-  (let [conn (fresh-conn)]
-    (d/transact conn [{:db/ident :pos/x
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
-    (let [report (d/transact conn
-                             {:tx-data [{:pos/x 42}]
-                              :tx-meta {:db.valid/from #inst "2024-01-01"
-                                        :db.valid/to   #inst "2024-07-01"}})
+(deftest-async valid-time-tx-meta-lands-on-the-tx-entity
+  (let [conn (<! (fresh-conn))]
+    (<! (d/transact! conn [{:db/ident :pos/x
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}]))
+    (let [report (<! (d/transact! conn
+                                  {:tx-data [{:pos/x 42}]
+                                   :tx-meta {:db.valid/from #inst "2024-01-01"
+                                             :db.valid/to   #inst "2024-07-01"}}))
           tx    (get-in report [:tempids :db/current-tx])
           db    (d/db conn)
           pulled (d/pull db '[*] tx)]
@@ -74,21 +93,26 @@
       (testing "tx-data contains exactly the meta datoms + the user datom + :db/txInstant"
         (is (= 4 (count (:tx-data report))))))))
 
-(deftest valid-time-attrs-are-indexed-and-queryable-via-history
+(deftest-async valid-time-attrs-are-indexed-and-queryable-via-history
   ;; The tx-entity isn't a "currently asserted" entity (no eid in user
   ;; space), so its datoms live in the temporal index. This is the same
   ;; place auditors look for `:db/txInstant`-keyed reads. Range queries
   ;; on `:db.valid/from` therefore run against `(d/history db)`, and
   ;; should run fast — the planner-rule rewrite (commit 3) leans on this.
-  (let [conn (fresh-conn)]
-    (d/transact conn [{:db/ident :pos/x
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
-    (dotimes [i 5]
-      (d/transact conn
-                  {:tx-data [{:pos/x i}]
-                   :tx-meta {:db.valid/from (java.util.Date.
-                                             (+ 1700000000000 (* i 86400000)))}}))
+  (let [conn (<! (fresh-conn))]
+    (<! (d/transact! conn [{:db/ident :pos/x
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}]))
+    (loop [i 0]
+      (when (< i 5)
+        (<! (d/transact! conn
+                         {:tx-data [{:pos/x i}]
+                          :tx-meta {:db.valid/from
+                                    #?(:clj  (java.util.Date.
+                                              (+ 1700000000000 (* i 86400000)))
+                                       :cljs (js/Date.
+                                              (+ 1700000000000 (* i 86400000))))}}))
+        (recur (inc i))))
     (let [db   (d/db conn)
           hist (d/history db)
           all-vts (d/q '[:find [?vf ...]
@@ -97,34 +121,36 @@
       (testing "all 5 vt-bearing txes are recoverable via history"
         (is (= 5 (count all-vts))))
       (testing "range query: find txes with vt-from in [t1, t2)"
+        ;; Use the native CollectionOrder-backed `<` / `<=` predicates —
+        ;; they're extended to both `java.util.Date` (JVM) and `js/Date`
+        ;; (CLJS) in `datahike.query`, so we don't need
+        ;; `(.compareTo ^java.util.Date ...)` which is JVM-only.
         (let [t1 #inst "2023-11-16T00:00:00.000-00:00"
               t2 #inst "2023-11-18T00:00:00.000-00:00"
               n (d/q '[:find (count ?tx) .
                        :in $ ?from ?to
                        :where
                        [?tx :db.valid/from ?vf]
-                       [(.compareTo ^java.util.Date ?vf ?from) ?cf]
-                       [(<= 0 ?cf)]
-                       [(.compareTo ^java.util.Date ?vf ?to) ?ct]
-                       [(< ?ct 0)]]
+                       [(<= ?from ?vf)]
+                       [(< ?vf ?to)]]
                      hist t1 t2)]
           (is (= 2 n)))))))
 
-(deftest valid-to-is-optional
-  (let [conn (fresh-conn)]
-    (d/transact conn [{:db/ident :pos/x
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
-    (let [report (d/transact conn
-                             {:tx-data [{:pos/x 1}]
-                              :tx-meta {:db.valid/from #inst "2024-01-01"}})
+(deftest-async valid-to-is-optional
+  (let [conn (<! (fresh-conn))]
+    (<! (d/transact! conn [{:db/ident :pos/x
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}]))
+    (let [report (<! (d/transact! conn
+                                  {:tx-data [{:pos/x 1}]
+                                   :tx-meta {:db.valid/from #inst "2024-01-01"}}))
           tx    (get-in report [:tempids :db/current-tx])
           pulled (d/pull (d/db conn) '[*] tx)]
       (testing "vt-from alone is sufficient; vt-to may be omitted"
         (is (= #inst "2024-01-01" (:db.valid/from pulled)))
         (is (nil? (:db.valid/to pulled)))))))
 
-(deftest system-attrs-show-up-as-indexed
+(deftest-async system-attrs-show-up-as-indexed
   ;; Regression: `:db.valid/from` / `:db.valid/to` must appear in
   ;; rschema's `:db/index` set so `(dbu/indexing? db ...)` returns
   ;; true and the planner's AVET pushdown for predicates pivoting on
@@ -138,7 +164,7 @@
   ;; `:db/txInstant` datom in AVET, a semantic change that breaks
   ;; existing tests + the existing `:db/txInstant`-by-tx lookup
   ;; path. See `non-ref-implicit-schema` in constants.cljc.
-  (let [conn (fresh-conn)
+  (let [conn (<! (fresh-conn))
         db   (d/db conn)
         rs   (datahike.db.interface/-rschema db)]
     (testing ":db.valid/from and :db.valid/to are recognised as indexed"
@@ -155,22 +181,22 @@
 ;; equivalence so the legacy shape doesn't silently regress.
 ;; ============================================================================
 
-(deftest inline-tempid-form-still-works-for-vt
+(deftest-async inline-tempid-form-still-works-for-vt
   ;; Guards backward-compat for the legacy inline form documented at
   ;; valid_time_test.cljc:L9-13 + schema.cljc:71-74. The "datomic.tx"
   ;; tempid resolves to `:db/current-tx`; the `:db.valid/from` /
   ;; `:db.valid/to` datoms then land on the tx-entity exactly as the
   ;; idiomatic `:tx-meta` form would. Both shapes are normalised via
   ;; the same `tx-id?` branch at `db/transaction.cljc:62`.
-  (let [conn (fresh-conn)]
-    (d/transact conn [{:db/ident :pos/x
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
-    (let [report (d/transact conn
-                             [{:pos/x 42}
-                              {:db/id "datomic.tx"
-                               :db.valid/from #inst "2024-01-01"
-                               :db.valid/to   #inst "2024-07-01"}])
+  (let [conn (<! (fresh-conn))]
+    (<! (d/transact! conn [{:db/ident :pos/x
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}]))
+    (let [report (<! (d/transact! conn
+                                  [{:pos/x 42}
+                                   {:db/id "datomic.tx"
+                                    :db.valid/from #inst "2024-01-01"
+                                    :db.valid/to   #inst "2024-07-01"}]))
           tx     (get-in report [:tempids :db/current-tx])
           pulled (d/pull (d/db conn) '[*] tx)]
       (testing "inline form lands vf/vt on the tx-entity"
@@ -192,23 +218,23 @@
 ;; mirroring `transact_test.cljc:377-398` (test-resolve-current-tx).
 ;; ============================================================================
 
-(deftest tuple-form-vt-meta-attr-lands-on-tx
+(deftest-async tuple-form-vt-meta-attr-lands-on-tx
   (doseq [tx-tempid [:db/current-tx "datomic.tx" "datahike.tx"]]
     (testing (str "tx-tempid = " tx-tempid)
-      (let [conn (fresh-conn)]
-        (d/transact conn [{:db/ident :emp/name
-                           :db/valueType :db.type/string
-                           :db/unique :db.unique/identity
-                           :db/cardinality :db.cardinality/one}
-                          {:db/ident :emp/salary
-                           :db/valueType :db.type/long
-                           :db/cardinality :db.cardinality/one}])
+      (let [conn (<! (fresh-conn))]
+        (<! (d/transact! conn [{:db/ident :emp/name
+                                :db/valueType :db.type/string
+                                :db/unique :db.unique/identity
+                                :db/cardinality :db.cardinality/one}
+                               {:db/ident :emp/salary
+                                :db/valueType :db.type/long
+                                :db/cardinality :db.cardinality/one}]))
         ;; The exact doc snippet shape — mixed entity-map + tuple in
         ;; one tx-data vector — with both vt-bounds via tuple.
-        (let [report (d/transact conn
-                                 [{:emp/name "Bob" :emp/salary 100000}
-                                  [:db/add tx-tempid :db.valid/from #inst "2026-01-01"]
-                                  [:db/add tx-tempid :db.valid/to   #inst "2026-12-31"]])
+        (let [report (<! (d/transact! conn
+                                      [{:emp/name "Bob" :emp/salary 100000}
+                                       [:db/add tx-tempid :db.valid/from #inst "2026-01-01"]
+                                       [:db/add tx-tempid :db.valid/to   #inst "2026-12-31"]]))
               tx     (get-in report [:tempids :db/current-tx])
               pulled (d/pull (d/db conn) '[*] tx)]
           (testing "tuple-form vt-meta lands on the writing tx-entity"
@@ -250,62 +276,76 @@
 
 ;; ============================================================================
 ;; Schema enforcement — :db.valid/from rejects non-instant values
+;;
+;; Cross-platform note: on JVM the async writer wraps the raw
+;; ExceptionInfo in an ExecutionException; we walk the cause chain to
+;; find the inner data. On CLJS the writer pipeline propagates the
+;; raw ex-data via `ex-info`/`(.-message)` directly, so the same probe
+;; pattern (look for `ex-data` on the error) works without unwrapping.
 ;; ============================================================================
 
-#?(:clj
-   (defn- transact-ex-data
-     "Walk the cause chain to find the inner ExceptionInfo's data —
-      the async writer wraps the raw ExceptionInfo in an
-      ExecutionException."
-     [^Throwable e]
+(defn- transact-ex-data
+  "Walk the cause chain (CLJ) / read the ex-data directly (CLJS) to
+   find an `ex-info`'s data map. Returns nil if none found."
+  [e]
+  #?(:clj
      (loop [t e]
        (cond
          (nil? t) nil
          (seq (ex-data t)) (ex-data t)
-         :else (recur (.getCause t))))))
+         :else (recur (.getCause ^Throwable t))))
+     :cljs
+     (loop [t e]
+       (cond
+         (nil? t) nil
+         (seq (ex-data t)) (ex-data t)
+         :else (recur (.-cause t))))))
 
-#?(:clj
-   (deftest valid-from-rejects-non-instant-value
-     (testing ":db.valid/from is :db.type/instant — the transactor must
-               reject a string (or any non-Date) value at write time."
-       (let [conn (fresh-conn)]
-         (d/transact conn [{:db/ident :pos/x
-                            :db/valueType :db.type/long
-                            :db/cardinality :db.cardinality/one}])
-         (let [thrown
-               (try
-                 (d/transact conn
-                             {:tx-data [{:pos/x 1}]
-                              :tx-meta {:db.valid/from "not-a-date"}})
-                 nil
-                 (catch Exception e
-                   (transact-ex-data e)))]
-           (is (some? thrown)
-               "non-instant :db.valid/from must throw")
-           (is (= :transact/schema (:error thrown))
-               "the throw must carry the schema-mismatch error code")
-           (is (= :db.valid/from (:attribute thrown))
-               "the throw must name the offending attribute"))))))
+(deftest-async valid-from-rejects-non-instant-value
+  (testing ":db.valid/from is :db.type/instant — the transactor must
+            reject a string (or any non-Date) value at write time."
+    (let [conn (<! (fresh-conn))]
+      (<! (d/transact! conn [{:db/ident :pos/x
+                              :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}]))
+      (let [thrown
+            (try
+              (let [r (<! (d/transact! conn
+                                       {:tx-data [{:pos/x 1}]
+                                        :tx-meta {:db.valid/from "not-a-date"}}))]
+                ;; On CLJS the writer pipeline may surface the
+                ;; exception as the channel value rather than via
+                ;; throw — handle both shapes.
+                (when (instance? #?(:clj Throwable :cljs js/Error) r)
+                  (transact-ex-data r)))
+              (catch #?(:clj Exception :cljs :default) e
+                (transact-ex-data e)))]
+        (is (some? thrown)
+            "non-instant :db.valid/from must throw")
+        (is (= :transact/schema (:error thrown))
+            "the throw must carry the schema-mismatch error code")
+        (is (= :db.valid/from (:attribute thrown))
+            "the throw must name the offending attribute")))))
 
-(deftest built-in-rules-work-without-in-percent
+(deftest-async built-in-rules-work-without-in-percent
   ;; `valid-at` / `valid-between` / `valid-during` / `period-overlaps?`
   ;; should be invokable in `:where` without the user declaring `%` in
   ;; `:in`. The auto-inject inside `normalize-q-input` adds `%` and
   ;; the built-in rule defs transparently.
-  (let [conn (fresh-conn)]
-    (d/transact conn [{:db/ident :emp/name
-                       :db/valueType :db.type/string
-                       :db/cardinality :db.cardinality/one
-                       :db/unique :db.unique/identity}
-                      {:db/ident :emp/salary
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
-    (d/transact conn [{:emp/name "Bob" :emp/salary 100000}])
-    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
-                      :tx-meta {:db.valid/from #inst "2024-01-01"
-                                :db.valid/to   #inst "2024-07-01"}})
-    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 120000}]
-                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
+  (let [conn (<! (fresh-conn))]
+    (<! (d/transact! conn [{:db/ident :emp/name
+                            :db/valueType :db.type/string
+                            :db/cardinality :db.cardinality/one
+                            :db/unique :db.unique/identity}
+                           {:db/ident :emp/salary
+                            :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}]))
+    (<! (d/transact! conn [{:emp/name "Bob" :emp/salary 100000}]))
+    (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                           :tx-meta {:db.valid/from #inst "2024-01-01"
+                                     :db.valid/to   #inst "2024-07-01"}}))
+    (<! (d/transact! conn {:tx-data [{:emp/name "Bob" :emp/salary 120000}]
+                           :tx-meta {:db.valid/from #inst "2024-07-01"}}))
     (let [hist (d/history (d/db conn))]
       ;; NOTE: `d/history` returns BOTH added and retracted datoms. A
       ;; cardinality-one upsert (like the salary updates here) produces

--- a/test/datahike/test/valid_time_test.cljc
+++ b/test/datahike/test/valid_time_test.cljc
@@ -3,9 +3,14 @@
    into the system schema:
 
    - `:db.valid/from` and `:db.valid/to` are pre-installed system attrs.
-   - Consumers can attach them to the tx entity via the standard
-     `{:db/id \"datomic.tx\" :db.valid/from #inst ... :db.valid/to #inst ...}`
-     tx-meta map — no schema declaration required.
+   - Consumers attach them to the writing tx via the `:tx-meta` map-arg
+     form — `(d/transact conn {:tx-data [...] :tx-meta {:db.valid/from
+     #inst ... :db.valid/to #inst ...}})`. The legacy inline-tempid form
+     `{:db/id \"datomic.tx\" :db.valid/from ...}` also works (both shapes
+     normalise to the same internal `{:tx-data :tx-meta}` representation
+     at `api/impl.cljc:29-41`), but the map-arg form is idiomatic — see
+     `schema.cljc:71-74`: \":db.valid/from and :db.valid/to graduate from
+     userland tx-meta into datahike system schema.\"
    - Both attrs are `:db/index true` so they materialise into the
      temporal AVET index for range seeks by the query planner.
 
@@ -44,10 +49,10 @@
       (d/transact conn [{:db/ident :pos/x
                          :db/valueType :db.type/long
                          :db/cardinality :db.cardinality/one}])
-      (is (some? (d/transact conn [{:db/id "datomic.tx"
-                                    :db.valid/from #inst "2024-01-01"
-                                    :db.valid/to   #inst "2024-07-01"}
-                                   {:pos/x 1}]))))))
+      (is (some? (d/transact conn
+                             {:tx-data [{:pos/x 1}]
+                              :tx-meta {:db.valid/from #inst "2024-01-01"
+                                        :db.valid/to   #inst "2024-07-01"}}))))))
 
 (deftest valid-time-tx-meta-lands-on-the-tx-entity
   (let [conn (fresh-conn)]
@@ -55,14 +60,13 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (let [report (d/transact conn
-                             [{:db/id "datomic.tx"
-                               :db.valid/from #inst "2024-01-01"
-                               :db.valid/to   #inst "2024-07-01"}
-                              {:pos/x 42}])
-          tx    (get-in report [:tempids "datomic.tx"])
+                             {:tx-data [{:pos/x 42}]
+                              :tx-meta {:db.valid/from #inst "2024-01-01"
+                                        :db.valid/to   #inst "2024-07-01"}})
+          tx    (get-in report [:tempids :db/current-tx])
           db    (d/db conn)
           pulled (d/pull db '[*] tx)]
-      (testing "the tempid `datomic.tx` resolves and the tx-meta attrs land"
+      (testing "the writing tx resolves via `:db/current-tx` and the tx-meta attrs land"
         (is (= #inst "2024-01-01" (:db.valid/from pulled)))
         (is (= #inst "2024-07-01" (:db.valid/to   pulled))))
       (testing "the user datom is on its own entity, not the tx"
@@ -81,10 +85,10 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (dotimes [i 5]
-      (d/transact conn [{:db/id "datomic.tx"
-                         :db.valid/from (java.util.Date.
-                                         (+ 1700000000000 (* i 86400000)))}
-                        {:pos/x i}]))
+      (d/transact conn
+                  {:tx-data [{:pos/x i}]
+                   :tx-meta {:db.valid/from (java.util.Date.
+                                             (+ 1700000000000 (* i 86400000)))}}))
     (let [db   (d/db conn)
           hist (d/history db)
           all-vts (d/q '[:find [?vf ...]
@@ -112,10 +116,9 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (let [report (d/transact conn
-                             [{:db/id "datomic.tx"
-                               :db.valid/from #inst "2024-01-01"}
-                              {:pos/x 1}])
-          tx    (get-in report [:tempids "datomic.tx"])
+                             {:tx-data [{:pos/x 1}]
+                              :tx-meta {:db.valid/from #inst "2024-01-01"}})
+          tx    (get-in report [:tempids :db/current-tx])
           pulled (d/pull (d/db conn) '[*] tx)]
       (testing "vt-from alone is sufficient; vt-to may be omitted"
         (is (= #inst "2024-01-01" (:db.valid/from pulled)))
@@ -156,13 +159,11 @@
                        :db/valueType :db.type/long
                        :db/cardinality :db.cardinality/one}])
     (d/transact conn [{:emp/name "Bob" :emp/salary 100000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-01-01"
-                       :db.valid/to   #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 110000}])
-    (d/transact conn [{:db/id "datomic.tx"
-                       :db.valid/from #inst "2024-07-01"}
-                      {:emp/name "Bob" :emp/salary 120000}])
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 110000}]
+                      :tx-meta {:db.valid/from #inst "2024-01-01"
+                                :db.valid/to   #inst "2024-07-01"}})
+    (d/transact conn {:tx-data [{:emp/name "Bob" :emp/salary 120000}]
+                      :tx-meta {:db.valid/from #inst "2024-07-01"}})
     (let [hist (d/history (d/db conn))]
       ;; NOTE: `d/history` returns BOTH added and retracted datoms. A
       ;; cardinality-one upsert (like the salary updates here) produces

--- a/tests.edn
+++ b/tests.edn
@@ -9,6 +9,13 @@
                                  {:id          :specs
                                   :skip-meta   [:no-spec]
                                   :ns-patterns ["datahike.test."]}
+                                 ;; The `:cljs` kaocha-type profile remains disabled — the
+                                 ;; canonical CLJS test workflow is `bb node-cljs-test`, which
+                                 ;; uses the shadow-cljs `:node-test` build defined in
+                                 ;; shadow-cljs.edn against `datahike.test.nodejs-test`. Wiring
+                                 ;; kaocha-cljs would duplicate that infra (karma/chrome-headless
+                                 ;; or node-runner glue + cljs.test integration), and there's no
+                                 ;; bb task that drives it today.
                                  #_{:id          :cljs
                                     :type        :kaocha.type/cljs
                                     :ns-patterns ["datahike.test."]}


### PR DESCRIPTION
## Summary

Brings first-class bitemporal valid-time support to datahike — system-schema attrs, planner-aware built-in rules, a public marker on the db value, and an SCD2 layout in the stratum secondary-index adapter that demonstrates the full path. Pairs with [replikativ/stratum#27](https://github.com/replikativ/stratum/pull/26) (column convention) and a pg-datahike PR (SQL surface).

**Schema (commits 48d347a6, 7cb5abac):**
- `:db.valid/from` and `:db.valid/to` graduated into `system-schema` and `non-ref-implicit-schema`; both `:db/index true` and `:db/cardinality/one`. Users can attach them directly to the tx entity via `{:db/id "datomic.tx" :db.valid/from ...}` — no per-user schema install.
- Built-in datalog rules `valid-at`, `valid-between`, `valid-during`, `period-overlaps?` are pre-registered. `auto-inject-built-in-rules` adds them transparently — users can write `(valid-at ?tx ?at)` without declaring `%` in `:in`. Native `<`/`<=`/`>`/`>=` on `java.util.Date` plus rschema-fix so AVET pushdown fires on the new system attrs.

**Secondary-index protocol (5cd44cfa):**
- New optional `IValidTimeAware` protocol with `-search-at-vt`. `ISecondaryIndex.-transact` now also carries `:tx-meta` per call, populated by `tx-meta-for-secondary` from the in-progress db state (the tx-entity's `:db/txInstant` / `:db.valid/from` / `:db.valid/to` datoms, available via EAVT seek after `flush-tx-meta`).

**Stratum SCD2 adapter (9b4bf00d):**
- Opt-in via `{:db.secondary/config {:valid-time true}}` on the index schema entry. Adapter materialises `:_valid_from` / `:_valid_to` columns on every row; on entity update, the previous open row's `:_valid_to` is closed to the new tx's vt-from and a merged-from-previous row is appended.
- `IValidTimeAware/-search-at-vt` translates `valid-at` / `[from to]` into stratum WHERE predicates on the two vt columns, pushing through stratum's zone-map pruner.

**Two adjacent engine bugs fixed (9b4bf00d, abd69fb8):**
1. `tx-meta-for-secondary` used `(dd/datom-tx datom)` which on retract datoms returns the original asserting tx's id — wrong for vt-aware adapters that need the writing tx's meta. Now uses `(inc max-tx)` for the in-progress tx-id. `meta-attrs-for-secondary` + `meta-for-tx-id` made public so `writing.cljc/build-secondary-index!` can reconstruct tx-meta during backfill.
2. `instantiate-secondary` previously promoted every newly-registered secondary index to `:building` status, which auto-dispatched async `build-secondary-index!`. When user writes were queued after the schema tx but before the async build finished, `install-secondary-index!` would replace the live-updated index with the empty/stale rebuild. Fix is detection-based: scan AEVT for any datoms covering the indexed attrs at registration time; only promote to `:building` when backfill is genuinely needed. Eliminates the race in the common case (register on a fresh DB).

**Versioning (deeedbab):**
- Two integration tests confirming SCD2 layout survives release/reconnect and branch via the existing `IVersionedSecondaryIndex` callbacks (no adapter change needed — stratum's commit 1 already wired metadata through `sync!`/`load`).

**Query-engine routing (f4c0c2e6):**
- `(d/valid-at db inst)` returns `(vary-meta db assoc :datahike/valid-at inst)`. `secondary/search-with-vt` centralises the routing — marker set + vt-aware → `-search-at-vt`; otherwise `-search`. `query/execute.cljc` external-engine `:filter` path uses the helper. Pure-datalog patterns hitting AEVT/AVET still require explicit `(valid-at ?tx ?at)` rule usage today (auto-injection deferred to a follow-up).

## Notes

- `bitemporal-v1` is a feature branch consolidating prior bitemporal work plus the new SCD2 / d/valid-at / writer fixes. Once stratum#26 cuts a release, the `:local/root "../stratum"` in this PR's deps can revert to `:mvn/version`.
- The "register a vt-aware index on a DB with existing data" path still has a narrower writer race (build snapshots at dispatch time; concurrent writes within the build window can be lost). Pre-existed this PR; proper fix requires a writer-architecture pass and is tracked as a follow-up.

## Test plan

- [x] 24 secondary tests / 119 assertions across stratum-bridge, secondary-vt, secondary-index, secondary-versioning, stratum-vt — all green via `clojure -M:test`, no Thread/sleep.
- [x] 4 secondary-dynamic tests + 10 secondary-integration tests stay green.
- [x] `cljfmt` clean on all touched files.