### PR TITLE
feat(graph): bfs-distances and lowest-common-ancestor

### DIFF
--- a/doc/graph-algorithms.md
+++ b/doc/graph-algorithms.md
@@ -94,11 +94,18 @@ are entity ids.
 (graph/all-paths g db a {:target b :max-depth 6})  ; seq of node vectors
 (graph/shortest-path g db a b)      ; [a ... b] with fewest edges, or nil
 (graph/path-length g db a b)        ; number of edges, or nil
+(graph/bfs-distances g db a)        ; {node hop-count} for a (0) and all reachable
+(graph/lowest-common-ancestor g db a b)  ; nearest node reachable from both (merge-base)
 (graph/semi-naive-transitive-closure g db)  ; #{[source target] ...}
 ```
 
 `transitive-closure` and `reachable?` follow at least one edge, so `a` is in its
-own closure exactly when it lies on a cycle.
+own closure exactly when it lies on a cycle. `bfs-distances` is the all-targets
+companion to `path-length` — the same single-source BFS, but it keeps the whole
+distance map and always includes the source at 0 (a distance map is keyed by
+cost-to-reach). `lowest-common-ancestor` composes two distance maps: the common
+node minimizing `(a→n) + (b→n)`, deterministic on ties — the merge-base when
+out-edges are parent edges.
 
 ### Connected components
 

--- a/src/datahike/experimental/graph.cljc
+++ b/src/datahike/experimental/graph.cljc
@@ -155,6 +155,38 @@
           (contains? seen n) (recur seen (pop q))
           :else (recur (conj seen n) (into (pop q) (gs/out-neighbors g db n))))))))
 
+(defn ^{:datahike/output-cardinality node-set-card
+        :datahike/cost linear-exec-cost} bfs-distances
+  "Map {node hop-count} for `start` (at distance 0) and every node reachable
+   from it via out-edges, measured in edges. Single-source unweighted BFS — the
+   whole-frontier companion to `path-length` (which is one target). Unlike
+   `transitive-closure`, `start` is always present at 0, since a distance map is
+   keyed by cost-to-reach and reaching `start` costs nothing."
+  [g db start]
+  (loop [q (conj gu/empty-queue start)
+         dist {start 0}]
+    (if (empty? q)
+      dist
+      (let [n (peek q)
+            d (inc (long (dist n)))
+            nbrs (remove #(contains? dist %) (gs/out-neighbors g db n))]
+        (recur (into (pop q) nbrs)
+               (reduce (fn [m nb] (assoc m nb d)) dist nbrs))))))
+
+(defn ^{:datahike/cost linear-exec-cost} lowest-common-ancestor
+  "The nearest common node reachable from both `a` and `b` via out-edges — where
+   each of `a`, `b` counts as its own ancestor at distance 0 — minimizing the
+   total distance (a→n) + (b→n). Ties are broken deterministically by node
+   ordering, so the result is stable across runs. nil when `a` and `b` share no
+   reachable node. This is the merge-base when out-edges are parent edges."
+  [g db a b]
+  (let [a-dist (bfs-distances g db a)
+        b-dist (bfs-distances g db b)
+        common (filter a-dist (keys b-dist))]
+    (first
+     (sort-by (fn [n] [(+ (long (a-dist n)) (long (b-dist n))) (str n)])
+              common))))
+
 ;; ===========================================================================
 ;; Path enumeration
 ;; ===========================================================================

--- a/test/datahike/test/experimental/graph_test.cljc
+++ b/test/datahike/test/experimental/graph_test.cljc
@@ -432,3 +432,38 @@
                 (and (= #{"A" "B"} #{(nm source) (nm target)}) (= 1 score)))
               cands)
         "(A,B) scored 1 by common neighbors")))
+
+;; ---------------------------------------------------------------------------
+;; BFS distances, lowest common ancestor
+;; ---------------------------------------------------------------------------
+
+;; Git-shaped history over parent edges (child :e/to parent):
+;;   c0 <- c1 <- c2 <- c3        (main line)
+;;               ^
+;;               \-- b1 <- b2    (branch off c1)
+(def hist (build [["c1" "c0"] ["c2" "c1"] ["c3" "c2"]
+                  ["b1" "c1"] ["b2" "b1"]]))
+
+(deftest test-bfs-distances
+  (let [[gr db] (g-of dag) id (:id dag) nm (:name dag)]
+    (is (= {"A" 0 "B" 1 "C" 1 "D" 2}
+           (into {} (map (fn [[e d]] [(nm e) d])) (g/bfs-distances gr db (id "A"))))
+        "start at 0; A→C→D is 2 hops, the short A→C not A→B→C")
+    (is (= {"D" 0} (into {} (map (fn [[e d]] [(nm e) d])) (g/bfs-distances gr db (id "D"))))
+        "a sink reaches only itself"))
+  (let [[gr db] (g-of cyc) id (:id cyc) nm (:name cyc)]
+    (is (= {"X" 0 "Y" 1 "Z" 2}
+           (into {} (map (fn [[e d]] [(nm e) d])) (g/bfs-distances gr db (id "X"))))
+        "start stays at 0 despite the cycle back to it")))
+
+(deftest test-lowest-common-ancestor
+  (let [[gr db] (g-of hist) id (:id hist) nm (:name hist)]
+    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c3") (id "b2"))))
+        "merge-base of the two branch tips is where they diverged")
+    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c2") (id "b1"))))
+        "nearest, not oldest, common ancestor")
+    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c1") (id "b2"))))
+        "an endpoint is its own ancestor at distance 0"))
+  (let [[gr db] (g-of dag) id (:id dag)]
+    (is (nil? (g/lowest-common-ancestor gr db (id "A") (id "E")))
+        "disjoint components have no common ancestor")))


### PR DESCRIPTION
Two additions to the experimental graph API, each filling a genuine gap in the reachability/paths family — surfaced by putting a real consumer on it (Geschichte's commit-DAG ancestry and merge-base).

Geschichte's commit graph is native datahike data: `:geschichte.commit/parents` is a `:db.type/ref`, so these run directly over it via `(attr-graph :geschichte.commit/parents)` — no new spec required.

## What & why

The reachability/paths family covers a matrix of {single-target, all-targets} × {reachable, distance, path}, but the all-targets *distance* cell was empty:

| | reachable | distance | path |
|---|---|---|---|
| all-targets, unweighted | `transitive-closure` | **`bfs-distances` (new)** | — |
| single-target, unweighted | `reachable?` | `path-length` | `shortest-path` |

- **`bfs-distances g db start`** → `{node hop-count}` for `start` (at 0) and every out-reachable node. The all-targets companion to `path-length`; not a duplicate of `transitive-closure` (that returns a *set*, no distances) — same traversal, strictly more info. `path-length`/`shortest-path`/`reachable?` keep their early-exit and are untouched.
- **`lowest-common-ancestor g db a b`** → nearest node reachable from both (each its own ancestor at distance 0) minimizing `(a→n)+(b→n)`, deterministic on ties. Composes two `bfs-distances` maps; the merge-base when out-edges are parent edges.

## Design note: additive, not a refactor

A unified BFS core deriving all of these as projections would be cleaner on paper but **regress** the single-target functions' early-exit (they'd traverse the whole component instead of stopping at the target), and churn already-shipped cost-annotated code. The API already keeps these as separate BFS functions for exactly that reason; these follow that convention. A future *additive* symmetry worth having is a weighted all-targets twin of `bfs-distances` (Dijkstra SSSP map, mirroring `weighted-shortest-path`).

_(An earlier revision also added a db-independent `fn-graph` spec; dropped, because the motivating consumer's data is in datahike and the coherent path is native `attr-graph` queries. A db-independent spec belongs in its own PR if a genuine external-graph use case appears.)_

## Tests

Graph suite green (fresh run: 99 tests / 342 assertions / 0 failures). New tests cover distances on a DAG (shortest of two routes) and around a cycle (source stays 0), and merge-base on a branched history incl. an endpoint being its own ancestor and disjoint components. cljfmt clean; docs updated.