### PR TITLE
docs: state the writer model — all writers for a database run in one JVM

### DIFF
--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -39,6 +39,8 @@ These capabilities are valuable even in centralized production environments: dif
 
 Datahike uses a **single-writer, multiple-reader** model—the same architectural choice as Datomic, Datalevin, and XTDB. While multiple readers can access indices concurrently via DIS, write operations are serialized through a single writer process to ensure strong consistency and linearizable transactions.
 
+Concretely: **all writers for a database run in one JVM.** A connection owns its branch head and serializes commits through it. Different branches may each have their own writer, but they belong in the same process — a database's writers coordinate in memory, not through the store — and writer-side maintenance such as [garbage collection](./gc.md#where-to-run-gc) runs there with them. Readers are unconstrained: any number, in any number of processes. To write from another process, give it a writer endpoint (below) rather than a second writer on the store.
+
 To provide distributed write access, you configure a writer endpoint (HTTP server or Kabel WebSocket). The writer:
 - Serializes all transactions for strong consistency guarantees
 - Publishes new index snapshots to the shared storage backend

--- a/doc/gc.md
+++ b/doc/gc.md
@@ -38,7 +38,19 @@ GC whitelists all current branches and marks snapshots as reachable based on a g
 
 Running without a date removes **only deleted branches**—all snapshots on active branches are preserved. This is safe to run anytime and reclaims storage from old experimental branches.
 
