### PR TITLE
feat: lazy rseek-datoms — lift persistent-sorted-set's rslice through the index protocols

### DIFF
--- a/src-hitchhiker-tree/datahike/index/hitchhiker_tree.cljc
+++ b/src-hitchhiker-tree/datahike/index/hitchhiker_tree.cljc
@@ -141,6 +141,12 @@
     (remove-datom tree datom index-type op-count))
   (-slice [tree from to index-type]
     (slice tree from to index-type))
+  (-rslice [tree from to index-type]
+    ;; hitchhiker-tree has no reverse iterator: realize the BOUNDED
+    ;; range [to .. from] forward and reverse it. Correct semantics
+    ;; (from = upper bound, descending), non-lazy — the pss index has
+    ;; the lazy fast path.
+    (-> (slice tree to from index-type) vec rseq))
   (-flush [tree backend]
     (flush-tree tree backend))
   (-transient [tree]
@@ -170,6 +176,12 @@
     (remove-datom tree datom index-type op-count))
   (-slice [tree from to index-type]
     (slice tree from to index-type))
+  (-rslice [tree from to index-type]
+    ;; hitchhiker-tree has no reverse iterator: realize the BOUNDED
+    ;; range [to .. from] forward and reverse it. Correct semantics
+    ;; (from = upper bound, descending), non-lazy — the pss index has
+    ;; the lazy fast path.
+    (-> (slice tree to from index-type) vec rseq))
   (-flush [tree backend]
     (flush-tree tree backend))
   (-transient [tree]

--- a/src-kabel/datahike/kabel/tx_broadcast.cljc
+++ b/src-kabel/datahike/kabel/tx_broadcast.cljc
@@ -12,10 +12,10 @@
   (:require [kabel.pubsub :as pubsub]
             [kabel.pubsub.protocol :as proto]
             [kabel.peer :as peer]
-            #?(:clj [kabel.platform-log :refer [debug info warn]])
+            #?(:clj  [replikativ.logging :refer [debug info warn]]
+               :cljs [replikativ.logging :refer [debug info warn] :include-macros true])
             #?(:clj [clojure.core.async :refer [go put! chan close!]]
-               :cljs [clojure.core.async :refer [go put! chan close!] :include-macros true]))
-  #?(:cljs (:require-macros [kabel.platform-log :refer [debug info warn]])))
+               :cljs [clojure.core.async :refer [go put! chan close!] :include-macros true])))
 
 ;; =============================================================================
 ;; Topic Naming

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -100,6 +100,21 @@
   [db {:keys [index components]}]
   (dbi/seek-datoms db index components))
 
+(defmulti rseek-datoms
+  (fn
+    ([_db arg-map] (if (map? arg-map) ::arg-map ::index))
+    ([_db _index & _components] ::index)))
+
+(defmethod rseek-datoms ::arg-map
+  [db {:keys [index components]}]
+  (dbi/rseek-datoms db index components))
+
+(defmethod rseek-datoms ::index
+  [db index & components]
+  (if (nil? components)
+    (dbi/rseek-datoms db index [])
+    (dbi/rseek-datoms db index components)))
+
 (defmethod seek-datoms ::index
   [db index & components]
   (if (nil? components)

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -418,6 +418,20 @@
                  :code "(seek-datoms db {:index :eavt :components [1]})"}]
      :impl datahike.api.impl/seek-datoms}
 
+    rseek-datoms
+    {:args [:function
+            [:=> [:cat :datahike/SDB :datahike/SIndexLookupArgs] [:maybe :datahike/SDatoms]]
+            [:=> [:cat :datahike/SDB :keyword [:* :any]] [:maybe :datahike/SDatoms]]]
+     :ret [:maybe :datahike/SDatoms]
+     :categories [:query :index :advanced]
+     :stability :experimental
+     :supports-remote? true
+     :referentially-transparent? true
+     :doc "Like seek-datoms, but iterates BACKWARDS: datoms <= the given components, descending to the beginning of the index. Lazy on the persistent-sorted-set index — the primitive for windowed backwards pagination (latest-N, N-before-cursor)."
+     :examples [{:desc "Latest room messages, newest first"
+                 :code "(take 20 (rseek-datoms db {:index :avet :components [:message/room room-eid]}))"}]
+     :impl datahike.api.impl/rseek-datoms}
+
     index-range
     {:args [:=> [:cat :datahike/SDB :datahike/SIndexRangeArgs] :datahike/SDatoms]
      :ret :datahike/SDatoms

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -262,15 +262,20 @@
                          index-type))
       (post-process-datoms db context)))
 
