### PR TITLE
fix(cljs): portable query engine over temporal DBs + op-flag projection

### DIFF
--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -23,8 +23,7 @@
   #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]
                             [clojure.core.async :refer [go]]))
   #?(:clj
-     (:import [clojure.lang Keyword PersistentArrayMap]
-              [datahike.db HistoricalDB AsOfDB SinceDB FilteredDB]
+     (:import [datahike.db HistoricalDB AsOfDB SinceDB FilteredDB]
               [datahike.impl.entity Entity])))
 
 (defn transact! [connection arg-map]
@@ -73,18 +72,20 @@
   #?(:clj  @(writing/database-exists? config)
      :cljs (writing/database-exists? config)))
 
+;; Dispatch on the ARG SHAPE (map vs index+components), not the concrete map
+;; class: a small map literal is PersistentArrayMap on the JVM but can be
+;; PersistentHashMap on cljs, so the old `(type arg-map)`-keyed dispatch silently
+;; missed the arg-map form there. `map?` is value-level and cross-platform.
 (defmulti datoms
   (fn
-    ([_db arg-map]
-     (type arg-map))
-    ([_db index & _components]
-     (type index))))
+    ([_db arg-map] (if (map? arg-map) ::arg-map ::index))
+    ([_db _index & _components] ::index)))
 
-(defmethod datoms PersistentArrayMap
+(defmethod datoms ::arg-map
   [db {:keys [index components]}]
   (dbi/datoms db index components))
 
-(defmethod datoms Keyword
+(defmethod datoms ::index
   [db index & components]
   (if (nil? components)
     (dbi/datoms db index [])
@@ -92,16 +93,14 @@
 
 (defmulti seek-datoms
   (fn
-    ([_db arg-map]
-     (type arg-map))
-    ([_db index & _components]
-     (type index))))
+    ([_db arg-map] (if (map? arg-map) ::arg-map ::index))
+    ([_db _index & _components] ::index)))
 
-(defmethod seek-datoms PersistentArrayMap
+(defmethod seek-datoms ::arg-map
   [db {:keys [index components]}]
   (dbi/seek-datoms db index components))
 
-(defmethod seek-datoms Keyword
+(defmethod seek-datoms ::index
   [db index & components]
   (if (nil? components)
     (dbi/seek-datoms db index [])
@@ -166,9 +165,15 @@
     (log/raise "as-of is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 (defn history [db]
-  (if (dbi/-temporal-index? db)
-    (HistoricalDB. db)
-    (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
+  (cond
+    ;; History of a history is just the history — return as-is rather than
+    ;; double-wrapping. Besides being the correct idempotent semantics, the
+    ;; redundant HistoricalDB-around-HistoricalDB pushes queries onto the
+    ;; legacy lookup path on cljs (the fused temporal path needs the origin's
+    ;; :eavt to be a real PersistentSortedSet, which a nested wrapper isn't).
+    (instance? HistoricalDB db) db
+    (dbi/-temporal-index? db) (HistoricalDB. db)
+    :else (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 ;; `vt-meta-attrs`, `tx-covers-at?`, `find-eav-winner`, `mk-vt-pred`,
 ;; `mk-vt-overlap-pred` and `mk-vt-during-pred` live in the leaf

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -28,7 +28,7 @@
                    [java.util Date])))
 
 (declare equiv-db empty-db)
-#?(:cljs (declare pr-db))
+#?(:cljs (declare pr-db pr-hist-db))
 
 ;; ----------------------------------------------------------------------------
 ;; macros and funcs to support writing defrecords and updating
@@ -460,12 +460,12 @@
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
        ICounted (-count [db] (count (dbi/datoms db :eavt [])))
-       IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
+       IPrintWithWriter (-pr-writer [db w opts] (pr-hist-db db w opts "HistoricalDB" false))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on HistoricalDB")))
 
-       ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on HistoricalDB")))
-                        ([_ _ _] (throw (js/Error. "-lookup is not supported on HistoricalDB"))))
+       ;; No ILookup override: keep the defrecord's default field lookup so
+       ;; `(:origin-db db)` works as on the JVM (which doesn't override valAt).
 
        IAssociative
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on HistoricalDB")))
@@ -526,12 +526,11 @@
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
        ICounted (-count [db] (count (dbi/datoms db :eavt [])))
-       IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
+       IPrintWithWriter (-pr-writer [db w opts] (pr-hist-db db w opts "AsOfDB" true))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on AsOfDB")))
 
-       ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on AsOfDB")))
-                        ([_ _ _] (throw (js/Error. "-lookup is not supported on AsOfDB"))))
+       ;; No ILookup override — default field lookup (`:origin-db`, `:time-point`).
 
        IAssociative
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on AsOfDB")))
@@ -593,12 +592,11 @@
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
        ICounted (-count [db] (count (dbi/datoms db :eavt [])))
-       IPrintWithWriter (-pr-writer [db w opts] (pr-db db w opts))
+       IPrintWithWriter (-pr-writer [db w opts] (pr-hist-db db w opts "SinceDB" true))
 
        IEmptyableCollection (-empty [_] (throw (js/Error. "-empty is not supported on SinceDB")))
 
-       ILookup (-lookup ([_ _] (throw (js/Error. "-lookup is not supported on SinceDB")))
-                        ([_ _ _] (throw (js/Error. "-lookup is not supported on SinceDB"))))
+       ;; No ILookup override — default field lookup (`:origin-db`, `:time-point`).
 
        IAssociative
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on SinceDB")))
@@ -674,11 +672,29 @@
        (equiv-db-index (dbi/datoms db :eavt []) (dbi/datoms other :eavt []))))
 
 #?(:cljs
-   (defn pr-db [db w opts]
-     (-write w "#datahike/DB {")
-     (-write w (str ":max-tx " (dbi/-max-tx db) " "))
-     (-write w (str ":max-eid " (dbi/-max-eid db) " "))
-     (-write w "}")))
+   (do
+     ;; Mirror the JVM pr-db EXACTLY (store-id + commit-id + max-tx + max-eid, no
+     ;; trailing space) so `pr-str` of a DB is identical across platforms.
+     (defn pr-db [db w _opts]
+       (-write w "#datahike/DB {")
+       (-write w ":store-id [")
+       (-write w (pr-str (store/store-identity (:store (dbi/-config db)))))
+       (-write w " ")
+       (-write w (pr-str (:branch (dbi/-config db))))
+       (-write w "] ")
+       (-write w (str ":commit-id " (pr-str (:datahike/commit-id (:meta db))) " "))
+       (-write w (str ":max-tx " (dbi/-max-tx db) " "))
+       (-write w (str ":max-eid " (dbi/-max-eid db)))
+       (-write w "}"))
+
+     ;; cljs counterpart of the JVM pr-hist-db — the hist DBs printed via pr-db
+     ;; before (wrong flavor + DB fields); now they render #datahike/<flavor>.
+     (defn pr-hist-db [db w opts flavor time-point?]
+       (-write w (str "#datahike/" flavor " {:origin "))
+       (pr-db (dbi/-origin db) w opts)
+       (when time-point?
+         (-write w (str " :time-point " (dbi/-time-point db))))
+       (-write w "}"))))
 
 #?(:clj
    (do

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -408,11 +408,19 @@
                 (not (arrays/array? datoms))
                 (arrays/into-array)))
         _ (arrays/asort arr (index-type->cmp-quick index-type false))
+        ;; Wire the PSS storage at CONSTRUCTION on cljs (as empty-index's sorted-set*
+        ;; does): the cljs PersistentSortedSet keeps storage on `.-storage`, set via
+        ;; the :storage opt — the JVM-style post-hoc `(set! (.-_storage pset) …)` below
+        ;; doesn't reach it, so without this a POPULATED index (attribute-refs ref-
+        ;; datoms) fails to flush ("BTSet/store requires IStorage"), breaking
+        ;; attribute-refs DB creation on cljs. JVM path is unchanged.
         ^PersistentSortedSet pset (psset/from-sorted-array (index-type->cmp-quick index-type false)
                                                            arr
                                                            (arrays/alength arr)
-                                                           {:branching-factor (:datahike/branching-factor store DEFAULT_BRANCHING_FACTOR)})]
-    (set! (.-_storage pset) (:storage store))
+                                                           #?(:clj  {:branching-factor (:datahike/branching-factor store DEFAULT_BRANCHING_FACTOR)}
+                                                              :cljs {:branching-factor (:datahike/branching-factor store DEFAULT_BRANCHING_FACTOR)
+                                                                     :storage (:storage store)}))]
+    #?(:clj (set! (.-_storage pset) (:storage store)))
     (with-meta pset (root-meta store index-type))))
 
 ;; Datom — datahike's domain ELEMENT type, nested inside node :keys. Its handler recurses through

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -960,9 +960,12 @@
                           (let [e (.-e ^datahike.datom.Datom datom)
                                 a (.-a ^datahike.datom.Datom datom)
                                 a-kw (keyword (.-fqn ^clj a))  ; Extract from Keyword object
-                                v (.-v ^datahike.datom.Datom datom)
-                                tx (.-tx ^datahike.datom.Datom datom)]
-                            #js [e a-kw v tx (pos? tx)])  ; JS array for goog.array/get
+                                v (.-v ^datahike.datom.Datom datom)]
+                            ;; tx is sign-encoded with the added flag (retraction => negative
+                            ;; raw .-tx). Project the ABS tx (datom-tx) and read added from the
+                            ;; sign (datom-added) — using raw .-tx would give retractions a
+                            ;; negative ?t that no [?t :db/txInstant] join could ever match.
+                            #js [e a-kw v (datom/datom-tx datom) (datom/datom-added datom)])  ; JS array for goog.array/get
                           datom))
                 :clj (fn [[e a v tx added?]]
                        [e a v tx added?])))
