### PR TITLE
fix(query): scale-sensitive cache keys for BigDecimal consts/args

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -2742,29 +2742,31 @@
         plan (lower-plan logical db rules)]
     plan))
 
-(defn- key-has-bigdec?
-  "Read-only scan: does `x` (a cache-key fragment) contain a BigDecimal?
+#?(:clj
+   (defn- key-has-bigdec?
+     "Read-only scan: does `x` (a cache-key fragment) contain a BigDecimal?
    Recurses only plain Clojure collections; records and opaque values
    (Datom, DB, fns, …) are treated as leaves so we never call unsupported
    ops on them. Lets `scale-sensitive-key` skip the (allocating) rebuild for
-   the overwhelmingly common BigDecimal-free key."
-  [x]
-  (cond
-    (instance? java.math.BigDecimal x) true
-    (record? x)                        false
-    (map? x)  (reduce-kv (fn [_ k v] (if (or (key-has-bigdec? k) (key-has-bigdec? v))
-                                       (reduced true) false))
-                         false x)
-    ;; indexed loop for vectors (cache keys are vectors of vectors) and a
-    ;; reducing scan for sets/seqs — both avoid allocating a lazy seq per node.
-    (vector? x) (let [n (count x)]
-                  (loop [i 0]
-                    (cond (= i n) false
-                          (key-has-bigdec? (nth x i)) true
-                          :else (recur (unchecked-inc i)))))
-    (or (set? x) (seq? x)) (reduce (fn [_ e] (if (key-has-bigdec? e) (reduced true) false))
-                                   false x)
-    :else                              false))
+   the overwhelmingly common BigDecimal-free key. CLJ only — ClojureScript
+   has no BigDecimal."
+     [x]
+     (cond
+       (instance? java.math.BigDecimal x) true
+       (record? x)                        false
+       (map? x)  (reduce-kv (fn [_ k v] (if (or (key-has-bigdec? k) (key-has-bigdec? v))
+                                          (reduced true) false))
+                            false x)
+       ;; indexed loop for vectors (cache keys are vectors of vectors) and a
+       ;; reducing scan for sets/seqs — both avoid allocating a lazy seq per node.
+       (vector? x) (let [n (count x)]
+                     (loop [i 0]
+                       (cond (= i n) false
+                             (key-has-bigdec? (nth x i)) true
+                             :else (recur (unchecked-inc i)))))
+       (or (set? x) (seq? x)) (reduce (fn [_ e] (if (key-has-bigdec? e) (reduced true) false))
+                                      false x)
+       :else                              false)))
 
 (defn scale-sensitive-key
   "Canonicalize a value for use as (part of) a cache key.
@@ -2782,21 +2784,26 @@
    `[::bigdec <unscaled BigInteger> <scale int>]`, recursing only plain Clojure
    collections (records and opaque values like Datom/DB are left as-is).
    Returns `x` itself when it contains no BigDecimal — no allocation on the
-   common path."
+   common path.
+
+   No-op in ClojureScript: JS has no BigDecimal (only doubles), so the
+   scale-insensitivity collision cannot arise there."
   [x]
-  (if-not (key-has-bigdec? x)
-    x
-    (letfn [(walk [v]
-              (cond
-                (instance? java.math.BigDecimal v)
-                [::bigdec (.unscaledValue ^java.math.BigDecimal v) (.scale ^java.math.BigDecimal v)]
-                (record? v) v
-                (map? v)    (into (empty v) (map (fn [e] [(walk (key e)) (walk (val e))])) v)
-                (vector? v) (mapv walk v)
-                (set? v)    (into (empty v) (map walk) v)
-                (seq? v)    (doall (map walk v))
-                :else       v))]
-      (walk x))))
+  #?(:cljs x
+     :clj
+     (if-not (key-has-bigdec? x)
+       x
+       (letfn [(walk [v]
+                 (cond
+                   (instance? java.math.BigDecimal v)
+                   [::bigdec (.unscaledValue ^java.math.BigDecimal v) (.scale ^java.math.BigDecimal v)]
+                   (record? v) v
+                   (map? v)    (into (empty v) (map (fn [e] [(walk (key e)) (walk (val e))])) v)
+                   (vector? v) (mapv walk v)
+                   (set? v)    (into (empty v) (map walk) v)
+                   (seq? v)    (doall (map walk v))
+                   :else       v))]
+         (walk x)))))
 
 (defn- get-or-create-plan
   "Get a cached query plan or create a new one. Plans are cached by

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -2742,14 +2742,74 @@
         plan (lower-plan logical db rules)]
     plan))
 
