### PR TITLE
diff-buf write-buffering + index-root fusion (PSS-backed indexes)

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,6 +1,8 @@
 (ns build
   (:refer-clojure :exclude [compile])
   (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.tools.build.api :as b]))
 
 (def class-dir "target/classes")
@@ -15,16 +17,31 @@
                          "-Xlint:deprecation"]}))
 
 (defn javadoc
-  "Generate Javadoc for the Java API.
-   Output will be in target/javadoc and automatically included in the jar."
+  "Generate Javadoc for the Java API into target/javadoc.
+   tools.build has no javadoc wrapper (there is no `b/javadoc`), so shell out to the JDK
+   `javadoc` tool via b/process, passing the project classpath so the Java API's imports
+   (clojure.lang.*, generated classes) resolve. Output is included in the jar at release."
   [_]
-  (b/javadoc {:src-dirs ["java/src"]
-              :output-dir "target/javadoc"
-              :javadoc-opts ["-public"
-                            "-Xdoclint:none"
-                            "-windowtitle" "Datahike Java API"
-                            "-doctitle" "Datahike Java API Documentation"
-                            "-link" "https://docs.oracle.com/javase/8/docs/api/"
-                            "-link" "https://clojure.github.io/clojure/"]})
-  (println "Javadoc generated in target/javadoc")
-  (println "Javadoc will be automatically published to javadoc.io when released to Clojars"))
+  (let [out   "target/javadoc"
+        cp    (str/join java.io.File/pathSeparator (:classpath-roots basis))
+        srcs  (->> (io/file "java/src")
+                   file-seq
+                   (filter #(and (.isFile ^java.io.File %)
+                                 (str/ends-with? (.getName ^java.io.File %) ".java")))
+                   (mapv #(.getPath ^java.io.File %)))
+        args  (into ["javadoc" "-d" out "-classpath" cp
+                     "-public" "-Xdoclint:none"
+                     "-windowtitle" "Datahike Java API"
+                     "-doctitle" "Datahike Java API Documentation"
+                     "-link" "https://docs.oracle.com/javase/8/docs/api/"
+                     "-link" "https://clojure.github.io/clojure/"]
+                    srcs)
+        {:keys [exit]} (b/process {:command-args args})]
+    ;; javadoc returns non-zero on warnings (the Java API has undocumented elements), which is
+    ;; non-fatal — the HTML is still produced. Only treat it as a failure if no output appeared.
+    (when-not (.exists (io/file out "index.html"))
+      (throw (ex-info "javadoc produced no output" {:exit exit})))
+    (when-not (zero? exit)
+      (println "Note: javadoc exited" exit "(warnings above); docs generated regardless."))
+    (println "Javadoc generated in" out)
+    (println "Javadoc will be automatically published to javadoc.io when released to Clojars")))

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,15 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.4"}
         org.replikativ/hasch                        {:mvn/version "0.4.98"
                                                      :exclusions [org.clojure/clojurescript]}
-        org.replikativ/konserve                     {:local/root "../konserve"  ;; dev: cljs header meta-size fix (cross-host)
+        org.replikativ/konserve                     {:mvn/version "0.9.349"  ;; includes cljs header meta-size cross-host fix (#143)
                                                      :exclusions [org.clojure/clojurescript
                                                                   org.clojars.mmb90/cljs-cache]}
                                                      
         org.replikativ/superv.async                 {:mvn/version "0.3.50"
                                                      :exclusions [org.clojure/clojurescript]}
         org.replikativ/datalog-parser               {:mvn/version "0.2.37"}
-        org.replikativ/persistent-sorted-set        {:local/root "../persistent-sorted-set"}  ;; op-buf-v5 (dev)
+        org.replikativ/persistent-sorted-set        {:git/url "https://github.com/replikativ/persistent-sorted-set.git"
+                                                     :git/sha "a36ecbe837100259d017c0ec9716ec4e42e47414"}  ;; diff-buf (feature/op-buf-v5); run `clojure -X:deps prep` to compile its Java
         environ/environ                             {:mvn/version "1.2.0"}
         nrepl/bencode                               {:mvn/version "1.2.0"}
         org.replikativ/logging                      {:mvn/version "0.1.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.4"}
         org.replikativ/hasch                        {:mvn/version "0.4.98"
                                                      :exclusions [org.clojure/clojurescript]}
-        org.replikativ/konserve                     {:mvn/version "0.9.346"
+        org.replikativ/konserve                     {:local/root "../konserve"  ;; dev: cljs header meta-size fix (cross-host)
                                                      :exclusions [org.clojure/clojurescript
                                                                   org.clojars.mmb90/cljs-cache]}
                                                      

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
                                                      :exclusions [org.clojure/clojurescript]}
         org.replikativ/datalog-parser               {:mvn/version "0.2.37"}
         org.replikativ/persistent-sorted-set        {:git/url "https://github.com/replikativ/persistent-sorted-set.git"
-                                                     :git/sha "a36ecbe837100259d017c0ec9716ec4e42e47414"}  ;; diff-buf (feature/op-buf-v5); run `clojure -X:deps prep` to compile its Java
+                                                     :git/sha "2063823a6fa78dcda5570906d9e7509b0394ba68"}  ;; diff-buf (feature/op-buf-v5); run `clojure -X:deps prep` to compile its Java
         environ/environ                             {:mvn/version "1.2.0"}
         nrepl/bencode                               {:mvn/version "1.2.0"}
         org.replikativ/logging                      {:mvn/version "0.1.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
         org.replikativ/superv.async                 {:mvn/version "0.3.50"
                                                      :exclusions [org.clojure/clojurescript]}
         org.replikativ/datalog-parser               {:mvn/version "0.2.37"}
-        org.replikativ/persistent-sorted-set        {:mvn/version "0.4.122"}
+        org.replikativ/persistent-sorted-set        {:local/root "../persistent-sorted-set"}  ;; op-buf-v5 (dev)
         environ/environ                             {:mvn/version "1.2.0"}
         nrepl/bencode                               {:mvn/version "1.2.0"}
         org.replikativ/logging                      {:mvn/version "0.1.3"}

--- a/doc/index-root-fusion.md
+++ b/doc/index-root-fusion.md
@@ -1,0 +1,95 @@
+# Index-root fusion (reduce write amplification)
+
+*Branch: `feat/fuse-index-roots`. Status: design, pre-implementation.*
+
+## Problem
+
+A datahike commit writes `(count pending-writes)` index-node objects + 2
+db-records (under the commit-id and under the branch). Measured ~7 PUTs/commit
+for small commits. The index-node objects include each index's **root**, which
+changes essentially every commit. On per-request object storage this
+amplification is the dominant cost (see saas `doc/cost-model.md`).
+
+## How the write path works today
+
+- `db->stored` (`writing.cljc`) calls `di/-flush` on each index → `psset/store`
+  walks dirty nodes and calls `CachedStorage.store` per node, which **appends
+  `[address node]` to `pending-writes`** and returns the (content- or squuid-)
+  address. The root's address becomes `pset._address`.
+- The stored-db map references each index as a small record. The PSS konserve
+  write-handler serializes a `PersistentSortedSet` to `{:meta, :address,
+  :count}`; the **root node lives separately** at `:address`. Read-handler:
+  `(PersistentSortedSet. meta cmp address @storage nil count settings 0)` — the
+  5th arg (currently `nil`) is the in-memory `_root`.
+- `commit!` drains `pending-writes` (`k/assoc store address node`, one PUT
+  each), then writes the db-record under `cid` and under `branch`.
+
+## The fusion seam
+
+Inline each index's **root node** into its db-record reference
+(`{:meta, :address, :count, :root <root-node>}`) and **drop the root from
+`pending-writes`** so it isn't PUT separately. Restore passes the inlined node
+as the constructor's 5th arg instead of `nil` — deeper children stay lazy.
+
+Win profile (sharper than "−3 PUTs"):
+- **Index = single leaf root (tiny tenant):** the *whole* index inlines → zero
+  separate node PUTs for it. A few-datom tenant's commit collapses to ~2
+  record PUTs.
+- **Deeper tree:** saves exactly **1 PUT per index** (the root); the dirty
+  leaf/intermediate path is still separate — that part is op-buf's job, later.
+Also **−1 GET per index on cold open** (root arrives with the record).
+
+## Options
+
+- **A — explicit fused index-ref in `db->stored`/`stored->db`** *(recommended)*.
+  Build `{:meta :address :count :root <node>}`, remove the root from
+  `pending-writes`, reconstruct via the root-seeding constructor. Contained to
+  `writing.cljc` + a small helper. Opt-in via config `:fuse-index-roots?` so
+  it's measurable against baseline.
+- **B — embed root in the PSS konserve write/read handler.** More automatic but
+  the handler would need storage access at serialize time + a way to skip the
+  separate write. Couples handler to pending state. Messier.
+- **C — fusion + branch-as-pointer.** On top of A: write the fused object once
+  under `cid`, a tiny `{:head cid}` under `branch`. Halves per-commit record
+  bytes; costs a 2nd GET on branch-open. Optional follow-on.
+- **D — inline the whole dirty path (op-buf / mini-WAL in the record).** The
+  deeper convergence; this is the PSS op-buf work, explicitly *after* A.
+
+## Implementation plan (Option A)
+
+Touchpoints, all in datahike (PSS untouched):
+
+1. **Config:** add `:fuse-index-roots?` (default false).
+2. **`db->stored`:** when enabled, for each flushed index pull its root node
+   (from `CachedStorage` cache at `pset._address`) and emit a fused ref; record
+   the root address so it can be excluded from the drain.
+3. **`commit!` drain:** filter the fused root addresses out of `pending-writes`
+   before `k/assoc`-ing the rest. (We have `pset._address` per index.)
+4. **`stored->db`:** detect the fused ref and reconstruct the index with the
+   inlined root node seeded into `_root` (constructor 5th arg) + `_address` +
+   storage for lazy children.
+5. **Serialization:** the inlined root is a `Leaf`/`Branch` — already has
+   konserve read/write handlers, so it nests in the record map for free.
+
+## Caveats to resolve
+
+1. **crypto-hash audit** (`index/persistent_set.cljc` `walk-pss-address!`)
+   starts at the root *address* via `k/get` — with the root inlined there's no
+   konserve object there. v1: gate fusion on `:crypto-hash? false`, or teach the
+   walk to take the root from the record. (The merkle `:address` is still
+   computable from the inlined node, so audit *can* be made to work.)
+2. **GC / `mark`:** the fused root has no konserve object; the reachability/free
+   path must not expect one at that address (don't add it to the konserve-key
+   reachable set; its children's addresses still are).
+3. **`pending-writes` skip must be exact:** only the per-index *root* address is
+   removed; every deeper dirty node stays. Identify by `pset._address`.
+4. **Backwards compat:** a fused db-record must be distinguishable from a legacy
+   one on read (presence of `:root`), so old stores still restore.
+
+## Validation
+
+- Roundtrip: write → restore → `(= (vec before) (vec after))`, counts, slices,
+  history (`as-of`) — at `:fuse-index-roots? true` and `false`.
+- Measure with the saas `commit-cost` probe: PUTs/commit and cold-open GETs,
+  baseline vs fused, across tiny (single-leaf) and deeper trees.
+- Full datahike test suite green with the flag off (byte-identical) and on.

--- a/src/datahike/audit.cljc
+++ b/src/datahike/audit.cljc
@@ -18,7 +18,12 @@
             [konserve.core :as k]
             [superv.async #?(:clj :refer :cljs :refer-macros) [go-try- <?-]]
             [konserve.utils :refer [#?(:clj async+sync) *default-sync-translation*]
-             #?@(:cljs [:refer-macros [async+sync]])]))
+             #?@(:cljs [:refer-macros [async+sync]])]
+            ;; cljs: superv.async/go-try- expands to clojure.core.async/go, so the `go`
+            ;; MACRO must be required here or it falls back to the JVM macro and fails to
+            ;; compile (vary-meta on keyword in go-impl). Mirrors datahike.versioning.
+            #?(:cljs [clojure.core.async :refer [<!]]))
+  #?(:cljs (:require-macros [clojure.core.async :refer [go]])))
 
 (defn- audit-grade-stored?
   "Mirror of writing/audit-grade? but for already-stored commits we're

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -79,6 +79,21 @@
 
 (def self-writer {:backend :self})
 
+(defn default-index-config-for-backend
+  "The default index-config for `index`, adjusted for the store `backend`.
+
+   diff-buf write-buffering (PSS `:diff-buf-size`) trades in-memory insert throughput
+   for fewer durable object PUTs — it only pays off on a request-priced object store.
+   An in-memory store has no PUTs to fold, so buffering there is pure overhead; default
+   `:diff-buf-size` to 0 for the in-memory backend. Index-agnostic: only touches the key
+   when the index's default actually carries it (PSS), and an explicit user `:index-config`
+   still wins (it is deep-merged over this default in load-config)."
+  [index backend]
+  (let [d (di/default-index-config index)]
+    (cond-> d
+      (and (contains? #{:memory :mem} backend) (contains? d :diff-buf-size))
+      (assoc :diff-buf-size 0))))
+
 (defn from-deprecated
   [{:keys [backend username password path host port id] :as _backend-cfg}
    & {:keys [schema-on-read temporal-index index initial-tx]
@@ -109,7 +124,7 @@
                                     #?(:clj (java.util.UUID/nameUUIDFromBytes (.getBytes path "UTF-8"))
                                        :cljs (uuid path))))}))
    :index index
-   :index-config (di/default-index-config index)
+   :index-config (default-index-config-for-backend index backend)
    :keep-history? temporal-index
    :attribute-refs? *default-attribute-refs?*
    :initial-tx initial-tx
@@ -161,7 +176,8 @@
    :crypto-hash? *default-crypto-hash?*
    :branch *default-db-branch*
    :writer self-writer
-   :index-config (di/default-index-config *default-index*)})
+   ;; storeless ⇒ inherently in-memory ⇒ diff-buf off (no PUTs to fold)
+   :index-config (default-index-config-for-backend *default-index* :memory)})
 
 (defn remove-nils
   "Thanks to https://stackoverflow.com/a/34221816"
@@ -230,7 +246,7 @@
                  :store-cache-size (int-from-env :datahike-store-cache-size *default-store-cache-size*)
                  :index-config (if-let [index-config (map-from-env :datahike-index-config nil)]
                                  index-config
-                                 (di/default-index-config index))}
+                                 (default-index-config-for-backend index (:backend store-config)))}
          merged-config ((comp remove-nils dt/deep-merge) config config-as-arg)
          {:keys [schema-flexibility initial-tx store attribute-refs?]} merged-config]
      ;; konserve now handles store config validation at runtime

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -26,12 +26,13 @@
 ;; When true, each index's root node is inlined into the db-record instead of
 ;; stored as a separate konserve object — one fewer PUT and one fewer cold GET
 ;; per index per commit. Experimental; see doc/index-root-fusion.md.
-;; Index-root fusion (one fewer PUT + cold GET per index per commit). Kept OFF by default:
-;; turning it on globally breaks the merkle-audit walk (and GC), which read index roots as
-;; separate konserve objects — fusion inlines them into the db-record. Until audit/GC are
-;; made fusion-aware, fusion is opt-in (e.g. the SaaS template sets it true per store);
-;; connect adopts the stored value (datahike.connector/adopt-stored-fixed) so fused and
-;; non-fused stores both reconnect cleanly.
+;; Index-root fusion (one fewer PUT + cold GET per index per commit). Now SAFE to enable —
+;; the merkle-audit walk and online GC are fusion-aware (verify/seed the inlined root from
+;; the db-record instead of fetching it as a separate object). Kept OFF as the global
+;; default for now only because flipping it churns count-based tests across the suite;
+;; opt in per store (the SaaS template does) — connect adopts the stored value
+;; (datahike.connector/adopt-stored-fixed) so fused and non-fused stores both reconnect.
+;; TODO: flip to true once the suite's object-count assertions are updated for fusion.
 (def ^:dynamic *default-fuse-index-roots?* false)
 (def ^:dynamic *default-store* :memory)                           ;; store-less = in-memory?
 (def ^:dynamic *default-db-name* nil)                         ;; when nil creates random name

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -23,6 +23,10 @@
 (def ^:dynamic *default-search-cache-size* 10000)
 (def ^:dynamic *default-store-cache-size* 1000)
 (def ^:dynamic *default-crypto-hash?* false)
+;; When true, each index's root node is inlined into the db-record instead of
+;; stored as a separate konserve object — one fewer PUT and one fewer cold GET
+;; per index per commit. Experimental; see doc/index-root-fusion.md.
+(def ^:dynamic *default-fuse-index-roots?* false)
 (def ^:dynamic *default-store* :memory)                           ;; store-less = in-memory?
 (def ^:dynamic *default-db-name* nil)                         ;; when nil creates random name
 (def ^:dynamic *default-db-branch* :db)                         ;; when nil creates random name
@@ -34,6 +38,7 @@
 (s/def ::search-cache-size nat-int?)
 (s/def ::store-cache-size pos-int?)
 (s/def ::crypto-hash? boolean?)
+(s/def ::fuse-index-roots? boolean?)
 (s/def ::writer map?)
 (s/def ::branch keyword?)
 (s/def ::entity (s/or :map associative? :vec vector?))
@@ -54,6 +59,7 @@
                                          ::search-cache-size
                                          ::store-cache-size
                                          ::crypto-hash?
+                                         ::fuse-index-roots?
                                          ::initial-tx
                                          ::name
                                          ::branch
@@ -211,6 +217,7 @@
                  :index index
                  :branch *default-db-branch*
                  :crypto-hash? *default-crypto-hash?*
+                 :fuse-index-roots? *default-fuse-index-roots?*
                  :writer self-writer
                  :search-cache-size (int-from-env :datahike-search-cache-size *default-search-cache-size*)
                  :store-cache-size (int-from-env :datahike-store-cache-size *default-store-cache-size*)

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -26,6 +26,12 @@
 ;; When true, each index's root node is inlined into the db-record instead of
 ;; stored as a separate konserve object — one fewer PUT and one fewer cold GET
 ;; per index per commit. Experimental; see doc/index-root-fusion.md.
+;; Index-root fusion (one fewer PUT + cold GET per index per commit). Kept OFF by default:
+;; turning it on globally breaks the merkle-audit walk (and GC), which read index roots as
+;; separate konserve objects — fusion inlines them into the db-record. Until audit/GC are
+;; made fusion-aware, fusion is opt-in (e.g. the SaaS template sets it true per store);
+;; connect adopts the stored value (datahike.connector/adopt-stored-fixed) so fused and
+;; non-fused stores both reconnect cleanly.
 (def ^:dynamic *default-fuse-index-roots?* false)
 (def ^:dynamic *default-store* :memory)                           ;; store-less = in-memory?
 (def ^:dynamic *default-db-name* nil)                         ;; when nil creates random name

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -167,11 +167,11 @@
 ;; Listed explicitly so any future addition is a deliberate decision.
 (def create-time-fixed-keys
   #{:keep-history? :attribute-refs? :schema-flexibility :index :crypto-hash? :fuse-index-roots?
-    ;; :index-config sub-keys (PSS): :branching-factor :op-buf-size
+    ;; :index-config sub-keys (PSS): :branching-factor :diff-buf-size
     :index-config})
 
 ;; Of the fixed keys, the ones whose datahike default has changed (:fuse-index-roots?) or
-;; that were newly added (:index-config {:branching-factor :op-buf-size}) are sourced from
+;; that were newly added (:index-config {:branching-factor :diff-buf-size}) are sourced from
 ;; the STORED config on connect — adopt the stored value, or drop the key when the store
 ;; predates it. This lets existing stores connect unchanged and new stores reconnect
 ;; without re-specifying, while the strict consistency check still guards every other key.
