### PR TITLE
Fix for #738

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -148,7 +148,7 @@
                             :task (build/clean (-> config :build :http-server-clj))}
 
          http-server-jcompile {:doc     "Compile java classes"
-                               :depends [http-server-clean]
+                               :depends [http-server-clean jcompile]
                                :task    (build/compile-java (-> config :build :http-server-clj))}
 
          http-server-ccompile {:doc  "Compile clojure namespaces for http-server"

--- a/http-server/datahike/http/middleware.clj
+++ b/http-server/datahike/http/middleware.clj
@@ -46,7 +46,7 @@
             response       (handler request)
             should-encode? (and encoder
                                 (not (instance? java.io.ByteArrayInputStream (:body response))))
-            ret     (if should-encode? (update response :body #(encoder %)) response)]
+            ret            (if should-encode? (update response :body #(encoder %)) response)]
         ret))))
 
 (defn patch-swagger-json [handler]

--- a/http-server/datahike/http/middleware.clj
+++ b/http-server/datahike/http/middleware.clj
@@ -41,12 +41,12 @@
 (defn encode-plain-value [muuntaja-with-opts]
   (fn [handler]
     (fn [request]
-      (let [format   (:content-type request)
-            encoder  (m/encoder muuntaja-with-opts format)
-            response (handler request)
-            ret      (if (not (instance? java.io.ByteArrayInputStream (:body response)))
-                       (update response :body #(encoder %))
-                       response)]
+      (let [format         (:content-type request)
+            encoder        (when format (m/encoder muuntaja-with-opts format))
+            response       (handler request)
+            should-encode? (and encoder
+                                (not (instance? java.io.ByteArrayInputStream (:body response))))
+            ret     (if should-encode? (update response :body #(encoder %)) response)]
         ret))))
 
 (defn patch-swagger-json [handler]

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -1,5 +1,7 @@
 (ns datahike.test.http.server-test
   (:require
+   [babashka.http-client :as http]
+   [clojure.string :as str]
    [clojure.test :as t :refer [is deftest testing]]
    [datahike.http.server :refer [start-server stop-server]]
    [datahike.http.client :as api]))
@@ -82,7 +84,15 @@
 
             test-db @conn
             _ (is (= (api/q query test-db)
-                     #{["Peter" 42]}))]
+                     #{["Peter" 42]}))
+
+            swagger-response (http/request {:method :get
+                                            :uri    (str (:url client-config) "/swagger.json")
+                                            :as     :stream})
+            swagger-body     (slurp (:body swagger-response))
+            _                (is (= 200 (:status swagger-response)))
+            _                (is (str/includes? swagger-body "\"swagger\":\"2.0\""))
+            _                (is (str/includes? swagger-body "\"paths\""))]
 
         (is (nil? (api/release conn)))
         (is (nil? (api/delete-database new-config)))


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #738. Root cause was not swagger code itself, but local GET requests to swagger not having Content-Type set. `encode-plain-value ` then calls a nil function, causing the crash. Fix was to make the encoder a noop if nil. Added basic tests to better catch swagger issues in the future. 

Note: Had to run `codegen-java` before running `bb http-server-uber` on a first clone. I added `jcompile` as build dependency to `http-server-jcompile` to workaround that.

#### Checks
<!--- Pick one below and delete the rest -->
##### Bugfix
- [x] Related issues linked using `fixes #number`

##### Feature
- [x] Related issues linked using `fixes #number`

#### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

New tests pass. Original reproduction is fixed too.

1. bb http-server-uber
2. java -jar target-http-server/datahike-http-server-XXX.jar resources/example_server.edn
3. browse http://localhost:4444/index.html

<!--- Paste verbatim command output below, e.g. before and after your change -->