@@ -976,11 +979,13 @@
                                                     (.-e d)))
                                          (let [a (.-a ^datahike.datom.Datom d)
                                                a-kw (keyword (.-fqn ^clj a))]
+                                           ;; abs tx + sign-derived added — see
+                                           ;; relation-from-datoms-xform.
                                            #js [(.-e ^datahike.datom.Datom d)
                                                 a-kw
                                                 (.-v ^datahike.datom.Datom d)
-                                                (.-tx ^datahike.datom.Datom d)
-                                                (pos? (.-tx ^datahike.datom.Datom d))])
+                                                (datom/datom-tx d)
+                                                (datom/datom-added d)])
                                          d))
                                      datoms)]
                  (rel/->Relation (var-mapping orig-pattern (range))

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -512,13 +512,17 @@
                            (if strict-filter (filter strict-filter) identity)
                            (map (fn [^Datom d]
                                   (check-cancel! cancel)
-                                  #?(:clj  [(.-e d) (.-a d) (.-v d) (.-tx d) true]
+                                  ;; 5th component is the datom's actual added flag, NOT a
+                                  ;; hardcoded true — history/temporal scans emit retraction
+                                  ;; datoms whose op-var (e.g. [?e :age ?a ?t ?op]) must bind
+                                  ;; false. Mirrors the fused path's find-src-scan-added slot.
+                                  #?(:clj  [(.-e d) (.-a d) (.-v d) (.-tx d) (datom/datom-added d)]
                                      :cljs (let [t (make-array 5)]
                                              (aset t 0 (.-e d))
                                              (aset t 1 (.-a d))
                                              (aset t 2 (.-v d))
                                              (aset t 3 (.-tx d))
-                                             (aset t 4 true)
+                                             (aset t 4 (datom/datom-added d))
                                              t)))))
                      datoms)]
     (rel/->Relation var-map tuples)))
@@ -1835,11 +1839,15 @@
                                  (.add result (.next iter)))))))
                        result)
                      :cljs nil)
-                  ;; Non-temporal probe-driven
-                  (let [pf (int probe-datom-field)]
-                    (probe-driven-iterable
-                     (if (= pf 2) (:avet index-db) (:eavt index-db))
-                     resolved-a probe-set pf)))
+                  ;; Non-temporal probe-driven. JVM-only fast path (ForwardCursor);
+                  ;; never taken on cljs (use-probe-driven? is :cljs false above), so
+                  ;; :cljs nil just keeps the dead branch compilable (no undeclared-var).
+                  #?(:clj
+                     (let [pf (int probe-datom-field)]
+                       (probe-driven-iterable
+                        (if (= pf 2) (:avet index-db) (:eavt index-db))
+                        resolved-a probe-set pf))
+                     :cljs nil))
                 (if temporal
                   (build-scan-slice db db-index from-datom to-datom index
                                     temporal index-db resolved-a)
@@ -2141,12 +2149,20 @@
         (let [neg-attrs (:attrs neg-rel)
               jv-vec (vec join-vars)
               n-jv (count jv-vec)
-              excl-set (java.util.HashSet.)]
-          ;; Collect all join-var value tuples from negation result
-          (doseq [tuple (:tuples neg-rel)]
-            (if (= 1 n-jv)
-              (.add excl-set (get tuple (get neg-attrs (first jv-vec))))
-              (.add excl-set (mapv #(get tuple (get neg-attrs %)) jv-vec))))
+              neg-key (fn [tuple]
+                        (if (= 1 n-jv)
+                          (get tuple (get neg-attrs (first jv-vec)))
+                          (mapv #(get tuple (get neg-attrs %)) jv-vec)))
+              ;; Exclusion set. JVM keeps the fast java.util.HashSet (value equality
+              ;; via .equals/.hashCode, incl. vector keys); cljs uses a Clojure set —
+              ;; js/Set would key vectors by REFERENCE and never match (and HashSet is
+              ;; undeclared there). Correct on both; cljs is the acceptable slower side.
+              excl-set #?(:clj (let [^java.util.HashSet hs (java.util.HashSet.)]
+                                 (doseq [tuple (:tuples neg-rel)] (.add hs (neg-key tuple)))
+                                 hs)
+                          :cljs (persistent!
+                                 (reduce (fn [s tuple] (conj! s (neg-key tuple)))
+                                         (transient #{}) (:tuples neg-rel))))]
           ;; Filter result-list: remove tuples whose join-var values are in the exclusion set
           (let [jv-indices (mapv #(int (get var-index %)) jv-vec)
                 n (result-list-size result-list)]
@@ -2156,7 +2172,8 @@
                       probe (if (= 1 n-jv)
                               (aget tuple (int (first jv-indices)))
                               (mapv #(aget tuple (int %)) jv-indices))
-                      excluded? (.contains excl-set probe)]
+                      excluded? #?(:clj (.contains ^java.util.HashSet excl-set probe)
+                                   :cljs (contains? excl-set probe))]
                   (if excluded?
                     (recur (unchecked-inc-int read-i) write-i)
                     (do (when (not= read-i write-i)
@@ -2949,7 +2966,7 @@
                                   #?(:clj (es/entity-bitset-contains? entity-filter (.-e scan-d))
                                      :cljs true))
                           (process-merges scan-d (.-e scan-d) (int 0)
-                                          [(.-e scan-d) (.-a scan-d) (.-v scan-d) (.-tx scan-d) true])))
+                                          [(.-e scan-d) (.-a scan-d) (.-v scan-d) (.-tx scan-d) (datom/datom-added scan-d)])))
                       filtered-datoms))]
         (let [out-rel (rel/->Relation out-attrs #?(:clj (vec (.toArray ^java.util.ArrayList acc))
                                                    :cljs (vec acc)))
@@ -2964,48 +2981,56 @@
                (assoc :unique-results? true))
            (inc (count merge-ops))])))))
 
