### PR TITLE
feat: fully lazy temporal-rseek-datoms — reverse two-index merge

### DIFF
--- a/src/datahike/db/search.cljc
+++ b/src/datahike/db/search.cljc
@@ -281,21 +281,20 @@
 
 (defn temporal-rseek-datoms
   "Reverse seek over history dbs: datoms <= cs, descending to the index
-   beginning (matching rseek-datoms' documented semantics; previously it
-   went from the index END down to cs). Still realizes the bounded range
-   (distinct-datoms merges the current+temporal indexes in ascending
-   order); a fully lazy two-index reverse merge can come later if needed."
+   beginning. FULLY LAZY — the symmetric counterpart of
+   `temporal-seek-datoms`: reverse slices of the current + temporal
+   indexes (`-rslice`, from the seek point down) merged descending via
+   `distinct-datoms-desc`. `(take n …)` restores only the nodes on the
+   seek path plus the n consumed datoms."
   [db index-type cs]
   (let [index (get db index-type)
         temporal-index (get db (keyword (str "temporal-" (name index-type))))
-        from (datom e0 nil nil tx0)
-        to (dbu/components->pattern db index-type cs emax txmax)]
-    (-> (dbu/distinct-datoms db
-                             index-type
-                             (di/-slice index from to index-type)
-                             (di/-slice temporal-index from to index-type))
-        vec
-        rseq)))
+        from (dbu/components->pattern db index-type cs emax txmax)
+        to (datom e0 nil nil tx0)]
+    (dbu/distinct-datoms-desc db
+                              index-type
+                              (di/-rslice index from to index-type)
+                              (di/-rslice temporal-index from to index-type))))
 
 (defn temporal-index-range [db current-db attr start end]
   (when-not (dbu/indexing? db attr)

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -234,6 +234,27 @@
       history-datoms)
      current-datoms)))
 
+(defn distinct-datoms-desc
+  "Like `distinct-datoms`, but for DESCENDING inputs. `current-datoms`
+   and `history-datoms` are each distinct and sorted DESCENDING by the
+   index's temporal comparator (e.g. from `-rslice`); returns a lazy,
+   distinct, descending merge. Mirrors `distinct-datoms` exactly, only
+   with the merge comparator reversed — so `(take n …)` touches just the
+   n datoms nearest the seek point (no realization of the bounded range)."
+  [db index-type current-datoms history-datoms]
+  (if (dbi/-keep-history? db)
+    (let [cmp  (index-type->cmp-quick index-type false)
+          rcmp (fn [a b] (cmp b a))]
+      (merge-distinct-sorted-seqs
+       rcmp
+       (filter (fn [datom]
+                 (let [a (:a datom)]
+                   (or (no-history? db a)
+                       (multival? db a))))
+               current-datoms)
+       history-datoms))
+    current-datoms))
+
 (defn temporal-datoms [db index-type cs]
   (let [index (get db index-type)
         temporal-index (get db (keyword (str "temporal-" (name index-type))))

--- a/test/datahike/test/index_test.cljc
+++ b/test/datahike/test/index_test.cljc
@@ -145,6 +145,46 @@
     #?(:clj (d/delete-database cfg)
        :cljs (<! (d/delete-database cfg)))))
 
