### PR TITLE
fix(kabel): tx-broadcast logging via replikativ.logging

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -78,7 +78,7 @@
 
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.95"}
-                               is.simm/distributed-scope     {:mvn/version "0.1.2"}
+                               is.simm/distributed-scope     {:mvn/version "0.1.6"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.30"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 

--- a/src-kabel/datahike/kabel/tx_broadcast.cljc
+++ b/src-kabel/datahike/kabel/tx_broadcast.cljc
@@ -12,10 +12,10 @@
   (:require [kabel.pubsub :as pubsub]
             [kabel.pubsub.protocol :as proto]
             [kabel.peer :as peer]
-            #?(:clj [kabel.platform-log :refer [debug info warn]])
+            #?(:clj  [replikativ.logging :refer [debug info warn]]
+               :cljs [replikativ.logging :refer [debug info warn] :include-macros true])
             #?(:clj [clojure.core.async :refer [go put! chan close!]]
-               :cljs [clojure.core.async :refer [go put! chan close!] :include-macros true]))
-  #?(:cljs (:require-macros [kabel.platform-log :refer [debug info warn]])))
+               :cljs [clojure.core.async :refer [go put! chan close!] :include-macros true])))
 
 ;; =============================================================================
 ;; Topic Naming


### PR DESCRIPTION
## Problem

`datahike.kabel.tx-broadcast` still requires `kabel.platform-log`, which kabel removed when it switched to the unified logging lib (kabel#9, `42bde08`). `datahike.kabel.handlers` was migrated to `replikativ.logging` in that transition; `tx-broadcast` was missed.

## Why CI never caught it (the interesting part)

The `:kabel` test suite DOES cover this ns (`tx_broadcast_test.clj`) — it passes for the wrong reason: **a groupId-migration shadow**. `is.simm/distributed-scope 0.1.2` still declares the pre-migration `io.replikativ/kabel 0.3.91`; Maven treats the old and new groupIds as distinct artifacts, so BOTH kabels land on the test classpath and the 2019-era jar silently provides the deleted namespace (verified: `(io/resource "kabel/platform_log.cljc")` → `io/replikativ/kabel/0.3.91`).

Adding `:exclusions [io.replikativ/kabel]` is the right hardening but is currently blocked: distributed-scope 0.1.2 itself fails to load without old kabel. **Follow-up**: release distributed-scope against `org.replikativ/kabel`, then add the exclusion so the `:kabel` suite genuinely tests current kabel — at which point a stale require like this fails CI immediately.

## Fix (this PR)

Swap the require to `replikativ.logging` — same namespace `handlers.cljc` already uses, identical call-site shapes (`debug`/`info`/`warn`, single-map args). No behavior change.