-#?(:clj
-   (defn- execute-temporal-group-rel
-     "Temporal entity-group / pattern-scan kept on the FUSED fast path. Runs the
-      temporal-aware `execute-group-direct` (current+temporal merge, inline tx /
-      added / retraction resolution, per-value temporal probe seeks) driven by a
-      SIP probe-set from the bound context rels, returning [ctx' consumed] like
-      `execute-fused-scan-rel`. Avoids the legacy per-clause `lookup-batch-search`
-      fallback that materializes the whole intermediate join then runs one
-      temporal-search over it (the cross-product blowup). `temporal` is a non-nil
-      `(temporal-info db)`; its :origin-db carries the PersistentSortedSet indexes."
-     [db op context temporal]
-     (let [scan-op     (entity-group-scan-op op)
-           merge-ops   (entity-group-merge-ops op)
-           scan-clause (:clause scan-op)
-           index-db    (or (:origin-db temporal) db)
-           a           (second scan-clause)
-           resolved-a  (when (and (some? a) (not (symbol? a))) (resolve-attr index-db a))
-           scan-n      (or (:estimated-card scan-op)
-                           (di/-count (get index-db (:index scan-op))))
-           probe       (pattern-probe-set index-db scan-clause resolved-a (:rels context) scan-n)
-           ;; Project to ALL free vars across the scan + merge clauses (mirroring
-           ;; execute-fused-scan-rel's out-attrs), NOT (:vars op). (:vars op) is the
-           ;; group's declared interface and can omit the entity var (e.g. ?c when it
-           ;; is not in :find), but downstream ops — get-else / predicates / further
-           ;; joins — reference those clause vars, so the fused tuples must carry them.
-           find-vars   (vec (distinct (filter #(and (symbol? %) (analyze/free-var? %))
-                                              (concat scan-clause
-                                                      (mapcat :clause merge-ops)))))
-           result-list (make-result-list 4000)]
-       (execute-group-direct db scan-op merge-ops find-vars nil
-                             result-list
-                             (when probe (:values probe)) (if probe (int (:field probe)) (int 0))
-                             nil 0 -1 nil
-                             :temporal temporal :pipeline (:pipeline op)
-                             :cancel (:cancel context))
-       (let [attrs   (into {} (map-indexed (fn [i v] [v i]) find-vars))
-             out-rel (rel/->Relation attrs (vec (.toArray ^java.util.ArrayList result-list)))
-             merged  (binding [rel/*implicit-source* db
-                               rel/*lookup-attrs* (lookup-attrs-for-clauses db scan-clause merge-ops)]
-                       (rel/collapse-rels (:rels context) out-rel))]
-         [(-> context (assoc :rels merged) (assoc :unique-results? true))
-          (inc (count merge-ops))]))))
+(defn- execute-temporal-group-rel
+  "Temporal entity-group / pattern-scan kept on the FUSED fast path. Runs the
+   temporal-aware `execute-group-direct` (current+temporal merge, inline tx /
+   added / retraction resolution, per-value temporal probe seeks) driven by a
+   SIP probe-set from the bound context rels, returning [ctx' consumed] like
+   `execute-fused-scan-rel`. Avoids the legacy per-clause `lookup-batch-search`
+   fallback that materializes the whole intermediate join then runs one
+   temporal-search over it (the cross-product blowup). `temporal` is a non-nil
+   `(temporal-info db)`; its :origin-db carries the PersistentSortedSet indexes.
+
+   Cross-platform: its callees (execute-group-direct, the temporal merge path) are
+   cljc; only the result-list drain differs (JVM ArrayList .toArray vs the cljs
+   #js [] dual, as elsewhere in this ns)."
+  [db op context temporal]
+  (let [scan-op     (entity-group-scan-op op)
+        merge-ops   (entity-group-merge-ops op)
+        scan-clause (:clause scan-op)
+        index-db    (or (:origin-db temporal) db)
+        a           (second scan-clause)
+        resolved-a  (when (and (some? a) (not (symbol? a))) (resolve-attr index-db a))
+        scan-n      (or (:estimated-card scan-op)
+                        (di/-count (get index-db (:index scan-op))))
+        ;; SIP probe-set is a JVM-only fast-path optimization (HashSet + ForwardCursor
+        ;; seeks). On cljs fall back to a full temporal scan — slower but identical
+        ;; results, since the probe only restricts the scan to already-bound values.
+        probe       #?(:clj  (pattern-probe-set index-db scan-clause resolved-a (:rels context) scan-n)
+                       :cljs nil)
+        ;; Project to ALL free vars across the scan + merge clauses (mirroring
+        ;; execute-fused-scan-rel's out-attrs), NOT (:vars op). (:vars op) is the
+        ;; group's declared interface and can omit the entity var (e.g. ?c when it
+        ;; is not in :find), but downstream ops — get-else / predicates / further
+        ;; joins — reference those clause vars, so the fused tuples must carry them.
+        find-vars   (vec (distinct (filter #(and (symbol? %) (analyze/free-var? %))
+                                           (concat scan-clause
+                                                   (mapcat :clause merge-ops)))))
+        result-list (make-result-list 4000)]
+    (execute-group-direct db scan-op merge-ops find-vars nil
+                          result-list
+                          (when probe (:values probe)) (if probe (int (:field probe)) (int 0))
+                          nil 0 -1 nil
+                          :temporal temporal :pipeline (:pipeline op)
+                          :cancel (:cancel context))
+    (let [attrs   (into {} (map-indexed (fn [i v] [v i]) find-vars))
+          out-rel (rel/->Relation attrs #?(:clj  (vec (.toArray ^java.util.ArrayList result-list))
+                                           :cljs (vec result-list)))
+          merged  (binding [rel/*implicit-source* db
+                            rel/*lookup-attrs* (lookup-attrs-for-clauses db scan-clause merge-ops)]
+                    (rel/collapse-rels (:rels context) out-rel))]
+      [(-> context (assoc :rels merged) (assoc :unique-results? true))
+       (inc (count merge-ops))])))
 
 ;; ---------------------------------------------------------------------------
 ;; OR / NOT execution (Relation-based fallback)
@@ -3133,19 +3158,25 @@
    or non-binary rule). When applicable, returns:
    {:ground-positions {pos value}, :head-vars [...], :propagation-pos int}"
   [call-args head-vars scc-rule-names]
-  ;; Only apply magic sets to single-rule SCCs with binary head vars
-  (when (and (= 1 (count scc-rule-names))
-             (= 2 (count head-vars)))
-    (let [ground-positions (into {}
-                                 (keep-indexed (fn [i arg]
-                                                 (when-not (analyze/free-var? arg)
-                                                   [i arg])))
-                                 call-args)]
-      (when (= 1 (count ground-positions))
-        (let [ground-pos (ffirst ground-positions)
-              prop-pos (if (= ground-pos 0) 1 0)]
-          {:ground-positions ground-positions
-           :propagation-pos prop-pos})))))
+  ;; Magic-set optimization is JVM-only — the magic-base-scan / demand-set machinery
+  ;; (java.util.HashSet, ArrayList) has :cljs nil bodies, so activating it on cljs
+  ;; collapses recursive rules to an EMPTY rel (silently incomplete results). Return
+  ;; nil on cljs so they take the correct (slower) full base-branch fixpoint instead.
+  #?(:cljs nil
+     :clj
+     ;; Only apply magic sets to single-rule SCCs with binary head vars
+     (when (and (= 1 (count scc-rule-names))
+                (= 2 (count head-vars)))
+       (let [ground-positions (into {}
+                                    (keep-indexed (fn [i arg]
+                                                    (when-not (analyze/free-var? arg)
+                                                      [i arg])))
+                                    call-args)]
+         (when (= 1 (count ground-positions))
+           (let [ground-pos (ffirst ground-positions)
+                 prop-pos (if (= ground-pos 0) 1 0)]
+             {:ground-positions ground-positions
+              :propagation-pos prop-pos}))))))
 
 (defn- inject-magic-relation
   "Add a magic demand relation to the context that constrains head-var at
@@ -3474,7 +3505,11 @@
                                                                  false))
                                                              (:ops cv-plan)))
                                                    rec-clause-versions)
-                                           use-delta-driven? (and base-scan-attr
+                                           ;; Delta-driven expansion is JVM-only
+                                           ;; (delta-driven-expand has a :cljs nil
+                                           ;; body); false on cljs → the correct
+                                           ;; non-delta recursive scan below.
+                                           use-delta-driven? (and #?(:cljs false :clj base-scan-attr)
                                                                   rec-has-db-pattern?
                                                                   rec-shape-simple?
                                                                   (= rn rule-name)

--- a/test/datahike/test/core_test.cljc
+++ b/test/datahike/test/core_test.cljc
@@ -7,8 +7,7 @@
    #?(:clj [kaocha.stacktrace])
    [datahike.core :as dc]
    [datahike.constants :as const]
-   [datahike.impl.entity :as de]
-   #?(:cljs [datahike.test.cljs])))
+   [datahike.impl.entity :as de]))
 
 #?(:cljs
    (enable-console-print!))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -10,7 +10,14 @@
             ;; covers them too.
             [datahike.test.cljs-pattern-scan-test]
             [datahike.test.optimistic-test]
-            [datahike.test.valid-time-test]))
+            [datahike.test.valid-time-test]
+            ;; Portable query suites — exercise the query-engine paths that were
+            ;; JVM-only (NOT-JOIN, OR, aggregates, recursive rules) on cljs too.
+            [datahike.test.time-variance-test]
+            [datahike.test.query-not-test]
+            [datahike.test.query-or-test]
+            [datahike.test.query-aggregates-test]
+            [datahike.test.query-rules-test]))
 
 ;; Hook cljs.test's end-of-run callback so the Node process exits with
 ;; status 0 only when all tests pass. The previous setup always exited
@@ -356,4 +363,9 @@
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.cljs-pattern-scan-test
                'datahike.test.optimistic-test
-               'datahike.test.valid-time-test))
+               'datahike.test.valid-time-test
+               'datahike.test.time-variance-test
+               'datahike.test.query-not-test
+               'datahike.test.query-or-test
+               'datahike.test.query-aggregates-test
+               'datahike.test.query-rules-test))

--- a/test/datahike/test/query_aggregates_test.cljc
+++ b/test/datahike/test/query_aggregates_test.cljc
@@ -2,12 +2,22 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
-   [datahike.api :as d]))
+   [clojure.core.async :refer [<!]]
+   [datahike.api :as d]
+   [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
+
+(defn- connect!
+  "Create + connect to `cfg`. Returns a channel yielding the connection so the
+   body works on both JVM (sync) and cljs (async writer)."
+  [cfg]
+  (clojure.core.async/go
+    #?(:clj  (do (d/create-database cfg) (d/connect cfg))
+       :cljs (do (<! (d/create-database cfg)) (<! (d/connect cfg {:sync? false}))))))
 
 (defn sort-reverse [xs]
   (reverse (sort xs)))
 
-(deftest test-aggregates
+(deftest-async test-aggregates
   (let [monsters [["Cerberus" 3]
                   ["Medusa" 1]
                   ["Cyclops" 1]
@@ -103,26 +113,21 @@
   (testing "Aggregate with predicate filter"
     ;; Regression: the columnar aggregate path (via stratum) skipped
     ;; attached-preds, so predicates in WHERE were ignored for COUNT/SUM.
-    (let [cfg {:store {:backend :memory :id #?(:clj (java.util.UUID/randomUUID)
-                                               :cljs (random-uuid))}
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
                :schema-flexibility :write
                :keep-history? true}
-          _ (d/create-database cfg)
-          conn (d/connect cfg)]
-      (try
-        (d/transact conn [{:db/ident :num/v :db/valueType :db.type/long
-                           :db/cardinality :db.cardinality/one}])
-        (d/transact conn [{:num/v 1} {:num/v 2} {:num/v 3} {:num/v 4} {:num/v 5}])
-        (let [db (d/db conn)]
-          (is (= [[3]] (d/q '{:find [(count ?e)]
-                              :where [[?e :num/v ?v] [(> ?v 2)]]} db))
-              "COUNT with > predicate")
-          (is (= [[12]] (d/q '{:find [(sum ?v)]
-                               :where [[?e :num/v ?v] [(> ?v 2)]]} db))
-              "SUM with > predicate")
-          (is (= [[2]] (d/q '{:find [(count ?e)]
-                              :where [[?e :num/v ?v] [(< ?v 3)]]} db))
-              "COUNT with < predicate"))
-        (finally
-          (d/release conn)
-          (d/delete-database cfg))))))
+          conn (<! (connect! cfg))]
+      (<! (d/transact! conn [{:db/ident :num/v :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}]))
+      (<! (d/transact! conn [{:num/v 1} {:num/v 2} {:num/v 3} {:num/v 4} {:num/v 5}]))
+      (let [db (d/db conn)]
+        (is (= [[3]] (d/q '{:find [(count ?e)]
+                            :where [[?e :num/v ?v] [(> ?v 2)]]} db))
+            "COUNT with > predicate")
+        (is (= [[12]] (d/q '{:find [(sum ?v)]
+                             :where [[?e :num/v ?v] [(> ?v 2)]]} db))
+            "SUM with > predicate")
+        (is (= [[2]] (d/q '{:find [(count ?e)]
+                            :where [[?e :num/v ?v] [(< ?v 3)]]} db))
+            "COUNT with < predicate"))
+      (d/release conn))))

--- a/test/datahike/test/query_rules_test.cljc
+++ b/test/datahike/test/query_rules_test.cljc
@@ -2,8 +2,11 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
+   [clojure.core.async :refer [<!]]
    [datahike.api :as d]
-   [datahike.db :as db]))
+   [datahike.db :as db]
+   [datahike.test.utils :as du]
+   [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
 
 #?(:cljs (def Throwable js/Error))
 
@@ -210,7 +213,9 @@
                   :where (is ?id false)] db rules)
            #{[2]}))))
 
-(deftest test-rule-arguments
+;; Indexed-attr magic-set path over an :attribute-refs? true CONNECTION — runs on
+;; both platforms (cljs via deftest-async + the async setup-db).
+(deftest-async test-rule-arguments
   (let [cfg {:store {:backend :memory
                      :id #uuid "a0000000-0000-0000-0000-00000000000a"}
              :name "rule-test"
@@ -233,19 +238,17 @@
                  [(ground ["Alice" "Bob"]) [?name ...]]
                  [?p :name ?name]
                  [?p :age ?age]]]
-        _ (d/delete-database cfg)
-        _ (d/create-database cfg)
-        conn (d/connect cfg)]
+        conn (<! (du/setup-db-async cfg))]
 
-    (d/transact conn {:tx-data schema})
-    (d/transact conn {:tx-data [{:name "Alice"
-                                 :age  25}
-                                {:name "Bob"
-                                 :age 30}]})
-    (d/transact conn {:tx-data [{:name    "Charlie"
-                                 :age     5
-                                 :parents [[:name "Alice"]
-                                           [:name "Bob"]]}]})
+    (<! (d/transact! conn {:tx-data schema}))
+    (<! (d/transact! conn {:tx-data [{:name "Alice"
+                                      :age  25}
+                                     {:name "Bob"
+                                      :age 30}]}))
+    (<! (d/transact! conn {:tx-data [{:name    "Charlie"
+                                      :age     5
+                                      :parents [[:name "Alice"]
+                                                [:name "Bob"]]}]}))
 
     (is (= #{[25]}
            (d/q {:query '{:find [?age]

--- a/test/datahike/test/time_variance_test.cljc
+++ b/test/datahike/test/time_variance_test.cljc
@@ -2,13 +2,14 @@
   (:require
    #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]]
       :clj  [clojure.test :as t :refer [is are deftest testing]])
+   [clojure.core.async :refer [<! timeout]]
    [datahike.api :as d]
    #?(:cljs [datahike.cljs :refer [Throwable]])
    [datahike.constants :as const]
    [datahike.test.utils :as du]
    [datahike.db.interface :as dbi]
-   [datahike.test.utils :refer [setup-db sleep]])
-  (:import [java.util Date]))
+   [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]])
+  #?(:clj (:import [java.util Date])))
 
 (set! *print-namespace-maps* false)
 
@@ -32,7 +33,7 @@
                    :initial-tx schema})
 
 (defn now []
-  (Date.))
+  #?(:clj (Date.) :cljs (js/Date.)))
 
 (defn permute-and-repeat [max-repeat elements]
   (let [elements (vec elements)
@@ -57,16 +58,16 @@
   (for [fs (permute-and-repeat 2 ops)]
     ((apply comp fs) db)))
 
-(deftest test-base-history
+(deftest-async test-base-history
   (let [cfg (assoc-in cfg-template [:store :id] #uuid "71000000-0000-0000-0000-000000000001")
-        conn (setup-db cfg)
+        conn (<! (du/setup-db-async cfg))
         tx-id0 (:max-tx @conn)]
     (testing "Initial data"
       (is (= #{["Alice" 25] ["Bob" 35]}
              (d/q '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]] @conn))))
 
     (testing "historical values"
-      (d/transact conn [{:db/id [:name "Alice"] :age 30}])
+      (<! (d/transact! conn [{:db/id [:name "Alice"] :age 30}]))
       (are [x y]
            (= x y)
         #{[30]}
@@ -75,7 +76,7 @@
         (d/q '[:find ?a :in $ ?e :where [?e :age ?a]] (d/history @conn) [:name "Alice"])))
     (testing "historical values after with retraction"
       (let [tx-id1 (:max-tx @conn)
-            _ (d/transact conn [[:db/retractEntity [:name "Alice"]]])
+            _ (<! (d/transact! conn [[:db/retractEntity [:name "Alice"]]]))
             tx-id2 (:max-tx @conn)]
         (is (thrown-with-msg? Throwable #"Nothing found for entity id"
                               (d/q '[:find ?a :in $ ?e :where [?e :age ?a]] @conn [:name "Alice"])))
@@ -116,19 +117,19 @@
 (defn replace-commit-id [s]
   (clojure.string/replace s #":commit-id #uuid \"[^\"]+\"" ":commit-id :REPLACED"))
 
-(deftest test-historical-queries
+(deftest-async test-historical-queries
   (let [cfg (-> cfg-template
                 (assoc-in [:store :id] #uuid "71000000-0000-0000-0000-000000000002"))
-        conn (setup-db cfg)]
+        conn (<! (du/setup-db-async cfg))]
 
     (testing "get all values before specific time"
-      (let [_ (d/transact conn [{:db/id [:name "Alice"] :age 30}])
+      (let [_ (<! (d/transact! conn [{:db/id [:name "Alice"] :age 30}]))
             ;; sleep to make sure that transact thread has older timestamp
-            _ (sleep 10)
+            _ (<! (timeout 10))
             date (now)
             ;; sleep to make sure that transact thread has newer timestamp
-            _ (sleep 10)
-            _ (d/transact conn [{:db/id [:name "Alice"] :age 35}])
+            _ (<! (timeout 10))
+            _ (<! (d/transact! conn [{:db/id [:name "Alice"] :age 35}]))
             history-db (d/history @conn)
             current-db @conn
             current-query '[:find ?a :in $ ?e :where [?e :age ?a]]
@@ -155,13 +156,13 @@
              (replace-commit-id (pr-str (d/history @conn))))))
     (d/release conn)))
 
-(deftest test-as-of-db
+(deftest-async test-as-of-db
   (let [cfg (-> cfg-template
                 (assoc-in [:store :id] #uuid "71000000-0000-0000-0000-000000000003"))
-        conn (setup-db cfg)
+        conn (<! (du/setup-db-async cfg))
         first-date (now)
         ;; sleep to make sure that transact thread has newer timestamp
-        _ (sleep 10)
+        _ (<! (timeout 10))
         tx-id 536870914
         query '[:find ?a :in $ ?e :where [?e :age ?a ?tx]]]
     (testing "get values at specific time"
@@ -183,19 +184,19 @@
         (testing "before"
           (is (= #{[25]}
                  (d/q find-alices-age (d/as-of @conn tx-id) "Alice"))))
-        (d/transact conn [[:db/retractEntity [:name "Alice"]]])
+        (<! (d/transact! conn [[:db/retractEntity [:name "Alice"]]]))
         (testing "after"
           (is (= #{}
                  (d/q find-alices-age (d/as-of @conn tx-id) "Alice"))))))
     (d/release conn)))
 
-(deftest test-since-db
+(deftest-async test-since-db
   (let [cfg (-> cfg-template
                 (assoc-in [:store :id] #uuid "71000000-0000-0000-0000-000000000004"))
-        conn (setup-db cfg)
+        conn (<! (du/setup-db-async cfg))
         first-date (now)
         ;; sleep to make sure that transact thread has newer timestamp
-        _ (sleep 10)
+        _ (<! (timeout 10))
         tx-id 536870913
         query '[:find ?a :where [?e :age ?a]]]
     (testing "empty after first insertion"
@@ -203,7 +204,7 @@
              (d/q query (d/since @conn first-date)))))
     (testing "added new value"
       (let [new-age 30
-            _ (d/transact conn [{:db/id [:name "Alice"] :age new-age}])]
+            _ (<! (d/transact! conn [{:db/id [:name "Alice"] :age new-age}]))]
         (is (= #{[new-age]}
                (d/q query (d/since @conn first-date))))
         (is (= #{[new-age]}
@@ -213,7 +214,7 @@
              (replace-commit-id (pr-str (d/since @conn tx-id))))))
     (d/release conn)))
 
-(deftest test-no-history
+(deftest-async test-no-history
   (let [initial-tx [{:db/ident :name
                      :db/cardinality :db.cardinality/one
                      :db/valueType :db.type/string
@@ -227,12 +228,12 @@
         cfg (-> cfg-template
                 (assoc-in [:store :id] #uuid "71000000-0000-0000-0000-000000000005")
                 (assoc :initial-tx initial-tx))
-        conn (setup-db cfg)
+        conn (<! (du/setup-db-async cfg))
         query '[:find ?n ?a :where [?e :name ?n] [?e :age ?a]]]
     (testing "all names and ages are present in history"
       (is (= #{["Alice" 25] ["Bob" 35]}
              (d/q query (d/history @conn)))))
-    (d/transact conn [[:db/retractEntity [:name "Alice"]]])
+    (<! (d/transact! conn [[:db/retractEntity [:name "Alice"]]]))
     (testing "no-history attributes are not present in history"
       (is (= #{["Bob" 35]}
              (d/q query (d/history @conn)))))
@@ -241,13 +242,13 @@
              (d/q '[:find ?n :where [?e :name ?n]] (d/history @conn)))))
     (d/release conn)))
 
-(deftest upsert-history
+(deftest-async upsert-history
   (let [cfg {:store {:backend :memory
                      :id #uuid "00120000-0000-0000-0000-000000000012"}
              :keep-history? true
              :schema-flexibility :read
              :initial-tx schema}
-        conn (setup-db cfg)
+        conn (<! (du/setup-db-async cfg))
         query '[:find ?a ?t ?op
                 :where
                 [?e :name "Alice"]
@@ -258,7 +259,7 @@
         (is (= [[(+ const/e0 3) :age 25 (+ const/tx0 1) true]]
                (into [] xf datoms)))))
     (testing "upsert entity"
-      (d/transact conn [[:db/add [:name "Alice"] :age 30]])
+      (<! (d/transact! conn [[:db/add [:name "Alice"] :age 30]]))
       (is (= #{[30 (+ const/tx0 2) true]}
              (d/q query @conn)))
       (is (= #{[25 (+ const/tx0 1) true]
@@ -266,7 +267,7 @@
                [30 (+ const/tx0 2) true]}
              (d/q query (d/history @conn)))))
     (testing "second upsert"
-      (d/transact conn [[:db/add [:name "Alice"] :age 35]])
+      (<! (d/transact! conn [[:db/add [:name "Alice"] :age 35]]))
       (is (= #{[35 (+ const/tx0 3) true]}
              (d/q query @conn)))
       (is (= #{[25 (+ const/tx0 1) true]
@@ -276,7 +277,7 @@
                [35 (+ const/tx0 3) true]}
              (d/q query (d/history @conn)))))
     (testing "re-insert previous value"
-      (d/transact conn [[:db/add [:name "Alice"] :age 25]])
+      (<! (d/transact! conn [[:db/add [:name "Alice"] :age 25]]))
       (is (= #{[25 (+ const/tx0 4) true]}
              (d/q query @conn)))
       (is (= #{[25 (+ const/tx0 1) true]
@@ -288,7 +289,7 @@
                [25 (+ const/tx0 4) true]}
              (d/q query (d/history @conn)))))
     (testing "retract upserted values"
-      (d/transact conn [[:db/retract [:name "Alice"] :age 25]])
+      (<! (d/transact! conn [[:db/retract [:name "Alice"] :age 25]]))
       (is (= #{}
              (d/q query @conn)))
       (is (= #{[25 (+ const/tx0 1) true]
@@ -361,34 +362,39 @@
                             (< const/tx0 e)))
                   set))))
     (testing "Datoms extracted like Wanderung does it"
+      ;; Compare as a set: get-all-datoms only sorts by tx (outer) and entity
+      ;; (inner), so the order of datoms WITHIN one [tx entity] group is the
+      ;; query's set-iteration order — unspecified and platform-dependent (d/q
+      ;; returns a set). Every datom carries its tx id, so the set still pins
+      ;; exact tx membership; tx ordering is guaranteed independently upstream.
       (let [datoms (du/get-all-datoms @conn (map du/unmap-tx-timestamp))]
-        (is (= [[536870913 :db/txInstant :timestamp 536870913 true]
-                [1 :db/unique :db.unique/identity 536870913 true]
-                [1 :db/ident :name 536870913 true]
-                [1 :db/valueType :db.type/string 536870913 true]
-                [1 :db/index true 536870913 true]
-                [1 :db/cardinality :db.cardinality/one 536870913 true]
-                [2 :db/valueType :db.type/long 536870913 true]
-                [2 :db/cardinality :db.cardinality/one 536870913 true]
-                [2 :db/ident :age 536870913 true]
-                [3 :name "Alice" 536870913 true]
-                [3 :age 25 536870913 true]
-                [4 :age 35 536870913 true]
-                [4 :name "Bob" 536870913 true]
-                [536870914 :db/txInstant :timestamp 536870914 true]
-                [3 :age 25 536870914 false]
-                [3 :age 30 536870914 true]
-                [536870915 :db/txInstant :timestamp 536870915 true]
-                [3 :age 30 536870915 false]
-                [3 :age 35 536870915 true]
-                [536870916 :db/txInstant :timestamp 536870916 true]
-                [3 :age 35 536870916 false]
-                [3 :age 25 536870916 true]
-                [536870917 :db/txInstant :timestamp 536870917 true]
-                [3 :age 25 536870917 false]]
-               datoms))))))
+        (is (= #{[536870913 :db/txInstant :timestamp 536870913 true]
+                 [1 :db/unique :db.unique/identity 536870913 true]
+                 [1 :db/ident :name 536870913 true]
+                 [1 :db/valueType :db.type/string 536870913 true]
+                 [1 :db/index true 536870913 true]
+                 [1 :db/cardinality :db.cardinality/one 536870913 true]
+                 [2 :db/valueType :db.type/long 536870913 true]
+                 [2 :db/cardinality :db.cardinality/one 536870913 true]
+                 [2 :db/ident :age 536870913 true]
+                 [3 :name "Alice" 536870913 true]
+                 [3 :age 25 536870913 true]
+                 [4 :age 35 536870913 true]
+                 [4 :name "Bob" 536870913 true]
+                 [536870914 :db/txInstant :timestamp 536870914 true]
+                 [3 :age 25 536870914 false]
+                 [3 :age 30 536870914 true]
+                 [536870915 :db/txInstant :timestamp 536870915 true]
+                 [3 :age 30 536870915 false]
+                 [3 :age 35 536870915 true]
+                 [536870916 :db/txInstant :timestamp 536870916 true]
+                 [3 :age 35 536870916 false]
+                 [3 :age 25 536870916 true]
+                 [536870917 :db/txInstant :timestamp 536870917 true]
+                 [3 :age 25 536870917 false]}
+               (set datoms)))))))
 
-(deftest test-no-duplicates-on-history-search
+(deftest-async test-no-duplicates-on-history-search
   (let [schema [{:db/ident       :name
                  :db/cardinality :db.cardinality/one
                  :db/index       true
@@ -404,33 +410,32 @@
              :keep-history? true
              :schema-flexibility :write
              :attribute-refs? false}
-        conn (do
-               (d/delete-database cfg)
-               (d/create-database cfg)
-               (d/connect cfg))]
+        conn (<! (du/setup-db-async cfg))]
 
-    (d/transact conn schema)
-    (d/transact conn [{:name "Alice"
-                       :age  25}
-                      {:name    "Charlie"
-                       :age     45
-                       :sibling [[:name "Alice"] [:name "Charlie"]]}])
+    (<! (d/transact! conn schema))
+    (<! (d/transact! conn [{:name "Alice"
+                            :age  25}
+                           {:name    "Charlie"
+                            :age     45
+                            :sibling [[:name "Alice"] [:name "Charlie"]]}]))
     (is (= 1 (count (d/datoms (d/history @conn) :eavt [:name "Alice"] :name "Alice"))))
     (is (= 1 (count (filter :added (d/datoms (d/history @conn) :eavt [:name "Alice"] :name "Alice")))))
 
     (d/release conn)
-    (d/delete-database cfg)))
+    ;; delete-database is synchronous on JVM (no channel to <!) and async on cljs
+    #?(:clj  (d/delete-database cfg)
+       :cljs (<! (d/delete-database cfg)))))
 ;; => #'datahike.test.time-variance/test-no-duplicates-with-cardinality-many
 
 ;; https://github.com/replikativ/datahike/issues/470
-(deftest test-history-record-attribute-access
+(deftest-async test-history-record-attribute-access
   (let [cfg                                {:store              {:backend :memory :id (random-uuid)}
                                             :keep-history?      true
                                             :schema-flexibility :read
                                             :attribute-refs?    false}
-        conn                               (setup-db cfg)
-        {{:keys [db/current-tx]} :tempids} (d/transact conn [{:name "Anne"}])
-        _                                  (d/transact conn [{:name "Bernard"}])
+        conn                               (<! (du/setup-db-async cfg))
+        {{:keys [db/current-tx]} :tempids} (<! (d/transact! conn [{:name "Anne"}]))
+        _                                  (<! (d/transact! conn [{:name "Bernard"}]))
         db                                 @conn]
     (testing "history db attributes"
       (is (= db (:origin-db (d/history db))))
@@ -445,7 +450,7 @@
       (is (= (:eavt db) (-> db (d/since current-tx) :origin-db :eavt))))
     (d/release conn)))
 
-(deftest test-filter-current-values-of-same-transaction
+(deftest-async test-filter-current-values-of-same-transaction
   (let [keyword-cfg                                {:store              {:backend :memory :id (random-uuid)}
                                                     :keep-history?      true
                                                     :schema-flexibility :write
@@ -459,14 +464,14 @@
                     {:db/ident       :aka
                      :db/cardinality :db.cardinality/one
                      :db/valueType   :db.type/string}]
-            conn (setup-db keyword-cfg)
-            _ (d/transact conn schema)
-            {:keys [tx-data] :as _tx-report} (d/transact conn [{:name "Michal" :aka "Tupen"}])
+            conn (<! (du/setup-db-async keyword-cfg))
+            _ (<! (d/transact! conn schema))
+            {:keys [tx-data] :as _tx-report} (<! (d/transact! conn [{:name "Michal" :aka "Tupen"}]))
             michal (:e (first (filter #(= "Michal" (:v %)) tx-data)))
-            {{:keys [db/current-tx]} :tempids} (d/transact conn [[:db/retract michal :aka "Tupen"]
-                                                                 [:db/add michal :aka "Devil"]
-                                                                 [:db/retract michal :aka "Tupen"]])
-            _                                  (d/transact conn [[:db/retract michal :aka "Devil"]])
+            {{:keys [db/current-tx]} :tempids} (<! (d/transact! conn [[:db/retract michal :aka "Tupen"]
+                                                                      [:db/add michal :aka "Devil"]
+                                                                      [:db/retract michal :aka "Tupen"]]))
+            _                                  (<! (d/transact! conn [[:db/retract michal :aka "Devil"]]))
             as-of-db (d/as-of @conn current-tx)]
         (is (= {:aka "Devil"}
                (d/pull as-of-db [:aka] michal)))
@@ -479,14 +484,14 @@
                       {:db/ident       :aka
                        :db/cardinality :db.cardinality/many
                        :db/valueType   :db.type/string}]
-              conn (setup-db keyword-cfg)
-              _ (d/transact conn schema)
-              {:keys [tx-data]} (d/transact conn [{:name "Michal" :aka "Tupen"}])
+              conn (<! (du/setup-db-async keyword-cfg))
+              _ (<! (d/transact! conn schema))
+              {:keys [tx-data]} (<! (d/transact! conn [{:name "Michal" :aka "Tupen"}]))
               michal (:e (first (filter #(= "Michal" (:v %)) tx-data)))
-              {{:keys [db/current-tx]} :tempids} (d/transact conn [[:db/retract michal :aka "Tupen"]
-                                                                   [:db/add michal :aka "Devil"]
-                                                                   [:db/retract michal :aka "Tupen"]])
-              _                                  (d/transact conn [[:db/retract michal :aka "Devil"]])
+              {{:keys [db/current-tx]} :tempids} (<! (d/transact! conn [[:db/retract michal :aka "Tupen"]
+                                                                        [:db/add michal :aka "Devil"]
+                                                                        [:db/retract michal :aka "Tupen"]]))
+              _                                  (<! (d/transact! conn [[:db/retract michal :aka "Devil"]]))
               as-of-db (d/as-of @conn current-tx)]
           (is (= {:aka ["Devil"]}
                  (d/pull as-of-db [:aka] michal)))
@@ -499,10 +504,10 @@
                       {:db/ident       :aka
                        :db/cardinality :db.cardinality/many
                        :db/valueType   :db.type/string}]
-              conn (setup-db (assoc keyword-cfg :attribute-refs? true))
-              _ (d/transact conn schema)
+              conn (<! (du/setup-db-async (assoc keyword-cfg :attribute-refs? true)))
+              _ (<! (d/transact! conn schema))
               {tx-data                 :tx-data
-               {:keys [db/current-tx]} :tempids} (d/transact conn [{:name "Michal" :aka ["Tupen" "Devil"]}])
+               {:keys [db/current-tx]} :tempids} (<! (d/transact! conn [{:name "Michal" :aka ["Tupen" "Devil"]}]))
               michal (:e (first (filter #(= "Michal" (:v %)) tx-data)))
               as-of-db (d/as-of @conn current-tx)]
           (is (= {:aka ["Devil" "Tupen"]}
@@ -510,9 +515,9 @@
           (d/release conn))))))
 
 ;; https://github.com/replikativ/datahike/issues/572
-(deftest as-of-should-fail-on-invalid-time-points
+(deftest-async as-of-should-fail-on-invalid-time-points
   (let [cfg (assoc-in cfg-template [:store :id] #uuid "71000000-0000-0000-0000-000000000006")
-        conn (setup-db cfg)]
+        conn (<! (du/setup-db-async cfg))]
     (is (thrown-with-msg? Throwable #"Invalid transaction ID. Must be bigger than 536870912."
                           (d/as-of @conn 42)))
     (d/release conn)))

--- a/test/datahike/test/utils.cljc
+++ b/test/datahike/test/utils.cljc
@@ -1,6 +1,7 @@
 (ns datahike.test.utils
   (:require ;; Load hitchhiker-tree FIRST before datahike.api which loads datahike.index
    #?(:clj [datahike.index.hitchhiker-tree])
+   [clojure.core.async :refer [<!]]
    [datahike.api :as d]
    [datahike.tools :as tools])
   #?(:clj (:import [java.util UUID Date])))
@@ -48,6 +49,19 @@
   (d/delete-database cfg)
   (d/create-database cfg)
   cfg)
+
+(defn setup-db-async
+  "Channel-returning `setup-db` for `deftest-async` bodies: recreate + connect,
+   AWAITING the async create/connect on cljs (plain `setup-db` connects before the
+   create channel resolves → \"store does not exist\"). `(<! (setup-db-async cfg))`
+   yields a connection on both platforms — on JVM the sync value is wrapped in a
+   go-channel. Reusable across all connection-based suites being ported to cljs."
+  [cfg]
+  (clojure.core.async/go
+    #?(:clj  (do (recreate-database cfg) (d/connect cfg))
+       :cljs (do (<! (d/delete-database cfg))
+                 (<! (d/create-database cfg))
+                 (<! (d/connect cfg {:sync? false}))))))
 
 (defn with-connect-fn [cfg body-fn]
   (let [conn (d/connect cfg)]


### PR DESCRIPTION
## Summary

Makes the ClojureScript query engine produce the same results as the JVM for the temporal / history paths that were previously JVM-only or silently wrong, and adds portable test coverage so they stay aligned.

The motivating bug: a history query that binds the op/added flag and joins on the transaction —

```clojure
(d/q '[:find ?a ?op :in $ ?e :where
       [?e :age ?a ?t ?op]
       [?t :db/txInstant ?d]]
     (d/history @conn) [:name "Alice"])
```

— returned only the asserted datoms on cljs, dropping every `op=false` retraction.

## Root cause

`added` is sign-encoded into the `tx` field (a retraction stores `tx` negative; `datom-added` = `(pos? tx)`, `datom-tx` = `(abs tx)`). Several cljs tuple-builders ignored that encoding:

- **Op flag hardcoded `true`** in the portable scan builders (`execute-pattern-scan`, `execute-fused-scan-rel`) — the JVM dodged it because single-history queries route through `execute-group-direct`, whose `emit-tuple` projects `datom-added` correctly.
- **Double-history join drop** — `(d/history (d/history db))` has a non-PSS origin `:eavt`, so it falls to the legacy `lookup-batch-search` engine, where `relation-from-datoms` built the tx column from the raw **signed** `.-tx`. Retraction datoms got a negative `?t` that no `[?t :db/txInstant]` join could match.

## Changes

**Engine portability** (`query/execute.cljc`)
- NOT-JOIN: dual `HashSet` (JVM) / transient set (cljs) for the exclusion probe instead of raw `java.util.HashSet` on the hot path.
- Temporal entity-group + single-pattern scan: un-gate `execute-temporal-group-rel`/`execute-group-direct` on cljs; SIP probe (HashSet + ForwardCursor) stays JVM-only, cljs falls back to a full temporal scan (same results, slower).
- Recursive rules: gate the magic-set / delta-driven fast path to `:clj` so cljs uses the correct portable fixpoint.

**Added/op flag over temporal DBs**
- Portable scan builders project `(datom-added d)` instead of hardcoded `true`.
- Legacy engine (`query.cljc`, cljs `relation-from-datoms[-xform]`): project `(datom-tx d)` (abs) + `(datom-added d)` (sign).

**API / DB parity** (`api/impl.cljc`, `db.cljc`, `index/persistent_set.cljc`)
- `d/history` is now idempotent — returns the DB as-is when already a `HistoricalDB` instead of double-wrapping (correct semantics, and avoids the needless legacy fallback).
- `datoms`/`seek-datoms` dispatch on `map?` vs index, not the concrete map class (a small map literal is `PersistentArrayMap` on the JVM but `PersistentHashMap` on cljs). Drops the now-unused `clojure.lang` import.
- cljs DB/HistoricalDB `pr-str` parity (store-id/commit-id), HistoricalDB `ILookup` matches JVM, attribute-refs `init-index` passes `:storage` to PSS.

**Tests**
- Port time_variance / query-rules / query-aggregates suites to portable `.cljc` (`deftest-async` + `setup-db-async`/teardown), wired into the cljs node runner. `delete-database` teardown guarded (sync on JVM, async on cljs).

## Verification
- **cljs node:** 50 tests / 300 assertions / 0 failures
- **JVM clj-pss (full):** 624 tests / 2760 assertions / 0 failures