### PR TITLE
test(gc,writer): use java.io.tmpdir, not ~/tmp/dh-tests — fix order-dependent CI failure

### DIFF
--- a/test/datahike/test/commit_graph_test.clj
+++ b/test/datahike/test/commit_graph_test.clj
@@ -14,7 +14,7 @@
 
 (defn- base-cfg [id]
   {:store {:backend :file
-           :path (str (System/getProperty "user.home") "/tmp/dh-tests/commit-graph-" id)
+           :path (str (System/getProperty "java.io.tmpdir") "/dh-commit-graph-" id)
            :id id}
    :schema-flexibility :write
    :keep-history? false

--- a/test/datahike/test/head_cache_test.clj
+++ b/test/datahike/test/head_cache_test.clj
@@ -11,7 +11,7 @@
 (deftest no-branch-head-read-per-commit
   (testing "steady-state commits do zero k/get reads of the branch-head key"
     (let [cfg {:store {:backend :file
-                       :path (str (System/getProperty "user.home") "/tmp/dh-tests/head-cache")
+                       :path (str (System/getProperty "java.io.tmpdir") "/dh-head-cache")
                        :id #uuid "6ead0000-0000-0000-0000-000000000001"}
                :schema-flexibility :write :keep-history? false}]
       (when (d/database-exists? cfg) (d/delete-database cfg))


### PR DESCRIPTION
## Symptom

`hitchhiker-tree-test` failed on main after #869 merged ([CircleCI job 19283](https://app.circleci.com/pipelines/github/replikativ/datahike/2779/workflows/18ce1e71-e844-4214-a7df-efb7ce3e0339/jobs/19283)), while both #867 and #869 were green on their PRs. The user asked whether this is stochastic — it is, and here is exactly why.

## Root cause (deterministic per seed, stochastic across runs)

```
java.nio.file.NoSuchFileException: /home/circleci/tmp/dh-tests
  commit_graph_test.clj:120  →  d/delete-database
```

`commit-graph-test` and `head-cache-test` hardcoded their store paths under `$HOME/tmp/dh-tests` — a directory that exists on the author's dev machine but not on CI. `commit-graph-test/crypto-hash-combination-rejected` calls `d/delete-database` **unconditionally as its first step**; `delete-database` fsyncs the store's *parent* directory, so when `$HOME/tmp/dh-tests` was absent it threw `NoSuchFileException`.

Whether that directory existed at that moment depended on whether an earlier test had already created a database under `$HOME/tmp/dh-tests` (`head-cache-test` does, which mkdir's the parent). **kaocha randomizes test order per run**, so the outcome was seed-dependent: the PR runs drew a seed that ordered a directory-creating test first (green); main drew one that ran the crypto test first (red).

This is **not** a concurrency or GC-correctness problem — the diff-buf / fusion / commit-graph code is not implicated. It is purely test-path hygiene.

## Fix

Both tests now use `java.io.tmpdir` (always present on every platform/CI), matching the rest of the suite (`store-test`, etc.). No production code changes.

## Verification

Removed `$HOME/tmp/dh-tests` locally to simulate a fresh CI checkout and ran both suites: **18 tests, 69 assertions, 0 failures**, order-independent.