@@ -182,7 +182,7 @@
         adopt-ic (fn [ic k] (if (contains? s-ic k) (assoc ic k (get s-ic k)) (dissoc ic k)))
         config  (adopt config :fuse-index-roots?)
         config  (update config :index-config
-                        (fn [ic] (reduce adopt-ic (or ic {}) [:branching-factor :op-buf-size])))]
+                        (fn [ic] (reduce adopt-ic (or ic {}) [:branching-factor :diff-buf-size])))]
     (if (empty? (:index-config config)) (dissoc config :index-config) config)))
 
 (defn- normalize-config [cfg]
@@ -232,7 +232,7 @@
                                  [config store stored-db]))
                              [config store stored-db]))
                          _ (version-check stored-db)
-                         ;; Source create-time-fixed settings (fuse / bf / op-buf-size) from the
+                         ;; Source create-time-fixed settings (fuse / bf / diff-buf-size) from the
                          ;; store so existing stores connect unchanged and new ones reconnect
                          ;; without re-specifying; flows into both the check and the running db.
                          config (adopt-stored-fixed config (:config stored-db))

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -162,6 +162,29 @@
                   :stored-config stored-config
                   :diff          (diff config stored-config)}))))
 
+;; Settings fixed at database creation — they describe the on-disk format/semantics and
+;; cannot be changed by reconnecting (changing them would be meaningless or corrupting).
+;; Listed explicitly so any future addition is a deliberate decision.
+(def create-time-fixed-keys
+  #{:keep-history? :attribute-refs? :schema-flexibility :index :crypto-hash? :fuse-index-roots?
+    ;; :index-config sub-keys (PSS): :branching-factor :op-buf-size
+    :index-config})
+
+;; Of the fixed keys, the ones whose datahike default has changed (:fuse-index-roots?) or
+;; that were newly added (:index-config {:branching-factor :op-buf-size}) are sourced from
+;; the STORED config on connect — adopt the stored value, or drop the key when the store
+;; predates it. This lets existing stores connect unchanged and new stores reconnect
+;; without re-specifying, while the strict consistency check still guards every other key.
+;; (:index is already reconciled with a warning in -connect-impl*.)
+(defn adopt-stored-fixed [config stored-config]
+  (let [adopt   (fn [c k] (if (contains? stored-config k) (assoc c k (get stored-config k)) (dissoc c k)))
+        s-ic    (or (:index-config stored-config) {})
+        adopt-ic (fn [ic k] (if (contains? s-ic k) (assoc ic k (get s-ic k)) (dissoc ic k)))
+        config  (adopt config :fuse-index-roots?)
+        config  (update config :index-config
+                        (fn [ic] (reduce adopt-ic (or ic {}) [:branching-factor :op-buf-size])))]
+    (if (empty? (:index-config config)) (dissoc config :index-config) config)))
+
 (defn- normalize-config [cfg]
   (-> cfg
       (dissoc :writer :store :store-cache-size :search-cache-size)))
@@ -209,6 +232,10 @@
                                  [config store stored-db]))
                              [config store stored-db]))
                          _ (version-check stored-db)
+                         ;; Source create-time-fixed settings (fuse / bf / op-buf-size) from the
+                         ;; store so existing stores connect unchanged and new ones reconnect
+                         ;; without re-specifying; flows into both the check and the running db.
+                         config (adopt-stored-fixed config (:config stored-db))
                          _ (when-not (:allow-unsafe-config config)
                              (ensure-stored-config-consistency config (:config stored-db)))
                          conn      (conn-from-db (dsi/stored->db (assoc stored-db :config config) store))]

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -1,6 +1,6 @@
 (ns datahike.gc
   (:require [clojure.set :as set]
-            [datahike.index.interface :refer [-mark]]
+            [datahike.index.interface :refer [-mark -seed-root!]]
             [datahike.index.secondary :as sec]
             [konserve.core :as k]
             [konserve.gc :refer [sweep!]]
@@ -25,11 +25,23 @@
                   (recur r visited reachable)
                   (let [{:keys                         [eavt-key avet-key aevt-key
                                                         temporal-eavt-key temporal-avet-key temporal-aevt-key
+                                                        eavt-root aevt-root avet-root
+                                                        temporal-eavt-root temporal-aevt-root temporal-avet-root
                                                         schema-meta-key secondary-index-keys]
                          {:keys [datahike/parents
                                  datahike/created-at
                                  datahike/updated-at]} :meta}
                         (<? S (k/get store to-check))
+                        ;; Root fusion: inlined roots aren't separate konserve objects, so
+                        ;; -mark on the lazy index would try to restore the root by address
+                        ;; and fail. Seed each inlined root into its index (mirrors stored->db)
+                        ;; so walk-addresses uses it and only its children are fetched.
+                        _ (do (when eavt-root (-seed-root! eavt-key eavt-root))
+                              (when aevt-root (-seed-root! aevt-key aevt-root))
+                              (when avet-root (-seed-root! avet-key avet-root))
+                              (when temporal-eavt-root (-seed-root! temporal-eavt-key temporal-eavt-root))
+                              (when temporal-aevt-root (-seed-root! temporal-aevt-key temporal-aevt-root))
+                              (when temporal-avet-root (-seed-root! temporal-avet-key temporal-avet-root)))
                         in-range? (> (get-time (or updated-at created-at))
                                      (get-time after-date))]
                     (let [sec-reachable (when (seq secondary-index-keys)

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -18,6 +18,8 @@
 (def -transient di/-transient)
 (def -persistent! di/-persistent!)
 (def -mark di/-mark)
+(def -root-node di/-root-node)
+(def -seed-root! di/-seed-root!)
 
 ;; Aliases for multimethods
 

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -18,7 +18,9 @@
   (-flush [index backend] "Saves the changes to the index to the given konserve backend")
   (-transient [index] "Returns a transient version of the index")
   (-persistent! [index] "Returns a persistent version of the index")
-  (-mark [index] "Return konserve addresses that should be whitelisted for mark and sweep gc."))
+  (-mark [index] "Return konserve addresses that should be whitelisted for mark and sweep gc.")
+  (-root-node [index] "Returns the in-memory root node of a flushed index, for root fusion (inlining the root into the db-record).")
+  (-seed-root! [index root-node] "Seeds the in-memory root node after restoring a db-record that inlined it (root fusion). Returns the index."))
 
 (defmulti empty-index
   "Creates an empty index"

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -240,13 +240,13 @@
 ;; makes the hash independent of the Datom type's identity), maps/seqs recursed. Used so a
 ;; slot's diff hashes the same whether it's a live PersistentTreeMap (store) or a plain
 ;; deserialized map (restore) — hasch already canonicalizes map key order.
-#?(:clj
-   (defn- canon [x]
-     (cond
-       (instance? Datom x)   (vec (seq x))
-       (map? x)              (persistent! (reduce-kv (fn [m k v] (assoc! m (canon k) (canon v))) (transient {}) x))
-       (sequential? x)       (mapv canon x)
-       :else                 x)))
+(defn- canon [x]
+  (cond
+    (instance? #?(:clj Datom :cljs dd/Datom) x)
+    (vec (seq x))
+    (map? x)        (persistent! (reduce-kv (fn [m k v] (assoc! m (canon k) (canon v))) (transient {}) x))
+    (sequential? x) (mapv canon x)
+    :else           x))
 
 ;; OP_BUF_V5 crypto address of a Branch. Baseline (no slots) hashes the child addresses —
 ;; UNCHANGED, so existing crypto stores keep their hashes. With op-buf the buffered diff
@@ -254,22 +254,26 @@
 ;; the address then reflects the durable representation (anchors + diff) and the audit
 ;; recomputes the same from the stored node. (Within-store integrity; consistent with the
 ;; baseline merkle already being shape/representation-dependent.)
-#?(:clj
-   (defn- branch-crypto-uuid [^Branch node]
-     (let [slots (.slotsForStorage node)]
-       (if slots
-         (uuid (canon [(vec (.addresses node)) slots]))
-         (uuid (vec (.addresses node)))))))
+(defn- branch-crypto-uuid [node]
+  (let [slots     #?(:clj (.slotsForStorage ^Branch node) :cljs (branch/slots-for-storage node))
+        addresses (vec #?(:clj (.addresses ^Branch node) :cljs (.-addresses node)))]
+    (if slots
+      (uuid (canon [addresses slots]))
+      (uuid addresses))))
 
-(defn- gen-address [^ANode node crypto-hash?]
+(defn- gen-address [node crypto-hash?]
   (if crypto-hash?
     (if (instance? Branch node)
-      #?(:clj (branch-crypto-uuid ^Branch node) :cljs (uuid (vec (.addresses ^Branch node))))
-      (uuid (mapv (comp vec seq) (.keys node))))
+      (branch-crypto-uuid node)   ;; folds op-buf slots on BOTH hosts (cross-host hash parity)
+      (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))
     (squuid)))  ;; Sequential UUID for better index locality
 
-#?(:clj
-   (defn- walk-pss-address!
+(declare walk-pss-address!)
+
+(defn- node-class-name [node]
+  #?(:clj (some-> node class .getName) :cljs (some-> node type pr-str)))
+
+(defn- walk-pss-address!
      "Read the node at `address` directly from konserve, recompute its
       content-addressed UUID, and confirm it matches `address`. Recurses
       into Branch children, accumulating any anomalies into the
@@ -299,92 +303,92 @@
            :else
            (let [recomputed (cond
                               (instance? Branch node)
-                              (branch-crypto-uuid ^Branch node)
+                              (branch-crypto-uuid node)
                               (instance? Leaf node)
-                              (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
+                              (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
              (cond
                (nil? recomputed)
                (swap! errors conj {:type :audit/unknown-node-class
                                    :address address
-                                   :node-class (some-> node class .getName)})
+                                   :node-class (node-class-name node)})
 
                (not= address recomputed)
                (swap! errors conj {:type :audit/merkle-mismatch
                                    :address address
                                    :expected address
                                    :recomputed recomputed
-                                   :node-class (some-> node class .getName)})
+                                   :node-class (node-class-name node)})
 
                :else
                (do
                  (when (instance? Branch node)
-                   (doseq [child-addr (.addresses ^Branch node)]
+                   (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
                      (walk-pss-address! store child-addr verified errors)))
-                 (swap! verified conj address)))))))))
+                 (swap! verified conj address))))))))
 