-(defn contextual-rseek-datoms [db index-type cs context]
+(defn contextual-rseek-datoms
+  "Datoms <= the components pattern, DESCENDING to the beginning of the
+   index — the documented rseek-datoms semantics ('same as seek-datoms,
+   but goes backwards until the beginning of the index'). The previous
+   implementation forward-sliced from cs to the END of the index and
+   reversed a realized vector: wrong direction per its own docstring,
+   and O(everything after cs) on lazy konserve-backed indexes."
+  [db index-type cs context]
   (-> (case (dbi/context-temporal? context)
         true (dbs/temporal-rseek-datoms db index-type cs)
-        false (-> (di/-slice (get db index-type)
-                             (dbu/components->pattern db index-type cs e0 tx0)
-                             (datom emax nil nil txmax)
-                             index-type)
-                  vec
-                  rseq))
+        false (di/-rslice (get db index-type)
+                          (dbu/components->pattern db index-type cs emax txmax)
+                          (datom e0 nil nil tx0)
+                          index-type))
       (post-process-datoms db context)))
 
 (defn contextual-index-range [db avet attr start end context]

--- a/src/datahike/db/search.cljc
+++ b/src/datahike/db/search.cljc
@@ -279,18 +279,23 @@
                          (di/-slice index from to index-type)
                          (di/-slice temporal-index from to index-type))))
 
-(defn temporal-rseek-datoms [db index-type cs]
+(defn temporal-rseek-datoms
+  "Reverse seek over history dbs: datoms <= cs, descending to the index
+   beginning (matching rseek-datoms' documented semantics; previously it
+   went from the index END down to cs). Still realizes the bounded range
+   (distinct-datoms merges the current+temporal indexes in ascending
+   order); a fully lazy two-index reverse merge can come later if needed."
+  [db index-type cs]
   (let [index (get db index-type)
         temporal-index (get db (keyword (str "temporal-" (name index-type))))
-        from (dbu/components->pattern db index-type cs e0 tx0)
-        to (datom emax nil nil txmax)]
-    (concat
-     (-> (dbu/distinct-datoms db
-                              index-type
-                              (di/-slice index from to index-type)
-                              (di/-slice temporal-index from to index-type))
-         vec
-         rseq))))
+        from (datom e0 nil nil tx0)
+        to (dbu/components->pattern db index-type cs emax txmax)]
+    (-> (dbu/distinct-datoms db
+                             index-type
+                             (di/-slice index from to index-type)
+                             (di/-slice temporal-index from to index-type))
+        vec
+        rseq)))
 
 (defn temporal-index-range [db current-db attr start end]
   (when-not (dbu/indexing? db attr)

--- a/src/datahike/index.cljc
+++ b/src/datahike/index.cljc
@@ -14,6 +14,7 @@
 (def -temporal-upsert di/-temporal-upsert)
 (def -remove di/-remove)
 (def -slice di/-slice)
+(def -rslice di/-rslice)
 (def -flush di/-flush)
 (def -transient di/-transient)
 (def -persistent! di/-persistent!)

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -12,6 +12,7 @@
   (-temporal-upsert [index datom index-type op-count old-datom] "Inserts or updates a datom in a history index")
   (-remove [index datom index-type op-count] "Removes a datom from the index")
   (-slice [index from to index-type] "Returns a slice of the index")
+  (-rslice [index from to index-type] "Returns a REVERSE slice of the index: a lazy backwards iterator over datoms d with to <= d <= from, starting at `from` and descending. Mirrors persistent-sorted-set's rslice argument order (from = upper bound).")
   (-lookup [index key cmp] "Look up a single key with custom comparator. Returns the stored element or nil.")
   (-count-slice [index from to cmp] "O(log n) count of elements in [from, to] range using the given comparator.")
   (-has-subtree-counts? [index] "Returns true if count-slice is O(log n). False means counts are missing and count-slice would degrade to O(n).")

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -181,6 +181,12 @@
   IIndex
   (-slice [^PersistentSortedSet pset from to index-type]
     (psset/slice pset from to (slice-comparator-constructor index-type from to)))
+  (-rslice [^PersistentSortedSet pset from to index-type]
+    ;; rslice iterates DESCENDING from `from` down to `to` (from = upper
+    ;; bound). Lazy: only the seek path + consumed range restore nodes.
+    ;; The generated comparator inspects nil components of both bounds
+    ;; symmetrically, so the same constructor serves both directions.
+    (psset/rslice pset from to (slice-comparator-constructor index-type from to)))
   (-lookup [^PersistentSortedSet pset key cmp]
     #?(:clj  (.lookup pset key cmp)
        :cljs (psset/lookup pset key cmp)))

--- a/test/datahike/test/index_test.cljc
+++ b/test/datahike/test/index_test.cljc
@@ -2,8 +2,10 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
+   [clojure.core.async :as a :refer [<! go]]
    [datahike.api :as d]
    [datahike.constants :refer [e0 tx0 emax txmax]]
+   [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]
    [datahike.datom :as dd]
    [datahike.db :as db]
    [datahike.index :as di]
@@ -84,34 +86,64 @@
              [[1 :name "Petr"]
               [3 :name "Sergey"]])))))
 