+(defn- key-has-bigdec?
+  "Read-only scan: does `x` (a cache-key fragment) contain a BigDecimal?
+   Recurses only plain Clojure collections; records and opaque values
+   (Datom, DB, fns, …) are treated as leaves so we never call unsupported
+   ops on them. Lets `scale-sensitive-key` skip the (allocating) rebuild for
+   the overwhelmingly common BigDecimal-free key."
+  [x]
+  (cond
+    (instance? java.math.BigDecimal x) true
+    (record? x)                        false
+    (map? x)  (reduce-kv (fn [_ k v] (if (or (key-has-bigdec? k) (key-has-bigdec? v))
+                                       (reduced true) false))
+                         false x)
+    ;; indexed loop for vectors (cache keys are vectors of vectors) and a
+    ;; reducing scan for sets/seqs — both avoid allocating a lazy seq per node.
+    (vector? x) (let [n (count x)]
+                  (loop [i 0]
+                    (cond (= i n) false
+                          (key-has-bigdec? (nth x i)) true
+                          :else (recur (unchecked-inc i)))))
+    (or (set? x) (seq? x)) (reduce (fn [_ e] (if (key-has-bigdec? e) (reduced true) false))
+                                   false x)
+    :else                              false))
+
+(defn scale-sensitive-key
+  "Canonicalize a value for use as (part of) a cache key.
+
+   Clojure's `=` and `hash` for BigDecimal are scale-INSENSITIVE
+   (compareTo-based): `(= 1.50M 1.500M)` => true and their hashes are equal,
+   so they collide as map/vector keys (e.g. `(get {1.50M :a} 1.500M)` => :a).
+   But query plans embed the substituted constant and query results carry the
+   value's scale (`1.50M` and `1.500M` print differently), so two
+   numerically-equal but differently-scaled values MUST map to DIFFERENT cache
+   keys — otherwise whichever scale is cached first wins and later queries get
+   the wrong scale. See clojure.org/guides/equality.
+
+   Replaces every BigDecimal with a scale-sensitive surrogate
+   `[::bigdec <unscaled BigInteger> <scale int>]`, recursing only plain Clojure
+   collections (records and opaque values like Datom/DB are left as-is).
+   Returns `x` itself when it contains no BigDecimal — no allocation on the
+   common path."
+  [x]
+  (if-not (key-has-bigdec? x)
+    x
+    (letfn [(walk [v]
+              (cond
+                (instance? java.math.BigDecimal v)
+                [::bigdec (.unscaledValue ^java.math.BigDecimal v) (.scale ^java.math.BigDecimal v)]
+                (record? v) v
+                (map? v)    (into (empty v) (map (fn [e] [(walk (key e)) (walk (val e))])) v)
+                (vector? v) (mapv walk v)
+                (set? v)    (into (empty v) (map walk) v)
+                (seq? v)    (doall (map walk v))
+                :else       v))]
+      (walk x))))
+
 (defn- get-or-create-plan
   "Get a cached query plan or create a new one. Plans are cached by
    [clauses bound-vars rules-keys schema-hash] since the plan structure
    (index selection, merge ordering) depends on query shape and schema,
-   not on the actual data."
+   not on the actual data.
+
+   `clauses` may embed substituted constants (substitute-consts-with-lookup-refs),
+   so the key is run through `scale-sensitive-key` to keep BigDecimals of
+   different scale distinct (Clojure `=`/`hash` would otherwise collapse them)."
   [db clauses bound-vars rules]
   (let [schema-hash (hash (dbi/-schema db))
-        cache-key [clauses bound-vars (when rules rules) schema-hash]]
+        cache-key (scale-sensitive-key [clauses bound-vars (when rules rules) schema-hash])]
     (if-some [cached (get @plan-cache cache-key nil)]
       cached
       (let [plan (create-plan-via-ir db clauses bound-vars rules)]
@@ -3762,7 +3822,12 @@
         (if-not cacheable?
           (uncached)
           (let [non-db-args (vec (rest args))
-                cache-key [query non-db-args offset limit order-by *force-legacy*]
+                ;; scale-sensitive-key: BigDecimal args/consts of equal value but
+                ;; different scale (1.50M vs 1.500M) are `=` with equal hash in
+                ;; Clojure, so they'd share a result-cache entry and return the
+                ;; first-cached scale. Keep them distinct.
+                cache-key (scale-sensitive-key
+                           [query non-db-args offset limit order-by *force-legacy*])
                 entry (result-cache-get db cache-key)]
             (if entry
               (:result entry)

--- a/test/datahike/test/query_cache_test.cljc
+++ b/test/datahike/test/query_cache_test.cljc
@@ -3,7 +3,7 @@
    #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer [is deftest testing]])
    [datahike.api :as d]
-   [datahike.query :as dq]))
+   #?(:clj [datahike.query :as dq])))
 
 (defn- with-temp-db
   "Create a temp in-memory db with schema, run f with the connection, then clean up."
@@ -130,27 +130,31 @@
                                  :where [?c :c/id]]
                                (:db-after tx))))))))))
 
