### PR TITLE
docs(gc,time-variance,secondary-indices): correct purge/GC procedure

### DIFF
--- a/doc/gc.md
+++ b/doc/gc.md
@@ -4,12 +4,22 @@ Datahike uses persistent data structures that enable structural sharing—each u
 
 **Garbage collection removes old database snapshots from storage while preserving current branch heads.**
 
-## GC vs Purging
+## GC and purging together
 
-Don't confuse garbage collection with data purging:
+Garbage collection and data purging are different operations:
 
-- **Garbage Collection** (this document): Removes old database *snapshots* to reclaim storage. Used for routine storage maintenance.
-- **[Data Purging](./time_variance.md#data-purging)**: Permanently deletes specific *data* for privacy compliance (GDPR, HIPAA, CCPA). Used only when legally required.
+- **Garbage Collection** (this document) reclaims storage by deleting old database *snapshots* that no branch head still points to. Routine maintenance; doesn't touch data on a live snapshot.
+- **[Data Purging](./time_variance.md#data-purging)** rewrites the indices to remove specific *data*. Used for privacy compliance (GDPR, HIPAA, CCPA).
+
+The two compose for actual erasure:
+
+1. `purge` produces a **new commit** whose indices no longer reach the targeted datoms.
+2. The **pre-purge commit** is now a live intermediate commit and still references the old nodes in storage. Until GC sweeps it, `(d/commit-as-db conn <pre-purge-uuid>)` still sees the purged data.
+3. `d/gc-storage` **with a grace-period cutoff** old enough to drop the pre-purge commit physically evicts those nodes from konserve.
+
+So the erasure recipe is **purge + cutoff-GC**, not purge alone. Plain `d/gc-storage` (no cutoff) only reclaims storage from deleted branches and leaves intermediate commits intact — useful as routine maintenance, but not as the eviction step for erasure.
+
+For multi-branch databases, purge on every branch that holds the datom; for how secondary indices participate, see [Secondary indices: purge propagation](./secondary-indices.md#purge-propagation).
 
 ## How Garbage Collection Works
 
@@ -270,4 +280,4 @@ GC preserves:
 - Snapshots created after the grace period
 - All data on retained snapshots (GC doesn't delete data, only snapshots)
 
-**Remember:** For deleting specific data (GDPR compliance), use [data purging](./time_variance.md#data-purging), not garbage collection.
+**Remember:** Actual erasure (GDPR / HIPAA / CCPA) requires [purging](./time_variance.md#data-purging) followed by a cutoff `d/gc-storage` sweep. Purge alone leaves the pre-purge commit reachable; GC alone doesn't delete data on a live snapshot.

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -231,6 +231,33 @@ Each index type uses its native CoW mechanism:
 
 Index state is persisted in commits via the `IVersionedSecondaryIndex` protocol. On reconnect, indices are restored from their durable storage — no AEVT backfill needed for versioned indices.
 
+## Purge propagation
+
+`:db/purge` / `:db.purge/entity` / `:db.purge/attribute` / `:db.history.purge/before` route a retraction event (`-transact` with `:added? false`) to every secondary index covering an affected attribute, the same way `:db/retract` does. After purge:
+
+- **Scriptum** no longer returns the purged datom from full-text search.
+- **Proximum** skips it on KNN queries (HNSW mark-delete).
+- **Stratum** excludes it from columnar aggregates (columnar rewrite).
+
+Two storage-layer caveats:
+
+### Konserve-backed indices (Stratum, Proximum)
+
+Stratum and Proximum store their durable state in konserve. `d/gc-storage` reclaims their unreachable blobs alongside the primary indices the same way: unreachable storage is swept once it ages past the grace-period cutoff, reachable structure persists. No extra step beyond the standard [purge + cutoff-GC](./gc.md) recipe.
+
+### Scriptum (filesystem)
+
+Scriptum's Lucene segments live on the writer node's local disk, not in konserve. Two consequences for erasure:
+
+1. **`d/gc-storage` cannot reach Scriptum's segments.** Scriptum's `-sec-mark` returns the empty set, so the konserve sweep skips Lucene segment files.
+2. **Lucene's own delete model is tombstones-until-segment-merge.** A purge marks the document as deleted in Scriptum's index, but the bytes linger inside the segment file until Lucene merges that segment away.
+
+For full Scriptum erasure you typically need to:
+- Force a Lucene segment merge so the purged document's bytes are physically removed from segments. Scriptum exposes this via its own API; see the [Scriptum repo](https://github.com/replikativ/scriptum).
+- Confirm the writer's filesystem snapshot / backup policy doesn't pin old segment files (NFS, ZFS snapshots, filesystem-level backups all retain segments on their own terms).
+
+For the full erasure procedure across the primary store and secondary indices, see [Garbage Collection: GC and purging together](./gc.md#gc-and-purging-together) and [Time-variance: Purge and storage](./time_variance.md#purge-and-storage).
+
 ## Distributed Deployment
 
 Datahike supports distributed deployments with remote writers (`:http` or `:kabel` backends). Each secondary index type has different characteristics for distributed use:

--- a/doc/time_variance.md
+++ b/doc/time_variance.md
@@ -323,3 +323,15 @@ your purposes.
 - History must be enabled (`:keep-history? true`)
 - Cannot purge schema attributes
 - Use retractions for normal data lifecycle - reserve purging for compliance requirements
+
+### Purge and storage
+
+The example above shows the new commit's indices: the datom is gone from `@conn` and from `(d/history @conn)`. Layers below the new commit need explicit attention:
+
+- **Pre-purge commit.** Each commit owns its own index roots. The commit that existed *before* the purge still references the old tree nodes containing the datom — `(d/commit-as-db conn <pre-purge-uuid>)` still sees the purged data until garbage collection sweeps that intermediate commit. The eviction step is `d/gc-storage` with a grace-period cutoff old enough to drop the pre-purge commit; see [Garbage Collection](./gc.md). Branch heads are always kept; only intermediate commits get swept.
+
+- **Secondary indices.** Purge routes a retraction event in-transaction to every secondary index covering an affected attribute, the same way `:db/retract` does. After purge, Scriptum full-text search, Proximum KNN, and Stratum columnar aggregates no longer return the purged datom on the live store. Scriptum has a filesystem caveat (Lucene tombstones-until-segment-merge); see [Secondary indices: purge propagation](./secondary-indices.md#purge-propagation).
+
+- **Multiple branches.** Purge is a transaction on one branch. If the same datom is reachable from another branch's head, or from its commits inside the GC window, purge that branch too. Structural sharing means the bytes are physically one copy in konserve, but the *paths to reach* them are independent.
+
+- **Backups and storage-layer history.** `purge` operates on the live store. Backups of the konserve store, S3 object versioning, ZFS snapshots, git-backed konserve backends, and logical replicas all retain pre-purge state on their own terms; addressing those is operational policy outside Datahike.


### PR DESCRIPTION
## Summary

Three docs described the GDPR erasure procedure incompletely:

- `gc.md` said *"For deleting specific data (GDPR compliance), use data purging, not garbage collection"* — but purge produces a new commit while leaving the pre-purge commit's tree nodes reachable in storage; cutoff-`d/gc-storage` is the eviction step.
- `time_variance.md`'s purge example showed only the new commit's view (datom gone from `@conn` and `(d/history @conn)`), not what happens below the new commit.
- `secondary-indices.md` was silent on purge entirely, even after #832 made purge propagate to secondary indices.

This pass:

- **`gc.md`** — rewrites "GC vs Purging" as "GC and purging together" with the explicit `purge → pre-purge commit → cutoff-GC` chain; updates the closing reminder to match.
- **`time_variance.md`** — adds a "Purge and storage" subsection covering: the pre-purge commit and `d/gc-storage` eviction; secondary-index propagation (per #832); multi-branch implications; the live-store-vs-backup boundary.
- **`secondary-indices.md`** — adds a "Purge propagation" section after "Branching and Versioning" describing the in-transaction retraction event to Stratum / Proximum / Scriptum, with the Scriptum filesystem caveat (Lucene tombstones-until-segment-merge; `-sec-mark` returns `#{}`, so `gc-storage` doesn't reach Scriptum segments).

## Test plan

Documentation-only change, no code modified. Cross-link anchors verified to match the section headings as GitHub slugifies them (`#gc-and-purging-together`, `#purge-and-storage`, `#purge-propagation`).

## No CHANGELOG entry

This catches docs up to behavior already shipped in #832 — it's documentation accuracy, not a user-visible behavior change.