-#_(deftest test-rseek-datoms ;; TODO: implement rseek within hitchhiker tree
-    (let [dvec #(vector (:e %) (:a %) (:v %))
-          db (-> (db/empty-db {:name {:db/index true}
-                               :age  {:db/index true}})
-                 (d/db-with [[:db/add 1 :name "Petr"]
-                             [:db/add 1 :age 44]
-                             [:db/add 2 :name "Ivan"]
-                             [:db/add 2 :age 25]
-                             [:db/add 3 :name "Sergey"]
-                             [:db/add 3 :age 11]]))]
+;; Connection-based + deftest-async so it runs cross-platform (CLJS
+;; connects async) and exercises the store-backed index. Assertions are
+;; [a v] pairs — eid-independent.
+(defn- rseek-cfg []
+  {:store {:backend :memory
+           :id #?(:clj (java.util.UUID/randomUUID)
+                  :cljs (random-uuid))}
+   :keep-history? false
+   :schema-flexibility :write
+   :initial-tx [{:db/ident :name
+                 :db/valueType :db.type/string
+                 :db/cardinality :db.cardinality/one
+                 :db/index true}
+                {:db/ident :age
+                 :db/valueType :db.type/long
+                 :db/cardinality :db.cardinality/one
+                 :db/index true}]})
 
-      (testing "Non-termination"
-        (is (= (map dvec (d/rseek-datoms db :avet :name "Petr"))
-               [[1 :name "Petr"]
-                [2 :name "Ivan"]
-                [1 :age 44]
-                [2 :age 25]
-                [3 :age 11]])))
+(deftest-async test-rseek-datoms
+  (let [cfg (rseek-cfg)
+        conn #?(:clj (do (d/create-database cfg) (d/connect cfg))
+                :cljs (do (<! (d/create-database cfg))
+                          (<! (d/connect cfg {:sync? false}))))
+        _ #?(:clj (d/transact conn [{:name "Petr" :age 44}
+                                    {:name "Ivan" :age 25}
+                                    {:name "Sergey" :age 11}])
+             :cljs (<! (d/transact! conn [{:name "Petr" :age 44}
+                                          {:name "Ivan" :age 25}
+                                          {:name "Sergey" :age 11}])))
+        db @conn
+        av #(vector (:a %) (:v %))]
 
-      (testing "Closest value lookup"
-        (is (= (map dvec (d/rseek-datoms db :avet :age 26))
-               [[2 :age 25]
-                [3 :age 11]])))
+    (testing "descends from the seek point to the index beginning"
+      (is (= (map av (d/rseek-datoms db :avet :name "Petr"))
+             [[:name "Petr"]
+              [:name "Ivan"]
+              [:age 44]
+              [:age 25]
+              [:age 11]])))
 
