### PR TITLE
Mark content-addressed writes immutable (konserve per-write meta)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,9 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.4"}
         org.replikativ/hasch                        {:mvn/version "0.4.98"
                                                      :exclusions [org.clojure/clojurescript]}
-        org.replikativ/konserve                     {:mvn/version "0.9.346"
+        ;; TEMPORARY: local konserve for the per-write metadata channel (5-arity +
+        ;; per-key multi-assoc meta — immutable marking). Revert to mvn after release.
+        org.replikativ/konserve                     {:local/root "../konserve"
                                                      :exclusions [org.clojure/clojurescript
                                                                   org.clojars.mmb90/cljs-cache]}
                                                      

--- a/deps.edn
+++ b/deps.edn
@@ -78,7 +78,7 @@
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.95"}
                                is.simm/distributed-scope     {:mvn/version "0.1.2"}
-                               org.replikativ/konserve-sync  {:mvn/version "0.1.15"}
+                               org.replikativ/konserve-sync  {:mvn/version "0.1.30"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,7 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.4"}
         org.replikativ/hasch                        {:mvn/version "0.4.98"
                                                      :exclusions [org.clojure/clojurescript]}
-        ;; TEMPORARY: local konserve for the per-write metadata channel (5-arity +
-        ;; per-key multi-assoc meta — immutable marking). Revert to mvn after release.
-        org.replikativ/konserve                     {:local/root "../konserve"
+        org.replikativ/konserve                     {:mvn/version "0.9.350"
                                                      :exclusions [org.clojure/clojurescript
                                                                   org.clojars.mmb90/cljs-cache]}
                                                      

--- a/src-kabel/datahike/kabel/handlers.cljc
+++ b/src-kabel/datahike/kabel/handlers.cljc
@@ -311,21 +311,32 @@
    Parameters:
    - store-id: UUID identifying the store (from store :id)
    - conn: The datahike connection
-   - peer: The kabel peer atom"
-  [store-id conn peer]
-  (log/info "Registering store for remote access" {:store-id store-id})
+   - peer: The kabel peer atom
+   - opts (optional): {:branches <scope>} forwarded to the walker. `:all`
+     (default) syncs every branch's nodes so a subscriber can `branch-as-db`
+     any branch locally; `:trunk` / a branch keyword / a coll scopes the
+     initial node sync to those branches (lean replica of the active branch —
+     out-of-scope branches must be fetched on demand). See
+     `konserve-sync.walkers.datahike/datahike-walk-fn`."
+  ([store-id conn peer]
+   (register-store-for-remote-access! store-id conn peer nil))
+  ([store-id conn peer {:keys [branches]}]
+   (log/info "Registering store for remote access" {:store-id store-id :branches branches})
 
   ;; Register connection lookup
-  (register-connection-for-store! store-id conn peer)
+   (register-connection-for-store! store-id conn peer)
 
   ;; Register for konserve-sync (use UUID directly as topic)
-  (let [store (:store @(:wrapped-atom conn))]
-    (sync/register-store! peer store-id store
-                          {:walk-fn dh-walker/datahike-walk-fn
-                           :key-sort-fn (fn [k] (if (= k :db) 1 0))}))
+   (let [store   (:store @(:wrapped-atom conn))
+         walk-fn (if branches
+                   (fn [s opts] (dh-walker/datahike-walk-fn s (assoc opts :branches branches)))
+                   dh-walker/datahike-walk-fn)]
+     (sync/register-store! peer store-id store
+                           {:walk-fn walk-fn
+                            :key-sort-fn (fn [k] (if (= k :db) 1 0))}))
 
   ;; Register tx-report topic for pubsub
-  (tx-broadcast/register-tx-report-topic! peer store-id))
+   (tx-broadcast/register-tx-report-topic! peer store-id)))
 
 (defn unregister-store-for-remote-access!
   "Unregister a datahike store from remote access.

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -293,10 +293,12 @@
   Handles synchronous and asynchronous writes.
   Assumes it's called within a go-try- block if sync? is false."
   [store kvs sync?]
+  ;; pending-kvs are content-addressed index nodes (write-once) → mark immutable so a sync
+  ;; peer can skip re-storing/re-publishing a node it already holds (anti-entropy/echo).
   (if sync?
     (doseq [[k v] kvs]
-      (k/assoc store k v {:sync? true}))
-    (let [pending-ops (mapv (fn [[k v]] (k/assoc store k v {:sync? false})) kvs)]
+      (k/assoc store k v {:immutable? true} {:sync? true}))
+    (let [pending-ops (mapv (fn [[k v]] (k/assoc store k v {:immutable? true} {:sync? false})) kvs)]
       (go-try- (doseq [op pending-ops] (<?- op))))))
 
 (defn commit!
@@ -327,17 +329,27 @@
                                        schema-meta-kv-to-write (assoc meta-key meta-val)
                                        true                    (assoc cid db-to-store)
                                        true                    (assoc (:branch config) db-to-store))]
