### PR TITLE
feat(query): let secondary indices own their external-engine query-spec

### DIFF
--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -173,3 +173,43 @@
     (assoc key-map
            :branch (name new-branch)
            :commit-id new-commit-id)))
+
+;; ---------------------------------------------------------------------------
+;; KNN as a Datalog clause (external-engine)
+;;
+;; With the query-spec-fn mechanism, a Proximum vector search is a first-class
+;; :where clause the planner recognizes — no manual EntityBitSet plumbing:
+;;
+;;   ;; retrieval — bind entity + cosine distance, then join like any relation
+;;   (d/q '[:find ?name ?distance
+;;          :in $ ?qvec
+;;          :where
+;;          [(datahike.index.secondary.proximum/knn :idx/embeddings ?qvec 10)
+;;           [[?e ?distance]]]
+;;          [?e :doc/name ?name]]
+;;        db query-float-array)
+;;
+;;   ;; filter — entities only (1 binding var)
+;;   [(datahike.index.secondary.proximum/knn :idx/embeddings ?qvec 10) [?e ...]]
+;;
+;; Planner-only: the base (relational) engine has no external-engine mechanism.
+(defn knn
+  "Vector k-nearest-neighbour search over a Proximum secondary index, callable
+   from a Datalog :where clause. Args: <idx-ident> <query-vector (float[])> <k>.
+   Binds [[?e ?distance]] (retrieval) or [?e ...] (filter). See the ns comment."
+  {:datahike/external-engine
+   {:index-key 0                                  ;; idx-ident is the first arg
+    :binding-columns [:entity-id :distance]       ;; 1 var → :filter, 2 → :retrieval
+    :accepts-entity-filter? true
+    ;; Proximum's own query-spec shape (not the full-text {:query :field} default)
+    :query-spec-fn (fn [query-args]
+                     {:vector (first query-args) :k (second query-args)})
+    :input-vars :all-bound
+    :cost-model (fn [_db _idx-ident args _n-cols]
+                  (let [k (nth (vec args) 2 10)]
+                    {:estimated-card (if (number? k) k 10)
+                     :cost-per-result 0.01}))}}
+  ;; Body is only the legacy/bare-fn fallback — the planner path calls the index
+  ;; directly through the executor. Returning the query-spec keeps it usable.
+  [_idx-ident query-vector k]
+  {:vector query-vector :k k})

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3859,7 +3859,11 @@
                  ;; Create relation from entity IDs
                  entity-var (first binding-vars)
                  eids (es/entity-bitset-seq result-bs)
-                 tuples (mapv (fn [eid] [eid]) eids)
+                 ;; EntityBitSet (Roaring) yields 32-bit Ints; datom entity ids
+                 ;; are Longs. Coerce so the downstream hash-join on the entity
+                 ;; var matches (Java Integer != Long even when numerically equal,
+                 ;; which silently drops every joined row).
+                 tuples (mapv (fn [eid] [(long eid)]) eids)
                  rel (rel/->Relation
                       {entity-var 0}
                       (set tuples))]
@@ -3883,7 +3887,8 @@
                  tuples (set (mapv (fn [r]
                                      (mapv (fn [v]
                                              (cond
-                                               (= v (first binding-vars)) (:entity-id r)
+                                               ;; entity id -> Long (Roaring yields Int; join needs Long)
+                                               (= v (first binding-vars)) (long (:entity-id r))
                                                :else (get r (keyword (name v)))))
                                            binding-vars))
                                    results))

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3883,14 +3883,23 @@
                                                     nil nil nil nil)
                  ;; Map binding vars to column indices
                  attrs (into {} (map-indexed (fn [i v] [v i]) binding-vars))
