### PR TITLE
fix(cljs): resolve :undeclared-var / shadowing warnings in core nss

### DIFF
--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -1,6 +1,6 @@
 (ns datahike.index.interface
   "All the functions in this namespace must be implemented for each index type"
-  #?(:cljs (:refer-clojure :exclude [-seq -count -persistent! -flush])))
+  #?(:cljs (:refer-clojure :exclude [-seq -count -persistent! -flush -lookup])))
 
 (defprotocol IIndex
   (-all [index] "Returns a sequence of all datoms in the index")

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -2,6 +2,8 @@
   "Pluggable secondary index protocol and registry.
    Secondary indices are declared through schema and maintained in-transaction.
    Anyone can register their own index type — the planner treats all uniformly."
+  ;; protocol methods -as-transient / -persistent! shadow cljs.core's names
+  #?(:cljs (:refer-clojure :exclude [-as-transient -persistent!]))
   (:require [replikativ.logging :as log]
             [datahike.bitemporal.predicate :as bp.pred]
             [datahike.db.interface :as dbi]

--- a/src/datahike/versioning.cljc
+++ b/src/datahike/versioning.cljc
@@ -9,8 +9,11 @@
                                       write-pending-kvs!]]
             [datahike.writer]
             [datahike.index.secondary :as sec]
+            ;; cljs: S is a VAR (the supervisor) → :refer; go-try-/<?-/<?/go-loop-try
+            ;; are MACROS → :refer-macros. (Was missing <? entirely and putting S
+            ;; under :refer-macros, so both were :undeclared-var on cljs.)
             #?(:clj  [superv.async :refer [go-try- <?- <? S go-loop-try]]
-               :cljs [superv.async :refer-macros [go-try- <?- S go-loop-try]])
+               :cljs [superv.async :refer [S] :refer-macros [go-try- <?- <? go-loop-try]])
             [datahike.db.utils :refer [db?]]
             [datahike.tools :as dt]
             [replikativ.logging :as log]

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -437,7 +437,7 @@
          safe-root      (fn [x]
                           (when x
                             (try (audit/-merkle-root x)
-                                 (catch Throwable _ nil))))
+                                 (catch #?(:clj Throwable :cljs :default) _ nil))))
          merkle-roots   (cond-> {:eavt-key (safe-root eavt')
                                  :aevt-key (safe-root aevt')
                                  :avet-key (safe-root avet')}


### PR DESCRIPTION
ClojureScript's single-pass analyzer flags several real cljs issues in core namespaces. All are benign on the JVM (the `:clj` reader branches are unchanged), but two are genuine cljs runtime bugs (`versioning`, `writing`) and the rest are noisy shadowing warnings.

## Fixes
- **`versioning.cljc`** — the `superv.async` cljs require put `S` (a **var** — the supervisor) under `:refer-macros` and omitted `<?` entirely, so both were `:undeclared-var` on cljs (and would fail at runtime). Split correctly: `:refer [S]` + `:refer-macros [go-try- <?- <? go-loop-try]`.
- **`writing.cljc`** — `(catch Throwable …)` → `(catch #?(:clj Throwable :cljs :default) …)` (`Throwable` is undeclared on cljs).
- **`index/interface.cljc`** — add `-lookup` to the cljs `:refer-clojure :exclude` (`IIndex` defines it, shadowing `cljs.core/-lookup`).
- **`index/secondary.cljc`** — add `#?(:cljs (:refer-clojure :exclude [-as-transient -persistent!]))` (`ITransientSecondaryIndex` defines both).

## Verification
- The `:node-test` cljs build compiles green and these warnings are gone.
- JVM is byte-identical: only `:cljs` reader branches / cljs-only `:refer-clojure :exclude`s changed. Confirmed clean `main` reproduces the same pre-existing bare-`clj` AOT class-load behaviour, so it's unaffected.

## Out of scope
The remaining cljs warnings all live in `datahike.query.execute` (`probe-driven-iterable`, `java`, `execute-temporal-group-rel`) — JVM-specific query fast-paths whose use sites aren't `#?(:clj)`-gated. Those want a maintainer's eye on the query engine's platform split, so I left them out of this focused PR.