### PR TITLE
fix(writer): dispatch secondary-index backfill once, not per tx-while-building

### DIFF
--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -212,16 +212,27 @@
     p))
 
 (defn- detect-new-building-indices
-  "Detect secondary indices that were just created (status :building) in a tx-report.
-   Returns a seq of idx-idents that need backfill."
+  "Detect secondary indices that *transitioned* into :building in this tx,
+   i.e. they are :building in db-after but were not already :building in
+   db-before. Returns a seq of idx-idents that need a one-time backfill.
+
+   Comparing against db-before is essential: any transaction applied while
+   an index is still building would otherwise re-dispatch a full backfill,
+   and a second backfill that runs after the first one's
+   install-secondary-index! has dissoc'd :db.secondary/building-since-tx
+   loses the snapshot guard and re-delivers post-creation datoms that were
+   already applied live — double-counting them in the index."
   [tx-report]
-  (when-let [schema (get-in tx-report [:db-after :schema])]
-    (keep (fn [[ident entry]]
-            (when (and (map? entry)
-                       (:db.secondary/type entry)
-                       (= :building (:db.secondary/status entry)))
-              ident))
-          schema)))
+  (let [before (get-in tx-report [:db-before :schema])
+        after  (get-in tx-report [:db-after :schema])]
+    (when after
+      (keep (fn [[ident entry]]
+              (when (and (map? entry)
+                         (:db.secondary/type entry)
+                         (= :building (:db.secondary/status entry))
+                         (not= :building (get-in before [ident :db.secondary/status])))
+                ident))
+            after))))
 
 (defn transact!
   [connection arg-map]

--- a/test/datahike/test/secondary_index_test.clj
+++ b/test/datahike/test/secondary_index_test.clj
@@ -5,7 +5,8 @@
    [datahike.api :as d]
    [datahike.db :as db]
    [datahike.index.secondary :as sec]
-   [datahike.index.entity-set :as es]))
+   [datahike.index.entity-set :as es]
+   [datahike.writer :as writer]))
 
 ;; ---------------------------------------------------------------------------
 ;; EntityBitSet tests
@@ -223,3 +224,33 @@
         (finally
           (d/release conn)
           (d/delete-database cfg))))))
+
+;; ---------------------------------------------------------------------------
+;; Backfill dispatch — regression for double-counting
+;;
+;; A secondary index is backfilled asynchronously after the tx that creates it
+;; (status :building). The backfill skips datoms with tx > building-since-tx so
+;; live transactions applied during the build are not re-delivered. The writer
+;; must therefore dispatch the backfill *exactly once* — on the tx that first
+;; flips the index to :building. If a later tx (applied while the index is still
+;; building) also dispatched a backfill, that second build could run after the
+;; first one's install-secondary-index! has dropped :building-since-tx, losing
+;; the guard and re-delivering post-creation datoms that were already applied
+;; live — counting them twice in the index.
+
+(deftest test-backfill-dispatched-once
+  (testing "backfill is dispatched only when an index transitions into :building"
+    (let [detect @#'writer/detect-new-building-indices
+          building {:db.secondary/type :scriptum :db.secondary/status :building}
+          ready    {:db.secondary/type :scriptum :db.secondary/status :ready}]
+      (testing "nil -> :building (index just created): dispatch"
+        (is (= [:idx/a]
+               (vec (detect {:db-before {:schema {}}
+                             :db-after  {:schema {:idx/a building}}})))))
+      (testing ":building -> :building (later tx during backfill): no re-dispatch"
+        (is (empty? (detect {:db-before {:schema {:idx/a building}}
+                             :db-after  {:schema {:idx/a building}}}))))
+      (testing ":ready -> :building (index re-enabled): dispatch"
+        (is (= [:idx/a]
+               (vec (detect {:db-before {:schema {:idx/a ready}}
+                             :db-after  {:schema {:idx/a building}}}))))))))


### PR DESCRIPTION
## What

`detect-new-building-indices` scanned only `db-after` and returned **every** secondary index currently in `:building` status. So *every* transaction applied while an index was still backfilling re-dispatched a full `build-secondary-index!`.

Combined with `install-secondary-index!` dropping `:db.secondary/building-since-tx` once the first build completes, a redundant second build runs **without** the snapshot guard (`tx > building-since-tx`) and re-delivers post-creation datoms that were already applied live — **double-counting** them in the index.

## Why it slipped through CI

This is an order/timing-dependent race. It stayed green in the #832 and #833 PR pipelines, but failed on `main` once kaocha's randomized test order (plus CI load) let the second build land *after* the first `install-secondary-index!`. 

Symptom: the secondary-index recorder saw **4** add events instead of **2** in `test-purge-propagates-to-secondary`, failing both `persistent-set-test` (clj-pss) and `hitchhiker-tree-test` (clj-hht) on main.

Root-cause analysis (instrumented, reproduced deterministically):
- index-create tx → index `:building` → backfill #1 dispatched
- data tx (Alice/Bob) → index *still* `:building` → backfill #2 dispatched (redundant)
- backfill #1 runs, guard correctly skips post-creation datoms, completes → install sets `:ready`, dissocs `building-since-tx`
- backfill #2 runs with `building-since-tx = nil` → guard disabled → re-delivers Alice/Bob → **4 events**

## Fix

Only dispatch a backfill for indices that *transition* into `:building` in this tx (`:building` in `db-after`, not already `:building` in `db-before`). The build then runs exactly once and the `building-since-tx` guard always holds. Re-enabling an index (`:ready → :building`) still dispatches.

Adds a deterministic regression test for the dispatch predicate (no timing dependence).

## Verification

- Full `clj-pss` and `clj-hht` suites re-run with the exact failing seed (`1811661864`) → **0 failures** (was 1 on main).
- Standalone race reproduction: the no-delay path that reliably produced 4 add-events now consistently produces 2.

Secondary indices are still experimental; this fixes a regression in freshly-landed #832, so no CHANGELOG entry.