-                 ;; Build tuples from results
+                 ;; The engine declares which result key each binding position
+                 ;; carries via :binding-columns (e.g. [:entity-id :distance]).
+                 ;; Map positionally by that — NOT by (keyword (name var)), which
+                 ;; would keep the leading `?` (?distance -> :?distance) and miss
+                 ;; the result key. Fall back to a `?`-stripped name if a column
+                 ;; isn't declared.
+                 binding-cols (:binding-columns (:engine-meta op))
                  tuples (set (mapv (fn [r]
-                                     (mapv (fn [v]
-                                             (cond
-                                               ;; entity id -> Long (Roaring yields Int; join needs Long)
-                                               (= v (first binding-vars)) (long (:entity-id r))
-                                               :else (get r (keyword (name v)))))
-                                           binding-vars))
+                                     (vec (map-indexed
+                                           (fn [i v]
+                                             (let [col (nth binding-cols i nil)]
+                                               (cond
+                                                 ;; entity id -> Long (Roaring yields Int; join needs Long)
+                                                 (= col :entity-id) (long (:entity-id r))
+                                                 (some? col) (get r col)
+                                                 :else (get r (keyword (subs (name v) 1))))))
+                                           binding-vars)))
                                    results))
                  rel (rel/->Relation attrs tuples)]
              (update ctx :rels rel/collapse-rels rel))

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3802,6 +3802,24 @@
        (into {} (map (fn [v] [v (keyword (subs (name v) 1))]) binding-vars)))))
 
 #?(:clj