-#?(:clj
-   (defn- walk-pss-node!
+(defn- walk-pss-node!
      "Like walk-pss-address! but for a node already in hand — used for a FUSED root, which
       is inlined in the db-record and therefore not a separate konserve object. Recomputes
       the node's content UUID, confirms it equals `address`, and recurses into its children
       (which ARE separate objects) via walk-pss-address!."
-     [store ^ANode node address verified errors]
+     [store node address verified errors]
      (when-not (contains? @verified address)
        (let [recomputed (cond
-                          (instance? Branch node) (branch-crypto-uuid ^Branch node)
-                          (instance? Leaf node)   (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
+                          (instance? Branch node) (branch-crypto-uuid node)
+                          (instance? Leaf node)   (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
          (cond
            (nil? recomputed)
            (swap! errors conj {:type :audit/unknown-node-class :address address
-                               :node-class (some-> node class .getName)})
+                               :node-class (node-class-name node)})
            (not= address recomputed)
            (swap! errors conj {:type :audit/merkle-mismatch :address address :expected address
-                               :recomputed recomputed :node-class (some-> node class .getName)})
+                               :recomputed recomputed :node-class (node-class-name node)})
            :else
            (do (when (instance? Branch node)
-                 (doseq [child-addr (.addresses ^Branch node)]
+                 (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
                    (walk-pss-address! store child-addr verified errors)))
-               (swap! verified conj address)))))))
+               (swap! verified conj address))))))
 
 (extend-type #?(:clj PersistentSortedSet :cljs BTSet)
   IAuditable
-  (-merkle-root [^PersistentSortedSet pset]
+  (-merkle-root [pset]
     ;; gen-address (below) makes every node UUID a recursive content
-    ;; hash of its datoms under :crypto-hash?, so the root _address
+    ;; hash of its datoms under :crypto-hash?, so the root address
     ;; captures the whole tree. Set by psset/store during -flush.
     ;; Returns nil when unflushed; never throws.
-    (.-_address pset))
-  (-recompute-merkle-root [^PersistentSortedSet pset]
+    #?(:clj (.-_address ^PersistentSortedSet pset) :cljs (.-address ^BTSet pset)))
+  (-recompute-merkle-root [pset]
     ;; Walk the tree from konserve, deserialize each node, and confirm
     ;; its bytes hash back to its address. Konserve does NOT verify
     ;; content on read, so without this walk a tampered .ksv file would
-    ;; round-trip undetected — only the in-memory `_address` would still
+    ;; round-trip undetected — only the in-memory address would still
     ;; look correct. Returns a result map; never throws on mismatch.
-    #?(:clj
-       (let [address (.-_address pset)
-             storage (.-_storage pset)
-             store   (some-> storage :store)]
-         (cond
-           (nil? address)
-           {:status :unsupported :reason :unflushed}
-           (nil? store)
-           {:status :unsupported :reason :no-store}
-           :else
-           (let [verified  (atom #{})
-                 errors    (atom [])
-                 ;; Fused root: inlined in the db-record, not a separate object. Detect by a
-                 ;; direct store read; when absent, verify the seeded in-memory root instead
-                 ;; (recomputing its content hash still detects db-record tampering of the
-                 ;; root), then recurse children (separate objects) as usual.
-                 root-node (k/get store address nil {:sync? true})]
-             (if (nil? root-node)
-               (walk-pss-node! store (.root ^PersistentSortedSet pset) address verified errors)
-               (walk-pss-node! store root-node address verified errors))
-             (if (seq @errors)
-               {:status :mismatch :root nil :errors @errors}
-               {:status :ok :root address}))))
-       :cljs
-       {:status :unsupported :reason :cljs-not-implemented})))
+    ;; Cross-platform: clj reads PersistentSortedSet._address/_storage/.root,
+    ;; cljs reads the BTSet's address/storage/root fields; the walk/recompute
+    ;; (branch-crypto-uuid + canon + uuid) is shared so hashes match cross-host.
+    (let [address #?(:clj (.-_address ^PersistentSortedSet pset) :cljs (.-address ^BTSet pset))
+          storage #?(:clj (.-_storage ^PersistentSortedSet pset) :cljs (.-storage ^BTSet pset))
+          store   (some-> storage :store)
+          root    #?(:clj (.root ^PersistentSortedSet pset)      :cljs (.-root ^BTSet pset))]
+      (cond
+        (nil? address)
+        {:status :unsupported :reason :unflushed}
+        (nil? store)
+        {:status :unsupported :reason :no-store}
+        :else
+        (let [verified  (atom #{})
+              errors    (atom [])
+              ;; Fused root: inlined in the db-record, not a separate object. Detect by a
+              ;; direct store read; when absent, verify the seeded in-memory root instead
+              ;; (recomputing its content hash still detects db-record tampering of the
+              ;; root), then recurse children (separate objects) as usual.
+              root-node (k/get store address nil {:sync? true})]
+          (if (nil? root-node)
+            (walk-pss-node! store root address verified errors)
+            (walk-pss-node! store root-node address verified errors))
+          (if (seq @errors)
+            {:status :mismatch :root nil :errors @errors}
+            {:status :ok :root address}))))))
 
 (defn- freelist-pop!
   "Atomically pop an address from the freelist. Returns nil if empty."

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -28,14 +28,14 @@
 
 ;; OP_BUF_V5 write-optimization knob (JVM only). A non-zero op-buf-size makes a commit
 ;; buffer content-only child diffs into the rewritten ancestor instead of rewriting the
-;; whole spine — ~1 PUT/commit for small commits. Single source of truth is the JVM
-;; system property `pss.opBufSize` (matches PSS Settings.defaultOpBufSize), so it can be
-;; varied per benchmark run without touching datahike's config specs. 0 ⇒ baseline.
-;; TODO(debt): promote to a first-class store/index config key once validated.
+;; whole spine — ~1 PUT/commit for small commits. Primary source is the persisted index
+;; config key `:op-buf-size` (so it round-trips with the store and the consistency check
+;; guards it); the `pss.opBufSize` JVM sysprop is a fallback for ad-hoc experiments only.
+;; 0 ⇒ baseline (off) — the default, protecting existing persistent-sorted-set stores.
 #?(:clj
-   (defn op-buf-size ^long []
-     (try (Long/parseLong (System/getProperty "pss.opBufSize" "0"))
-          (catch Exception _ 0))))
+   (defn op-buf-size ^long [index-config]
+     (long (or (:op-buf-size index-config)
+               (try (Long/parseLong (System/getProperty "pss.opBufSize" "0")) (catch Exception _ 0))))))
 
 (def index-type->kwseq
   {:eavt [:e :a :v :tx :added]
@@ -417,17 +417,25 @@
 
 (def ^:const DEFAULT_BRANCHING_FACTOR 512)
 
-(defmethod di/empty-index :datahike.index/persistent-set [_index-name store index-type _]
+;; Branching factor is create-time-fixed: a tree built at one bf must never be mutated
+;; at another (mixed node sizes break the min/max invariants). Sourced from the persisted
+;; index-config (default 512 ⇒ existing stores, built at 512, are unaffected). Must reach
+;; BOTH fresh-set creation AND the deserialization Settings, else a non-512 store would be
+;; mutated at 512 on restore. The consistency check guards against accidental change.
+(defn- branching-factor ^long [index-config]
+  (long (or (:branching-factor index-config) DEFAULT_BRANCHING_FACTOR)))
+
+(defmethod di/empty-index :datahike.index/persistent-set [_index-name store index-type index-config]
   (let [cmp (index-type->cmp-quick index-type false)
         ^PersistentSortedSet pset (psset/sorted-set* {:comparator cmp
                                                       :storage #?(:clj (with-comparator (:storage store) cmp)
                                                                   :cljs (:storage store))
-                                                      :branching-factor DEFAULT_BRANCHING_FACTOR
-                                                      :op-buf-size #?(:clj (op-buf-size) :cljs 0)})]
+                                                      :branching-factor (branching-factor index-config)
+                                                      :op-buf-size #?(:clj (op-buf-size index-config) :cljs 0)})]
     (with-meta pset
       {:index-type index-type})))
 
-(defmethod di/init-index :datahike.index/persistent-set [_index-name store datoms index-type _ {:keys [indexed]}]
+(defmethod di/init-index :datahike.index/persistent-set [_index-name store datoms index-type _ {:keys [indexed] :as index-config}]
   (let [arr (if (= index-type :avet)
               (->> datoms
                    (filter #(contains? indexed (.-a ^Datom %)))
@@ -440,8 +448,8 @@
         ^PersistentSortedSet pset (psset/from-sorted-array cmp
                                                            arr
                                                            (arrays/alength arr)
-                                                           {:branching-factor DEFAULT_BRANCHING_FACTOR
-                                                            :op-buf-size #?(:clj (op-buf-size) :cljs 0)})]
+                                                           {:branching-factor (branching-factor index-config)
+                                                            :op-buf-size #?(:clj (op-buf-size index-config) :cljs 0)})]
     (set! (.-_storage pset) #?(:clj (with-comparator (:storage store) cmp)
                                :cljs (:storage store)))
     (with-meta pset
@@ -450,10 +458,12 @@
 ;; temporary import from psset until public
 (defn- map->settings ^Settings [m]
   #?(:cljs m
+     ;; 5-arg normalizing ctor (bf, refType, measure, leaf-processor, opBufSize): defaults
+     ;; refType to SOFT when nil. OP_BUF_V5: deserialized nodes need opBufSize>0 to project.
      :clj (Settings.
            (int (or (:branching-factor m) 0))
-           nil                                             ;; weak ref default
-           )))
+           nil nil nil
+           (int (or (:op-buf-size m) 0)))))
 
 (defmethod di/add-konserve-handlers :datahike.index/persistent-set [config store]
   ;; Check if store has pre-configured handlers (e.g., LMDB with buffer encoder).
@@ -467,7 +477,8 @@
 
     ;; Standard fressian store - set up serializers
     ;; deal with circular reference between storage and store
-    (let [settings (map->settings {:branching-factor DEFAULT_BRANCHING_FACTOR})
+    (let [settings (map->settings {:branching-factor (branching-factor (:index-config config))
+                                   :op-buf-size (op-buf-size (:index-config config))})
           storage (atom nil)
           store
           (k/assoc-serializers

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -274,7 +274,7 @@
   #?(:clj (some-> node class .getName) :cljs (some-> node type pr-str)))
 
 (defn- walk-pss-address!
-     "Read the node at `address` directly from konserve, recompute its
+  "Read the node at `address` directly from konserve, recompute its
       content-addressed UUID, and confirm it matches `address`. Recurses
       into Branch children, accumulating any anomalies into the
       `errors` atom (instead of throwing).
@@ -293,61 +293,61 @@
       Reads go through `k/get store` directly, bypassing the live
       `CachedStorage` LRU; otherwise a hot in-memory copy could mask a
       tampered on-disk blob."
-     [store address verified errors]
-     (when-not (contains? @verified address)
-       (let [node (k/get store address nil {:sync? true})]
-         (cond
-           (nil? node)
-           (swap! errors conj {:type :audit/node-missing :address address})
+  [store address verified errors]
+  (when-not (contains? @verified address)
+    (let [node (k/get store address nil {:sync? true})]
+      (cond
+        (nil? node)
+        (swap! errors conj {:type :audit/node-missing :address address})
 
-           :else
-           (let [recomputed (cond
-                              (instance? Branch node)
-                              (branch-crypto-uuid node)
-                              (instance? Leaf node)
-                              (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
-             (cond
-               (nil? recomputed)
-               (swap! errors conj {:type :audit/unknown-node-class
-                                   :address address
-                                   :node-class (node-class-name node)})
+        :else
+        (let [recomputed (cond
+                           (instance? Branch node)
+                           (branch-crypto-uuid node)
+                           (instance? Leaf node)
+                           (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
+          (cond
+            (nil? recomputed)
+            (swap! errors conj {:type :audit/unknown-node-class
+                                :address address
+                                :node-class (node-class-name node)})
 
-               (not= address recomputed)
-               (swap! errors conj {:type :audit/merkle-mismatch
-                                   :address address
-                                   :expected address
-                                   :recomputed recomputed
-                                   :node-class (node-class-name node)})
+            (not= address recomputed)
+            (swap! errors conj {:type :audit/merkle-mismatch
+                                :address address
+                                :expected address
+                                :recomputed recomputed
+                                :node-class (node-class-name node)})
 
-               :else
-               (do
-                 (when (instance? Branch node)
-                   (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
-                     (walk-pss-address! store child-addr verified errors)))
-                 (swap! verified conj address))))))))
+            :else
+            (do
+              (when (instance? Branch node)
+                (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
+                  (walk-pss-address! store child-addr verified errors)))
+              (swap! verified conj address))))))))
 
 (defn- walk-pss-node!
-     "Like walk-pss-address! but for a node already in hand — used for a FUSED root, which
+  "Like walk-pss-address! but for a node already in hand — used for a FUSED root, which
       is inlined in the db-record and therefore not a separate konserve object. Recomputes
       the node's content UUID, confirms it equals `address`, and recurses into its children
       (which ARE separate objects) via walk-pss-address!."
-     [store node address verified errors]
-     (when-not (contains? @verified address)
-       (let [recomputed (cond
-                          (instance? Branch node) (branch-crypto-uuid node)
-                          (instance? Leaf node)   (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
-         (cond
-           (nil? recomputed)
-           (swap! errors conj {:type :audit/unknown-node-class :address address
-                               :node-class (node-class-name node)})
-           (not= address recomputed)
-           (swap! errors conj {:type :audit/merkle-mismatch :address address :expected address
-                               :recomputed recomputed :node-class (node-class-name node)})
-           :else
-           (do (when (instance? Branch node)
-                 (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
-                   (walk-pss-address! store child-addr verified errors)))
-               (swap! verified conj address))))))
+  [store node address verified errors]
+  (when-not (contains? @verified address)
+    (let [recomputed (cond
+                       (instance? Branch node) (branch-crypto-uuid node)
+                       (instance? Leaf node)   (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))]
+      (cond
+        (nil? recomputed)
+        (swap! errors conj {:type :audit/unknown-node-class :address address
+                            :node-class (node-class-name node)})
+        (not= address recomputed)
+        (swap! errors conj {:type :audit/merkle-mismatch :address address :expected address
+                            :recomputed recomputed :node-class (node-class-name node)})
+        :else
+        (do (when (instance? Branch node)
+              (doseq [child-addr #?(:clj (.addresses ^Branch node) :cljs (.-addresses node))]
+                (walk-pss-address! store child-addr verified errors)))
+            (swap! verified conj address))))))
 
 (extend-type #?(:clj PersistentSortedSet :cljs BTSet)
   IAuditable
@@ -403,9 +403,8 @@
             addr
             (recur)))))))
 
-(defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn cmp]
+(defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn]
   IStorage
-  (comparator [_] cmp)   ;; diff-buf: per-index comparator for buffered-leaf projection
   (store [_ node #?(:cljs opts)]
     (@cost-center-fn :store)
     (swap! stats update :writes inc)
@@ -464,17 +463,7 @@
                   (atom [])  ;; freed-addresses: vector of [address timestamp] pairs
                   (atom #{}) ;; freed-set: HashSet for O(1) isFreed lookups
                   (atom [])  ;; freelist: vector of reusable addresses (used as stack via peek/pop)
-                  (atom (fn [_] nil))
-                  nil))      ;; cmp: per-index comparator, set via (with-comparator storage cmp)
-
-;; Per-index view of the (shared) storage carrying the index comparator. Returns a new
-;; CachedStorage sharing all atoms (cache/pending-writes/stats/freed/freelist) — only the
-;; cmp field differs — so diff-buf projection can read storage.comparator() per index
-;; while writes/cache stay unified across indexes.
-(defn with-comparator [storage cmp]
-  (if (instance? CachedStorage storage)   ;; pass through nil / non-CachedStorage (e.g. mem backend) unchanged
-    (assoc storage :cmp cmp)
-    storage))
+                  (atom (fn [_] nil))))
 
 (def ^:const DEFAULT_BRANCHING_FACTOR 512)
 
@@ -489,7 +478,7 @@
 (defmethod di/empty-index :datahike.index/persistent-set [_index-name store index-type index-config]
   (let [cmp (index-type->cmp-quick index-type false)
         ^PersistentSortedSet pset (psset/sorted-set* {:comparator cmp
-                                                      :storage (with-comparator (:storage store) cmp)
+                                                      :storage (:storage store)
                                                       :branching-factor (branching-factor index-config)
                                                       :diff-buf-size (diff-buf-size index-config)})]
     (with-meta pset
@@ -510,7 +499,7 @@
                                                            (arrays/alength arr)
                                                            {:branching-factor (branching-factor index-config)
                                                             :diff-buf-size (diff-buf-size index-config)})]
-    (set! (.-_storage pset) (with-comparator (:storage store) cmp))
+    (set! (.-_storage pset) (:storage store))
     (with-meta pset
       {:index-type index-type})))
 
@@ -554,17 +543,19 @@
                                          ;; The following fields are reset as they cannot be accessed from outside:
                                          ;; - 'edit' is set to false, i.e. the set is assumed to be persistent, not transient
                                          ;; - 'version' is set back to 0
-                                         ;; diff-buf: give the set a storage view carrying its index comparator
-                                         ;; so buffered-leaf projection (Branch.child) can route by value on restore.
-                                           (PersistentSortedSet. meta cmp address (with-comparator @storage cmp) nil count settings 0))))
+                                         ;; diff-buf: the set's per-index comparator (cmp) is propagated to its
+                                         ;; Branch nodes (Branch._projCmp) for buffered-leaf projection; the
+                                         ;; shared storage carries no comparator.
+                                           (PersistentSortedSet. meta cmp address @storage nil count settings 0))))
                                      :cljs
                                      (fn [reader _tag _component-count]
                                        (let [{:keys [meta address count]} (fress/read-object reader)
                                              cmp                          (index-type->cmp-quick (:index-type meta) false)]
                                        ;; CLJS BTSet deftype: [root cnt comparator meta _hash storage address settings]
-                                       ;; diff-buf: give the set a storage view carrying its index comparator so
-                                       ;; buffered-leaf projection (Branch.child) can route by value on restore.
-                                         (BTSet. nil count cmp meta nil (with-comparator @storage cmp) address settings))))
+                                       ;; diff-buf: the set's per-index comparator (cmp) is propagated to its
+                                       ;; Branch nodes (_projCmp) for buffered-leaf projection; shared storage
+                                       ;; carries no comparator.
+                                         (BTSet. nil count cmp meta nil @storage address settings))))
                                   "datahike.index.PersistentSortedSet.Leaf"
                                   #?(:clj
                                      (reify ReadHandler

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -411,7 +411,9 @@
 ;; cmp field differs — so OP_BUF_V5 projection can read storage.comparator() per index
 ;; while writes/cache stay unified across indexes.
 (defn with-comparator [storage cmp]
-  (assoc storage :cmp cmp))
+  (if (instance? CachedStorage storage)   ;; pass through nil / non-CachedStorage (e.g. mem backend) unchanged
+    (assoc storage :cmp cmp)
+    storage))
 
 (def ^:const DEFAULT_BRANCHING_FACTOR 512)
 

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -26,16 +26,16 @@
                    [org.replikativ.persistent_sorted_set PersistentSortedSet IStorage Leaf Branch ANode Settings Slot]
                    [java.util List])))
 
-;; OP_BUF_V5 write-optimization knob (JVM only). A non-zero op-buf-size makes a commit
+;; DIFF_BUF_V5 write-optimization knob (JVM only). A non-zero diff-buf-size makes a commit
 ;; buffer content-only child diffs into the rewritten ancestor instead of rewriting the
 ;; whole spine — ~1 PUT/commit for small commits. Primary source is the persisted index
-;; config key `:op-buf-size` (so it round-trips with the store and the consistency check
-;; guards it); the `pss.opBufSize` JVM sysprop is a fallback for ad-hoc experiments only.
+;; config key `:diff-buf-size` (so it round-trips with the store and the consistency check
+;; guards it); the `pss.diffBufSize` JVM sysprop is a fallback for ad-hoc experiments only.
 ;; 0 ⇒ baseline (off) — the default, protecting existing persistent-sorted-set stores.
-(defn op-buf-size ^long [index-config]
-  (long (or (:op-buf-size index-config)
+(defn diff-buf-size ^long [index-config]
+  (long (or (:diff-buf-size index-config)
             ;; JVM-only sysprop fallback for ad-hoc experiments; cljs has no sysprops.
-            #?(:clj  (try (Long/parseLong (System/getProperty "pss.opBufSize" "0")) (catch Exception _ 0))
+            #?(:clj  (try (Long/parseLong (System/getProperty "pss.diffBufSize" "0")) (catch Exception _ 0))
                :cljs 0))))
 
 (def index-type->kwseq
@@ -248,8 +248,8 @@
     (sequential? x) (mapv canon x)
     :else           x))
 
-;; OP_BUF_V5 crypto address of a Branch. Baseline (no slots) hashes the child addresses —
-;; UNCHANGED, so existing crypto stores keep their hashes. With op-buf the buffered diff
+;; DIFF_BUF_V5 crypto address of a Branch. Baseline (no slots) hashes the child addresses —
+;; UNCHANGED, so existing crypto stores keep their hashes. With diff-buf the buffered diff
 ;; lives in the slots (not reflected in the anchor child-addresses), so fold the slots in:
 ;; the address then reflects the durable representation (anchors + diff) and the audit
 ;; recomputes the same from the stored node. (Within-store integrity; consistent with the
@@ -264,7 +264,7 @@
 (defn- gen-address [node crypto-hash?]
   (if crypto-hash?
     (if (instance? Branch node)
-      (branch-crypto-uuid node)   ;; folds op-buf slots on BOTH hosts (cross-host hash parity)
+      (branch-crypto-uuid node)   ;; folds diff-buf slots on BOTH hosts (cross-host hash parity)
       (uuid (mapv (comp vec seq) #?(:clj (.keys ^Leaf node) :cljs (.-keys node)))))
     (squuid)))  ;; Sequential UUID for better index locality
 
@@ -405,7 +405,7 @@
 
 (defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn cmp]
   IStorage
-  (comparator [_] cmp)   ;; OP_BUF_V5: per-index comparator for buffered-leaf projection
+  (comparator [_] cmp)   ;; DIFF_BUF_V5: per-index comparator for buffered-leaf projection
   (store [_ node #?(:cljs opts)]
     (@cost-center-fn :store)
     (swap! stats update :writes inc)
@@ -469,7 +469,7 @@
 
 ;; Per-index view of the (shared) storage carrying the index comparator. Returns a new
 ;; CachedStorage sharing all atoms (cache/pending-writes/stats/freed/freelist) — only the
-;; cmp field differs — so OP_BUF_V5 projection can read storage.comparator() per index
+;; cmp field differs — so DIFF_BUF_V5 projection can read storage.comparator() per index
 ;; while writes/cache stay unified across indexes.
 (defn with-comparator [storage cmp]
   (if (instance? CachedStorage storage)   ;; pass through nil / non-CachedStorage (e.g. mem backend) unchanged
@@ -491,7 +491,7 @@
         ^PersistentSortedSet pset (psset/sorted-set* {:comparator cmp
                                                       :storage (with-comparator (:storage store) cmp)
                                                       :branching-factor (branching-factor index-config)
-                                                      :op-buf-size (op-buf-size index-config)})]
+                                                      :diff-buf-size (diff-buf-size index-config)})]
     (with-meta pset
       {:index-type index-type})))
 
@@ -509,7 +509,7 @@
                                                            arr
                                                            (arrays/alength arr)
                                                            {:branching-factor (branching-factor index-config)
-                                                            :op-buf-size (op-buf-size index-config)})]
+                                                            :diff-buf-size (diff-buf-size index-config)})]
     (set! (.-_storage pset) (with-comparator (:storage store) cmp))
     (with-meta pset
       {:index-type index-type})))
@@ -517,12 +517,12 @@
 ;; temporary import from psset until public
 (defn- map->settings ^Settings [m]
   #?(:cljs m
-     ;; 5-arg normalizing ctor (bf, refType, measure, leaf-processor, opBufSize): defaults
-     ;; refType to SOFT when nil. OP_BUF_V5: deserialized nodes need opBufSize>0 to project.
+     ;; 5-arg normalizing ctor (bf, refType, measure, leaf-processor, diffBufSize): defaults
+     ;; refType to SOFT when nil. DIFF_BUF_V5: deserialized nodes need diffBufSize>0 to project.
      :clj (Settings.
            (int (or (:branching-factor m) 0))
            nil nil nil
-           (int (or (:op-buf-size m) 0)))))
+           (int (or (:diff-buf-size m) 0)))))
 
 (defmethod di/add-konserve-handlers :datahike.index/persistent-set [config store]
   ;; Check if store has pre-configured handlers (e.g., LMDB with buffer encoder).
@@ -537,7 +537,7 @@
     ;; Standard fressian store - set up serializers
     ;; deal with circular reference between storage and store
     (let [settings (map->settings {:branching-factor (branching-factor (:index-config config))
-                                   :op-buf-size (op-buf-size (:index-config config))})
+                                   :diff-buf-size (diff-buf-size (:index-config config))})
           storage (atom nil)
           store
           (k/assoc-serializers
@@ -554,7 +554,7 @@
                                          ;; The following fields are reset as they cannot be accessed from outside:
                                          ;; - 'edit' is set to false, i.e. the set is assumed to be persistent, not transient
                                          ;; - 'version' is set back to 0
-                                         ;; OP_BUF_V5: give the set a storage view carrying its index comparator
+                                         ;; DIFF_BUF_V5: give the set a storage view carrying its index comparator
                                          ;; so buffered-leaf projection (Branch.child) can route by value on restore.
                                            (PersistentSortedSet. meta cmp address (with-comparator @storage cmp) nil count settings 0))))
                                      :cljs
@@ -562,7 +562,7 @@
                                        (let [{:keys [meta address count]} (fress/read-object reader)
                                              cmp                          (index-type->cmp-quick (:index-type meta) false)]
                                        ;; CLJS BTSet deftype: [root cnt comparator meta _hash storage address settings]
-                                       ;; OP_BUF_V5: give the set a storage view carrying its index comparator so
+                                       ;; DIFF_BUF_V5: give the set a storage view carrying its index comparator so
                                        ;; buffered-leaf projection (Branch.child) can route by value on restore.
                                          (BTSet. nil count cmp meta nil (with-comparator @storage cmp) address settings))))
                                   "datahike.index.PersistentSortedSet.Leaf"