-                      (<?- (k/multi-assoc store writes-map {:sync? sync?})))
+                      ;; nodes + schema-meta (uuid) + commit (cid) are content-addressed →
+                      ;; immutable; the branch-head pointer (:branch config) stays mutable.
+                      ;; per-key meta map: every key but the branch head marked immutable.
+                      (<?- (k/multi-assoc store writes-map
+                                          (reduce-kv (fn [m k _] (cond-> m
+                                                                   (not= k (:branch config))
+                                                                   (assoc k {:immutable? true})))
+                                                     {} writes-map)
+                                          {:sync? sync?})))
                     ;; Then write schema-meta, commit-log, branch
                     (let [[meta-key meta-val] schema-meta-kv-to-write
                           schema-meta-written (when schema-meta-kv-to-write
-                                                (k/assoc store meta-key meta-val {:sync? sync?}))
+                                                ;; schema-meta-key = (uuid schema-meta) → content-addressed → immutable
+                                                (k/assoc store meta-key meta-val {:immutable? true} {:sync? sync?}))
 
                           ;; Make sure all pointed to values are written before the commit log and branch
                           _ (when schema-meta-kv-to-write (<?- schema-meta-written))
                           _ (<?- (write-pending-kvs! store pending-kvs sync?))
 
-                          commit-log-written (k/assoc store cid db-to-store {:sync? sync?})
+                          ;; the commit is content-addressed by cid → immutable; the branch head is mutable
+                          commit-log-written (k/assoc store cid db-to-store {:immutable? true} {:sync? sync?})
                           branch-written     (k/assoc store (:branch config) db-to-store {:sync? sync?})]
                       (when-not sync?
                         (<?- commit-log-written)
@@ -453,7 +465,8 @@
          meta (assoc meta :datahike/commit-id cid)
          db-to-store (assoc pre-cid-stored :meta meta)]
      ;;we just created the first data base in this store, so the write cache is empty
-     (<?- (k/assoc store schema-meta-key schema-meta opts))
+     ;; schema-meta-key = (uuid schema-meta) → content-addressed, immutable
+     (<?- (k/assoc store schema-meta-key schema-meta {:immutable? true} opts))
      (sc/add-to-write-cache (:store config) schema-meta-key)
      (when-not (sc/cache-has? schema-meta-key)
        (sc/cache-miss schema-meta-key schema-meta))
@@ -462,9 +475,9 @@
      (let [pending-kvs (get-and-clear-pending-kvs! store)]
        (<?- (write-pending-kvs! store pending-kvs false)))
 
-     (<?- (k/assoc store :branches #{:db} opts))
-     (<?- (k/assoc store cid db-to-store opts))
-     (<?- (k/assoc store :db db-to-store opts))
+     (<?- (k/assoc store :branches #{:db} opts))           ; mutable: branch set
+     (<?- (k/assoc store cid db-to-store {:immutable? true} opts)) ; content-addressed commit
+     (<?- (k/assoc store :db db-to-store opts))             ; mutable: branch head
      (ks/release-store store-config store)
      config)))
 


### PR DESCRIPTION
Marks every write-once, content-addressed value with `{:immutable? true}` via konserve's per-write metadata channel, so konserve-sync can skip echoing nodes a peer already has (echo-free p2p sync of a datahike store). Mutable pointers — the branch head and the `:branches` set — stay unmarked so peers still converge on the latest head.

## What's marked
- index nodes (`write-pending-kvs!`): immutable
- the commit batch (`multi-assoc`): per-key data map marks all but the branch head
- schema-meta (`(uuid schema-meta)`) and the commit id (`cid`): immutable — both the `create-database` and `commit!` paths
- `:branches` set + branch head (`:db`): left mutable

Verified in-store: 7/9 keys immutable, only the branch head + `:branches` set mutable. api/gc/online-gc/history suites green.

## Also here
- **deps:** konserve `0.9.350` + konserve-sync `0.1.30` (both released; drops the temporary local konserve pin). Full-mvn, no local-root deps.
- **kabel:** `register-store-for-remote-access!` gains an optional `{:branches <scope>}` arg forwarded to the konserve-sync datahike walker — scope the initial node sync to the active branch (lean replica) instead of every fork. Default stays `:all`. Forward-compatible (older walker ignores it).

Independent of the PSS MST/canonical arc — builds against released PSS 0.4.122.