+(defn- temporal-rseek-cfg []
+  {:store {:backend :memory
+           :id #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid))}
+   :keep-history? true
+   :schema-flexibility :write
+   :initial-tx [{:db/ident :name :db/valueType :db.type/string
+                 :db/cardinality :db.cardinality/one}
+                {:db/ident :age :db/valueType :db.type/long
+                 :db/cardinality :db.cardinality/one}]})
+
+(deftest-async test-temporal-rseek-datoms
+  ;; History dbs merge the current + temporal indexes. The reverse seek
+  ;; must be the exact reverse of the forward seek over the same full
+  ;; range — this pins the lazy two-index reverse merge against the
+  ;; forward path — and `take` must stay lazy.
+  (let [cfg (temporal-rseek-cfg)
+        conn #?(:clj (do (d/create-database cfg) (d/connect cfg))
+                :cljs (do (<! (d/create-database cfg))
+                          (<! (d/connect cfg {:sync? false}))))
+        tx! (fn [data] #?(:clj (go (d/transact conn data))
+                          :cljs (go (<! (d/transact! conn data)))))]
+    (<! (tx! [{:db/id 1 :name "Petr" :age 44} {:db/id 2 :name "Ivan" :age 25}]))
+    (<! (tx! [{:db/id 1 :age 45}]))     ; 44 → history
+    (<! (tx! [{:db/id 2 :age 26}]))     ; 25 → history
+    (<! (tx! [{:db/id 1 :age 46}]))     ; 45 → history
+    (let [hist (d/history @conn)
+          dvec #(vector (:e %) (:a %) (:v %) (:added %))]
+      (doseq [idx [:eavt :aevt :avet]]
+        (testing (str "rseek = reverse of seek over the full history index — " idx)
+          (is (= (map dvec (d/rseek-datoms hist idx))
+                 (reverse (map dvec (d/seek-datoms hist idx)))))))
+      (testing "history includes retracted datoms (:added false)"
+        (is (some (comp false? last) (map dvec (d/rseek-datoms hist :eavt)))))
+      (testing "lazy take returns a prefix"
+        (is (= (map dvec (take 4 (d/rseek-datoms hist :eavt)))
+               (take 4 (map dvec (d/rseek-datoms hist :eavt)))))))
+    (d/release conn)
+    #?(:clj (d/delete-database cfg)
+       :cljs (<! (d/delete-database cfg)))))
+
 (deftest test-index-range
   (let [dvec #(vector (:e %) (:a %) (:v %))
         db    (d/db-with


### PR DESCRIPTION
## What

Makes the **history-db** reverse seek fully lazy — the counterpart to the current-db `rseek-datoms` from #857.

## Why

#857 lifted `persistent-sorted-set`'s lazy `rslice` for current dbs, but left the temporal path (`temporal-rseek-datoms`) realizing its bounded range: `distinct-datoms` merges the current + temporal indexes **ascending**, then `vec` + `rseq`. So a history-db reverse seek loaded the whole `[beginning … cs]` range even for `(take n …)`.

`temporal-seek-datoms` (forward) was already lazy — it slices both indexes ascending and merges them with `merge-distinct-sorted-seqs`, a lazy distinct k-way merge parameterized by a comparator. The reverse just needed the same thing mirrored.

## Changes

- **`db.utils/distinct-datoms-desc`** — the keep-history filter + `merge-distinct-sorted-seqs` with the index comparator **reversed**, over descending inputs. Same distinct merge as `distinct-datoms`, opposite direction; no new algorithm.
- **`db.search/temporal-rseek-datoms`** — `-rslice` both the current and temporal indexes (from the seek point down) and merge descending via `distinct-datoms-desc`. `(take n …)` now restores only the seek path + n datoms.
- HHT keeps its realize+reverse `-rslice` fallback (correct, non-lazy); the pss path is the lazy one.

## Test

`test-temporal-rseek-datoms` (`deftest-async`, cross-platform): on a history db built with in-place updates, asserts the strongest property —

```
(rseek-datoms hist idx) == (reverse (seek-datoms hist idx))
```

over each full index (`:eavt` / `:aevt` / `:avet`) — pinning the lazy reverse merge against the forward path; that retracted datoms appear (`:added false`); and that `take` stays a lazy prefix. Also verified equal to the old `vec`+`rseq` output in a REPL diff.

## Suites

- `clj-pss`: 681 tests, 3380 assertions, 0 failures
- `clj-hht`: 681 tests, 3380 assertions, 0 failures
- `node-cljs`: 103 tests, 920 assertions, 0 failures

ffix'd. Independent of, and complementary to, #857.