-      (testing "Exact value lookup"
-        (is (= (map dvec (d/rseek-datoms db :avet :age 25))
-               [[2 :age 25]
-                [3 :age 11]])))))
+    (testing "closest value lookup (no exact match)"
+      (is (= (map av (d/rseek-datoms db :avet :age 26))
+             [[:age 25]
+              [:age 11]])))
+
+    (testing "exact value lookup is inclusive"
+      (is (= (map av (d/rseek-datoms db :avet :age 25))
+             [[:age 25]
+              [:age 11]])))
+
+    (testing "windowed take touches only the tail"
+      (is (= (map av (take 2 (d/rseek-datoms db :avet :age)))
+             [[:age 44]
+              [:age 25]])))
+
+    (d/release conn)
+    #?(:clj (d/delete-database cfg)
+       :cljs (<! (d/delete-database cfg)))))
 
 (deftest test-index-range
   (let [dvec #(vector (:e %) (:a %) (:v %))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -8,6 +8,7 @@
             [cljs.nodejs :as nodejs]
             ;; Sibling test namespaces — included so `bb node-cljs-test`
             ;; covers them too.
+            [datahike.test.index-test]
             [datahike.test.cljs-pattern-scan-test]
             [datahike.test.optimistic-test]
             [datahike.test.valid-time-test]
@@ -365,6 +366,7 @@
 
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
+               'datahike.test.index-test
                'datahike.test.cljs-pattern-scan-test
                'datahike.test.optimistic-test
                'datahike.test.valid-time-test


### PR DESCRIPTION
## What

Lifts `persistent-sorted-set`'s lazy reverse iterator (`rslice`) through datahike's index protocols and exports a working `rseek-datoms`.

## Why

`rseek-datoms` existed only in `datahike.core`, and its implementation contradicted its own docstring ("goes backwards until the beginning of the index"): it forward-sliced from the given components to the **end** of the index, realized the whole tail into a vector, and `rseq`'d it — wrong direction, and O(everything after `cs`) on lazy konserve-backed indexes. Meanwhile `org.replikativ/persistent-sorted-set` has had a lazy reverse iterator (`rslice`) all along; it was simply never lifted through the index protocols.

Motivation: efficient **windowed backwards pagination** on client replicas — "latest N" / "N before cursor" walks in eid order at O(log n + N) instead of O(run) full scans. (Surfaced building chat history windowing over a konserve-synced datahike replica.)

## Changes

- **`index/interface`**: new `-rslice` protocol method (`from` = upper bound, descending — mirrors pss `rslice` argument order); re-exported via `datahike.index`.
- **`index/persistent-set`**: `-rslice` via `psset/rslice` — lazy on both platforms, only the seek path + consumed range restore nodes. The generated slice comparator inspects nil components of both bounds symmetrically, so it serves both directions.
- **`index/hitchhiker-tree`**: bounded realize+reverse fallback (HHT has no native reverse iterator) — correct semantics, and strictly better than the old realize-to-index-end.
- **`db` / `db.search`**: `contextual-rseek-datoms` + `temporal-rseek-datoms` reimplemented to the documented semantics — datoms `<= cs`, descending to the index beginning (inclusive closest-match, cross-attribute continuation).
- **`api`**: `rseek-datoms` exported through the specification (experimental), both arg-map and positional forms, mirroring `seek-datoms`.
- **tests**: the dormant `test-rseek-datoms` (`;; TODO: implement rseek within hitchhiker tree`) resurrected as a connection-based `deftest-async` so it runs cross-platform against the store-backed index, with eid-independent `[a v]` assertions + a windowed-take case; `datahike.test.index-test` added to the Node.js suite.

## Semantics fix

The old `rseek-datoms` went from the index **end** down to `cs`; it now goes from `cs` down to the index **beginning** — matching the docstring and the (previously-dormant, datascript-inherited) test's expectations. Inclusive closest-match; continues across attributes to the start of the index.

## Tests

- `clj-pss` full suite: 680 tests, 0 failures
- `clj-hht` full suite: 680 tests, 0 failures
- `node-cljs`: 102 tests, 915 assertions, 0 failures (exercises the real CLJS store-backed index via the async test)
- Verified on a live konserve-backed browser replica: reverse room-message walk, descending order, ~0.3ms.

## Notes

- `temporal-rseek-datoms` (history dbs) still realizes its now-**bounded** range (`distinct-datoms` merges current+temporal indexes ascending, then reverses); a fully lazy two-index reverse merge can come later if history walks need it. The pss path (current dbs) is fully lazy.
- ffix'd.