-(deftest test-bigdecimal-scale-not-collapsed-by-cache
-  (testing "BigDecimals of equal value but different scale must not share a
+;; CLJ only: ClojureScript has no BigDecimal (`bigdec`), and the
+;; scale-insensitivity collision the fix guards against cannot arise on JS
+;; numbers — so there is nothing to test under CLJS.
+#?(:clj
+   (deftest test-bigdecimal-scale-not-collapsed-by-cache
+     (testing "BigDecimals of equal value but different scale must not share a
             plan/result cache entry (Clojure = / hash are scale-insensitive:
             (= 1.50M 1.500M) => true with equal hash). Querying one scale must
             not make a later numerically-equal query return the first scale."
-    (with-temp-db
-      [{:db/ident :x/n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]
-      (fn [conn]
-        (let [db @conn
-              ;; const-only fn binding: value flows through verbatim, so the
-              ;; result's scale is exactly the input's scale.
-              run (fn [legacy? s]
-                    (binding [dq/*force-legacy* legacy?]
-                      (str (ffirst (d/q '{:find [?v] :in [$ ?p ?f] :where [[(?f ?p) ?v]]}
-                                        db (bigdec s) identity)))))]
-          (doseq [legacy? [true false]]
-            (let [tag (str "force-legacy=" legacy?)]
-              ;; seed cache with one scale, then query equal-value other scales
-              (is (= "0.001" (run legacy? "0.001")) tag)
-              (is (= "0.001000" (run legacy? "0.001000"))
-                  (str tag " — second query must keep its own scale, not the cached one"))
-              (is (= "1.5" (run legacy? "1.5")) tag)
-              (is (= "1.50" (run legacy? "1.50")) tag)
-              (is (= "1.500" (run legacy? "1.500")) tag))))))))
+       (with-temp-db
+         [{:db/ident :x/n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]
+         (fn [conn]
+           (let [db @conn
+                 ;; const-only fn binding: value flows through verbatim, so the
+                 ;; result's scale is exactly the input's scale.
+                 run (fn [legacy? s]
+                       (binding [dq/*force-legacy* legacy?]
+                         (str (ffirst (d/q '{:find [?v] :in [$ ?p ?f] :where [[(?f ?p) ?v]]}
+                                           db (bigdec s) identity)))))]
+             (doseq [legacy? [true false]]
+               (let [tag (str "force-legacy=" legacy?)]
+                 ;; seed cache with one scale, then query equal-value other scales
+                 (is (= "0.001" (run legacy? "0.001")) tag)
+                 (is (= "0.001000" (run legacy? "0.001000"))
+                     (str tag " — second query must keep its own scale, not the cached one"))
+                 (is (= "1.5" (run legacy? "1.5")) tag)
+                 (is (= "1.50" (run legacy? "1.50")) tag)
+                 (is (= "1.500" (run legacy? "1.500")) tag)))))))))

--- a/test/datahike/test/query_cache_test.cljc
+++ b/test/datahike/test/query_cache_test.cljc
@@ -2,7 +2,8 @@
   (:require
    #?(:cljs [cljs.test :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer [is deftest testing]])
-   [datahike.api :as d]))
+   [datahike.api :as d]
+   [datahike.query :as dq]))
 
 (defn- with-temp-db
   "Create a temp in-memory db with schema, run f with the connection, then clean up."
@@ -128,3 +129,28 @@
           (is (= 1 (count (d/q '[:find [(pull ?c [:c/id :c/labels]) ...]
                                  :where [?c :c/id]]
                                (:db-after tx))))))))))
+
+(deftest test-bigdecimal-scale-not-collapsed-by-cache
+  (testing "BigDecimals of equal value but different scale must not share a
+            plan/result cache entry (Clojure = / hash are scale-insensitive:
+            (= 1.50M 1.500M) => true with equal hash). Querying one scale must
+            not make a later numerically-equal query return the first scale."
+    (with-temp-db
+      [{:db/ident :x/n :db/valueType :db.type/long :db/cardinality :db.cardinality/one}]
+      (fn [conn]
+        (let [db @conn
+              ;; const-only fn binding: value flows through verbatim, so the
+              ;; result's scale is exactly the input's scale.
+              run (fn [legacy? s]
+                    (binding [dq/*force-legacy* legacy?]
+                      (str (ffirst (d/q '{:find [?v] :in [$ ?p ?f] :where [[(?f ?p) ?v]]}
+                                        db (bigdec s) identity)))))]
+          (doseq [legacy? [true false]]
+            (let [tag (str "force-legacy=" legacy?)]
+              ;; seed cache with one scale, then query equal-value other scales
+              (is (= "0.001" (run legacy? "0.001")) tag)
+              (is (= "0.001000" (run legacy? "0.001000"))
+                  (str tag " — second query must keep its own scale, not the cached one"))
+              (is (= "1.5" (run legacy? "1.5")) tag)
+              (is (= "1.50" (run legacy? "1.50")) tag)
+              (is (= "1.500" (run legacy? "1.500")) tag))))))))


### PR DESCRIPTION
## Problem

`SELECT \$1::numeric` (via a query that projects a BigDecimal constant/param) returns the **wrong trailing-zero scale** depending on which scale was queried first in the process — e.g. querying `0.001` then `0.001000` returns `0.001` for both. It looked non-deterministic across processes but is a **deterministic cache-key collision**.

## Root cause

The plan cache (`get-or-create-plan`) and result cache (`raw-q`) key on structures that embed BigDecimal values:
- the **plan cache** on `clauses`, which have constants substituted in (`substitute-consts-with-lookup-refs`), e.g. `[(?f 0.001000M) ?v]` — and the cached plan bakes that constant in;
- the **result cache** on the query's non-db args.

Clojure's `=` and `hash` for BigDecimal are **scale-insensitive** (compareTo-based):

```clojure
(= 1.50M 1.500M)             ;=> true
(= (hash 1.50M) (hash 1.500M)) ;=> true
(get {1.50M :a} 1.500M)      ;=> :a   ; map key collision
```

So two numerically-equal but differently-scaled values share a cache entry, and whichever scale is cached first is returned for all of them. A cached plan/result is scale-*sensitive* (the value's scale is observable), so the assumption "equal keys ⇒ equivalent results" is violated.

## Fix

Run both cache keys through `scale-sensitive-key`, which replaces every BigDecimal with a scale-sensitive surrogate `[::bigdec <unscaled BigInteger> <scale int>]`. It:
- recurses **only plain Clojure collections** — records and opaque values (`Datom`, `DB`, fns) are left as-is (an earlier naive `postwalk` blew up calling `empty` on `Datom` args);
- returns the input **unchanged with no allocation** when it contains no BigDecimal (cheap read-only scan on the common path).

Adds `datahike.test.query-cache-test/test-bigdecimal-scale-not-collapsed-by-cache` (both `*force-legacy*` true/false).

## Verification
- New regression test + full `clj-pss` unit suite: **616 tests, 2711 assertions, 0 failures**; query/cache/planner/fns/aggregates focus: 0 failures (also green under `clj-hht`).
- Surfaced via [pg-datahike](https://github.com/replikativ) `SELECT \$1::numeric`; fixes asyncpg `test_codecs::test_numeric`'s scale cases.

## Performance
Per-query overhead on the cache-key path (microbench, warm JVM):
- BigDecimal-free key (common case): ~**220 ns** read-only scan, returns the key object unchanged (no allocation). For reference `(hash key)` ≈ 26 ns; full query execution is µs+, so this is <1% there but ~non-trivial for pure cache hits.
- BigDecimal-containing key: ~**740 ns** (scan + rebuild).

## Notes / follow-ups
- The deeper smell is that `get-or-create-plan` **bakes substituted constants into the cached plan** (its docstring says plans are cached "not on the actual data"). A more fundamental fix keeps constants parametric so plans are value-agnostic; the scale-sensitive key is the minimal, low-risk correctness fix.
- Same class of bug applies to any cache/set keyed on values whose `=` is coarser than the distinction the result preserves (BigDecimal scale here).