### PR TITLE
fix(writer): close queues before delivering the failed callback — shutdown race

### DIFF
--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -147,11 +147,19 @@
                                                   (assoc :db-after commit-db))]
                                 (>! callback tx-report))))
                           (catch #?(:clj Throwable :cljs js/Error) e
+                            ;; Close the queues BEFORE delivering the failed
+                            ;; callbacks. Delivering first unblocks the caller
+                            ;; while the queues are still open, so a subsequent
+                            ;; transact could race into the still-open queue and
+                            ;; commit AFTER the fatal error (writer_error_test
+                            ;; saw the "dead" writer accept a further write).
+                            ;; Closing first makes that transact observe the
+                            ;; closed queue and fail loudly (:writer-shut-down).
+                            (close! commit-queue)
+                            (close! transaction-queue)
                             (doseq [[_ callback] txs]
                               (put! callback e))
                             (log/error :datahike/writer-shutdown {:error e})
-                            (close! commit-queue)
-                            (close! transaction-queue)
                             ;; Re-throw Errors (AssertionError, OutOfMemoryError, etc.) to crash the writer
                             #?(:clj (when (instance? Error e)
                                       (throw e)))))


### PR DESCRIPTION
## Symptom

`writer-error-test/fatal-error-in-commit-fails-loudly` is flaky on CI ([job 19338](https://app.circleci.com/pipelines/github/replikativ/datahike/2784/workflows/b739af73-308c-4bcc-84e7-cc99a13b40d6/jobs/19338), `persistent-set-test-base-engine`). All three tail assertions fail together:

- `subsequent transacts on the dead writer fail loudly` — the transact did **not** throw;
- `store intact at the last successful commit` — extra entity present;
- `fresh connection transacts normally` — expected 2, got 3.

Reproduced locally at ~4-of-5 runs.

## Root cause (race, pre-existing since #867)

In the commit loop's fatal-error handler, the order was: **deliver the error to the failed transact's callback, *then* close the queues.** Delivering first unblocks the caller while the transaction queue is still open, so a subsequent `transact` (the test's `{:db/id 3}`) can race into the still-open queue and get applied + committed **after** the fatal error — the writer that was supposed to be dead accepts one more write. The extra entity then shows up on the next connection.

## Fix

Close both queues **first**, then deliver the callbacks. The caller unblocks only after the queues are closed, so its next `transact` observes the closed queue and fails loudly with `:writer-shut-down` (via `dispatch!`'s `put!`-returns-false path). One-line reorder; no behavior change to the success path or to what shuts the writer down — only *when* the queues close relative to the callback.

## Verification

An in-process probe replicating the test 25× in one JVM: **before** the fix the race fires ~80% of the time (stray commit or a hang); **after**, 25/25 clean. `writer-error-test` green (18 assertions, 0 failures).