@@ -583,7 +583,7 @@
                                          (let [{:keys [keys level addresses subtree-count slots]} (.readObject reader)
                                                addr-vec (vec addresses)
                                                ^Branch b (Branch. (int level) (count keys) (into-array Object keys) (into-array Object (seq addresses)) nil (long (or subtree-count -1)) settings)]
-                                           ;; OP_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                           ;; DIFF_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
                                            ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
                                            (when slots
                                              (let [arr (object-array (count keys))]
@@ -598,7 +598,7 @@
                                              addr-arr (clj->js addresses)
                                              ;; CLJS Branch deftype: [level keys children addresses subtree-count _measure settings _slots _rebalanced]
                                              b (Branch. (int level) (clj->js keys) nil addr-arr (or subtree-count -1) nil settings nil false)]
-                                         ;; OP_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                         ;; DIFF_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
                                          ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
                                          (when slots
                                            (let [arr (make-array (count keys))]
@@ -648,8 +648,8 @@
                                       (reify WriteHandler
                                         (write [_ writer node]
                                           (.writeTag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                          ;; OP_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
-                                          ;; the pre-op-buf format, so opBufSize=0 / legacy DBs are unaffected).
+                                          ;; DIFF_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                          ;; the pre-diff-buf format, so diffBufSize=0 / legacy DBs are unaffected).
                                           (let [slots (.slotsForStorage ^Branch node)]
                                             (.writeObject writer (cond-> {:level     (.level ^Branch node)
                                                                           :keys      (.keys ^Branch node)
@@ -684,8 +684,8 @@
                                      Branch
                                      (fn [writer node]
                                        (fress/write-tag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                       ;; OP_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
-                                       ;; the pre-op-buf format, so op-buf-size=0 / legacy DBs are unaffected).
+                                       ;; DIFF_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                       ;; the pre-diff-buf format, so diff-buf-size=0 / legacy DBs are unaffected).
                                        (let [slots (branch/slots-for-storage ^Branch node)]
                                          (fress/write-object writer (cond-> {:level     (.-level ^Branch node)
                                                                              :keys      (vec (.-keys ^Branch node))

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -235,10 +235,35 @@
     #?(:clj (set! (.-_root pset) root-node))
     pset))
 
+;; Normalize a value for content hashing: Datoms → vectors (mirrors the leaf hash, and
+;; makes the hash independent of the Datom type's identity), maps/seqs recursed. Used so a
+;; slot's diff hashes the same whether it's a live PersistentTreeMap (store) or a plain
+;; deserialized map (restore) — hasch already canonicalizes map key order.
+#?(:clj
+   (defn- canon [x]
+     (cond
+       (instance? Datom x)   (vec (seq x))
+       (map? x)              (persistent! (reduce-kv (fn [m k v] (assoc! m (canon k) (canon v))) (transient {}) x))
+       (sequential? x)       (mapv canon x)
+       :else                 x)))
+
+;; OP_BUF_V5 crypto address of a Branch. Baseline (no slots) hashes the child addresses —
+;; UNCHANGED, so existing crypto stores keep their hashes. With op-buf the buffered diff
+;; lives in the slots (not reflected in the anchor child-addresses), so fold the slots in:
+;; the address then reflects the durable representation (anchors + diff) and the audit
+;; recomputes the same from the stored node. (Within-store integrity; consistent with the
+;; baseline merkle already being shape/representation-dependent.)
+#?(:clj
+   (defn- branch-crypto-uuid [^Branch node]
+     (let [slots (.slotsForStorage node)]
+       (if slots
+         (uuid (canon [(vec (.addresses node)) slots]))
+         (uuid (vec (.addresses node)))))))
+
 (defn- gen-address [^ANode node crypto-hash?]
   (if crypto-hash?
     (if (instance? Branch node)
-      (uuid (vec (.addresses ^Branch node)))
+      #?(:clj (branch-crypto-uuid ^Branch node) :cljs (uuid (vec (.addresses ^Branch node))))
       (uuid (mapv (comp vec seq) (.keys node))))
     (squuid)))  ;; Sequential UUID for better index locality
 
@@ -273,7 +298,7 @@
            :else
            (let [recomputed (cond
                               (instance? Branch node)
-                              (uuid (vec (.addresses ^Branch node)))
+                              (branch-crypto-uuid ^Branch node)
                               (instance? Leaf node)
                               (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
              (cond
@@ -305,7 +330,7 @@
      [store ^ANode node address verified errors]
      (when-not (contains? @verified address)
        (let [recomputed (cond
-                          (instance? Branch node) (uuid (vec (.addresses ^Branch node)))
+                          (instance? Branch node) (branch-crypto-uuid ^Branch node)
                           (instance? Leaf node)   (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
          (cond
            (nil? recomputed)

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -296,6 +296,30 @@
                      (walk-pss-address! store child-addr verified errors)))
                  (swap! verified conj address)))))))))
 
+#?(:clj
+   (defn- walk-pss-node!
+     "Like walk-pss-address! but for a node already in hand — used for a FUSED root, which
+      is inlined in the db-record and therefore not a separate konserve object. Recomputes
+      the node's content UUID, confirms it equals `address`, and recurses into its children
+      (which ARE separate objects) via walk-pss-address!."
+     [store ^ANode node address verified errors]
+     (when-not (contains? @verified address)
+       (let [recomputed (cond
+                          (instance? Branch node) (uuid (vec (.addresses ^Branch node)))
+                          (instance? Leaf node)   (uuid (mapv (comp vec seq) (.keys ^Leaf node))))]
+         (cond
+           (nil? recomputed)
+           (swap! errors conj {:type :audit/unknown-node-class :address address
+                               :node-class (some-> node class .getName)})
+           (not= address recomputed)
+           (swap! errors conj {:type :audit/merkle-mismatch :address address :expected address
+                               :recomputed recomputed :node-class (some-> node class .getName)})
+           :else
+           (do (when (instance? Branch node)
+                 (doseq [child-addr (.addresses ^Branch node)]
+                   (walk-pss-address! store child-addr verified errors)))
+               (swap! verified conj address)))))))
+
 (extend-type #?(:clj PersistentSortedSet :cljs BTSet)
   IAuditable
   (-merkle-root [^PersistentSortedSet pset]
@@ -320,9 +344,16 @@
            (nil? store)
            {:status :unsupported :reason :no-store}
            :else
-           (let [verified (atom #{})
-                 errors   (atom [])]
-             (walk-pss-address! store address verified errors)
+           (let [verified  (atom #{})
+                 errors    (atom [])
+                 ;; Fused root: inlined in the db-record, not a separate object. Detect by a
+                 ;; direct store read; when absent, verify the seeded in-memory root instead
+                 ;; (recomputing its content hash still detects db-record tampering of the
+                 ;; root), then recurse children (separate objects) as usual.
+                 root-node (k/get store address nil {:sync? true})]
+             (if (nil? root-node)
+               (walk-pss-node! store (.root ^PersistentSortedSet pset) address verified errors)
+               (walk-pss-node! store root-node address verified errors))
              (if (seq @errors)
                {:status :mismatch :root nil :errors @errors}
                {:status :ok :root address}))))

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -26,7 +26,7 @@
                    [org.replikativ.persistent_sorted_set PersistentSortedSet IStorage Leaf Branch ANode Settings Slot]
                    [java.util List])))
 
-;; DIFF_BUF_V5 write-optimization knob (JVM only). A non-zero diff-buf-size makes a commit
+;; diff-buf write-optimization knob (JVM only). A non-zero diff-buf-size makes a commit
 ;; buffer content-only child diffs into the rewritten ancestor instead of rewriting the
 ;; whole spine — ~1 PUT/commit for small commits. Primary source is the persisted index
 ;; config key `:diff-buf-size` (so it round-trips with the store and the consistency check
@@ -248,7 +248,7 @@
     (sequential? x) (mapv canon x)
     :else           x))
 
-;; DIFF_BUF_V5 crypto address of a Branch. Baseline (no slots) hashes the child addresses —
+;; diff-buf crypto address of a Branch. Baseline (no slots) hashes the child addresses —
 ;; UNCHANGED, so existing crypto stores keep their hashes. With diff-buf the buffered diff
 ;; lives in the slots (not reflected in the anchor child-addresses), so fold the slots in:
 ;; the address then reflects the durable representation (anchors + diff) and the audit
@@ -405,7 +405,7 @@
 
 (defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn cmp]
   IStorage
-  (comparator [_] cmp)   ;; DIFF_BUF_V5: per-index comparator for buffered-leaf projection
+  (comparator [_] cmp)   ;; diff-buf: per-index comparator for buffered-leaf projection
   (store [_ node #?(:cljs opts)]
     (@cost-center-fn :store)
     (swap! stats update :writes inc)
@@ -469,7 +469,7 @@
 
 ;; Per-index view of the (shared) storage carrying the index comparator. Returns a new
 ;; CachedStorage sharing all atoms (cache/pending-writes/stats/freed/freelist) — only the
-;; cmp field differs — so DIFF_BUF_V5 projection can read storage.comparator() per index
+;; cmp field differs — so diff-buf projection can read storage.comparator() per index
 ;; while writes/cache stay unified across indexes.
 (defn with-comparator [storage cmp]
   (if (instance? CachedStorage storage)   ;; pass through nil / non-CachedStorage (e.g. mem backend) unchanged
@@ -518,7 +518,7 @@
 (defn- map->settings ^Settings [m]
   #?(:cljs m
      ;; 5-arg normalizing ctor (bf, refType, measure, leaf-processor, diffBufSize): defaults
-     ;; refType to SOFT when nil. DIFF_BUF_V5: deserialized nodes need diffBufSize>0 to project.
+     ;; refType to SOFT when nil. diff-buf: deserialized nodes need diffBufSize>0 to project.
      :clj (Settings.
            (int (or (:branching-factor m) 0))
            nil nil nil
@@ -554,7 +554,7 @@
                                          ;; The following fields are reset as they cannot be accessed from outside:
                                          ;; - 'edit' is set to false, i.e. the set is assumed to be persistent, not transient
                                          ;; - 'version' is set back to 0
-                                         ;; DIFF_BUF_V5: give the set a storage view carrying its index comparator
+                                         ;; diff-buf: give the set a storage view carrying its index comparator
                                          ;; so buffered-leaf projection (Branch.child) can route by value on restore.
                                            (PersistentSortedSet. meta cmp address (with-comparator @storage cmp) nil count settings 0))))
                                      :cljs
@@ -562,7 +562,7 @@
                                        (let [{:keys [meta address count]} (fress/read-object reader)
                                              cmp                          (index-type->cmp-quick (:index-type meta) false)]
                                        ;; CLJS BTSet deftype: [root cnt comparator meta _hash storage address settings]
-                                       ;; DIFF_BUF_V5: give the set a storage view carrying its index comparator so
+                                       ;; diff-buf: give the set a storage view carrying its index comparator so
                                        ;; buffered-leaf projection (Branch.child) can route by value on restore.
                                          (BTSet. nil count cmp meta nil (with-comparator @storage cmp) address settings))))
                                   "datahike.index.PersistentSortedSet.Leaf"
@@ -583,7 +583,7 @@
                                          (let [{:keys [keys level addresses subtree-count slots]} (.readObject reader)
                                                addr-vec (vec addresses)
                                                ^Branch b (Branch. (int level) (count keys) (into-array Object keys) (into-array Object (seq addresses)) nil (long (or subtree-count -1)) settings)]
-                                           ;; DIFF_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                           ;; diff-buf: reconstruct per-child buffered diffs (anchor = the child's
                                            ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
                                            (when slots
                                              (let [arr (object-array (count keys))]
@@ -598,7 +598,7 @@
                                              addr-arr (clj->js addresses)
                                              ;; CLJS Branch deftype: [level keys children addresses subtree-count _measure settings _slots _rebalanced]
                                              b (Branch. (int level) (clj->js keys) nil addr-arr (or subtree-count -1) nil settings nil false)]
-                                         ;; DIFF_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                         ;; diff-buf: reconstruct per-child buffered diffs (anchor = the child's
                                          ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
                                          (when slots
                                            (let [arr (make-array (count keys))]
@@ -648,7 +648,7 @@
                                       (reify WriteHandler
                                         (write [_ writer node]
                                           (.writeTag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                          ;; DIFF_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                          ;; diff-buf: emit :slots only when present (nil ⇒ byte-identical to
                                           ;; the pre-diff-buf format, so diffBufSize=0 / legacy DBs are unaffected).
                                           (let [slots (.slotsForStorage ^Branch node)]
                                             (.writeObject writer (cond-> {:level     (.level ^Branch node)
@@ -684,7 +684,7 @@
                                      Branch
                                      (fn [writer node]
                                        (fress/write-tag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                       ;; DIFF_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                       ;; diff-buf: emit :slots only when present (nil ⇒ byte-identical to
                                        ;; the pre-diff-buf format, so diff-buf-size=0 / legacy DBs are unaffected).
                                        (let [slots (branch/slots-for-storage ^Branch node)]
                                          (fress/write-object writer (cond-> {:level     (.-level ^Branch node)
@@ -705,7 +705,7 @@
   store)
 
 (defmethod di/default-index-config :datahike.index/persistent-set [_index-name]
-  ;; DIFF_BUF_V5: diff-buffering ON by default for NEW stores (budget 256) — ~1 PUT/commit
+  ;; diff-buf: diff-buffering ON by default for NEW stores (budget 256) — ~1 PUT/commit
   ;; for small commits on object stores. Baked into the stored config at create time, so
   ;; existing stores keep their own value (adopt-stored-fixed sources it from the store, and
   ;; `diff-buf-size` defaults to 0 when absent ⇒ pre-diff-buf stores stay baseline). Set

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -23,8 +23,19 @@
   #?(:cljs (:require-macros [datahike.index.persistent-set :refer [generate-slice-comparator-constructor]]))
   #?(:clj (:import [datahike.datom Datom]
                    [org.fressian.handlers WriteHandler ReadHandler]
-                   [org.replikativ.persistent_sorted_set PersistentSortedSet IStorage Leaf Branch ANode Settings]
+                   [org.replikativ.persistent_sorted_set PersistentSortedSet IStorage Leaf Branch ANode Settings Slot]
                    [java.util List])))
+
+;; OP_BUF_V5 write-optimization knob (JVM only). A non-zero op-buf-size makes a commit
+;; buffer content-only child diffs into the rewritten ancestor instead of rewriting the
+;; whole spine — ~1 PUT/commit for small commits. Single source of truth is the JVM
+;; system property `pss.opBufSize` (matches PSS Settings.defaultOpBufSize), so it can be
+;; varied per benchmark run without touching datahike's config specs. 0 ⇒ baseline.
+;; TODO(debt): promote to a first-class store/index config key once validated.
+#?(:clj
+   (defn op-buf-size ^long []
+     (try (Long/parseLong (System/getProperty "pss.opBufSize" "0"))
+          (catch Exception _ 0))))
 
 (def index-type->kwseq
   {:eavt [:e :a :v :tx :added]
@@ -331,8 +342,9 @@
             addr
             (recur)))))))
 
-(defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn]
+(defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn cmp]
   IStorage
+  #?(:clj (comparator [_] cmp))   ;; OP_BUF_V5: per-index comparator for buffered-leaf projection
   (store [_ node #?(:cljs opts)]
     (@cost-center-fn :store)
     (swap! stats update :writes inc)
@@ -391,14 +403,25 @@
                   (atom [])  ;; freed-addresses: vector of [address timestamp] pairs
                   (atom #{}) ;; freed-set: HashSet for O(1) isFreed lookups
                   (atom [])  ;; freelist: vector of reusable addresses (used as stack via peek/pop)
-                  (atom (fn [_] nil))))
+                  (atom (fn [_] nil))
+                  nil))      ;; cmp: per-index comparator, set via (with-comparator storage cmp)
+
+;; Per-index view of the (shared) storage carrying the index comparator. Returns a new
+;; CachedStorage sharing all atoms (cache/pending-writes/stats/freed/freelist) — only the
+;; cmp field differs — so OP_BUF_V5 projection can read storage.comparator() per index
+;; while writes/cache stay unified across indexes.
+(defn with-comparator [storage cmp]
+  (assoc storage :cmp cmp))
 
 (def ^:const DEFAULT_BRANCHING_FACTOR 512)
 
 (defmethod di/empty-index :datahike.index/persistent-set [_index-name store index-type _]
-  (let [^PersistentSortedSet pset (psset/sorted-set* {:comparator (index-type->cmp-quick index-type false)
-                                                      :storage (:storage store)
-                                                      :branching-factor DEFAULT_BRANCHING_FACTOR})]
+  (let [cmp (index-type->cmp-quick index-type false)
+        ^PersistentSortedSet pset (psset/sorted-set* {:comparator cmp
+                                                      :storage #?(:clj (with-comparator (:storage store) cmp)
+                                                                  :cljs (:storage store))
+                                                      :branching-factor DEFAULT_BRANCHING_FACTOR
+                                                      :op-buf-size #?(:clj (op-buf-size) :cljs 0)})]
     (with-meta pset
       {:index-type index-type})))
 
@@ -411,11 +434,14 @@
                 (not (arrays/array? datoms))
                 (arrays/into-array)))
         _ (arrays/asort arr (index-type->cmp-quick index-type false))
-        ^PersistentSortedSet pset (psset/from-sorted-array (index-type->cmp-quick index-type false)
+        cmp (index-type->cmp-quick index-type false)
+        ^PersistentSortedSet pset (psset/from-sorted-array cmp
                                                            arr
                                                            (arrays/alength arr)
-                                                           {:branching-factor DEFAULT_BRANCHING_FACTOR})]
-    (set! (.-_storage pset) (:storage store))
+                                                           {:branching-factor DEFAULT_BRANCHING_FACTOR
+                                                            :op-buf-size #?(:clj (op-buf-size) :cljs 0)})]
+    (set! (.-_storage pset) #?(:clj (with-comparator (:storage store) cmp)
+                               :cljs (:storage store)))
     (with-meta pset
       {:index-type index-type})))
 
@@ -456,7 +482,9 @@
                                          ;; The following fields are reset as they cannot be accessed from outside:
                                          ;; - 'edit' is set to false, i.e. the set is assumed to be persistent, not transient
                                          ;; - 'version' is set back to 0
-                                           (PersistentSortedSet. meta cmp address @storage nil count settings 0))))
+                                         ;; OP_BUF_V5: give the set a storage view carrying its index comparator
+                                         ;; so buffered-leaf projection (Branch.child) can route by value on restore.
+                                           (PersistentSortedSet. meta cmp address (with-comparator @storage cmp) nil count settings 0))))
                                      :cljs
                                      (fn [reader _tag _component-count]
                                        (let [{:keys [meta address count]} (fress/read-object reader)
@@ -478,8 +506,18 @@
                                   #?(:clj
                                      (reify ReadHandler
                                        (read [_ reader _tag _component-count]
-                                         (let [{:keys [keys level addresses subtree-count]} (.readObject reader)]
-                                           (Branch. (int level) (count keys) (into-array Object keys) (into-array Object (seq addresses)) nil (long (or subtree-count -1)) settings))))
+                                         (let [{:keys [keys level addresses subtree-count slots]} (.readObject reader)
+                                               addr-vec (vec addresses)
+                                               ^Branch b (Branch. (int level) (count keys) (into-array Object keys) (into-array Object (seq addresses)) nil (long (or subtree-count -1)) settings)]
+                                           ;; OP_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                           ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
+                                           (when slots
+                                             (let [arr (object-array (count keys))]
+                                               (doseq [[idx entry] slots]
+                                                 (aset arr (int idx)
+                                                       (Slot. (:diff entry) (long (:count entry)) (:measure entry) (nth addr-vec (int idx)))))
+                                               (set! (.-_slots b) arr)))
+                                           b)))
                                      :cljs
                                      (fn [reader _tag _component-count]
                                        (let [{:keys [keys level addresses subtree-count]} (fress/read-object reader)]
@@ -523,10 +561,14 @@
                                       (reify WriteHandler
                                         (write [_ writer node]
                                           (.writeTag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                          (.writeObject writer {:level     (.level ^Branch node)
-                                                                :keys      (.keys ^Branch node)
-                                                                :addresses (.addresses ^Branch node)
-                                                                :subtree-count (.subtreeCount ^Branch node)})))}
+                                          ;; OP_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                          ;; the pre-op-buf format, so opBufSize=0 / legacy DBs are unaffected).
+                                          (let [slots (.slotsForStorage ^Branch node)]
+                                            (.writeObject writer (cond-> {:level     (.level ^Branch node)
+                                                                          :keys      (.keys ^Branch node)
+                                                                          :addresses (.addresses ^Branch node)
+                                                                          :subtree-count (.subtreeCount ^Branch node)}
+                                                                   slots (assoc :slots slots))))))}
 
                                      datahike.datom.Datom
                                      {"datahike.datom.Datom"

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -212,7 +212,17 @@
   (-persistent! [^PersistentSortedSet pset]
     (persistent! pset))
   (-mark [^PersistentSortedSet pset]
-    (mark pset)))
+    (mark pset))
+  (-root-node [^PersistentSortedSet pset]
+    ;; In-memory top node; populated after -flush set _root/_address.
+    #?(:clj  (.root pset)
+       :cljs (.-root pset)))
+  (-seed-root! [^PersistentSortedSet pset root-node]
+    ;; Install an inlined (fused) root so root() returns it without a
+    ;; storage round-trip; deeper children stay lazy via the set's storage.
+    ;; clj only — root fusion is a JVM feature for now.
+    #?(:clj (set! (.-_root pset) root-node))
+    pset))
 
 (defn- gen-address [^ANode node crypto-hash?]
   (if crypto-hash?

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.string]
             [org.replikativ.persistent-sorted-set :as psset]
             #?(:cljs [org.replikativ.persistent-sorted-set.btset :refer [BTSet]])
-            #?(:cljs [org.replikativ.persistent-sorted-set.branch :refer [Branch]])
+            #?(:cljs [org.replikativ.persistent-sorted-set.branch :refer [Branch] :as branch])
             #?(:cljs [org.replikativ.persistent-sorted-set.leaf :refer [Leaf]])
             #?(:cljs [org.replikativ.persistent-sorted-set.impl.storage :refer [IStorage]])
             [org.replikativ.persistent-sorted-set.arrays :as arrays]
@@ -32,10 +32,11 @@
 ;; config key `:op-buf-size` (so it round-trips with the store and the consistency check
 ;; guards it); the `pss.opBufSize` JVM sysprop is a fallback for ad-hoc experiments only.
 ;; 0 ⇒ baseline (off) — the default, protecting existing persistent-sorted-set stores.
-#?(:clj
-   (defn op-buf-size ^long [index-config]
-     (long (or (:op-buf-size index-config)
-               (try (Long/parseLong (System/getProperty "pss.opBufSize" "0")) (catch Exception _ 0))))))
+(defn op-buf-size ^long [index-config]
+  (long (or (:op-buf-size index-config)
+            ;; JVM-only sysprop fallback for ad-hoc experiments; cljs has no sysprops.
+            #?(:clj  (try (Long/parseLong (System/getProperty "pss.opBufSize" "0")) (catch Exception _ 0))
+               :cljs 0))))
 
 (def index-type->kwseq
   {:eavt [:e :a :v :tx :added]
@@ -400,7 +401,7 @@
 
 (defrecord CachedStorage [store config cache stats pending-writes freed-addresses freed-set freelist cost-center-fn cmp]
   IStorage
-  #?(:clj (comparator [_] cmp))   ;; OP_BUF_V5: per-index comparator for buffered-leaf projection
+  (comparator [_] cmp)   ;; OP_BUF_V5: per-index comparator for buffered-leaf projection
   (store [_ node #?(:cljs opts)]
     (@cost-center-fn :store)
     (swap! stats update :writes inc)
@@ -484,10 +485,9 @@
 (defmethod di/empty-index :datahike.index/persistent-set [_index-name store index-type index-config]
   (let [cmp (index-type->cmp-quick index-type false)
         ^PersistentSortedSet pset (psset/sorted-set* {:comparator cmp
-                                                      :storage #?(:clj (with-comparator (:storage store) cmp)
-                                                                  :cljs (:storage store))
+                                                      :storage (with-comparator (:storage store) cmp)
                                                       :branching-factor (branching-factor index-config)
-                                                      :op-buf-size #?(:clj (op-buf-size index-config) :cljs 0)})]
+                                                      :op-buf-size (op-buf-size index-config)})]
     (with-meta pset
       {:index-type index-type})))
 
@@ -505,9 +505,8 @@
                                                            arr
                                                            (arrays/alength arr)
                                                            {:branching-factor (branching-factor index-config)
-                                                            :op-buf-size #?(:clj (op-buf-size index-config) :cljs 0)})]
-    (set! (.-_storage pset) #?(:clj (with-comparator (:storage store) cmp)
-                               :cljs (:storage store)))
+                                                            :op-buf-size (op-buf-size index-config)})]
+    (set! (.-_storage pset) (with-comparator (:storage store) cmp))
     (with-meta pset
       {:index-type index-type})))
 
@@ -559,7 +558,9 @@
                                        (let [{:keys [meta address count]} (fress/read-object reader)
                                              cmp                          (index-type->cmp-quick (:index-type meta) false)]
                                        ;; CLJS BTSet deftype: [root cnt comparator meta _hash storage address settings]
-                                         (BTSet. nil count cmp meta nil @storage address settings))))
+                                       ;; OP_BUF_V5: give the set a storage view carrying its index comparator so
+                                       ;; buffered-leaf projection (Branch.child) can route by value on restore.
+                                         (BTSet. nil count cmp meta nil (with-comparator @storage cmp) address settings))))
                                   "datahike.index.PersistentSortedSet.Leaf"
                                   #?(:clj
                                      (reify ReadHandler
@@ -589,9 +590,22 @@
                                            b)))
                                      :cljs
                                      (fn [reader _tag _component-count]
-                                       (let [{:keys [keys level addresses subtree-count]} (fress/read-object reader)]
-                                       ;; CLJS Branch deftype: [level keys children addresses subtree-count _measure settings]
-                                         (Branch. (int level) (clj->js keys) nil (clj->js addresses) (or subtree-count -1) nil settings))))
+                                       (let [{:keys [keys level addresses subtree-count slots]} (fress/read-object reader)
+                                             addr-arr (clj->js addresses)
+                                             ;; CLJS Branch deftype: [level keys children addresses subtree-count _measure settings _slots _rebalanced]
+                                             b (Branch. (int level) (clj->js keys) nil addr-arr (or subtree-count -1) nil settings nil false)]
+                                         ;; OP_BUF_V5: reconstruct per-child buffered diffs (anchor = the child's
+                                         ;; durable address). Branch.child projects them on descent. Absent ⇒ baseline.
+                                         (when slots
+                                           (let [arr (make-array (count keys))]
+                                             (doseq [[idx entry] slots]
+                                               (aset arr (int idx)
+                                                     {:diff    (:diff entry)
+                                                      :count   (long (:count entry))
+                                                      :measure (:measure entry)
+                                                      :anchor  (aget addr-arr (int idx))}))
+                                             (set! (.-_slots b) arr)))
+                                         b)))
                                   "datahike.datom.Datom"
                                   #?(:clj
                                      (reify ReadHandler
@@ -666,10 +680,14 @@
                                      Branch
                                      (fn [writer node]
                                        (fress/write-tag writer "datahike.index.PersistentSortedSet.Branch" 1)
-                                       (fress/write-object writer {:level     (.-level ^Branch node)
-                                                                   :keys      (vec (.-keys ^Branch node))
-                                                                   :addresses (vec (.-addresses ^Branch node))
-                                                                   :subtree-count (.-subtree-count ^Branch node)}))
+                                       ;; OP_BUF_V5: emit :slots only when present (nil ⇒ byte-identical to
+                                       ;; the pre-op-buf format, so op-buf-size=0 / legacy DBs are unaffected).
+                                       (let [slots (branch/slots-for-storage ^Branch node)]
+                                         (fress/write-object writer (cond-> {:level     (.-level ^Branch node)
+                                                                             :keys      (vec (.-keys ^Branch node))
+                                                                             :addresses (vec (.-addresses ^Branch node))
+                                                                             :subtree-count (.-subtree-count ^Branch node)}
+                                                                      slots (assoc :slots slots)))))
 
                                      datahike.datom.Datom
                                      (fn [writer datom]

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -705,4 +705,9 @@
   store)
 
 (defmethod di/default-index-config :datahike.index/persistent-set [_index-name]
-  {})
+  ;; DIFF_BUF_V5: diff-buffering ON by default for NEW stores (budget 256) — ~1 PUT/commit
+  ;; for small commits on object stores. Baked into the stored config at create time, so
+  ;; existing stores keep their own value (adopt-stored-fixed sources it from the store, and
+  ;; `diff-buf-size` defaults to 0 when absent ⇒ pre-diff-buf stores stay baseline). Set
+  ;; {:diff-buf-size 0} explicitly to disable.
+  {:diff-buf-size 256})

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -133,10 +133,10 @@
             (assoc :secondary sec-roots))
           ;; Root fusion: inline each flushed index's root node into the
           ;; db-record. `commit!` then skips writing those root nodes as
