### PR TITLE
fix(datom): compare byte arrays element-wise in compare-value

### DIFF
--- a/src/datahike/array.cljc
+++ b/src/datahike/array.cljc
@@ -1,4 +1,5 @@
 (ns ^:no-doc datahike.array
+  (:refer-clojure :exclude [bytes?])
   #?(:cljs (:require [goog.array]))
   #?(:clj (:import [java.util Arrays])))
 
@@ -44,7 +45,10 @@
                       (recur (inc i#)))))))
        `(array-compare ~a ~b))))
 
-#?(:cljs
+#?(:clj
+   (defn bytes? [x]
+     (clojure.core/bytes? x))
+   :cljs
    (defn bytes? [x]
      (and (instance? js/ArrayBuffer (.-buffer x))
           (number? (.-byteLength x)))))

--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc datahike.datom
   (:require  [clojure.walk]
              [clojure.data]
+             [datahike.array :as da]
              [datahike.constants :refer [tx0]]
              [datahike.tools :refer [combine-hashes]]
              #?(:cljs [goog.array :as garray]))
@@ -261,11 +262,16 @@
 (defn compare-value
   "Compare two values with cross-platform UUID compatibility.
    CLJS UUID comparison is adjusted to match CLJ's signed comparison,
-   ensuring consistent ordering when indices are built on CLJ and queried on CLJS."
+   ensuring consistent ordering when indices are built on CLJ and queried on CLJS.
+   Byte arrays are compared element-wise via datahike.array/compare-arrays,
+   since byte[] does not implement Comparable."
   [v1 v2]
-  #?(:clj (compare v1 v2)
+  #?(:clj (if (and (da/bytes? v1) (da/bytes? v2))
+            (da/compare-arrays v1 v2)
+            (compare v1 v2))
      :cljs
-     (if (and (uuid? v1) (uuid? v2))
+     (cond
+       (and (uuid? v1) (uuid? v2))
        ;; Match Java's signed UUID comparison where MSB is treated as signed
        ;; In signed comparison: 0x8... is negative, so 0x8... < 0x0...
        (let [s1 (.-uuid ^cljs.core/UUID v1)
@@ -279,7 +285,11 @@
            (and neg1 (not neg2)) -1  ;; v1 "negative", v2 "positive" → v1 < v2
            (and neg2 (not neg1)) 1   ;; v2 "negative", v1 "positive" → v1 > v2
            :else (compare s1 s2)))   ;; same sign → string compare works
-       (compare v1 v2))))
+
+       (and (da/bytes? v1) (da/bytes? v2))
+       (da/compare-arrays v1 v2)
+
+       :else (compare v1 v2))))
 
 (defn- safe-compare [a b]
   (try

--- a/test/datahike/test/store_test.cljc
+++ b/test/datahike/test/store_test.cljc
@@ -70,6 +70,35 @@
                   (byte-array [0 2 3]))))
       (d/release conn))))
 
+(deftest test-bytes-schema-upsert
+  ;; Regression test: upserting a :db.type/bytes attribute used to throw
+  ;; "byte[] cannot be cast to java.lang.Comparable" because compare-value
+  ;; passed byte arrays to clojure.core/compare, which requires Comparable.
+  (let [config {:store {:backend :memory
+                        :id #uuid "00100000-0000-0000-0000-000000000011"}
+                :schema-flexibility :write
+                :initial-tx
+                [{:db/ident :doc/id
+                  :db/unique :db.unique/identity
+                  :db/valueType :db.type/string
+                  :db/cardinality :db.cardinality/one}
+                 {:db/ident :doc/save
+                  :db/valueType :db.type/bytes
+                  :db/cardinality :db.cardinality/one}]}]
+    (d/delete-database config)
+    (d/create-database config)
+    (let [conn (d/connect config)]
+      (testing "first transact with bytes value"
+        (d/transact conn [{:doc/id "k" :doc/save (byte-array [1 2 3])}])
+        (is (some? (d/entity @conn [:doc/id "k"]))))
+      (testing "upsert with identical bytes value"
+        (d/transact conn [{:doc/id "k" :doc/save (byte-array [1 2 3])}])
+        (is (some? (d/entity @conn [:doc/id "k"]))))
+      (testing "upsert with different bytes value"
+        (d/transact conn [{:doc/id "k" :doc/save (byte-array [4 5 6])}])
+        (is (some? (d/entity @conn [:doc/id "k"]))))
+      (d/release conn))))
+
 (deftest test-database-exists-with-invalid-store
   (testing "Store with missing :id"
     (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)


### PR DESCRIPTION
## Summary
- Transacting a `:db.type/bytes` attribute and then upserting on the same entity threw `byte[] cannot be cast to java.lang.Comparable` because `datahike.datom/compare-value` passed values straight to `clojure.core/compare`, which requires `Comparable`. Byte-array pairs are now routed to `datahike.array/compare-arrays` so AVET/EAVT/AEVT ordering works on bytes.
- Bug reported by @phronmophobic in Slack; reproduces on the JVM in-memory and file backends (not native-image specific).
- `datahike.array` now exposes a cross-platform `bytes?` predicate (delegates to `clojure.core/bytes?` on the JVM) so the comparator can dispatch without a redef warning. No reflection on the comparator hot path.

## Reproducer (now passes)
```clojure
(def cfg {:store {:backend :memory :id #uuid "550e8400-e29b-41d4-a716-446655440000"}
          :schema-flexibility :write
          :initial-tx [{:db/ident :doc/id    :db/unique :db.unique/identity
                        :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
                       {:db/ident :doc/save  :db/valueType :db.type/bytes
                        :db/cardinality :db.cardinality/one}]})
(d/create-database cfg)
(def conn (d/connect cfg))
(d/transact conn [{:doc/id "k" :doc/save (byte-array [1 2 3])}])
(d/transact conn [{:doc/id "k" :doc/save (byte-array [1 2 3])}]) ;; <- used to throw
```

## Test plan
- [x] Added `test-bytes-schema-upsert` in `store_test.cljc` covering first transact, upsert with identical bytes, and upsert with different bytes
- [x] `clojure -M:test -m kaocha.runner --focus datahike.test.store-test` — 18 tests / 39 assertions, 0 failures (default, clj-hht, specs profiles)
- [x] `clojure -M:test -m kaocha.runner --focus datahike.test.array-test` — 6 tests / 60 assertions, 0 failures
- [x] `clojure -M:test -m kaocha.runner --focus datahike.test.schema-test` — 27 tests / 204 assertions, 0 failures
- [x] Verified original reproducer scenario against `:memory` and `:file` backends with `:keep-history? true`
- [x] `*warn-on-reflection*` shows no new reflection on the comparator path