### PR TITLE
fix(codegen,pydatahike): JSON Long coercion in transact + test cleanup

### DIFF
--- a/libdatahike/src/datahike/impl/LibDatahike.java
+++ b/libdatahike/src/datahike/impl/LibDatahike.java
@@ -333,7 +333,7 @@ public final class LibDatahike extends LibDatahikeBase {
         }
     }
     /**
-     * Applies transaction to the database and updates connection.
+     * Applies transaction to the database and updates connection. Blocks until committed. WARNING: Do not call from listener callbacks or transaction functions — use transact! instead to avoid deadlocks.
    * 
    * Examples:
    *   Add single datom:
@@ -359,8 +359,8 @@ public final class LibDatahike extends LibDatahikeBase {
             Object conn = Datahike.connect(readConfig(db_config));
             Object txData = loadInput(tx_format, tx_data);
 
-            // Apply schema-aware type conversions for JSON format
-            // (e.g., Integer → Long for :db.type/long attributes)
+            // JSON inputs need schema-aware coercion (e.g. Integer → Long
+            // for :db.type/long attrs). EDN/CBOR carry types natively.
             String format = CTypeConversion.toJavaString(tx_format);
             if ("json".equals(format)) {
                 txData = libdatahike.transformJSONForTx(txData, conn);

--- a/pydatahike/src/datahike/_native.py
+++ b/pydatahike/src/datahike/_native.py
@@ -123,11 +123,23 @@ CALLBACK_FUNC = CFUNCTYPE(c_void_p, c_char_p)
 # Result Parsing
 # =============================================================================
 
-def _cbor_tag_hook(decoder, tag, shareable_index=None):
-    """Handle CBOR tags (e.g., Clojure keywords)."""
-    # Tag 39 is used for Clojure keywords - just return the value
-    if tag.tag == 39:
-        return tag.value
+def _cbor_tag_hook(*args, **kwargs):
+    """Handle CBOR tags (e.g., Clojure keywords).
+
+    Tolerates multiple cbor2 calling conventions, since the C-accelerated
+    and pure-Python decoders have shipped different signatures across 5.x
+    releases. Observed shapes:
+      - (decoder, CBORTag)               # pure-Python 5.x
+      - (CBORTag, True, None)            # some C-extension builds
+      - (decoder, CBORTag, shareable)    # pre-5.x
+    We pick the CBORTag from wherever it lands.
+    """
+    tag = next((a for a in args if isinstance(a, cbor2.CBORTag)), None)
+    if tag is None:
+        # Degrade gracefully — shouldn't happen with a real CBOR tag stream.
+        return args[0] if args else None
+    # Tag 39 is the IANA assignment for "identifier" — used here for
+    # Clojure keywords. Returning .value strips the tag wrapper.
     return tag.value
 
 

--- a/pydatahike/tests/test_database.py
+++ b/pydatahike/tests/test_database.py
@@ -10,30 +10,28 @@ from datahike import (
 
 
 def test_create_and_delete(mem_config):
-    """Test create and delete database."""
-    # Create
+    """Test create and delete database via the low-level functional API."""
     create_database(mem_config)
-
-    # Check exists
     assert database_exists(mem_config) is True
 
-    # Delete
     delete_database(mem_config)
-
-    # Check deleted
     assert database_exists(mem_config) is False
 
 
 def test_database_context_manager(mem_config):
-    """Test database context manager for automatic cleanup."""
+    """Test database() context manager creates on enter, deletes on exit.
+
+    The context manager yields a Database instance, not the config string.
+    Use Database methods (db.exists(), db.transact(), ...) inside the block.
+    The underlying config is available via db.config if you need to pass it
+    to the low-level functional API."""
     # Database should not exist before
     assert database_exists(mem_config) is False
 
-    # Use context manager
-    with database(mem_config) as cfg:
-        # Should exist inside context
-        assert database_exists(cfg) is True
-        assert cfg == mem_config
+    with database(mem_config) as db:
+        assert db.exists() is True
+        # The yielded Database carries the config we passed in.
+        assert db.config == mem_config
 
     # Should be deleted after context
     assert database_exists(mem_config) is False

--- a/pydatahike/tests/test_query.py
+++ b/pydatahike/tests/test_query.py
@@ -1,99 +1,81 @@
-"""Tests for query and data retrieval operations."""
-import json
+"""Tests for query and data retrieval operations.
+
+These exercise the high-level Database API (db.transact / db.q / db.pull)
+inside the database() context manager. The low-level functional API
+(transact / q / pull on bare config strings) is covered by test_basic.py."""
 import pytest
-from datahike import (
-    create_database,
-    delete_database,
-    transact,
-    q,
-    pull,
-    database,
-)
+from datahike import database
+
+
+def _unwrap_set(result):
+    """Strip the !set wrapper from JSON-formatted query results."""
+    if isinstance(result, list) and len(result) == 2 and result[0] == '!set':
+        return result[1]
+    return result
 
 
 def test_transact_and_query_json(mem_config_flexible):
-    """Test transact and query with JSON format."""
-    with database(mem_config_flexible) as cfg:
-        # Transact data using JSON format
-        tx_data = json.dumps([
+    """Transact via JSON, query via Datalog."""
+    with database(mem_config_flexible) as db:
+        db.transact([
             {"name": "Alice", "age": 30},
             {"name": "Bob", "age": 25}
         ])
-        result = transact(cfg, tx_data, input_format='json')
-        assert result is not None
 
-        # Query for Alice
-        query_result = q(
+        results = db.q(
             '[:find ?e ?name :where [?e :name ?name] [?e :name "Alice"]]',
-            [('db', cfg)],
             output_format='json'
         )
-        assert len(query_result) > 0
+        assert len(_unwrap_set(results)) > 0
 
 
 def test_pull_entity(mem_config_flexible):
-    """Test pull API to retrieve entity."""
-    with database(mem_config_flexible) as cfg:
-        # Transact data
-        tx_data = json.dumps([{"name": "Alice", "age": 30}])
-        transact(cfg, tx_data, input_format='json')
+    """Pull an entity by id after transacting."""
+    with database(mem_config_flexible) as db:
+        db.transact([{"name": "Alice", "age": 30}])
 
-        # Query to get entity ID
-        query_result = q(
+        results = _unwrap_set(db.q(
             '[:find ?e ?name :where [?e :name ?name] [?e :name "Alice"]]',
-            [('db', cfg)],
             output_format='json'
-        )
+        ))
+        entity_id = results[0][0]
 
-        # Extract entity ID from result
-        actual_results = query_result[1] if query_result[0] == '!set' else query_result
-        entity_id = actual_results[0][0]
-
-        # Pull entity
-        entity = pull(cfg, '[*]', entity_id, output_format='json')
+        entity = db.pull('[*]', entity_id, output_format='json')
         assert entity.get('name') == 'Alice' or entity.get(':name') == 'Alice'
 
 
 def test_query_with_multiple_results(mem_config_flexible):
-    """Test query returning multiple results."""
-    with database(mem_config_flexible) as cfg:
-        # Transact multiple entities
-        tx_data = json.dumps([
+    """Query returns one row per matching entity."""
+    with database(mem_config_flexible) as db:
+        db.transact([
             {"name": "Alice", "age": 30},
             {"name": "Bob", "age": 25},
             {"name": "Charlie", "age": 35}
         ])
-        transact(cfg, tx_data, input_format='json')
 
-        # Query all names
-        query_result = q(
+        results = _unwrap_set(db.q(
             '[:find ?name :where [?e :name ?name]]',
-            [('db', cfg)],
             output_format='json'
-        )
-
-        # Should have 3 results
-        actual_results = query_result[1] if query_result[0] == '!set' else query_result
-        assert len(actual_results) == 3
+        ))
+        assert len(results) == 3
 
 
 def test_query_with_parameters(mem_config_flexible):
-    """Test query with input parameters."""
-    with database(mem_config_flexible) as cfg:
-        # Transact data
-        tx_data = json.dumps([
+    """Query with a bound parameter passed as an additional input source.
+
+    libdatahike's loadInput supports input formats: db / history / since /
+    asof / json / edn / cbor. Parameters are passed as ('edn', '<edn-form>')
+    pairs — the EDN parser produces a plain Clojure value bound to the
+    query's :in variable."""
+    with database(mem_config_flexible) as db:
+        db.transact([
             {"name": "Alice", "age": 30},
             {"name": "Bob", "age": 25}
         ])
-        transact(cfg, tx_data, input_format='json')
 
-        # Query with parameter
-        query_result = q(
+        results = _unwrap_set(db.q(
             '[:find ?e :in $ ?name :where [?e :name ?name]]',
-            [('db', cfg), ('param', '"Alice"')],
+            ('edn', '"Alice"'),
             output_format='json'
-        )
-
-        # Should find Alice
-        actual_results = query_result[1] if query_result[0] == '!set' else query_result
-        assert len(actual_results) > 0
+        ))
+        assert len(results) > 0

--- a/pydatahike/tests/test_schema.py
+++ b/pydatahike/tests/test_schema.py
@@ -1,17 +1,21 @@
 """Tests for schema operations."""
 import pytest
-from datahike import (
-    transact,
-    schema,
-    q,
-    database,
-)
+from datahike import database
+
+
+def _unwrap_set(result):
+    if isinstance(result, list) and len(result) == 2 and result[0] == '!set':
+        return result[1]
+    return result
 
 
 def test_explicit_schema(mem_config):
-    """Test transact and query with explicit schema."""
-    with database(mem_config) as cfg:
-        # Transact schema using EDN format
+    """Transact an explicit schema, then JSON data; the schema-aware coercion
+    in libdatahike's transact entry point should convert JSON Integer values
+    to Java Long for :db.type/long attributes. This is the canary for the
+    codegen template's JSON-aware transact body (see
+    src/datahike/codegen/native.clj generate-transact)."""
+    with database(mem_config) as db:
         schema_tx = '''[
             {:db/ident :name
              :db/valueType :db.type/string
@@ -20,36 +24,31 @@ def test_explicit_schema(mem_config):
              :db/valueType :db.type/long
              :db/cardinality :db.cardinality/one}
         ]'''
-        transact(cfg, schema_tx, input_format='edn')
+        db.transact(schema_tx, input_format='edn')
 
-        # Check schema was added
-        db_schema = schema(cfg, output_format='json')
+        # Schema should be present
+        db_schema = db.schema(output_format='json')
         assert db_schema is not None
 
-        # Transact data using EDN
-        tx_data = '[{:name "Charlie" :age 35} {:name "Diana" :age 28}]'
-        transact(cfg, tx_data, input_format='edn')
+        # JSON data — values get coerced via the schema (Integer → Long for :age)
+        db.transact([
+            {"name": "Charlie", "age": 35},
+            {"name": "Diana", "age": 28}
+        ])
 
-        # Query
-        query_result = q(
+        results = _unwrap_set(db.q(
             '[:find ?e ?name ?age :where [?e :name ?name] [?e :age ?age]]',
-            [('db', cfg)],
             output_format='json'
-        )
-        actual_results = query_result[1] if query_result[0] == '!set' else query_result
-        assert len(actual_results) == 2
+        ))
+        assert len(results) == 2
 
 
 def test_schema_flexibility_read(mem_config_flexible):
-    """Test schema-flexibility :read allows dynamic attributes."""
-    with database(mem_config_flexible) as cfg:
-        # Transact data without predefined schema
-        tx_data = '[{:dynamic-attr "test" :another-attr 42}]'
-        transact(cfg, tx_data, input_format='edn')
+    """Schema-flexibility :read accepts dynamic attributes without a declared
+    schema."""
+    with database(mem_config_flexible) as db:
+        db.transact('[{:dynamic-attr "test" :another-attr 42}]',
+                    input_format='edn')
 
-        # Query should work
-        query_result = q(
-            '[:find ?e ?val :where [?e :dynamic-attr ?val]]',
-            [('db', cfg)]
-        )
-        assert len(query_result) > 0
+        results = db.q('[:find ?e ?val :where [?e :dynamic-attr ?val]]')
+        assert len(results) > 0

--- a/src/datahike/codegen/native.clj
+++ b/src/datahike/codegen/native.clj
@@ -40,10 +40,11 @@
     {:pattern :query
      :java-call "Datahike.q(CTypeConversion.toJavaString(query_edn), loadInputs(num_inputs, input_formats, raw_inputs))"}
 
-    ;; Transaction
+    ;; Transaction. :java-call is intentionally absent — the :transact pattern
+    ;; emits a multi-line body that does its own Datahike.connect / loadInput /
+    ;; conditional JSON-coercion / transact sequence; see generate-transact.
     transact
-    {:pattern :transact
-     :java-call "((java.util.Map)Datahike.transact(Datahike.connect(readConfig(db_config)), (java.util.List)loadInput(tx_format, tx_data))).get(Util.kwd(\":tx-meta\"))"}
+    {:pattern :transact}
 
     ;; Pull API
     pull
@@ -232,8 +233,15 @@
 
 (defn generate-transact
   "Generate entry point for transact operation.
-   Pattern: (db_config, tx_format, tx_data) -> tx-meta"
-  [op-name {:keys [java-call doc-comment] :as config}]
+   Pattern: (db_config, tx_format, tx_data) -> tx-meta
+
+   Emits a JSON-aware transact body: when input_format is 'json', the parsed
+   tx-data is passed through libdatahike.transformJSONForTx so values are
+   coerced against the schema (e.g. Integer → Long for :db.type/long attrs).
+   Without this pass, JSON inserts against a strict schema fail with
+   :transact/schema validation errors — see
+   pydatahike/tests/test_basic.py::test_transact_with_explicit_schema."
+  [op-name {:keys [doc-comment] :as config}]
   (let [c-name (get-c-name op-name config)]
     (format "%s
     @CEntryPoint(name = \"%s\")
@@ -245,12 +253,22 @@
             @CConst CCharPointer output_format,
             @CConst OutputReader output_reader) {
         try {
-            output_reader.call(toOutput(output_format, %s));
+            Object conn = Datahike.connect(readConfig(db_config));
+            Object txData = loadInput(tx_format, tx_data);
+
+            // JSON inputs need schema-aware coercion (e.g. Integer → Long
+            // for :db.type/long attrs). EDN/CBOR carry types natively.
+            String format = CTypeConversion.toJavaString(tx_format);
+            if (\"json\".equals(format)) {
+                txData = libdatahike.transformJSONForTx(txData, conn);
+            }
+
+            output_reader.call(toOutput(output_format, ((java.util.Map)Datahike.transact(conn, (java.util.List)txData)).get(Util.kwd(\":tx-meta\"))));
         } catch (Exception e) {
             output_reader.call(toException(e));
         }
     }"
-            (or doc-comment "") c-name c-name java-call)))
+            (or doc-comment "") c-name c-name)))
 
 (defn generate-db-only
   "Generate entry point for db-only operations.
@@ -552,7 +570,12 @@ public final class LibDatahike extends LibDatahikeBase {
     ;; Validate coverage
     (validation/validate-coverage "Native" native-operations native-excluded-operations)
     (validation/validate-exclusion-reasons "Native" native-excluded-operations)
-    (validation/validate-overlay-completeness "Native" native-operations [:pattern :java-call])
+    ;; :transact pattern emits a self-contained body and doesn't need :java-call;
+    ;; exclude it from the :java-call completeness check.
+    (validation/validate-overlay-completeness
+     "Native"
+     (into {} (remove (fn [[_ cfg]] (= :transact (:pattern cfg))) native-operations))
+     [:pattern :java-call])
 
     ;; Generate bindings
     (write-libdatahike! output-dir)

--- a/test/datahike/test/json_test.cljc
+++ b/test/datahike/test/json_test.cljc
@@ -1,0 +1,47 @@
+(ns datahike.test.json-test
+  "Unit tests for datahike.json — primarily the schema-aware tx-data
+  coercion used by libdatahike's transact entry point (and any other
+  caller that feeds JSON-parsed values into a strict-schema database).
+
+  Without this coercion, JSON-parsed integers arrive as java.lang.Integer
+  and fail schema validation for :db.type/long attributes. Regression
+  tested end-to-end by pydatahike's test_transact_with_explicit_schema."
+  (:require
+   #?(:cljs [cljs.test :as t :refer-macros [is deftest]]
+      :clj [clojure.test :as t :refer [is deftest]])
+   [datahike.api :as d]
+   [datahike.json :as djson]))
+
+(defn- with-schema-db [f]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn [{:db/ident :age
+                         :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (try
+        (f @conn)
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest xf-data-for-tx-coerces-integer-to-long
+  (with-schema-db
+    (fn [db]
+      ;; Simulate JSON-parsed tx data: small numbers arrive as Integer.
+      (let [tx-data [{:age (int 35)}]
+            xformed (djson/xf-data-for-tx tx-data db)
+            coerced-val (-> xformed first :age)]
+        (is (instance? java.lang.Long coerced-val)
+            (str ":age should be coerced from Integer to Long, got "
+                 (class coerced-val)))
+        (is (= 35 coerced-val))))))
+
+(deftest xf-data-for-tx-leaves-non-schema-attrs-alone
+  (with-schema-db
+    (fn [db]
+      ;; Attribute not in schema is passed through as-is (no coercion).
+      (let [tx-data [{:unknown-attr (int 99)}]
+            xformed (djson/xf-data-for-tx tx-data db)]
+        (is (= [{:unknown-attr (int 99)}] (vec xformed)))))))


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the Python test job that were masked by the cbor2 hook crash until that was fixed in #829. With #829 in, these two now surface.

**This branch is based on `fix/cbor2-tag-hook` (#829)**, so it includes that commit. Land #829 first and this rebases cleanly, or land this one and #829 becomes redundant — either order works.

### Bug 1: codegen template lost the JSON→Long coercion

The `transact` C entry point in libdatahike has to call `transformJSONForTx` to coerce JSON-parsed values against the schema (Integer → Long for `:db.type/long` attrs). Without it, JSON inserts against a strict schema fail with `:transact/schema` validation errors.

The committed `LibDatahike.java` had the call, but the `generate-transact` template in `src/datahike/codegen/native.clj` did not — every `bb codegen-native` run silently wiped the manual edit. The file header literally says *"DO NOT EDIT MANUALLY — changes will be overwritten."* This silently regressed every time CI ran `bb ni-compile` (which depends on `bb codegen-native`).

Bake the multi-line JSON-aware body into `generate-transact` itself. The `:transact` overlay no longer needs `:java-call`. Loosen `validate-overlay-completeness` to skip the `:java-call` check for the `:transact` pattern. After regeneration, `LibDatahike.java` matches what was manually committed, modulo a longer docstring picked up from the spec and minor comment wording.

### Bug 2: tests confused `Database` instances with config strings

The `database()` context manager yields a `Database` instance (per its docstring). Several tests wrote

```python
with database(mem_config) as cfg:
    transact(cfg, ...)            # cfg is Database, not str
    q('...', [('db', cfg)], ...)  # same
```

which crashes in the low-level wrapper at `config.encode('utf-8')` with `AttributeError: 'Database' object has no attribute 'encode'`.

Rewrite `test_database.py` / `test_query.py` / `test_schema.py` to use the high-level `Database` methods (`db.transact` / `db.q` / `db.pull` / `db.exists`) inside the `with` block. This is the idiomatic API; `test_basic.py` still exercises the low-level functional API against bare config strings, so both layers stay covered.

Also fix `test_query_with_parameters`: the previous version passed `('param', '"Alice"')` as an input, but `libdatahike`'s `loadInput` supports only `db` / `history` / `since` / `asof` / `json` / `edn` / `cbor`. Use `('edn', '"Alice"')` instead — the EDN parser produces the right Clojure value for the `:in` variable.

### Regression coverage added

- `pydatahike/tests/test_basic.py::test_transact_with_explicit_schema` — end-to-end via FFI (already existed; will now run to completion).
- `test/datahike/test/json_test.cljc` — new unit test of `xf-data-for-tx` that doesn't need libdatahike built. Catches future regressions in the coercion logic itself, fast.

## Test plan (local, completed)

- [x] `bb codegen-native` — regenerates `LibDatahike.java` with the JSON-aware body; no warnings beyond the known 11 versioning-API gaps (separate work item).
- [x] `bb test` (kaocha, `datahike.test.json-test` focused) — 6 tests, 9 assertions, 0 failures.
- [x] `bb ni-compile` — libdatahike.so built (3m38s on local).
- [x] `bb test python` — **59 / 59 passed**. No regressions.

## Notes

- Did *not* touch the 11 missing-operation warnings (`branch!`, `merge-db`, `branch-as-db`, etc.) — that's the separate work item to expose the new versioning API in libdatahike / pydatahike / dthk via real `:pattern` / `:java-call` overlays.