+   (defn- external-query-spec
+     "Build the query-spec passed to a secondary index's `-search` /
+      `-slice-ordered` from an external-engine call's (index-ident-stripped)
+      args.
+
+      The `ISecondaryIndex` protocol treats query-spec as index-type-specific
+      (opaque). An engine may declare a `:query-spec-fn` in its
+      `:datahike/external-engine` metadata to construct an arbitrary, arity-free
+      spec from `query-args`; absent that, we default to the text-search-shaped
+      `{:query <arg0> :field <arg1>}` for backward compatibility (so existing
+      engines are unaffected)."
+     [engine-meta query-args]
+     (if-let [f (:query-spec-fn engine-meta)]
+       (f (vec query-args))
+       {:query (first query-args)
+        :field (second query-args)})))
+
+#?(:clj
    (defn- execute-external-engine
      "Execute an external engine op and merge results into context.
       Dispatches on :mode — :filter, :retrieval, or :solver."
@@ -3815,7 +3833,9 @@
            binding-vars (if (and (sequential? binding-form)
                                  (sequential? (first binding-form)))
                           (first binding-form)
-                          [binding-form])]
+                          [binding-form])
+           engine-meta (:engine-meta op)
+           build-query-spec (fn [query-args] (external-query-spec engine-meta query-args))]
        (case mode
          ;; Filter: produce EntityBitSet, create single-column relation of entity IDs.
          ;; Also stores the bitmap in :entity-filters for downstream entity-group optimization.
@@ -3829,13 +3849,11 @@
                  resolved-fn (when (and (symbol? fn-sym) (namespace fn-sym))
                                (some-> (resolve fn-sym) deref))
                  result-bs (if resolved-fn
-                             ;; Call the function which should return results.
                              ;; `search-with-vt` reads the db's `:datahike/valid-at`
                              ;; marker (set by `d/valid-at`) and routes through
                              ;; `-search-at-vt` for vt-aware indices.
                              (sec/search-with-vt db idx
-                                                 {:query (first resolved-args)
-                                                  :field (second resolved-args)}
+                                                 (build-query-spec resolved-args)
                                                  nil)
                              (es/entity-bitset))
                  ;; Create relation from entity IDs
@@ -3857,8 +3875,7 @@
          (if idx
            (let [query-args (vec (drop 1 args))
                  results (sec/slice-ordered-with-vt db idx
-                                                    {:query (first query-args)
-                                                     :field (second query-args)}
+                                                    (build-query-spec query-args)
                                                     nil nil nil nil)
                  ;; Map binding vars to column indices
                  attrs (into {} (map-indexed (fn [i v] [v i]) binding-vars))

--- a/test/datahike/test/external_engine_query_spec_test.clj
+++ b/test/datahike/test/external_engine_query_spec_test.clj
@@ -1,0 +1,27 @@
+(ns datahike.test.external-engine-query-spec-test
+  "The external-engine executor lets a secondary index own its query-spec format
+   via an optional `:query-spec-fn` in the `:datahike/external-engine` metadata,
+   with a backward-compatible `{:query :field}` default."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.query.execute]))
+
+(def ^:private build @#'datahike.query.execute/external-query-spec)
+
+(deftest default-query-spec-is-backward-compatible
+  (testing "no :query-spec-fn → the legacy {:query <arg0> :field <arg1>} shape"
+    (is (= {:query :a :field :b} (build {} [:a :b])))
+    (is (= {:query :a :field :b} (build {} [:a :b :c])) "extra args ignored by default")
+    (is (= {:query :a :field nil} (build {} [:a])) "missing field is nil")
+    (is (= {:query :a :field :b} (build {:some :other-meta} [:a :b])))))
+
+(deftest custom-query-spec-fn-is-honored
+  (testing ":query-spec-fn builds an arbitrary, arity-free opaque spec"
+    (let [em {:query-spec-fn (fn [args]
+                               {:pattern (nth args 0)
+                                :depth (nth args 1)
+                                :flags (nth args 2)})}]
+      (is (= {:pattern :p :depth 3 :flags :f} (build em [:p 3 :f]))
+          "index receives its own >2-arity spec, not {:query :field}"))
+    (testing "the fn receives a vector of the args"
+      (is (vector? (build {:query-spec-fn identity} '(:x :y)))))))

--- a/test/datahike/test/external_engine_query_spec_test.clj
+++ b/test/datahike/test/external_engine_query_spec_test.clj
@@ -4,9 +4,43 @@
    with a backward-compatible `{:query :field}` default."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.index.secondary :as sec]
+   [datahike.index.entity-set :as es]
    [datahike.query.execute]))
 
 (def ^:private build @#'datahike.query.execute/external-query-spec)
+
+;; ---- minimal self-contained secondary index for the join regression ----
+;; Stores the eids it is fed; -search returns all of them. Enough to exercise
+;; the external-engine :filter execution path end-to-end via datalog.
+(defrecord AllEidsIndex [state attrs]
+  sec/ISecondaryIndex
+  (-search [_ _query-spec entity-filter]
+    (let [bs (es/entity-bitset)]
+      (doseq [eid @state
+              :when (or (nil? entity-filter)
+                        (es/entity-bitset-contains? entity-filter (long eid)))]
+        (es/entity-bitset-add! bs (long eid)))
+      bs))
+  (-estimate [_ _] (count @state))
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [this {:keys [datom added?]}]
+    (when added? (swap! state conj (long (nth datom 0))))
+    this))
+
+(defonce ^:private register-all-eids
+  (sec/register-index-type! :test/all-eids
+                            (fn [config _db]
+                              (->AllEidsIndex (atom #{}) (set (:db.secondary/attrs config))))))
+
+;; :filter-mode foreign var — binds ?e to each entity the index produces.
+(defn ^{:datahike/external-engine
+        {:index-key 0 :binding-columns [:entity-id] :input-vars :all-bound
+         :cost-model (fn [_db _idx _args _n] {:estimated-card 10})}}
+  all-eids-match [_idx-ident _q] true)
 
 (deftest default-query-spec-is-backward-compatible
   (testing "no :query-spec-fn → the legacy {:query <arg0> :field <arg1>} shape"
@@ -25,3 +59,36 @@
           "index receives its own >2-arity spec, not {:query :field}"))
     (testing "the fn receives a vector of the args"
       (is (vector? (build {:query-spec-fn identity} '(:x :y)))))))
+
+(deftest external-engine-entities-join-as-long
+  (testing "entities produced by an external-engine index JOIN correctly with a
+            scalar-attr scan. Roaring EntityBitSet yields 32-bit Int eids while
+            datom eids are Longs; before the coercion fix the hash-join on the
+            entity var silently dropped EVERY row (Java Integer != Long)."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write :keep-history? false}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one}])
+        (d/transact conn [{:db/ident :idx/test :db.secondary/type :test/all-eids
+                           :db.secondary/attrs [:name]}])
+        (d/transact conn [{:name "a"} {:name "b"} {:name "c"}])
+        (Thread/sleep 200)                       ; let the index backfill
+        ;; The DIRECT guard: the entity relation the external engine emits must
+        ;; carry Long eids. Before the fix these were java.lang.Integer (Roaring),
+        ;; so any hash-join keyed on the entity var (Integer != Long) dropped
+        ;; every row. `:find ?e` alone surfaces the relation values directly.
+        (let [es (d/q '[:find [?e ...] :where
+                        [(datahike.test.external-engine-query-spec-test/all-eids-match :idx/test :_) [[?e]]]]
+                      @conn)]
+          (is (= 3 (count es)))
+          (is (every? #(instance? Long %) es)
+              "external-engine relation eids are Longs (were Integer before the fix)"))
+        ;; And the end-to-end join to a scalar attribute yields the rows.
+        (let [rows (d/q '[:find ?e ?n :where
+                          [(datahike.test.external-engine-query-spec-test/all-eids-match :idx/test :_) [[?e]]]
+                          [?e :name ?n]]
+                        @conn)]
+          (is (= #{"a" "b" "c"} (set (map second rows))))
+          (d/release conn))))))

--- a/test/datahike/test/external_engine_query_spec_test.clj
+++ b/test/datahike/test/external_engine_query_spec_test.clj
@@ -3,11 +3,20 @@
    via an optional `:query-spec-fn` in the `:datahike/external-engine` metadata,
    with a backward-compatible `{:query :field}` default."
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [datahike.api :as d]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
+   [datahike.query :as q]
    [datahike.query.execute]))
+
+;; External-engine clauses are a planner feature: the planner recognizes the
+;; `:datahike/external-engine` metadata and generates the op. The base
+;; (relational) engine has no such mechanism, so under `persistent-set-test-
+;; base-engine` (which disables the planner globally) the clause is evaluated as
+;; an ordinary fn call and can't bind to `[[?e]]`. Force the planner on for the
+;; d/q-driven tests here.
+(use-fixtures :each (fn [f] (binding [q/*disable-planner* false] (f))))
 
 (def ^:private build @#'datahike.query.execute/external-query-spec)
 

--- a/test/datahike/test/secondary_integration_test.clj
+++ b/test/datahike/test/secondary_integration_test.clj
@@ -6,6 +6,7 @@
    [datahike.db :as db]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
+   [datahike.query :as q]
    [datahike.index.secondary.scriptum]
    [datahike.index.secondary.stratum]))
 
@@ -240,6 +241,47 @@
           (is (= 2 (es/entity-bitset-cardinality results)))
           (is (es/entity-bitset-contains? results 1))
           (is (es/entity-bitset-contains? results 2)))))))
+
+(deftest test-proximum-knn-clause
+  ;; KNN as a first-class Datalog :where clause via the external-engine
+  ;; query-spec-fn. Planner-only (the base engine has no external-engine op).
+  (when-not proximum-available?
+    (is (not proximum-available?) "SKIP: proximum requires Java 22+"))
+  (when proximum-available?
+    (binding [q/*disable-planner* false]
+      (let [cfg {:store {:backend :memory :id (random-uuid)} :schema-flexibility :write}]
+        (d/create-database cfg)
+        (try
+          (let [conn (d/connect cfg)]
+            (d/transact conn [{:db/ident :doc/name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+                              {:db/ident :doc/embedding :db/valueType :db.type/float-array
+                               :db/cardinality :db.cardinality/one :db.secondary/only true}])
+            (d/transact conn [{:db/ident :idx/emb :db.secondary/type :proximum :db.secondary/attrs [:doc/embedding]
+                               :db.secondary/config {:dim 4 :distance :cosine :capacity 100
+                                                     :store-config {:backend :memory :id (random-uuid)}}}])
+            (Thread/sleep 800)
+            (d/transact conn [{:doc/name "east"  :doc/embedding (float-array [1.0 0.0 0.0 0.0])}
+                              {:doc/name "east2" :doc/embedding (float-array [0.9 0.1 0.0 0.0])}
+                              {:doc/name "north" :doc/embedding (float-array [0.0 1.0 0.0 0.0])}])
+            (Thread/sleep 500)
+            (testing "retrieval: [[?e ?distance]] binds entity + cosine distance and joins to a scalar attr"
+              (let [rows (d/q '[:find ?name ?distance :in $ ?qvec
+                                :where [(datahike.index.secondary.proximum/knn :idx/emb ?qvec 3) [[?e ?distance]]]
+                                [?e :doc/name ?name]]
+                              @conn (float-array [1.0 0.0 0.0 0.0]))
+                    m (into {} (map (fn [[n d]] [n d]) rows))]
+                (is (= #{"east" "east2" "north"} (set (keys m))))
+                (is (< (m "east") (m "east2") (m "north")) "distances present and ordered")
+                (is (== 0.0 (m "east")))))
+            (testing "filter: [?e ...] composes with a Datalog predicate"
+              (let [names (d/q '[:find [?name ...] :in $ ?qvec
+                                 :where [(datahike.index.secondary.proximum/knn :idx/emb ?qvec 3) [?e ...]]
+                                 [?e :doc/name ?name]
+                                 [(clojure.string/starts-with? ?name "east")]]
+                               @conn (float-array [1.0 0.0 0.0 0.0]))]
+                (is (= #{"east" "east2"} (set names)))))
+            (d/release conn))
+          (finally (d/delete-database cfg)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Stratum Entity-Filter Aggregate Tests


### PR DESCRIPTION
## Problem

The external-engine executor (`execute-external-engine`, `query/execute.cljc`) hardcodes the query-spec passed to a secondary index's `-search`/`-slice-ordered` as `{:query <arg0> :field <arg1>}` in `:filter` and `:retrieval` mode — a text-search shape — even though the `ISecondaryIndex` protocol states query-spec is **index-type-specific (opaque)**. The in-code comment even says *"call the resolved function with args to get query-spec"* but the code doesn't.

This limits any non-text secondary index (e.g. a term / discrimination-tree index over structured values) to two positional args and a misnamed `:query`/`:field` key — the one thing standing between *"works with an awkward shape"* and *"first-class external term index"*.

## Change

An engine may declare an optional `:query-spec-fn` in its `:datahike/external-engine` metadata to build an arbitrary, arity-free spec from the (index-ident-stripped) args:

```clojure
(defn ^{:datahike/external-engine
        {:index-key 0
         :binding-columns [:entity-id]
         :query-spec-fn (fn [args] {:pattern (nth args 1) :depth (nth args 2)})}}
  dt-match [idx pattern depth] ...)
```

Absent it, the executor falls back to the legacy `{:query :field}` shape, so **existing engines (incl. stratum) are unaffected**.

- extract `external-query-spec` (honors `:query-spec-fn`, else the default)
- use it in both `:filter` and `:retrieval` execution modes
- unit test: default backward-compat shape + custom >2-arity opaque spec

## Motivation

Enables an external library to register a first-class term/structural secondary index queryable from datalog **without patching the executor**. (Context: building a CIC discrimination-tree index over declaration types in an external prover, fed incrementally via the existing `ISecondaryIndex` `-transact` signed-delta stream.)

## Testing

New unit test `external-engine-query-spec-test` (2 tests / 6 assertions). No regression: `query-ir` + `stratum-bridge` + `secondary-*` suites green (**43 tests / 141 assertions / 0 failures**).