-**Note:** Returns a `core.async` channel. Use `<??` to block, or run without it for background execution. GC requires no coordination and won't slow down transactions or reads.
+**Note:** Returns a `core.async` channel. Use `<??` to block, or run without it for background execution. GC never blocks transactions or reads.
+
+## Where to run GC
+
+**Run GC in the process that writes.** `d/gc-storage` is a writer operation and already runs there, so in the normal case you get this for free — but it is worth stating, because "collect from a cron job during the quiet hours" is a tempting shape and it is the wrong one.
+
+This follows from Datahike's writer model rather than from anything about GC:
+
+> **All writers for a database run in one JVM.** A connection owns its branch head and serializes commits through it. Different branches of the same database may each have their own writer, but they belong in the same process — a database's writers coordinate in memory, not through the store. **Readers are unconstrained**: any number of them, in any number of processes, anywhere.
+
+The collector belongs on the writers' side of that line because it has to know what they are *currently* writing. A commit writes every value the new head references and only *then* flips the head — so for the duration of that sequence, those objects exist in the store and nothing yet names them. A collector in the same process knows a commit is in flight and leaves them alone. A collector in another process cannot know, and Datahike cannot tell you it doesn't: a second process looks like a writer too.
+
+(Cross-process writers are outside the model for a more basic reason as well — there is no head fencing yet, so two writers on a branch can lose each other's commits regardless of GC. See [#878](https://github.com/replikativ/datahike/issues/878).)
 
 ## Grace Periods for Distributed Readers
 

--- a/doc/storage-backends.md
+++ b/doc/storage-backends.md
@@ -79,7 +79,7 @@ Datahike provides pluggable storage through [konserve](https://github.com/replik
 
 All distributed backends support **Distributed Index Space (DIS)**: multiple reader processes can directly access shared storage without database connections, enabling massive read scalability.
 
-**Important**: Datahike uses a single-writer model. Multiple readers can access indices concurrently, but only one writer process should transact at a time. This is the same model used by Datomic, Datalevin, and XTDB.
+**Important**: Datahike uses a single-writer model — the same one used by Datomic, Datalevin and XTDB. Multiple readers can access indices concurrently, but **all writers for a database live in one JVM**: a connection owns its branch head and serializes commits through it, and a database's writers (one per branch) coordinate in memory rather than through the store. Maintenance that runs on the writers' side — notably [garbage collection](./gc.md#where-to-run-gc) — belongs in that process too. Readers are unconstrained. To write from elsewhere, point those processes at a writer endpoint (see [Distributed](./distributed.md)) rather than opening a second writer on the store.
 
 ### JDBC Backend
 

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -105,12 +105,16 @@
   makes GC collect MORE. The safe point is a SWEEP-side bound (how recently written
   an object may be and still be judged) and makes it collect LESS.
 
-  SINGLE-PROCESS REQUIREMENT. The safe point is process-local. Run the collector in
-  the SAME process as the writers — which is where `d/gc-storage` already runs, as a
-  writer op. A collector in a second process (a cron sidecar, a maintenance job)
-  cannot see the writer's in-flight sequences and WILL delete a live commit's
-  objects, silently and only under load. Datahike cannot detect this for you: a
-  second process gets a `:self` writer by default and looks identical to the first."
+  RUN IT WHERE THE WRITERS ARE. This follows from datahike's writer model, not from
+  anything specific to GC: ALL WRITERS FOR A DATABASE RUN IN ONE JVM — they coordinate
+  in memory, not through the store — and writer-side maintenance runs with them.
+  `d/gc-storage` is a writer op, so it is already in the right place; the note is here
+  because \"collect from a cron sidecar\" is a tempting shape and it is outside the
+  model. Such a collector cannot observe the writer's in-flight sequences, and datahike
+  cannot warn you: a second process gets a `:self` writer by default and looks like a
+  writer too. (Cross-process writers are outside the model for a more basic reason as
+  well — there is no head fencing yet, so they can lose each other's commits regardless
+  of GC. See issue #878.) Readers are unconstrained."
   ([db] (gc-storage! db (#?(:clj Date. :cljs js/Date.) 0)))
   ([db remove-before]
    (go-try S
@@ -155,9 +159,9 @@
 
    It runs CONCURRENTLY with the writer, and is safe to do so because the sweep
    stops at the store's SAFE POINT rather than at `now`: an in-flight commit's
-   objects are written after that point and are spared (see `gc-storage!`). This
-   requires the writers to be in THIS process — see the single-process requirement
-   on `gc-storage!`.
+   objects are written after that point and are spared (see `gc-storage!`). Like all
+   writer-side maintenance, it belongs in the process the writers run in — which is
+   datahike's writer model, not a GC-specific rule (`gc-storage!`).
 
    Options:
      :interval-ms       — cycle period (default 300000 = 5 min).

--- a/src/datahike/gc_guard.cljc
+++ b/src/datahike/gc_guard.cljc
@@ -33,10 +33,12 @@
    are unreachable, i.e. garbage, and a later cycle collects them. Correct by
    construction.
 
-   LIMIT: this is in-process state. A writer in ANOTHER process is invisible to
-   a collector here, and no in-process mechanism can change that — it is the same
-   gap as the missing cross-process writer fencing (issue #878). Run the collector
-   where the writer is."
+   SCOPE: this is in-process state, which matches datahike's writer model — ALL
+   WRITERS FOR A DATABASE RUN IN ONE JVM, coordinating in memory rather than through
+   the store, and writer-side maintenance runs with them. A writer in another process
+   is outside that model (and outside it for a more basic reason than GC: without head
+   fencing, two writers on a branch can lose each other's commits — issue #878).
+   Readers are unconstrained."
   #?(:clj (:import [java.util Date])))
 
 (defn- now [] #?(:clj (Date.) :cljs (js/Date.)))


### PR DESCRIPTION
The single-writer model was documented per-branch (*"only one writer process should transact at a time"*) but never as the rule that actually matters:

> **All writers for a database run in one JVM.** A connection owns its branch head and serializes commits through it. Different branches may each have their own writer, but they coordinate **in memory, not through the store**, so they belong in the same process. **Readers are unconstrained.**

Writer-side maintenance follows from that, and **garbage collection is the case people hit**. `d/gc-storage` is a writer op and so already runs in the right place — but *"collect from a cron sidecar during the quiet hours"* is a tempting shape and sits outside the model. Such a collector cannot observe the writers' in-flight commits, and datahike cannot warn about it: a second process gets a `:self` writer by default and looks like a writer too.

(Cross-process writers are outside the model for a more basic reason as well — without head fencing they can lose each other's commits regardless of GC. #878.)

**Changes**
- `doc/gc.md` — new *Where to run GC* section stating the model and why the collector sits on the writers' side of it.
- `doc/storage-backends.md`, `doc/distributed.md` — the two places that already described the single-writer model now state the whole rule, so a reader meets it where they're already looking.
- `gc-storage!` / `start-background-gc!` / `gc-guard` docstrings — derive the constraint from the writer model rather than restating it as a GC-specific caveat.

Docs only; no behaviour change.