### PR TITLE
fix(kabel): drop :key-sort-fn; never dedup the branch head by timestamp

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -86,7 +86,7 @@
                                ;; kabel integration for distributed datahike
                                org.replikativ/kabel          {:mvn/version "0.3.100"}
                                is.simm/distributed-scope     {:mvn/version "0.1.6"}
-                               org.replikativ/konserve-sync  {:mvn/version "0.1.33"}
+                               org.replikativ/konserve-sync  {:mvn/version "0.1.35"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}

--- a/src-kabel/datahike/kabel/handlers.cljc
+++ b/src-kabel/datahike/kabel/handlers.cljc
@@ -173,9 +173,12 @@
 
             ;; Register for konserve-sync (use UUID as topic to match client)
                   store (:store @(:wrapped-atom conn))
+                  ;; no :key-sort-fn — the walk and the commit batch both carry the order
+                  ;; (mutable branch pointers last); :always-send-mutable? so a branch head
+                  ;; is never timestamp-deduped away. See register-store-for-remote-access!
                   _ (sync/register-store! peer store-id store
                                           {:walk-fn dh-walker/datahike-walk-fn
-                                           :key-sort-fn (fn [k] (if (keyword? k) 1 0))})
+                                           :always-send-mutable? true})
                   _ (log/trace "Registered for sync" {:store-id store-id})
 
             ;; Register tx-report topic for pubsub (use UUID directly)
@@ -331,11 +334,30 @@
          walk-fn (if branches
                    (fn [s opts] (dh-walker/datahike-walk-fn s (assoc opts :branches branches)))
                    dh-walker/datahike-walk-fn)]
-     (sync/register-store! peer store-id store
-                           {:walk-fn walk-fn
-                            ;; sort ALL branch pointers (keywords) last, not just :db,
-                            ;; so non-trunk branch HEADs fetch-gate correctly on sync
-                            :key-sort-fn (fn [k] (if (keyword? k) 1 0))}))
+     ;; No :key-sort-fn. The order is CARRIED, not guessed:
+     ;;   • handshake — datahike-walk-fn returns an ordered vector, index nodes first and
+     ;;     the mutable branch pointers LAST, and konserve-sync preserves walk order;
+     ;;   • ongoing   — a commit is an ordered multi-assoc batch (branch head last), which
+     ;;     konserve-sync relays verbatim.
+     ;; Both give the one guarantee that matters: a branch head is applied only after every
+     ;; index node it references. :key-sort-fn used to reconstruct that downstream by
+     ;; sorting on the SHAPE of the key ("keywords are roots, sort them last") — a guess
+     ;; that happened to fit datahike's keys, and would silently misorder any store whose
+     ;; keys didn't.
+     ;;
+     ;; :always-send-mutable? — the branch heads must never be timestamp-deduped away.
+     ;; Index nodes are content-addressed and write-once, so "does the peer have it?" is
+     ;; settled by presence and the timestamps are harmless. A branch HEAD is the one
+     ;; MUTABLE cell — same key, new value every commit — and there a wall-clock compare
+     ;; across two machines answers the wrong question: a peer that wrote its own copy
+     ;; (e.g. a tiered reader pre-filling its cache from the backing store before it
+     ;; subscribes) stamps a LATER time than our commit, so we would conclude it is
+     ;; "current" and skip the head entirely. It would then never receive one — and a
+     ;; peer whose clock merely runs fast would sit on a stale head indefinitely.
+     ;; Commit metadata already marks the nodes :immutable? and leaves the head unmarked,
+     ;; so this needs no guesswork about keys.
+     (sync/register-store! peer store-id store {:walk-fn walk-fn
+                                                :always-send-mutable? true}))
 
   ;; Register tx-report topic for pubsub
    (tx-broadcast/register-tx-report-topic! peer store-id)))


### PR DESCRIPTION
> **Blocked on** konserve-sync#7 (merged) + konserve-sync#8 being released, then pin it in `deps.edn`.

Two changes to how a store is registered for sync. Both replace an **inference** with a **fact**.

## 1. `:key-sort-fn` is gone

It existed to make the branch head land **after** the index nodes it points at — by sorting on the **shape of the key**: *"keywords are roots, sort them last."* That guess happened to fit datahike's keys, and would silently misorder any store whose keys didn't.

It's now unnecessary, because the order is **carried** rather than reconstructed:

- **handshake** — `datahike-walk-fn` returns an ordered vector: index nodes first, mutable branch pointers **last** (konserve-sync#7), and konserve-sync preserves walk order;
- **ongoing** — a commit is an ordered `multi-assoc` batch with the head last (#875), relayed verbatim.

## 2. `:always-send-mutable? true` — and this one was a real, silent bug

The handshake dedups by comparing `:last-write` timestamps. But `:last-write` says **when each side wrote its own copy, on its own wall clock** — not **which version it holds**.

For content-addressed nodes that's harmless (presence settles it). For the **branch head** — the one *mutable* cell, same key and a new value every commit — it's the wrong question, and it was **failing silently**:

> A tiered reader pre-fills its cache from the backing store **before** subscribing, stamping a **later** time than our commit. The server therefore concluded *"already current"* and **never sent the head at all.**

It only *appeared* to work because the connector separately read a **cached** head out of the store — and raised `:kabel-no-head` whenever that cache came up empty (an intermittent failure I hit). And a reader whose clock merely ran fast would sit on a **stale head** indefinitely.

Commit metadata already marks nodes `:immutable?` and leaves the head unmarked, so this needs **no guesswork about keys**.

## Net effect

The gate added in **#874 is now backed by the protocol rather than by a cache**: the head is delivered **by the handshake**, after every node it references.

## Verification (MinIO, tiered `{lmdb, s3}`)

- Instrumented the connector: the head now arrives via the handshake — **`HEAD-DELIVERED-BY-HANDSHAKE :db`** — instead of from `cached-stored-db`.
- Cold connect (4000 notes) + live-commit warming (LMDB 3 → 37) + **warm reconnect** (37-key cache reused): **3/3 clean**, no `:kabel-no-head`.
- `datahike.kabel.integration-test`: **6 tests, 41 assertions, 0 failures**.