### PR TITLE
fix(pydatahike): tolerate cbor2 tag_hook signature variants

### DIFF
--- a/pydatahike/src/datahike/_native.py
+++ b/pydatahike/src/datahike/_native.py
@@ -123,11 +123,23 @@ CALLBACK_FUNC = CFUNCTYPE(c_void_p, c_char_p)
 # Result Parsing
 # =============================================================================
 
-def _cbor_tag_hook(decoder, tag, shareable_index=None):
-    """Handle CBOR tags (e.g., Clojure keywords)."""
-    # Tag 39 is used for Clojure keywords - just return the value
-    if tag.tag == 39:
-        return tag.value
+def _cbor_tag_hook(*args, **kwargs):
+    """Handle CBOR tags (e.g., Clojure keywords).
+
+    Tolerates multiple cbor2 calling conventions, since the C-accelerated
+    and pure-Python decoders have shipped different signatures across 5.x
+    releases. Observed shapes:
+      - (decoder, CBORTag)               # pure-Python 5.x
+      - (CBORTag, True, None)            # some C-extension builds
+      - (decoder, CBORTag, shareable)    # pre-5.x
+    We pick the CBORTag from wherever it lands.
+    """
+    tag = next((a for a in args if isinstance(a, cbor2.CBORTag)), None)
+    if tag is None:
+        # Degrade gracefully — shouldn't happen with a real CBOR tag stream.
+        return args[0] if args else None
+    # Tag 39 is the IANA assignment for "identifier" — used here for
+    # Clojure keywords. Returning .value strips the tag wrapper.
     return tag.value
 
 


### PR DESCRIPTION
## Summary

The Python test job has been failing on CI with:

```
AttributeError: 'bool' object has no attribute 'tag'
src/datahike/_native.py:129: AttributeError
```

Root cause: `_cbor_tag_hook` assumed a single calling convention (`(decoder, tag, shareable_index=None)`), but cbor2 has shipped multiple signatures across 5.x releases. The pure-Python decoder calls `(decoder, CBORTag)`; some C-extension builds (including whatever ships in the wheel CI installs) call `(CBORTag, True, None)`; pre-5.x called `(decoder, CBORTag, shareable)`. The dep is declared `cbor2>=5.4.0` with no upper bound, so CI eventually pulled a wheel whose decoder calls the hook in a way the function couldn't handle.

This change makes the hook tolerant of any of those shapes by accepting `*args, **kwargs` and picking the `CBORTag` from wherever it landed.

## Test plan

- [x] Verified locally against all three observed cbor2 calling conventions
- [x] Verified against a real `cbor2.loads` round-trip with the installed cbor2 5.8.0
- [ ] CI Python tests pass

## Notes

- Did *not* pin the cbor2 version. The tolerant hook makes the pin unnecessary; keeping the dep range flexible avoids future "what version is OK?" debates.
- Did *not* touch the 11 missing operations in `native-operations` / `python-operations` (warned about by `bb codegen-python` / `bb codegen-native`). That's a separate work item — adding real `:pattern` / `:java-call` overlays so the new versioning ops (`branch!`, `merge-db`, etc.) actually generate in the bindings. Worth a follow-up branch.