-          ;; separate objects (see fused-root-addresses). Disabled under
-          ;; crypto-hash? for now — the audit walk reads the root from
-          ;; storage at its address (see doc/index-root-fusion.md).
-          fuse? (and flush! (:fuse-index-roots? config) (not (:crypto-hash? config)))
+          ;; separate objects (see fused-root-addresses). Works under crypto-hash?:
+          ;; the root's address is still its content hash, and the audit walk
+          ;; verifies the inlined root (walk-pss-node!) + recurses children.
+          fuse? (and flush! (:fuse-index-roots? config))
           fused-roots (when fuse?
                         (cond-> {:eavt-root (di/-root-node eavt')
                                  :aevt-root (di/-root-node aevt')

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -130,7 +130,21 @@
                    :temporal-aevt-key (safe-root temporal-aevt')
                    :temporal-avet-key (safe-root temporal-avet'))
             sec-roots
-            (assoc :secondary sec-roots))]
+            (assoc :secondary sec-roots))
+          ;; Root fusion: inline each flushed index's root node into the
+          ;; db-record. `commit!` then skips writing those root nodes as
+          ;; separate objects (see fused-root-addresses). Disabled under
+          ;; crypto-hash? for now — the audit walk reads the root from
+          ;; storage at its address (see doc/index-root-fusion.md).
+          fuse? (and flush! (:fuse-index-roots? config) (not (:crypto-hash? config)))
+          fused-roots (when fuse?
+                        (cond-> {:eavt-root (di/-root-node eavt')
+                                 :aevt-root (di/-root-node aevt')
+                                 :avet-root (di/-root-node avet')}
+                          (:keep-history? config)
+                          (assoc :temporal-eavt-root (di/-root-node temporal-eavt')
+                                 :temporal-aevt-root (di/-root-node temporal-aevt')
+                                 :temporal-avet-root (di/-root-node temporal-avet'))))]
       [schema-meta-kv-to-write
        (merge
         {:schema-meta-key  schema-meta-key
@@ -149,7 +163,8 @@
            :temporal-aevt-key temporal-aevt'
            :temporal-avet-key temporal-avet'})
         (when secondary-index-keys
-          {:secondary-index-keys secondary-index-keys}))])))
+          {:secondary-index-keys secondary-index-keys})
+        fused-roots)])))
 
 (defn- restore-secondary-indices
   "Restore secondary index instances from stored key-maps.
@@ -200,10 +215,22 @@
   [stored-db store]
   (let [{:keys [eavt-key aevt-key avet-key
                 temporal-eavt-key temporal-aevt-key temporal-avet-key
+                eavt-root aevt-root avet-root
+                temporal-eavt-root temporal-aevt-root temporal-avet-root
                 secondary-index-keys
                 schema rschema system-entities ref-ident-map ident-ref-map
                 config max-tx max-eid op-count hash meta schema-meta-key]
          :or   {op-count 0}} stored-db
+        ;; Root fusion: if the record inlined index roots, seed them into the
+        ;; restored indexes so root() returns them with no storage round-trip
+        ;; (deeper children stay lazy). Presence-based, so fused and legacy
+        ;; records both restore — no reader config needed.
+        _ (do (when eavt-root (di/-seed-root! eavt-key eavt-root))
+              (when aevt-root (di/-seed-root! aevt-key aevt-root))
+              (when avet-root (di/-seed-root! avet-key avet-root))
+              (when temporal-eavt-root (di/-seed-root! temporal-eavt-key temporal-eavt-root))
+              (when temporal-aevt-root (di/-seed-root! temporal-aevt-key temporal-aevt-root))
+              (when temporal-avet-root (di/-seed-root! temporal-avet-key temporal-avet-root)))
         schema-meta (or (sc/cache-lookup schema-meta-key)
                         ;; not in store in case we load an old db where the schema meta data was inline
                         (when-let [schema-meta (k/get store schema-meta-key nil {:sync? true})]
@@ -287,6 +314,21 @@
        content-uuid
        (squuid content-uuid)))))
 
+(defn- fused-root-addresses
+  "When root fusion is enabled, the addresses of the index root nodes that
+  `db->stored` inlined into the record. These must be excluded from the
+  pending-writes drain so they are not also written as separate objects.
+  Under root fusion (non-crypto-hash) `:merkle-roots` holds each index's
+  root `_address`, which is exactly its pending-writes key."
+  [config db-to-store]
+  (when (:fuse-index-roots? config)
+    (->> (select-keys (:merkle-roots db-to-store)
+                      [:eavt-key :aevt-key :avet-key
+                       :temporal-eavt-key :temporal-aevt-key :temporal-avet-key])
+         vals
+         (remove nil?)
+         set)))
+
 (defn write-pending-kvs!
   "Writes a collection of key-value pairs to the store.
   Handles synchronous and asynchronous writes.
@@ -318,7 +360,12 @@
                       db            (assoc-in db [:meta :datahike/commit-id] cid)
                       db-to-store   (assoc-in db-to-store-pre
                                               [:meta :datahike/commit-id] cid)
-                      pending-kvs   (get-and-clear-pending-kvs! store)]
+                      ;; Root fusion: roots are inlined in db-to-store, so drop
+                      ;; them from the separate-object writes.
+                      fused-addrs   (fused-root-addresses config db-to-store)
+                      pending-kvs   (cond->> (get-and-clear-pending-kvs! store)
+                                      (seq fused-addrs)
+                                      (remove (fn [[k _]] (contains? fused-addrs k))))]
 
                   (if (multi-key-capable? store)
                     (let [[meta-key meta-val] schema-meta-kv-to-write

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -38,7 +38,7 @@
                          :keep-history? true
                          :initial-tx nil
                          :index :datahike.index/persistent-set
-                         :index-config {:diff-buf-size 256}  ;; DIFF_BUF_V5 default-on for new stores
+                         :index-config {:diff-buf-size 256}  ;; diff-buf default-on for new stores
                          :schema-flexibility :write
                          :crypto-hash? false
                          :branch :db

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -38,18 +38,21 @@
                          :keep-history? true
                          :initial-tx nil
                          :index :datahike.index/persistent-set
-                         :index-config {:diff-buf-size 256}  ;; diff-buf default-on for new stores
                          :schema-flexibility :write
                          :crypto-hash? false
                          :branch :db
                          :writer c/self-writer
                          :search-cache-size c/*default-search-cache-size*
                          :store-cache-size c/*default-store-cache-size*}]
+    ;; diff-buf defaults backend-aware: 0 in-memory (no PUTs to fold ⇒ pure overhead),
+    ;; on (256) for durable object stores like :file.
     (is (= (merge default-new-cfg
-                  {:store {:backend :memory :id #uuid "ec3537bd-3f0d-3719-acd5-40751bbb1012"}})
+                  {:index-config {:diff-buf-size 0}
+                   :store {:backend :memory :id #uuid "ec3537bd-3f0d-3719-acd5-40751bbb1012"}})
            (c/from-deprecated mem-cfg)))
     (is (= (merge default-new-cfg
-                  {:store {:backend :file
+                  {:index-config {:diff-buf-size 256}
+                   :store {:backend :file
                            :path "/deprecated/test"
                            :id #uuid "908d33ed-b562-3301-9a9f-94b961e56f05"}})
            (c/from-deprecated file-cfg)))))
@@ -68,8 +71,9 @@
                      :writer c/self-writer
                      :search-cache-size c/*default-search-cache-size*
                      :store-cache-size c/*default-store-cache-size*}
+                    ;; default store is :memory ⇒ diff-buf defaults off (backend-aware)
                     (when (seq (di/default-index-config c/*default-index*))
-                      {:index-config (di/default-index-config c/*default-index*)}))
+                      {:index-config (c/default-index-config-for-backend c/*default-index* :memory)}))
              (update config :store dissoc :id :scope))))))
 
 (deftest core-config-test

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -63,6 +63,7 @@
                      :schema-flexibility c/*default-schema-flexibility*
                      :index c/*default-index*
                      :crypto-hash? c/*default-crypto-hash?*
+                     :fuse-index-roots? c/*default-fuse-index-roots?*
                      :branch c/*default-db-branch*
                      :writer c/self-writer
                      :search-cache-size c/*default-search-cache-size*

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -38,7 +38,7 @@
                          :keep-history? true
                          :initial-tx nil
                          :index :datahike.index/persistent-set
-                         :index-config {}
+                         :index-config {:diff-buf-size 256}  ;; DIFF_BUF_V5 default-on for new stores
                          :schema-flexibility :write
                          :crypto-hash? false
                          :branch :db

--- a/test/datahike/test/diff_buf_generative.clj
+++ b/test/datahike/test/diff_buf_generative.clj
@@ -1,0 +1,77 @@
+(ns datahike.test.diff-buf-generative
+  "Seeded end-to-end generative model test for diff-buf write-buffering. Random
+   transact / value-upsert / retractEntity against a Clojure model, with a release+
+   reconnect each cycle (forces a fressian reload from the store). This exercises the
+   full stack together — PSS diff-buf + the fressian :slots handlers + commit-log + HEAD
+   + crypto-hash — which the PSS-level harness (edn storage) can't reach.
+
+   Deterministic via (java.util.Random seed): a failure reproduces from (seed, params).
+   Swept over {diff-buf 0/256} × {crypto-hash off/on}. The bounded `diff-buf-generative`
+   deftest runs in the suite; `run` drives bigger on-demand sweeps."
+  (:require [datahike.api :as d]
+            [clojure.test :refer [deftest is]])
+  (:import [java.util Random]))
+
+(def schema
+  [{:db/ident :id :db/valueType :db.type/long   :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+   {:db/ident :a  :db/valueType :db.type/long   :db/cardinality :db.cardinality/one}
+   {:db/ident :b  :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+
+(defn run-trial
+  "One deterministic trial. Returns nil on success, or a failure map (never throws on a
+   content mismatch — only real errors propagate)."
+  [seed {:keys [idrange cycles ops crypto? diff-buf]}]
+  (let [rng  (Random. seed)
+        path (str (System/getProperty "java.io.tmpdir") "/dh-diffbuf-gen-" seed "-" diff-buf "-" (if crypto? "c" "p"))
+        cfg  {:store {:backend :file :path path :id (java.util.UUID/randomUUID)}
+              :schema-flexibility :write :keep-history? false
+              :crypto-hash? (boolean crypto?)
+              :index-config {:diff-buf-size diff-buf :branching-factor 16}}
+        model (atom {})]                                  ; id -> {:a long :b string}
+    (d/delete-database cfg)
+    (d/create-database cfg)
+    (let [conn (atom (d/connect cfg)) fail (atom nil)]
+      (try
+        (d/transact @conn schema)
+        (dotimes [c cycles]
+          (when-not @fail
+            (dotimes [_ ops]
+              (let [r (.nextInt rng 3) id (long (.nextInt rng (int idrange)))]
+                (cond
+                  (= r 0) (let [a (long (.nextInt rng 1000)) b (str (.nextInt rng 1000))]
+                            (swap! model assoc id {:a a :b b})
+                            (d/transact @conn [{:id id :a a :b b}]))
+                  (and (= r 1) (contains? @model id))      ; value-upsert (change :a only)
+                  (let [a (long (.nextInt rng 1000))]
+                    (swap! model update id assoc :a a)
+                    (d/transact @conn [{:id id :a a}]))
+                  (and (= r 2) (contains? @model id))      ; retract whole entity
+                  (do (swap! model dissoc id)
+                      (d/transact @conn [[:db/retractEntity [:id id]]])))))
+            ;; reopen — forces a cold fressian reload from the store
+            (d/release @conn)
+            (reset! conn (d/connect cfg))
+            (let [db  @@conn
+                  got (into {} (map (fn [[id a b]] [id {:a a :b b}]))
+                            (d/q '[:find ?id ?a ?b :where [?e :id ?id] [?e :a ?a] [?e :b ?b]] db))]
+              (when (not= @model got)
+                (reset! fail {:seed seed :cycle c :params {:crypto? crypto? :diff-buf diff-buf}
+                              :model-n (count @model) :got-n (count got)})))))
+        @fail
+        (finally
+          (try (d/release @conn) (catch Throwable _))
+          (try (d/delete-database cfg) (catch Throwable _)))))))
+
+(defn run
+  "Sweep grid × seeds; returns the seq of failures (empty = all good)."
+  [grid seeds]
+  (->> (for [params grid seed (range seeds)] (run-trial seed params))
+       (remove nil?)
+       vec))
+
+(deftest diff-buf-generative
+  (let [grid   (for [crypto? [false true] diff-buf [0 256]]
+                 {:idrange 250 :cycles 6 :ops 35 :crypto? crypto? :diff-buf diff-buf})
+        fails  (run grid 3)]
+    (is (empty? fails)
+        (str (count fails) " generative trial(s) diverged from model: " (pr-str (vec (take 6 fails)))))))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -354,7 +354,7 @@
              (finally
                (done))))))
 
-;; DIFF_BUF_V5 phase-1 gate: read a JVM-written diff-buf store from cljs and verify the
+;; diff-buf phase-1 gate: read a JVM-written diff-buf store from cljs and verify the
 ;; buffered-leaf projection (Branch.child) reconstructs identical datoms cross-host.
 ;; The store + reference datoms are produced by /tmp/dh_exchange_build.clj on the JVM;
 ;; this test is a no-op (passes) when that artifact is absent (e.g. normal CI).
@@ -392,7 +392,7 @@
         (finally
           (done))))))
 
-;; DIFF_BUF_V5 phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
+;; diff-buf phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
 ;; avoiding the pre-existing cross-host connect bug). Incremental commits make leaves
 ;; content-only dirty → buffered leaf slots in the root → on cold reopen they project back.
 ;; Writes to a FIXED dir (not deleted) so buffering can be confirmed externally (grep slots).
@@ -436,7 +436,7 @@
           (finally
             (done)))))))
 
-;; DIFF_BUF_V5 phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
+;; diff-buf phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
 ;; exercising the rotate/merge/merge-split slot-carry). Insert 2000, retract the even ones,
 ;; cold-reopen and verify the surviving odd set exactly.
 (def ^:private cljs-opbuf-rm-dir "/tmp/dh-cljs-opbuf-rm")
@@ -483,7 +483,7 @@
           (finally
             (done)))))))
 
-;; DIFF_BUF_V5 phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
+;; diff-buf phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
 ;; old value) routes through psset/replace → Branch.$replace for eavt/aevt. Insert 1000 ids
 ;; with :n 0, then update each :n to its id in small commits, cold-reopen and verify :n == id.
 (def ^:private cljs-opbuf-rep-dir "/tmp/dh-cljs-opbuf-rep")
@@ -530,7 +530,7 @@
           (finally
             (done)))))))
 
-;; DIFF_BUF_V5 phase-2 soundness gate: randomized insert/retract churn under a SMALL diff-buf
+;; diff-buf phase-2 soundness gate: randomized insert/retract churn under a SMALL diff-buf
 ;; budget (more frequent buffer/write decisions, merges, borrows, splits) with periodic cold
 ;; reopens, compared against a reference set. Seeded LCG ⇒ deterministic/reproducible.
 (def ^:private cljs-opbuf-gen-dir "/tmp/dh-cljs-opbuf-gen")
@@ -586,7 +586,7 @@
           (finally
             (done)))))))
 
-;; DIFF_BUF_V5 phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
+;; diff-buf phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
 ;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root, exercised via the real
 ;; datahike.audit/verify-chain :deep? API (which re-derives every node's content hash from
 ;; storage and confirms it matches its address). Covers baseline crypto AND crypto+diff-buf

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.test :refer [deftest is async] :as t]
             [cljs.reader]
             [datahike.api :as d]
+            [datahike.index.audit :as ia]
             [datahike.online-gc :as online-gc]
             [konserve.core :as k]
             [konserve.node-filestore] ;; Register :file backend for Node.js
@@ -583,6 +584,48 @@
             (is false (str "cljs-opbuf-generative error: " (.-message e))))
           (finally
             (done)))))))
+
+;; OP_BUF_V5 phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
+;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root: for each index it must
+;; re-derive every node's content hash from storage and confirm it matches its address —
+;; baseline crypto AND crypto+op-buf (branch hash folds the slots), warm and after a cold
+;; reopen (projection-on-read). Calls the index-level protocol directly (datahike.audit's
+;; verify-chain does not yet cljs-compile — separate core.async go-try- issue).
+(defn- audit-indices [db]
+  (mapv (fn [k] [k (:status (ia/-recompute-merkle-root (get db k)))])
+        [:eavt :aevt :avet]))
+
+(deftest cljs-merkle-audit-test
+  (async done
+    (go
+      (try
+        (doseq [[label opbuf] [["crypto baseline" 0] ["crypto + op-buf" 256]]]
+          (let [dir (tmp-dir)
+                cfg {:store {:backend :file :path dir :id (random-uuid)}
+                     :schema-flexibility :write :keep-history? false
+                     :crypto-hash? true
+                     :index :datahike.index/persistent-set
+                     :index-config (when (pos? opbuf) {:op-buf-size opbuf})}]
+            (<! (d/create-database cfg))
+            (let [conn (d/connect cfg)]
+              (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+              (loop [bs (partition-all 100 (range 2000))]
+                (when (seq bs)
+                  (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                  (recur (rest bs))))
+              (let [res (audit-indices @conn)]
+                (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm audit: " (pr-str res))))
+              (d/release conn))
+            ;; cold reopen → audit must still re-derive matching hashes (op-buf projection)
+            (let [conn2 (d/connect cfg)
+                  res   (audit-indices @conn2)]
+              (is (every? (fn [[_ s]] (= :ok s)) res) (str label " cold audit: " (pr-str res)))
+              (d/release conn2))
+            (<! (d/delete-database cfg))))
+        (catch js/Error e
+          (is false (str "cljs-merkle-audit error: " (.-message e))))
+        (finally
+          (done))))))
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -1,5 +1,6 @@
 (ns datahike.test.nodejs-test
   (:require [cljs.test :refer [deftest is async] :as t]
+            [cljs.reader]
             [datahike.api :as d]
             [datahike.online-gc :as online-gc]
             [konserve.core :as k]
@@ -350,6 +351,88 @@
                (is false (str "Error in online-gc-multi-branch-safety-test: " (.-message e))))
              (finally
                (done))))))
+
+;; OP_BUF_V5 phase-1 gate: read a JVM-written op-buf store from cljs and verify the
+;; buffered-leaf projection (Branch.child) reconstructs identical datoms cross-host.
+;; The store + reference datoms are produced by /tmp/dh_exchange_build.clj on the JVM;
+;; this test is a no-op (passes) when that artifact is absent (e.g. normal CI).
+(def ^:private exchange-expected-file "/tmp/dh-exchange-expected.edn")
+
+(deftest jvm-opbuf-exchange-test
+  (async done
+    (go
+      (try
+        (if-not (fs.existsSync exchange-expected-file)
+          (is true "JVM op-buf exchange artifact absent — skipped")
+          (let [{:keys [store-id dir n-count n-sum datom-count datoms]}
+                (cljs.reader/read-string (.readFileSync fs exchange-expected-file "utf8"))
+                cfg {:store {:backend :file :path dir :id store-id}
+                     :schema-flexibility :write :keep-history? false}
+                conn (d/connect cfg)
+                db   @conn
+                got-datoms (->> (d/datoms db :eavt)
+                                (map (fn [d] [(:e d) (name (:a d)) (str (:v d))]))
+                                (sort)
+                                (vec))
+                got-n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
+                got-n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
+            (is (= datom-count (count got-datoms))
+                (str "cljs read same datom count (jvm=" datom-count " cljs=" (count got-datoms) ")"))
+            (is (= n-count got-n-count)
+                (str ":n entity count matches (jvm=" n-count " cljs=" got-n-count ")"))
+            (is (= n-sum got-n-sum)
+                (str ":n value sum matches (projection-sound) (jvm=" n-sum " cljs=" got-n-sum ")"))
+            (is (= datoms got-datoms)
+                "cljs eavt datoms identical to JVM (full buffered-leaf projection)")
+            (d/release conn)))
+        (catch js/Error e
+          (is false (str "jvm-opbuf-exchange-test error: " (.-message e))))
+        (finally
+          (done))))))
+
+;; OP_BUF_V5 phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
+;; avoiding the pre-existing cross-host connect bug). Incremental commits make leaves
+;; content-only dirty → buffered leaf slots in the root → on cold reopen they project back.
+;; Writes to a FIXED dir (not deleted) so buffering can be confirmed externally (grep slots).
+(def ^:private cljs-opbuf-dir "/tmp/dh-cljs-opbuf")
+
+(deftest cljs-opbuf-write-roundtrip-test
+  (let [sid #uuid "00000000-0000-0000-0000-00000000c1c5"
+        cfg {:store {:backend :file :path cljs-opbuf-dir :id sid}
+             :schema-flexibility :write :keep-history? false
+             :index :datahike.index/persistent-set
+             :index-config {:op-buf-size 256}}]
+    (async done
+      (go
+        (try
+          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+          (<! (d/create-database cfg))
+          (let [conn (d/connect cfg)]
+            (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+            (loop [bs (partition-all 100 (range 3000))]
+              (when (seq bs)
+                (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                (recur (rest bs))))
+            (let [db @conn
+                  n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
+                  n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
+              (is (= 3000 n-count) (str "warm n-count=" n-count))
+              (is (= 4498500 n-sum) (str "warm n-sum=" n-sum)))
+            (d/release conn))
+          ;; cold reopen → forces projection-on-read of buffered slots
+          (let [conn2 (d/connect cfg)
+                db2   @conn2
+                n-count2 (d/q '[:find (count ?e) . :where [?e :n _]] db2)
+                n-sum2   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt))))
+                all-vs   (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))]
+            (is (= 3000 n-count2) (str "cold n-count=" n-count2))
+            (is (= 4498500 n-sum2) (str "cold n-sum=" n-sum2))
+            (is (= (vec (range 3000)) all-vs) "cold :n values exact 0..2999 (buffered-leaf projection sound)")
+            (d/release conn2))
+          (catch js/Error e
+            (is false (str "cljs-opbuf-write-roundtrip error: " (.-message e))))
+          (finally
+            (done)))))))
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -5,7 +5,7 @@
             [datahike.index.audit :as ia]
             [datahike.online-gc :as online-gc]
             [konserve.core :as k]
-            [konserve.node-filestore] ;; Register :file backend for Node.js
+            [konserve.node-filestore :as nfs] ;; Register :file backend for Node.js
             [cljs.core.async :refer [go <!] :include-macros true]
             [cljs.nodejs :as nodejs]
             ;; Sibling test namespaces — included so `bb node-cljs-test`
@@ -624,6 +624,27 @@
             (<! (d/delete-database cfg))))
         (catch js/Error e
           (is false (str "cljs-merkle-audit error: " (.-message e))))
+        (finally
+          (done))))))
+
+;; Isolation probe: read a JVM-konserve-written map (default fressian serializer) cross-host
+;; to test fress deserialization of namespaced keywords etc. (datahike-independent).
+;; Written by /tmp/kons_probe_write.clj. Skips if absent.
+(deftest xhost-fress-probe-test
+  (async done
+    (go
+      (try
+        (if-not (fs.existsSync "/tmp/kons-probe")
+          (is true "kons-probe artifact absent — skipped")
+          (let [store (<! (nfs/connect-fs-store "/tmp/kons-probe" :opts {:sync? false}))
+                v     (<! (k/get store :probe nil {:sync? false}))]
+            (is (= :datahike.index/persistent-set (:ns-kw v)) (str ":ns-kw = " (pr-str (:ns-kw v))))
+            (is (= :db.type/long (:ns-kw2 v)) (str ":ns-kw2 = " (pr-str (:ns-kw2 v))))
+            (is (= :write (:simple-kw v)) (str ":simple-kw = " (pr-str (:simple-kw v))))
+            (is (= :x/y (get-in v [:nested :inner])) (str ":nested :inner = " (pr-str (get-in v [:nested :inner]))))
+            (is (= [:a/b :c] (:vec v)) (str ":vec = " (pr-str (:vec v))))))
+        (catch js/Error e
+          (is false (str "xhost-fress-probe error: " (.-message e))))
         (finally
           (done))))))
 

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -528,6 +528,62 @@
           (finally
             (done)))))))
 
+;; OP_BUF_V5 phase-2 soundness gate: randomized insert/retract churn under a SMALL op-buf
+;; budget (more frequent buffer/write decisions, merges, borrows, splits) with periodic cold
+;; reopens, compared against a reference set. Seeded LCG ⇒ deterministic/reproducible.
+(def ^:private cljs-opbuf-gen-dir "/tmp/dh-cljs-opbuf-gen")
+
+(deftest cljs-opbuf-generative-test
+  (let [sid  #uuid "00000000-0000-0000-0000-0000000c1c5d"
+        cfg  {:store {:backend :file :path cljs-opbuf-gen-dir :id sid}
+              :schema-flexibility :write :keep-history? false
+              :index :datahike.index/persistent-set
+              :index-config {:op-buf-size 64}}
+        seed (atom 777)
+        rnd  (fn [n] (mod (swap! seed (fn [x] (mod (+ (* x 1103515245) 12345) 2147483648))) n))
+        idset (fn [c] (set (d/q '[:find [?id ...] :where [_ :id ?id]] @c)))]
+    (async done
+      (go
+        (try
+          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+          (<! (d/create-database cfg))
+          (let [present (atom #{})
+                conn0 (d/connect cfg)]
+            (<! (d/transact! conn0 [{:db/ident :id :db/valueType :db.type/long
+                                     :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}]))
+            ;; bulk-seed >bf entities so the index has BRANCH nodes (op-buf only engages on
+            ;; branches; a sub-512 tree is a single leaf and never buffers).
+            (loop [bs (partition-all 200 (range 2000))]
+              (when (seq bs)
+                (<! (d/transact! conn0 (mapv (fn [i] {:id i}) (first bs))))
+                (recur (rest bs))))
+            (reset! present (set (range 2000)))
+            (loop [conn conn0, round 0]
+              (if (>= round 40)
+                (do (d/release conn)
+                    (let [c (d/connect cfg)]
+                      (is (= @present (idset c)) (str "final ref=" (count @present) " got=" (count (idset c))))
+                      (d/release c)))
+                (let [insert? (even? (rnd 2))
+                      cand    (vec (distinct (repeatedly 40 #(rnd 4000))))
+                      ops     (if insert? (vec (remove @present cand)) (vec (filter @present cand)))]
+                  (when (seq ops)
+                    (if insert?
+                      (do (<! (d/transact! conn (mapv (fn [i] {:id i}) ops)))
+                          (swap! present into ops))
+                      (do (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:id i]]) ops)))
+                          (swap! present (fn [s] (reduce disj s ops))))))
+                  (if (zero? (mod (inc round) 8))
+                    (do (d/release conn)
+                        (let [c (d/connect cfg)]
+                          (is (= @present (idset c)) (str "round " round " ref=" (count @present) " got=" (count (idset c))))
+                          (recur c (inc round))))
+                    (recur conn (inc round)))))))
+          (catch js/Error e
+            (is false (str "cljs-opbuf-generative error: " (.-message e))))
+          (finally
+            (done)))))))
+
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.cljs-pattern-scan-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -362,35 +362,35 @@
 
 (deftest jvm-opbuf-exchange-test
   (async done
-    (go
-      (try
-        (if-not (fs.existsSync exchange-expected-file)
-          (is true "JVM diff-buf exchange artifact absent — skipped")
-          (let [{:keys [store-id dir n-count n-sum datom-count datoms]}
-                (cljs.reader/read-string (.readFileSync fs exchange-expected-file "utf8"))
-                cfg {:store {:backend :file :path dir :id store-id}
-                     :schema-flexibility :write :keep-history? false}
-                conn (d/connect cfg)
-                db   @conn
-                got-datoms (->> (d/datoms db :eavt)
-                                (map (fn [d] [(:e d) (name (:a d)) (str (:v d))]))
-                                (sort)
-                                (vec))
-                got-n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
-                got-n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
-            (is (= datom-count (count got-datoms))
-                (str "cljs read same datom count (jvm=" datom-count " cljs=" (count got-datoms) ")"))
-            (is (= n-count got-n-count)
-                (str ":n entity count matches (jvm=" n-count " cljs=" got-n-count ")"))
-            (is (= n-sum got-n-sum)
-                (str ":n value sum matches (projection-sound) (jvm=" n-sum " cljs=" got-n-sum ")"))
-            (is (= datoms got-datoms)
-                "cljs eavt datoms identical to JVM (full buffered-leaf projection)")
-            (d/release conn)))
-        (catch js/Error e
-          (is false (str "jvm-opbuf-exchange-test error: " (.-message e))))
-        (finally
-          (done))))))
+         (go
+           (try
+             (if-not (fs.existsSync exchange-expected-file)
+               (is true "JVM diff-buf exchange artifact absent — skipped")
+               (let [{:keys [store-id dir n-count n-sum datom-count datoms]}
+                     (cljs.reader/read-string (.readFileSync fs exchange-expected-file "utf8"))
+                     cfg {:store {:backend :file :path dir :id store-id}
+                          :schema-flexibility :write :keep-history? false}
+                     conn (d/connect cfg)
+                     db   @conn
+                     got-datoms (->> (d/datoms db :eavt)
+                                     (map (fn [d] [(:e d) (name (:a d)) (str (:v d))]))
+                                     (sort)
+                                     (vec))
+                     got-n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
+                     got-n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
+                 (is (= datom-count (count got-datoms))
+                     (str "cljs read same datom count (jvm=" datom-count " cljs=" (count got-datoms) ")"))
+                 (is (= n-count got-n-count)
+                     (str ":n entity count matches (jvm=" n-count " cljs=" got-n-count ")"))
+                 (is (= n-sum got-n-sum)
+                     (str ":n value sum matches (projection-sound) (jvm=" n-sum " cljs=" got-n-sum ")"))
+                 (is (= datoms got-datoms)
+                     "cljs eavt datoms identical to JVM (full buffered-leaf projection)")
+                 (d/release conn)))
+             (catch js/Error e
+               (is false (str "jvm-opbuf-exchange-test error: " (.-message e))))
+             (finally
+               (done))))))
 
 ;; diff-buf phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
 ;; avoiding the pre-existing cross-host connect bug). Incremental commits make leaves
@@ -405,36 +405,36 @@
              :index :datahike.index/persistent-set
              :index-config {:diff-buf-size 256}}]
     (async done
-      (go
-        (try
-          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
-          (<! (d/create-database cfg))
-          (let [conn (d/connect cfg)]
-            (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
-            (loop [bs (partition-all 100 (range 3000))]
-              (when (seq bs)
-                (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
-                (recur (rest bs))))
-            (let [db @conn
-                  n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
-                  n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
-              (is (= 3000 n-count) (str "warm n-count=" n-count))
-              (is (= 4498500 n-sum) (str "warm n-sum=" n-sum)))
-            (d/release conn))
+           (go
+             (try
+               (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+               (<! (d/create-database cfg))
+               (let [conn (d/connect cfg)]
+                 (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+                 (loop [bs (partition-all 100 (range 3000))]
+                   (when (seq bs)
+                     (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                     (recur (rest bs))))
+                 (let [db @conn
+                       n-count (d/q '[:find (count ?e) . :where [?e :n _]] db)
+                       n-sum   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db :eavt))))]
+                   (is (= 3000 n-count) (str "warm n-count=" n-count))
+                   (is (= 4498500 n-sum) (str "warm n-sum=" n-sum)))
+                 (d/release conn))
           ;; cold reopen → forces projection-on-read of buffered slots
-          (let [conn2 (d/connect cfg)
-                db2   @conn2
-                n-count2 (d/q '[:find (count ?e) . :where [?e :n _]] db2)
-                n-sum2   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt))))
-                all-vs   (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))]
-            (is (= 3000 n-count2) (str "cold n-count=" n-count2))
-            (is (= 4498500 n-sum2) (str "cold n-sum=" n-sum2))
-            (is (= (vec (range 3000)) all-vs) "cold :n values exact 0..2999 (buffered-leaf projection sound)")
-            (d/release conn2))
-          (catch js/Error e
-            (is false (str "cljs-opbuf-write-roundtrip error: " (.-message e))))
-          (finally
-            (done)))))))
+               (let [conn2 (d/connect cfg)
+                     db2   @conn2
+                     n-count2 (d/q '[:find (count ?e) . :where [?e :n _]] db2)
+                     n-sum2   (reduce + (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt))))
+                     all-vs   (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))]
+                 (is (= 3000 n-count2) (str "cold n-count=" n-count2))
+                 (is (= 4498500 n-sum2) (str "cold n-sum=" n-sum2))
+                 (is (= (vec (range 3000)) all-vs) "cold :n values exact 0..2999 (buffered-leaf projection sound)")
+                 (d/release conn2))
+               (catch js/Error e
+                 (is false (str "cljs-opbuf-write-roundtrip error: " (.-message e))))
+               (finally
+                 (done)))))))
 
 ;; diff-buf phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
 ;; exercising the rotate/merge/merge-split slot-carry). Insert 2000, retract the even ones,
@@ -448,40 +448,40 @@
              :index :datahike.index/persistent-set
              :index-config {:diff-buf-size 256}}]
     (async done
-      (go
-        (try
-          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
-          (<! (d/create-database cfg))
-          (let [conn (d/connect cfg)]
-            (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long
-                                    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}]))
-            (loop [bs (partition-all 100 (range 2000))]
-              (when (seq bs)
-                (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
-                (recur (rest bs))))
+           (go
+             (try
+               (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+               (<! (d/create-database cfg))
+               (let [conn (d/connect cfg)]
+                 (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long
+                                         :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}]))
+                 (loop [bs (partition-all 100 (range 2000))]
+                   (when (seq bs)
+                     (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                     (recur (rest bs))))
             ;; retract even-:n entities (unique :n ⇒ lookup-ref retraction) in small commits
-            (loop [bs (partition-all 100 (filter even? (range 2000)))]
-              (when (seq bs)
-                (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:n i]]) (first bs))))
-                (recur (rest bs))))
-            (let [db @conn
-                  vs (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db :eavt)))))]
-              (is (= 1000 (count vs)) (str "warm survivors=" (count vs)))
-              (is (= (vec (range 1 2000 2)) vs) "warm: exactly the odd :n survive"))
-            (d/release conn))
+                 (loop [bs (partition-all 100 (filter even? (range 2000)))]
+                   (when (seq bs)
+                     (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:n i]]) (first bs))))
+                     (recur (rest bs))))
+                 (let [db @conn
+                       vs (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db :eavt)))))]
+                   (is (= 1000 (count vs)) (str "warm survivors=" (count vs)))
+                   (is (= (vec (range 1 2000 2)) vs) "warm: exactly the odd :n survive"))
+                 (d/release conn))
           ;; cold reopen → projection-on-read of buffered slots after structural removes
-          (let [conn2 (d/connect cfg)
-                db2   @conn2
-                vs    (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))
-                sum   (reduce + vs)]
-            (is (= 1000 (count vs)) (str "cold survivors=" (count vs)))
-            (is (= 1000000 sum) (str "cold sum of odds=" sum))
-            (is (= (vec (range 1 2000 2)) vs) "cold: exactly the odd :n survive (remove+merge slot-carry sound)")
-            (d/release conn2))
-          (catch js/Error e
-            (is false (str "cljs-opbuf-remove-roundtrip error: " (.-message e))))
-          (finally
-            (done)))))))
+               (let [conn2 (d/connect cfg)
+                     db2   @conn2
+                     vs    (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))
+                     sum   (reduce + vs)]
+                 (is (= 1000 (count vs)) (str "cold survivors=" (count vs)))
+                 (is (= 1000000 sum) (str "cold sum of odds=" sum))
+                 (is (= (vec (range 1 2000 2)) vs) "cold: exactly the odd :n survive (remove+merge slot-carry sound)")
+                 (d/release conn2))
+               (catch js/Error e
+                 (is false (str "cljs-opbuf-remove-roundtrip error: " (.-message e))))
+               (finally
+                 (done)))))))
 
 ;; diff-buf phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
 ;; old value) routes through psset/replace → Branch.$replace for eavt/aevt. Insert 1000 ids
@@ -495,40 +495,40 @@
              :index :datahike.index/persistent-set
              :index-config {:diff-buf-size 256}}]
     (async done
-      (go
-        (try
-          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
-          (<! (d/create-database cfg))
-          (let [conn (d/connect cfg)]
-            (<! (d/transact! conn [{:db/ident :id :db/valueType :db.type/long
-                                    :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}
-                                   {:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
-            (loop [bs (partition-all 100 (range 1000))]
-              (when (seq bs)
-                (<! (d/transact! conn (mapv (fn [i] {:id i :n 0}) (first bs))))
-                (recur (rest bs))))
+           (go
+             (try
+               (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+               (<! (d/create-database cfg))
+               (let [conn (d/connect cfg)]
+                 (<! (d/transact! conn [{:db/ident :id :db/valueType :db.type/long
+                                         :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}
+                                        {:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+                 (loop [bs (partition-all 100 (range 1000))]
+                   (when (seq bs)
+                     (<! (d/transact! conn (mapv (fn [i] {:id i :n 0}) (first bs))))
+                     (recur (rest bs))))
             ;; cardinality-one update of :n in small commits → upsert → $replace (eavt/aevt)
-            (loop [bs (partition-all 100 (range 1000))]
-              (when (seq bs)
-                (<! (d/transact! conn (mapv (fn [i] [:db/add [:id i] :n i]) (first bs))))
-                (recur (rest bs))))
-            (let [db @conn
-                  pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db)]
-              (is (= 1000 (count pairs)) (str "warm pairs=" (count pairs)))
-              (is (every? (fn [[id n]] (= id n)) pairs) "warm: every :n updated to its :id"))
-            (d/release conn))
+                 (loop [bs (partition-all 100 (range 1000))]
+                   (when (seq bs)
+                     (<! (d/transact! conn (mapv (fn [i] [:db/add [:id i] :n i]) (first bs))))
+                     (recur (rest bs))))
+                 (let [db @conn
+                       pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db)]
+                   (is (= 1000 (count pairs)) (str "warm pairs=" (count pairs)))
+                   (is (every? (fn [[id n]] (= id n)) pairs) "warm: every :n updated to its :id"))
+                 (d/release conn))
           ;; cold reopen → projection-on-read after $replace buffering
-          (let [conn2 (d/connect cfg)
-                db2   @conn2
-                pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db2)
-                nsum  (reduce + (map second pairs))]
-            (is (= 1000 (count pairs)) (str "cold pairs=" (count pairs)))
-            (is (every? (fn [[id n]] (= id n)) pairs) "cold: every :n == its :id ($replace projection sound)")
-            (is (= 499500 nsum) (str "cold sum :n=" nsum)))
-          (catch js/Error e
-            (is false (str "cljs-opbuf-replace-roundtrip error: " (.-message e))))
-          (finally
-            (done)))))))
+               (let [conn2 (d/connect cfg)
+                     db2   @conn2
+                     pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db2)
+                     nsum  (reduce + (map second pairs))]
+                 (is (= 1000 (count pairs)) (str "cold pairs=" (count pairs)))
+                 (is (every? (fn [[id n]] (= id n)) pairs) "cold: every :n == its :id ($replace projection sound)")
+                 (is (= 499500 nsum) (str "cold sum :n=" nsum)))
+               (catch js/Error e
+                 (is false (str "cljs-opbuf-replace-roundtrip error: " (.-message e))))
+               (finally
+                 (done)))))))
 
 ;; diff-buf phase-2 soundness gate: randomized insert/retract churn under a SMALL diff-buf
 ;; budget (more frequent buffer/write decisions, merges, borrows, splits) with periodic cold
@@ -545,46 +545,46 @@
         rnd  (fn [n] (mod (swap! seed (fn [x] (mod (+ (* x 1103515245) 12345) 2147483648))) n))
         idset (fn [c] (set (d/q '[:find [?id ...] :where [_ :id ?id]] @c)))]
     (async done
-      (go
-        (try
-          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
-          (<! (d/create-database cfg))
-          (let [present (atom #{})
-                conn0 (d/connect cfg)]
-            (<! (d/transact! conn0 [{:db/ident :id :db/valueType :db.type/long
-                                     :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}]))
+           (go
+             (try
+               (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+               (<! (d/create-database cfg))
+               (let [present (atom #{})
+                     conn0 (d/connect cfg)]
+                 (<! (d/transact! conn0 [{:db/ident :id :db/valueType :db.type/long
+                                          :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}]))
             ;; bulk-seed >bf entities so the index has BRANCH nodes (diff-buf only engages on
             ;; branches; a sub-512 tree is a single leaf and never buffers).
-            (loop [bs (partition-all 200 (range 2000))]
-              (when (seq bs)
-                (<! (d/transact! conn0 (mapv (fn [i] {:id i}) (first bs))))
-                (recur (rest bs))))
-            (reset! present (set (range 2000)))
-            (loop [conn conn0, round 0]
-              (if (>= round 40)
-                (do (d/release conn)
-                    (let [c (d/connect cfg)]
-                      (is (= @present (idset c)) (str "final ref=" (count @present) " got=" (count (idset c))))
-                      (d/release c)))
-                (let [insert? (even? (rnd 2))
-                      cand    (vec (distinct (repeatedly 40 #(rnd 4000))))
-                      ops     (if insert? (vec (remove @present cand)) (vec (filter @present cand)))]
-                  (when (seq ops)
-                    (if insert?
-                      (do (<! (d/transact! conn (mapv (fn [i] {:id i}) ops)))
-                          (swap! present into ops))
-                      (do (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:id i]]) ops)))
-                          (swap! present (fn [s] (reduce disj s ops))))))
-                  (if (zero? (mod (inc round) 8))
-                    (do (d/release conn)
-                        (let [c (d/connect cfg)]
-                          (is (= @present (idset c)) (str "round " round " ref=" (count @present) " got=" (count (idset c))))
-                          (recur c (inc round))))
-                    (recur conn (inc round)))))))
-          (catch js/Error e
-            (is false (str "cljs-opbuf-generative error: " (.-message e))))
-          (finally
-            (done)))))))
+                 (loop [bs (partition-all 200 (range 2000))]
+                   (when (seq bs)
+                     (<! (d/transact! conn0 (mapv (fn [i] {:id i}) (first bs))))
+                     (recur (rest bs))))
+                 (reset! present (set (range 2000)))
+                 (loop [conn conn0, round 0]
+                   (if (>= round 40)
+                     (do (d/release conn)
+                         (let [c (d/connect cfg)]
+                           (is (= @present (idset c)) (str "final ref=" (count @present) " got=" (count (idset c))))
+                           (d/release c)))
+                     (let [insert? (even? (rnd 2))
+                           cand    (vec (distinct (repeatedly 40 #(rnd 4000))))
+                           ops     (if insert? (vec (remove @present cand)) (vec (filter @present cand)))]
+                       (when (seq ops)
+                         (if insert?
+                           (do (<! (d/transact! conn (mapv (fn [i] {:id i}) ops)))
+                               (swap! present into ops))
+                           (do (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:id i]]) ops)))
+                               (swap! present (fn [s] (reduce disj s ops))))))
+                       (if (zero? (mod (inc round) 8))
+                         (do (d/release conn)
+                             (let [c (d/connect cfg)]
+                               (is (= @present (idset c)) (str "round " round " ref=" (count @present) " got=" (count (idset c))))
+                               (recur c (inc round))))
+                         (recur conn (inc round)))))))
+               (catch js/Error e
+                 (is false (str "cljs-opbuf-generative error: " (.-message e))))
+               (finally
+                 (done)))))))
 
 ;; diff-buf phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
 ;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root, exercised via the real
@@ -602,60 +602,60 @@
 
 (deftest cljs-merkle-audit-test
   (async done
-    (go
-      (try
-        (doseq [[label opbuf] [["crypto baseline" 0] ["crypto + diff-buf" 256]]]
-          (let [dir (tmp-dir)
-                cfg {:store {:backend :file :path dir :id (random-uuid)}
-                     :schema-flexibility :write :keep-history? false
-                     :crypto-hash? true
-                     :index :datahike.index/persistent-set
-                     :index-config (when (pos? opbuf) {:diff-buf-size opbuf})}]
-            (<! (d/create-database cfg))
-            (let [conn (d/connect cfg)]
-              (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
-              (loop [bs (partition-all 100 (range 2000))]
-                (when (seq bs)
-                  (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
-                  (recur (rest bs))))
-              (let [res (audit-indices @conn)
-                    [st deep diffs] (deep-verify-ok? @conn)]
-                (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm index audit: " (pr-str res)))
-                (is (and (= :ok st) (= :ok deep)) (str label " warm verify-chain deep: " st "/" deep " diffs=" (pr-str diffs))))
-              (d/release conn))
+         (go
+           (try
+             (doseq [[label opbuf] [["crypto baseline" 0] ["crypto + diff-buf" 256]]]
+               (let [dir (tmp-dir)
+                     cfg {:store {:backend :file :path dir :id (random-uuid)}
+                          :schema-flexibility :write :keep-history? false
+                          :crypto-hash? true
+                          :index :datahike.index/persistent-set
+                          :index-config (when (pos? opbuf) {:diff-buf-size opbuf})}]
+                 (<! (d/create-database cfg))
+                 (let [conn (d/connect cfg)]
+                   (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+                   (loop [bs (partition-all 100 (range 2000))]
+                     (when (seq bs)
+                       (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                       (recur (rest bs))))
+                   (let [res (audit-indices @conn)
+                         [st deep diffs] (deep-verify-ok? @conn)]
+                     (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm index audit: " (pr-str res)))
+                     (is (and (= :ok st) (= :ok deep)) (str label " warm verify-chain deep: " st "/" deep " diffs=" (pr-str diffs))))
+                   (d/release conn))
             ;; cold reopen → audit must still re-derive matching hashes (diff-buf projection)
-            (let [conn2 (d/connect cfg)
-                  res   (audit-indices @conn2)
-                  [st deep diffs] (deep-verify-ok? @conn2)]
-              (is (every? (fn [[_ s]] (= :ok s)) res) (str label " cold index audit: " (pr-str res)))
-              (is (and (= :ok st) (= :ok deep)) (str label " cold verify-chain deep: " st "/" deep " diffs=" (pr-str diffs)))
-              (d/release conn2))
-            (<! (d/delete-database cfg))))
-        (catch js/Error e
-          (is false (str "cljs-merkle-audit error: " (.-message e))))
-        (finally
-          (done))))))
+                 (let [conn2 (d/connect cfg)
+                       res   (audit-indices @conn2)
+                       [st deep diffs] (deep-verify-ok? @conn2)]
+                   (is (every? (fn [[_ s]] (= :ok s)) res) (str label " cold index audit: " (pr-str res)))
+                   (is (and (= :ok st) (= :ok deep)) (str label " cold verify-chain deep: " st "/" deep " diffs=" (pr-str diffs)))
+                   (d/release conn2))
+                 (<! (d/delete-database cfg))))
+             (catch js/Error e
+               (is false (str "cljs-merkle-audit error: " (.-message e))))
+             (finally
+               (done))))))
 
 ;; Isolation probe: read a JVM-konserve-written map (default fressian serializer) cross-host
 ;; to test fress deserialization of namespaced keywords etc. (datahike-independent).
 ;; Written by /tmp/kons_probe_write.clj. Skips if absent.
 (deftest xhost-fress-probe-test
   (async done
-    (go
-      (try
-        (if-not (fs.existsSync "/tmp/kons-probe")
-          (is true "kons-probe artifact absent — skipped")
-          (let [store (<! (nfs/connect-fs-store "/tmp/kons-probe" :opts {:sync? false}))
-                v     (<! (k/get store :probe nil {:sync? false}))]
-            (is (= :datahike.index/persistent-set (:ns-kw v)) (str ":ns-kw = " (pr-str (:ns-kw v))))
-            (is (= :db.type/long (:ns-kw2 v)) (str ":ns-kw2 = " (pr-str (:ns-kw2 v))))
-            (is (= :write (:simple-kw v)) (str ":simple-kw = " (pr-str (:simple-kw v))))
-            (is (= :x/y (get-in v [:nested :inner])) (str ":nested :inner = " (pr-str (get-in v [:nested :inner]))))
-            (is (= [:a/b :c] (:vec v)) (str ":vec = " (pr-str (:vec v))))))
-        (catch js/Error e
-          (is false (str "xhost-fress-probe error: " (.-message e))))
-        (finally
-          (done))))))
+         (go
+           (try
+             (if-not (fs.existsSync "/tmp/kons-probe")
+               (is true "kons-probe artifact absent — skipped")
+               (let [store (<! (nfs/connect-fs-store "/tmp/kons-probe" :opts {:sync? false}))
+                     v     (<! (k/get store :probe nil {:sync? false}))]
+                 (is (= :datahike.index/persistent-set (:ns-kw v)) (str ":ns-kw = " (pr-str (:ns-kw v))))
+                 (is (= :db.type/long (:ns-kw2 v)) (str ":ns-kw2 = " (pr-str (:ns-kw2 v))))
+                 (is (= :write (:simple-kw v)) (str ":simple-kw = " (pr-str (:simple-kw v))))
+                 (is (= :x/y (get-in v [:nested :inner])) (str ":nested :inner = " (pr-str (get-in v [:nested :inner]))))
+                 (is (= [:a/b :c] (:vec v)) (str ":vec = " (pr-str (:vec v))))))
+             (catch js/Error e
+               (is false (str "xhost-fress-probe error: " (.-message e))))
+             (finally
+               (done))))))
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -354,7 +354,7 @@
              (finally
                (done))))))
 
-;; OP_BUF_V5 phase-1 gate: read a JVM-written op-buf store from cljs and verify the
+;; DIFF_BUF_V5 phase-1 gate: read a JVM-written diff-buf store from cljs and verify the
 ;; buffered-leaf projection (Branch.child) reconstructs identical datoms cross-host.
 ;; The store + reference datoms are produced by /tmp/dh_exchange_build.clj on the JVM;
 ;; this test is a no-op (passes) when that artifact is absent (e.g. normal CI).
@@ -365,7 +365,7 @@
     (go
       (try
         (if-not (fs.existsSync exchange-expected-file)
-          (is true "JVM op-buf exchange artifact absent — skipped")
+          (is true "JVM diff-buf exchange artifact absent — skipped")
           (let [{:keys [store-id dir n-count n-sum datom-count datoms]}
                 (cljs.reader/read-string (.readFileSync fs exchange-expected-file "utf8"))
                 cfg {:store {:backend :file :path dir :id store-id}
@@ -392,7 +392,7 @@
         (finally
           (done))))))
 
-;; OP_BUF_V5 phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
+;; DIFF_BUF_V5 phase-2 gate: cljs WRITE path. Same-host (create+transact+query all in cljs,
 ;; avoiding the pre-existing cross-host connect bug). Incremental commits make leaves
 ;; content-only dirty → buffered leaf slots in the root → on cold reopen they project back.
 ;; Writes to a FIXED dir (not deleted) so buffering can be confirmed externally (grep slots).
@@ -403,7 +403,7 @@
         cfg {:store {:backend :file :path cljs-opbuf-dir :id sid}
              :schema-flexibility :write :keep-history? false
              :index :datahike.index/persistent-set
-             :index-config {:op-buf-size 256}}]
+             :index-config {:diff-buf-size 256}}]
     (async done
       (go
         (try
@@ -436,7 +436,7 @@
           (finally
             (done)))))))
 
-;; OP_BUF_V5 phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
+;; DIFF_BUF_V5 phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
 ;; exercising the rotate/merge/merge-split slot-carry). Insert 2000, retract the even ones,
 ;; cold-reopen and verify the surviving odd set exactly.
 (def ^:private cljs-opbuf-rm-dir "/tmp/dh-cljs-opbuf-rm")
@@ -446,7 +446,7 @@
         cfg {:store {:backend :file :path cljs-opbuf-rm-dir :id sid}
              :schema-flexibility :write :keep-history? false
              :index :datahike.index/persistent-set
-             :index-config {:op-buf-size 256}}]
+             :index-config {:diff-buf-size 256}}]
     (async done
       (go
         (try
@@ -483,7 +483,7 @@
           (finally
             (done)))))))
 
-;; OP_BUF_V5 phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
+;; DIFF_BUF_V5 phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
 ;; old value) routes through psset/replace → Branch.$replace for eavt/aevt. Insert 1000 ids
 ;; with :n 0, then update each :n to its id in small commits, cold-reopen and verify :n == id.
 (def ^:private cljs-opbuf-rep-dir "/tmp/dh-cljs-opbuf-rep")
@@ -493,7 +493,7 @@
         cfg {:store {:backend :file :path cljs-opbuf-rep-dir :id sid}
              :schema-flexibility :write :keep-history? false
              :index :datahike.index/persistent-set
-             :index-config {:op-buf-size 256}}]
+             :index-config {:diff-buf-size 256}}]
     (async done
       (go
         (try
@@ -530,7 +530,7 @@
           (finally
             (done)))))))
 
-;; OP_BUF_V5 phase-2 soundness gate: randomized insert/retract churn under a SMALL op-buf
+;; DIFF_BUF_V5 phase-2 soundness gate: randomized insert/retract churn under a SMALL diff-buf
 ;; budget (more frequent buffer/write decisions, merges, borrows, splits) with periodic cold
 ;; reopens, compared against a reference set. Seeded LCG ⇒ deterministic/reproducible.
 (def ^:private cljs-opbuf-gen-dir "/tmp/dh-cljs-opbuf-gen")
@@ -540,7 +540,7 @@
         cfg  {:store {:backend :file :path cljs-opbuf-gen-dir :id sid}
               :schema-flexibility :write :keep-history? false
               :index :datahike.index/persistent-set
-              :index-config {:op-buf-size 64}}
+              :index-config {:diff-buf-size 64}}
         seed (atom 777)
         rnd  (fn [n] (mod (swap! seed (fn [x] (mod (+ (* x 1103515245) 12345) 2147483648))) n))
         idset (fn [c] (set (d/q '[:find [?id ...] :where [_ :id ?id]] @c)))]
@@ -553,7 +553,7 @@
                 conn0 (d/connect cfg)]
             (<! (d/transact! conn0 [{:db/ident :id :db/valueType :db.type/long
                                      :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}]))
-            ;; bulk-seed >bf entities so the index has BRANCH nodes (op-buf only engages on
+            ;; bulk-seed >bf entities so the index has BRANCH nodes (diff-buf only engages on
             ;; branches; a sub-512 tree is a single leaf and never buffers).
             (loop [bs (partition-all 200 (range 2000))]
               (when (seq bs)
@@ -586,10 +586,10 @@
           (finally
             (done)))))))
 
-;; OP_BUF_V5 phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
+;; DIFF_BUF_V5 phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
 ;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root, exercised via the real
 ;; datahike.audit/verify-chain :deep? API (which re-derives every node's content hash from
-;; storage and confirms it matches its address). Covers baseline crypto AND crypto+op-buf
+;; storage and confirms it matches its address). Covers baseline crypto AND crypto+diff-buf
 ;; (branch hash folds the slots), warm and after a cold reopen (projection-on-read). Also
 ;; spot-checks the index-level protocol directly.
 (defn- audit-indices [db]
@@ -604,13 +604,13 @@
   (async done
     (go
       (try
-        (doseq [[label opbuf] [["crypto baseline" 0] ["crypto + op-buf" 256]]]
+        (doseq [[label opbuf] [["crypto baseline" 0] ["crypto + diff-buf" 256]]]
           (let [dir (tmp-dir)
                 cfg {:store {:backend :file :path dir :id (random-uuid)}
                      :schema-flexibility :write :keep-history? false
                      :crypto-hash? true
                      :index :datahike.index/persistent-set
-                     :index-config (when (pos? opbuf) {:op-buf-size opbuf})}]
+                     :index-config (when (pos? opbuf) {:diff-buf-size opbuf})}]
             (<! (d/create-database cfg))
             (let [conn (d/connect cfg)]
               (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
@@ -623,7 +623,7 @@
                 (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm index audit: " (pr-str res)))
                 (is (and (= :ok st) (= :ok deep)) (str label " warm verify-chain deep: " st "/" deep " diffs=" (pr-str diffs))))
               (d/release conn))
-            ;; cold reopen → audit must still re-derive matching hashes (op-buf projection)
+            ;; cold reopen → audit must still re-derive matching hashes (diff-buf projection)
             (let [conn2 (d/connect cfg)
                   res   (audit-indices @conn2)
                   [st deep diffs] (deep-verify-ok? @conn2)]

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -434,6 +434,53 @@
           (finally
             (done)))))))
 
+;; OP_BUF_V5 phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
+;; exercising the rotate/merge/merge-split slot-carry). Insert 2000, retract the even ones,
+;; cold-reopen and verify the surviving odd set exactly.
+(def ^:private cljs-opbuf-rm-dir "/tmp/dh-cljs-opbuf-rm")
+
+(deftest cljs-opbuf-remove-roundtrip-test
+  (let [sid #uuid "00000000-0000-0000-0000-0000000c1c5b"
+        cfg {:store {:backend :file :path cljs-opbuf-rm-dir :id sid}
+             :schema-flexibility :write :keep-history? false
+             :index :datahike.index/persistent-set
+             :index-config {:op-buf-size 256}}]
+    (async done
+      (go
+        (try
+          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+          (<! (d/create-database cfg))
+          (let [conn (d/connect cfg)]
+            (<! (d/transact! conn [{:db/ident :n :db/valueType :db.type/long
+                                    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}]))
+            (loop [bs (partition-all 100 (range 2000))]
+              (when (seq bs)
+                (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
+                (recur (rest bs))))
+            ;; retract even-:n entities (unique :n ⇒ lookup-ref retraction) in small commits
+            (loop [bs (partition-all 100 (filter even? (range 2000)))]
+              (when (seq bs)
+                (<! (d/transact! conn (mapv (fn [i] [:db/retractEntity [:n i]]) (first bs))))
+                (recur (rest bs))))
+            (let [db @conn
+                  vs (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db :eavt)))))]
+              (is (= 1000 (count vs)) (str "warm survivors=" (count vs)))
+              (is (= (vec (range 1 2000 2)) vs) "warm: exactly the odd :n survive"))
+            (d/release conn))
+          ;; cold reopen → projection-on-read of buffered slots after structural removes
+          (let [conn2 (d/connect cfg)
+                db2   @conn2
+                vs    (vec (sort (map :v (filter #(= :n (:a %)) (d/datoms db2 :eavt)))))
+                sum   (reduce + vs)]
+            (is (= 1000 (count vs)) (str "cold survivors=" (count vs)))
+            (is (= 1000000 sum) (str "cold sum of odds=" sum))
+            (is (= (vec (range 1 2000 2)) vs) "cold: exactly the odd :n survive (remove+merge slot-carry sound)")
+            (d/release conn2))
+          (catch js/Error e
+            (is false (str "cljs-opbuf-remove-roundtrip error: " (.-message e))))
+          (finally
+            (done)))))))
+
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.cljs-pattern-scan-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -481,6 +481,53 @@
           (finally
             (done)))))))
 
+;; OP_BUF_V5 phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
+;; old value) routes through psset/replace → Branch.$replace for eavt/aevt. Insert 1000 ids
+;; with :n 0, then update each :n to its id in small commits, cold-reopen and verify :n == id.
+(def ^:private cljs-opbuf-rep-dir "/tmp/dh-cljs-opbuf-rep")
+
+(deftest cljs-opbuf-replace-roundtrip-test
+  (let [sid #uuid "00000000-0000-0000-0000-0000000c1c5c"
+        cfg {:store {:backend :file :path cljs-opbuf-rep-dir :id sid}
+             :schema-flexibility :write :keep-history? false
+             :index :datahike.index/persistent-set
+             :index-config {:op-buf-size 256}}]
+    (async done
+      (go
+        (try
+          (when (<! (d/database-exists? cfg)) (<! (d/delete-database cfg)))
+          (<! (d/create-database cfg))
+          (let [conn (d/connect cfg)]
+            (<! (d/transact! conn [{:db/ident :id :db/valueType :db.type/long
+                                    :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}
+                                   {:db/ident :n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]))
+            (loop [bs (partition-all 100 (range 1000))]
+              (when (seq bs)
+                (<! (d/transact! conn (mapv (fn [i] {:id i :n 0}) (first bs))))
+                (recur (rest bs))))
+            ;; cardinality-one update of :n in small commits → upsert → $replace (eavt/aevt)
+            (loop [bs (partition-all 100 (range 1000))]
+              (when (seq bs)
+                (<! (d/transact! conn (mapv (fn [i] [:db/add [:id i] :n i]) (first bs))))
+                (recur (rest bs))))
+            (let [db @conn
+                  pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db)]
+              (is (= 1000 (count pairs)) (str "warm pairs=" (count pairs)))
+              (is (every? (fn [[id n]] (= id n)) pairs) "warm: every :n updated to its :id"))
+            (d/release conn))
+          ;; cold reopen → projection-on-read after $replace buffering
+          (let [conn2 (d/connect cfg)
+                db2   @conn2
+                pairs (d/q '[:find ?id ?n :where [?e :id ?id] [?e :n ?n]] db2)
+                nsum  (reduce + (map second pairs))]
+            (is (= 1000 (count pairs)) (str "cold pairs=" (count pairs)))
+            (is (every? (fn [[id n]] (= id n)) pairs) "cold: every :n == its :id ($replace projection sound)")
+            (is (= 499500 nsum) (str "cold sum :n=" nsum)))
+          (catch js/Error e
+            (is false (str "cljs-opbuf-replace-roundtrip error: " (.-message e))))
+          (finally
+            (done)))))))
+
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.cljs-pattern-scan-test

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -3,6 +3,7 @@
             [cljs.reader]
             [datahike.api :as d]
             [datahike.index.audit :as ia]
+            [datahike.audit :as audit]
             [datahike.online-gc :as online-gc]
             [konserve.core :as k]
             [konserve.node-filestore :as nfs] ;; Register :file backend for Node.js
@@ -586,14 +587,18 @@
             (done)))))))
 
 ;; OP_BUF_V5 phase-3 gate: cljs MERKLE AUDIT (crypto-hash). Validates the cljs port of
-;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root: for each index it must
-;; re-derive every node's content hash from storage and confirm it matches its address —
-;; baseline crypto AND crypto+op-buf (branch hash folds the slots), warm and after a cold
-;; reopen (projection-on-read). Calls the index-level protocol directly (datahike.audit's
-;; verify-chain does not yet cljs-compile — separate core.async go-try- issue).
+;; branch-crypto-uuid/canon/walk-pss + -recompute-merkle-root, exercised via the real
+;; datahike.audit/verify-chain :deep? API (which re-derives every node's content hash from
+;; storage and confirms it matches its address). Covers baseline crypto AND crypto+op-buf
+;; (branch hash folds the slots), warm and after a cold reopen (projection-on-read). Also
+;; spot-checks the index-level protocol directly.
 (defn- audit-indices [db]
   (mapv (fn [k] [k (:status (ia/-recompute-merkle-root (get db k)))])
         [:eavt :aevt :avet]))
+
+(defn- deep-verify-ok? [db]
+  (let [rep (audit/verify-chain db nil {:deep? true})]
+    [(:status rep) (get-in rep [:deep :status]) (get-in rep [:deep :diffs])]))
 
 (deftest cljs-merkle-audit-test
   (async done
@@ -613,13 +618,17 @@
                 (when (seq bs)
                   (<! (d/transact! conn (mapv (fn [i] {:n i}) (first bs))))
                   (recur (rest bs))))
-              (let [res (audit-indices @conn)]
-                (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm audit: " (pr-str res))))
+              (let [res (audit-indices @conn)
+                    [st deep diffs] (deep-verify-ok? @conn)]
+                (is (every? (fn [[_ s]] (= :ok s)) res) (str label " warm index audit: " (pr-str res)))
+                (is (and (= :ok st) (= :ok deep)) (str label " warm verify-chain deep: " st "/" deep " diffs=" (pr-str diffs))))
               (d/release conn))
             ;; cold reopen → audit must still re-derive matching hashes (op-buf projection)
             (let [conn2 (d/connect cfg)
-                  res   (audit-indices @conn2)]
-              (is (every? (fn [[_ s]] (= :ok s)) res) (str label " cold audit: " (pr-str res)))
+                  res   (audit-indices @conn2)
+                  [st deep diffs] (deep-verify-ok? @conn2)]
+              (is (every? (fn [[_ s]] (= :ok s)) res) (str label " cold index audit: " (pr-str res)))
+              (is (and (= :ok st) (= :ok deep)) (str label " cold verify-chain deep: " st "/" deep " diffs=" (pr-str diffs)))
               (d/release conn2))
             (<! (d/delete-database cfg))))
         (catch js/Error e

--- a/test/datahike/test/store_test.cljc
+++ b/test/datahike/test/store_test.cljc
@@ -105,3 +105,34 @@
                           #"\s+:id\s+"
                           (d/database-exists?
                            {:store {:backend :memory}})))))
+
+#?(:clj
+   (deftest test-diff-buf-upsert-reopen
+     ;; Regression: diff-buf buffers a value-changing upsert as Absent(old)+Present(new) in a leaf-diff.
+     ;; The leaf-diff must serialize to the comparator-agnostic {:absent :present} form; if it were a
+     ;; map keyed by the Datom, fressian round-trip would re-key by Datom equality (e,a,v — ignores tx),
+     ;; collapsing the two entries and dropping the removal → a stale old datom survives reopen.
+     (testing "many value-changing upserts survive store→reopen with no stale/duplicate datoms (diff-buf)"
+       (let [cfg {:store {:backend :file
+                          :path (str (System/getProperty "java.io.tmpdir") "/dh-diffbuf-upsert")
+                          :id #uuid "d1ffb000-0000-0000-0000-00000000d1ff"}
+                  :schema-flexibility :write :keep-history? false
+                  :index-config {:diff-buf-size 256 :branching-factor 16}}
+             n   400]
+         (d/delete-database cfg)
+         (d/create-database cfg)
+         (let [conn (d/connect cfg)]
+           (d/transact conn [{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                             {:db/ident :age  :db/valueType :db.type/long   :db/cardinality :db.cardinality/one}])
+           (doseq [i (range n)]       (d/transact conn [{:name (str "p" i) :age (mod (* i 7) 100)}]))
+           (doseq [i (range 0 n 3)]   (d/transact conn [{:name (str "p" i) :age (+ 100 i)}]))   ; value-changing upserts
+           (d/release conn))
+         (let [conn (d/connect cfg)
+               db   @conn
+               got  (set (d/q '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]] db))
+               exp  (into #{} (for [i (range n)] [(str "p" i) (if (zero? (mod i 3)) (+ 100 i) (mod (* i 7) 100))]))]
+           (is (= exp got) "name/age query exact after reopen")
+           (is (= (* 2 n) (count (filter #(#{:name :age} (:a %)) (d/datoms db :eavt))))
+               "exactly one :name + one :age datom per entity (no stale buffered-replace duplicate)")
+           (d/release conn))
+         (d/delete-database cfg)))))

--- a/test/datahike/test/upsert_impl_test.cljc
+++ b/test/datahike/test/upsert_impl_test.cljc
@@ -29,7 +29,9 @@
                              projected-vec}))]
     (testing "Against an entry in the projection area,"
       (testing "we are in a projection"
-        (is (= (:key (first (:diff-buf tree))) projected-vec)))
+        ;; NOTE: :op-buf here is the hitchhiker-tree's own Bε operation buffer — unrelated to
+        ;; persistent-sorted-set's diff-buf. Do NOT rename.
+        (is (= (:key (first (:op-buf tree))) projected-vec)))
       (testing "basic lookup works"
         (is (= [[1 :age 44 1] nil] (first (msg/lookup-fwd-iter tree [1 :age 44 1])))))
       (testing "a totally new entry is persisted"

--- a/test/datahike/test/upsert_impl_test.cljc
+++ b/test/datahike/test/upsert_impl_test.cljc
@@ -29,7 +29,7 @@
                              projected-vec}))]
     (testing "Against an entry in the projection area,"
       (testing "we are in a projection"
-        (is (= (:key (first (:op-buf tree))) projected-vec)))
+        (is (= (:key (first (:diff-buf tree))) projected-vec)))
       (testing "basic lookup works"
         (is (= [[1 :age 44 1] nil] (first (msg/lookup-fwd-iter tree [1 :age 44 1])))))
       (testing "a totally new entry is persisted"


### PR DESCRIPTION
## diff-buf write-buffering + index-root fusion (PSS-backed indexes)

Two related write-amplification reductions for content-addressed (konserve) persistence, both landing on the persistent-sorted-set index.

### 1. diff-buf (per-child diff buffering at the serialization boundary)
Backed by persistent-sorted-set PR replikativ/persistent-sorted-set#6. A normal commit rewrites the whole root→leaf spine (~`depth+1` object PUTs). With diff-buf, a rewritten branch *buffers* each content-only child's diff into a per-child slot and re-points the child to its durable anchor, so a content-only commit costs **~1 PUT** instead of `~depth+1`. Reads project the buffered diff back lazily on descent (baseline read cost). datahike wiring:
- `:slots` round-trip in the fressian `Branch` read/write handlers (clj + cljs).
- `:diff-buf-size` / `:branching-factor` are create-time-fixed via `:index-config` (round-trips with the store; `connect` adopts the stored value). **Default ON (256) for new stores.**
- crypto-hash / merkle: a branch's content UUID folds its slots; GC/`markFreed` defer freeing to commit so a re-pointed anchor is never freed.

### 2. index-root fusion
Inlines each index's root node into the db-record, so `commit!` skips writing those roots as separate objects (one fewer PUT/commit, and it composes with diff-buf toward ~2 PUTs/commit). **Opt-in, default OFF** (`*default-fuse-index-roots?*`) for now — flipping the default churns object-count assertions across the suite; the SaaS template opts in, and `connect` adopts the stored value so fused and non-fused stores both reconnect. Design note: `doc/index-root-fusion.md`.

### Comparator on the tree (storage stays comparator-agnostic)
The per-index comparator now lives on the PSS and propagates to its Branch nodes (`Branch._projCmp`), instead of being carried on storage. This PR removes `CachedStorage`'s `cmp` field, its `comparator` impl, and `with-comparator`. (Mirrors the upstream PSS change; resolves the earlier review note about a storage-carried comparator.)

### Dependencies (no local checkouts)
- `persistent-sorted-set` → git `a36ecbe…` (branch `feature/op-buf-v5`). Its Java is compiled by tools.deps prep — run **`clojure -X:deps prep`** once after fetching (CI step).
- `konserve` → released **`0.9.349`** (includes the cljs cross-host header meta-size fix #143), replacing the former local dev checkout.

### Validation
- `clj-pss` (default index = persistent-set, diff-buf on): **522 tests / 2475 assertions / 0 failures** (`-Xmx4g`).
- Crash-safety: crash-injection at both sides of the commit HEAD-flip (file backend, diff-buf on) recovers to the old-or-new consistent state — indices agree, no torn/duplicate datoms.
- New regression: `store-test/test-diff-buf-upsert-reopen` (value-changing upserts survive store→reopen with no stale/duplicate datoms — guards the comparator-agnostic `{:absent :present}` leaf-diff serialization).

### Known, non-critical (deferred — not addressed here)
A **fatal `Error`** (e.g. OOM) thrown inside the async write/commit pipeline can hang a synchronous `transact` (the no-timeout deref never completes, because `superv.async` `go-try` catches `Exception`, not `Throwable`). It does **not** corrupt data (commit is copy-on-write + atomic HEAD flip + free-after-flip). Pre-existing, orthogonal to this PR; the clean fix is a deref timeout. Tracked internally.

### Notes
- PSS naming was `op-buf` (hitchhiker/Bε operation buffer); renamed `diff-buf` since this buffers a per-child *diff* at the serialization boundary. History can be squashed on merge.
