### PR TITLE
test(cljs): tiered-store durability regression (validates #854 on CLJS)

### DIFF
--- a/test/datahike/test/cljs_tiered_storage_test.cljs
+++ b/test/datahike/test/cljs_tiered_storage_test.cljs
@@ -1,0 +1,69 @@
+(ns datahike.test.cljs-tiered-storage-test
+  "CLJS validation of the tiered-store durability fix (#854): the
+   `datahike.index/with-storage` :cljs branch (BTSet ctor) was only
+   JVM-exercised. This is the config the bug targets — a memory frontend
+   over a durable (node-filestore) backend. We write through the tiered
+   store, then COLD-READ the durable backend directly via a plain :file
+   store at the same path/id (a process restart / second peer). Without
+   the fix the backend holds a root pointing at node blobs stranded in an
+   orphaned buffer → `Node not found in storage`; with it the data is
+   recoverable, including a write made after a cold reconnect."
+  (:require [cljs.test :refer [deftest is async]]
+            [datahike.api :as d]
+            [konserve.node-filestore] ;; register :file backend for Node.js
+            [cljs.nodejs :as nodejs]
+            [cljs.core.async :refer [go <!] :include-macros true]))
+
+(def os (nodejs/require "os"))
+(def path (nodejs/require "path"))
+(defn- tmp-dir [] (.join path (.tmpdir os) (str "dh-cljs-tiered-" (rand-int 1000000))))
+
+(deftest tiered-frontend-deletion-recovery-test
+  (async
+   done
+   (go
+     (let [store-id  (random-uuid)
+           dir       (tmp-dir)
+           front-cfg {:backend :memory :id store-id}
+           tiered    {:store {:backend :tiered :id store-id
+                              :frontend-config front-cfg
+                              :backend-config {:backend :file :path dir :id store-id}}
+                      :keep-history? false :schema-flexibility :read
+                      :index :datahike.index/persistent-set}
+           ;; the durable backend alone — no frontend (cold read)
+           backend   {:store {:backend :file :path dir :id store-id}
+                      :keep-history? false :schema-flexibility :read
+                      :index :datahike.index/persistent-set}]
+       (try
+         (<! (d/delete-database tiered))
+         (<! (d/create-database tiered))
+         (let [conn (<! (d/connect tiered {:sync? false}))]
+           (<! (d/transact! conn [{:db/ident :name :db/valueType :db.type/string
+                                   :db/cardinality :db.cardinality/one}
+                                  {:name "Alice"}]))
+           (d/release conn))
+
+         ;; COLD read #1 — plain :file store over the same backend
+         (let [conn (<! (d/connect backend {:sync? false}))
+               res  (try (d/q '[:find ?n :where [_ :name ?n]] @conn)
+                         (catch :default e (str "THREW " (.-message e))))]
+           (is (= #{["Alice"]} res)
+               "tiered write must reach the durable backend (cold :file read)")
+           (d/release conn))
+
+         ;; write again through a RECONNECTED tiered store …
+         (let [conn (<! (d/connect tiered {:sync? false}))]
+           (<! (d/transact! conn [{:name "Bob"}]))
+           (d/release conn))
+
+         ;; COLD read #2 — the post-reconnect write must also be durable
+         (let [conn (<! (d/connect backend {:sync? false}))
+               res  (try (d/q '[:find ?n :where [_ :name ?n]] @conn)
+                         (catch :default e (str "THREW " (.-message e))))]
+           (is (= #{["Alice"] ["Bob"]} res)
+               "post-cold-reconnect write must also be durable")
+           (d/release conn))
+
+         (<! (d/delete-database tiered))
+         (catch :default e (is false (str "unexpected throw: " (.-message e)))))
+       (done)))))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -9,6 +9,7 @@
             ;; Sibling test namespaces — included so `bb node-cljs-test`
             ;; covers them too.
             [datahike.test.index-test]
+            [datahike.test.cljs-tiered-storage-test]
             [datahike.test.cljs-pattern-scan-test]
             [datahike.test.optimistic-test]
             [datahike.test.valid-time-test]
@@ -371,6 +372,7 @@
 (defn -main []
   (t/run-tests 'datahike.test.nodejs-test
                'datahike.test.index-test
+               'datahike.test.cljs-tiered-storage-test
                'datahike.test.cljs-pattern-scan-test
                'datahike.test.optimistic-test
                'datahike.test.valid-time-test


### PR DESCRIPTION
## What

A Node.js regression test validating the **CLJS branch** of the #854 tiered-store durability fix.

## Why

#854 fixed silent data loss through a tiered store (memory frontend + durable backend) by binding index storage per connection (`datahike.index/with-storage`). Its `:cljs` branch — the `BTSet` `with-storage` ctor — was written but **only JVM-exercised**, even though *memory frontend over IndexedDB is the recommended browser config*. This closes that gap.

## The test

`datahike.test.cljs-tiered-storage-test/tiered-frontend-deletion-recovery-test` (added to the Node runner):

1. Write through a `tiered{:memory, :file}` store, release.
2. **Cold-read the durable backend directly** via a plain `:file` store at the same path/id — a genuine process-restart / second-peer read, with no frontend involved.
3. Assert `Alice` is recoverable from the backend alone.
4. Write `Bob` through a *reconnected* tiered store; cold-read again; assert both survive.

Cold-reading the backend directly is cleaner than the JVM test's "drop the frontend" step, because `konserve.store/delete-store` on a `:memory` store is a nil-returning no-op in CLJS (it doesn't return a channel). The plain-`:file`-over-same-path approach is the more faithful cold-read anyway.

## Verified

- **Without #854** (fix reverted in a worktree): fails with `Node not found in storage` — the exact durability bug, reproduced on CLJS.
- **With #854**: passes; both writes recovered from the backend.
- Full Node suite green (112 tests, 942 assertions, 0 failures).

Test-only; no source changes. ffix'd.
