### PR TITLE
Fix predicate over fully-bound :in vars not filtering bindings (#848)

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -2215,21 +2215,29 @@
      (-collect [start-array] rels symbols)))
   ([acc rels symbols]
    (if-some [rel (first rels)]
-     (let [keep-attrs (select-keys (:attrs rel) symbols)]
-       (if (empty? keep-attrs)
-         (recur acc (next rels) symbols)
-         (let [copy-map (to-array (map #(get keep-attrs %) symbols))
-               len (count symbols)]
-           (recur (for [#?(:cljs t1
-                           :clj ^{:tag "[[Ljava.lang.Object;"} t1) acc
-                        t2 (:tuples rel)]
-                    (let [res (aclone t1)]
-                      (dotimes [i len]
-                        (when-some [idx (aget copy-map i)]
-                          (aset res i (get t2 idx))))
-                      res))
-                  (next rels)
-                  symbols))))
+     (if (empty? (:tuples rel))
+       ;; A zero-tuple relation means this conjunct has no satisfying bindings,
+       ;; so the whole conjunctive result is empty — annihilate. This must run
+       ;; before the keep-attrs test below: a const-only / no-find-var clause
+       ;; (e.g. a predicate over `:in` constants like `[(= ?e 999)]`) produces
+       ;; an empty-attrs eliminating relation that would otherwise be skipped,
+       ;; letting the const-seeded accumulator survive unfiltered (issue #848).
+       []
+       (let [keep-attrs (select-keys (:attrs rel) symbols)]
+         (if (empty? keep-attrs)
+           (recur acc (next rels) symbols)
+           (let [copy-map (to-array (map #(get keep-attrs %) symbols))
+                 len (count symbols)]
+             (recur (for [#?(:cljs t1
+                             :clj ^{:tag "[[Ljava.lang.Object;"} t1) acc
+                          t2 (:tuples rel)]
+                      (let [res (aclone t1)]
+                        (dotimes [i len]
+                          (when-some [idx (aget copy-map i)]
+                            (aset res i (get t2 idx))))
+                        res))
+                    (next rels)
+                    symbols)))))
      acc)))
 
 (defprotocol IContextResolve

--- a/test/datahike/test/query_fns_test.cljc
+++ b/test/datahike/test/query_fns_test.cljc
@@ -288,6 +288,93 @@
                   [])
              #{})))))
 
+(deftest test-predicate-over-bound-vars
+  ;; Issue #848: a predicate/function clause whose vars are all bound by `:in`
+  ;; constants (no relation in context) was never allowed to eliminate those
+  ;; bindings — the const passed through unfiltered. Root cause was in -collect:
+  ;; a zero-tuple eliminating relation with no find-var attrs was skipped instead
+  ;; of annihilating the const-seeded accumulator. Datomic semantics: a predicate
+  ;; that returns false/nil removes the binding (present->drop, absent->keep,
+  ;; false->drop), including when every input is an `:in` const. (CI runs the
+  ;; whole suite under both the compiled planner and the legacy engine, so these
+  ;; plain assertions cover both.)
+  (let [db (-> (db/empty-db) (d/db-with [{:db/id 100 :a "v" :b "v"}]))]
+
+    (testing "const-only predicate over :in binding filters that binding"
+      ;; present attribute -> missing? false -> binding dropped
+      (is (= nil (d/q '[:find ?e . :in $ ?e
+                        :where [(missing? $ ?e :a)]] db 100)))
+      ;; absent attribute -> missing? true -> binding kept
+      (is (= 100 (d/q '[:find ?e . :in $ ?e
+                        :where [(missing? $ ?e :c)]] db 100)))
+      ;; plain predicate, false / true over a const
+      (is (= nil (d/q '[:find ?e . :in $ ?e :where [(= ?e 999)]] db 100)))
+      (is (= 100 (d/q '[:find ?e . :in $ ?e :where [(= ?e 100)]] db 100))))
+
+    (testing "const-only predicate with no var args"
+      (is (= 100 (d/q '[:find ?e . :in $ ?e :where [(= 1 1)]] db 100)))
+      (is (= nil (d/q '[:find ?e . :in $ ?e :where [(= 1 2)]] db 100))))
+
+    (testing "multiple const-only predicates compose"
+      (is (= 100 (d/q '[:find ?e . :in $ ?e
+                        :where [(= ?e 100)] [(missing? $ ?e :c)]] db 100)))
+      (is (= nil (d/q '[:find ?e . :in $ ?e
+                        :where [(= ?e 100)] [(missing? $ ?e :a)]] db 100))))
+
+    (testing "a where-clause with no matches and a const find-var annihilates"
+      (is (= nil (d/q '[:find ?e . :in $ ?e
+                        :where [?x :nope ?y]] db 100))))
+
+    (testing "pattern-bound predicates are unaffected (no regression)"
+      ;; present -> missing? false -> []
+      (is (= [] (d/q '[:find [?e ...] :where
+                       [?e :b ?v] [(missing? $ ?e :a)]] db)))
+      ;; absent -> missing? true -> [100]  (the case a stale REPL mis-reported)
+      (is (= [100] (d/q '[:find [?e ...] :where
+                          [?e :a ?v] [(missing? $ ?e :c)]] db)))
+      (is (= [] (d/q '[:find [?e ...] :where
+                       [?e :a ?v] [(= ?e 999)]] db)))
+      (is (= [100] (d/q '[:find [?e ...] :where
+                          [?e :a ?v] [(> ?e 0)]] db))))
+
+    (testing "mixed const+pattern predicate"
+      (is (= [] (d/q '[:find [?x ...] :in $ ?e
+                       :where [?e :a ?x] [(= ?e 999)]] db 100)))
+      (is (= ["v"] (d/q '[:find [?x ...] :in $ ?e
+                          :where [?e :a ?x] [(= ?e 100)]] db 100))))
+
+    (testing "const-only predicate alongside a db-bound pattern"
+      ;; The empty eliminating relation produced by a false const-only predicate
+      ;; must annihilate even when a separate, non-empty pattern relation is also
+      ;; in context (it is conj'd onto :rels and -collect honors it). A true one
+      ;; is a no-op. Before the fix this diverged: the legacy engine kept all
+      ;; tuples for the false case while the planner correctly dropped them.
+      (let [ndb (-> (db/empty-db) (d/db-with [{:db/id 1 :v 10}
+                                              {:db/id 2 :v 20}]))]
+        (is (= [] (d/q '[:find [?v ...] :in $ ?lim
+                         :where [?e :v ?v] [(< 1 ?lim)]] ndb 0)))
+        (is (= #{10 20} (set (d/q '[:find [?v ...] :in $ ?lim
+                                    :where [?e :v ?v] [(< 1 ?lim)]] ndb 99))))
+        ;; mixed within a single predicate: db var + :in const, all/some filtered
+        (is (= [] (d/q '[:find [?v ...] :in $ ?lim
+                         :where [?e :v ?v] [(< ?v ?lim)]] ndb 5)))
+        (is (= #{10} (set (d/q '[:find [?v ...] :in $ ?lim
+                                 :where [?e :v ?v] [(< ?v ?lim)]] ndb 15))))))
+
+    (testing "binding fns and negation unaffected"
+      (is (= ["def"] (d/q '[:find [?x ...] :where
+                            [?e :a ?v] [(get-else $ ?e :c "def") ?x]] db)))
+      (is (= [100] (d/q '[:find [?e ...] :where
+                          [?e :a ?v] (not [?e :c ?z])] db))))
+
+    (testing "empty-result aggregates agree across const and pattern paths"
+      ;; const-false path and empty-pattern path now both yield nil (they
+      ;; disagreed before the fix: const-false wrongly counted 1)
+      (is (= nil (d/q '[:find (count ?e) . :in $ ?e
+                        :where [(= ?e 999)]] db 100)))
+      (is (= nil (d/q '[:find (count ?e) . :where [?e :nope ?v]] db)))
+      (is (= 1 (d/q '[:find (count ?e) . :where [?e :a ?v]] db))))))
+
 (deftest test-predicates
   (let [entities [{:db/id 1 :name "Ivan" :age 10}
                   {:db/id 2 :name "Ivan" :age 20}


### PR DESCRIPTION
Fixes #848.

## Problem

A predicate or function-predicate clause whose variables are all bound by `:in` constants (so no relation is in context) was never able to eliminate those bindings — the constant passed through unfiltered:

```clojure
(def db (-> (db/empty-db) (d/db-with [{:db/id 100 :a "v" :b "v"}])))

;; :a is present, so missing? is false — the binding should be filtered out
(d/q '[:find ?e . :in $ ?e :where [(missing? $ ?e :a)]] db 100)
;; => 100   (wrong; want nil)

;; plain predicate over a constant
(d/q '[:find ?e . :in $ ?e :where [(= ?e 999)]] db 100)
;; => 100   (wrong; want nil)
```

This is the bug from #848 (`missing?` "returns true" for a present attribute). It is not specific to `missing?` — any predicate over fully `:in`-bound vars was affected — and it reproduces under both the compiled planner and the legacy engine.

## Root cause

In `-collect` (`datahike.query`), the accumulator is seeded from `:consts`, then the relations are folded in, skipping any relation whose attrs don't intersect the find-vars. A predicate that eliminates all bindings produces a **zero-tuple, empty-attrs** relation, which was silently skipped — so the const-seeded accumulator survived unfiltered. `filter-by-pred` itself was already correct (it produces the right empty relation and always conj's it onto `:rels`); the loss was purely in projection.

## Fix

In `-collect`, a zero-tuple relation now annihilates the conjunctive result (returns empty) **before** the keep-attrs skip. A zero-tuple relation means the conjunct has no satisfying bindings, so the whole conjunctive result must be empty. The fix also corrects:

- the non-predicate manifestations of the same defect:
  ```clojure
  (d/q '[:find ?e . :in $ ?e :where [(= 1 2)]] db 100)        ;; now nil (was 100)
  (d/q '[:find ?e . :in $ ?e :where [?x :nope ?y]] db 100)    ;; now nil (was 100)
  ```
- a related **legacy/planner divergence**: a false const-only predicate alongside a db-bound pattern previously kept all tuples on the legacy engine while the planner correctly dropped them:
  ```clojure
  (d/q '[:find [?v ...] :in $ ?lim :where [?e :v ?v] [(< 1 ?lim)]] ndb 0)
  ;; planner => []   legacy => [10 20 ...]   (now [] on both)
  ```

It applies to both engines, which share `collect`. The unit relation `{:attrs {} :tuples [[]]}` (a *true* predicate — one empty tuple) is unaffected, so `[(= 1 1)]` still passes the binding through. Mixed predicates (db var + `:in` const, e.g. `[(< ?v ?lim)]`) were already correct and remain so — they produce a relation carrying the db var, which the existing for-comprehension already empties when all tuples are filtered.

Matches Datomic semantics: a predicate returning false/nil removes the binding (present → drop, absent → keep, false → drop), including when every input is an `:in` constant.

## Tests

Adds `test-predicate-over-bound-vars` to `query_fns_test.cljc` covering const present/absent, plain true/false predicates, multiple predicates, mixed const+pattern (both within a predicate and a const-only predicate beside a pattern), `get-else`, `not`, and empty-result aggregate consistency. The CI suite runs the whole test set under both the planner and the legacy engine, so these assertions cover both.

Full JVM and ClojureScript suites pass.