### PR TITLE
feat(graph): lowest-common-ancestors set (replace the LCA heuristic)

### DIFF
--- a/doc/graph-algorithms.md
+++ b/doc/graph-algorithms.md
@@ -95,7 +95,7 @@ are entity ids.
 (graph/shortest-path g db a b)      ; [a ... b] with fewest edges, or nil
 (graph/path-length g db a b)        ; number of edges, or nil
 (graph/bfs-distances g db a)        ; {node hop-count} for a (0) and all reachable
-(graph/lowest-common-ancestor g db a b)  ; nearest node reachable from both (merge-base)
+(graph/lowest-common-ancestors g db a b)  ; #{lowest common ancestors} (merge-base set)
 (graph/semi-naive-transitive-closure g db)  ; #{[source target] ...}
 ```
 
@@ -103,9 +103,25 @@ are entity ids.
 own closure exactly when it lies on a cycle. `bfs-distances` is the all-targets
 companion to `path-length` — the same single-source BFS, but it keeps the whole
 distance map and always includes the source at 0 (a distance map is keyed by
-cost-to-reach). `lowest-common-ancestor` composes two distance maps: the common
-node minimizing `(a→n) + (b→n)`, deterministic on ties — the merge-base when
-out-edges are parent edges.
+cost-to-reach). `lowest-common-ancestors` is the graph-theoretic LCA set: the
+common ancestors that are *minimal* (none reachable from another) — the true
+merge-base set, which for a criss-cross has more than one member. It is the set
+you compose with in a query:
+
+```clojure
+(d/q '[:find ?id
+       :in $ ?g ?a ?b
+       :where [(graph/lowest-common-ancestors ?g $ ?a ?b) [?base ...]]
+              [?base :geschichte.commit/id ?id]]
+     db (gs/attr-graph :geschichte.commit/parents) a b)
+```
+
+There is deliberately no singular "the LCA": a criss-cross genuinely has several,
+and *which* one to prefer is a caller policy, not a property of the graph. Pick
+from the set where you need one — join it to a stable attribute in the query, or
+`sort-by` a stable key in Clojure (`(first (sort-by stable-key (lowest-common-ancestors …)))`).
+A `str`/entity-id order is deterministic within a database but not stable across
+peers, so it is never a safe default to bake in.
 
 ### Connected components
 

--- a/src/datahike/experimental/graph.cljc
+++ b/src/datahike/experimental/graph.cljc
@@ -173,19 +173,26 @@
         (recur (into (pop q) nbrs)
                (reduce (fn [m nb] (assoc m nb d)) dist nbrs))))))
 
-(defn ^{:datahike/cost linear-exec-cost} lowest-common-ancestor
-  "The nearest common node reachable from both `a` and `b` via out-edges — where
-   each of `a`, `b` counts as its own ancestor at distance 0 — minimizing the
-   total distance (a→n) + (b→n). Ties are broken deterministically by node
-   ordering, so the result is stable across runs. nil when `a` and `b` share no
-   reachable node. This is the merge-base when out-edges are parent edges."
+(defn ^{:datahike/output-cardinality node-set-card
+        :datahike/cost quadratic-exec-cost} lowest-common-ancestors
+  "The lowest common ancestors of `a` and `b` over out-edges: the common
+   ancestors — each of `a`, `b` counting as its own ancestor — that are
+   *minimal*, i.e. no other common ancestor is reachable from them. This is the
+   graph-theoretic LCA set, and the true merge-base set when out-edges are parent
+   edges; a DAG can have several (a criss-cross). Empty when `a` and `b` share no
+   ancestor."
   [g db a b]
-  (let [a-dist (bfs-distances g db a)
-        b-dist (bfs-distances g db b)
-        common (filter a-dist (keys b-dist))]
-    (first
-     (sort-by (fn [n] [(+ (long (a-dist n)) (long (b-dist n))) (str n)])
-              common))))
+  (let [a-anc (conj (transitive-closure g db a) a)
+        b-anc (conj (transitive-closure g db b) b)
+        common (set/intersection a-anc b-anc)]
+    (if (empty? common)
+      #{}
+      ;; A common node is dominated (not lowest) when it is an ancestor of
+      ;; another common node — i.e. it appears in that node's out-closure.
+      (let [dominated (into #{}
+                            (mapcat (fn [c] (set/intersection (transitive-closure g db c) common)))
+                            common)]
+        (set/difference common dominated)))))
 
 ;; ===========================================================================
 ;; Path enumeration

--- a/test/datahike/test/experimental/graph_test.cljc
+++ b/test/datahike/test/experimental/graph_test.cljc
@@ -456,14 +456,24 @@
            (into {} (map (fn [[e d]] [(nm e) d])) (g/bfs-distances gr db (id "X"))))
         "start stays at 0 despite the cycle back to it")))
 
-(deftest test-lowest-common-ancestor
-  (let [[gr db] (g-of hist) id (:id hist) nm (:name hist)]
-    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c3") (id "b2"))))
-        "merge-base of the two branch tips is where they diverged")
-    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c2") (id "b1"))))
-        "nearest, not oldest, common ancestor")
-    (is (= "c1" (nm (g/lowest-common-ancestor gr db (id "c1") (id "b2"))))
-        "an endpoint is its own ancestor at distance 0"))
+;; Criss-cross: m1 and m2 each merge a1 and a2 (in opposite parent order);
+;; ours descends from m1, theirs from m2. Both a1 and a2 are genuine merge
+;; bases — neither is an ancestor of the other.
+(def criss (build [["m1" "a1"] ["m1" "a2"] ["m2" "a2"] ["m2" "a1"]
+                   ["ours" "m1"] ["theirs" "m2"]]))
+
+(deftest test-lowest-common-ancestors
+  (let [[gr db] (g-of hist) id (:id hist) nm (:name hist)
+        lcas (fn [a b] (set (map nm (g/lowest-common-ancestors gr db (id a) (id b)))))]
+    (is (= #{"c1"} (lcas "c3" "b2")) "the divergence point; the older c0 is dominated by c1")
+    (is (= #{"c1"} (lcas "c2" "b1")) "nearest, not oldest, common ancestor")
+    (is (= #{"c1"} (lcas "c1" "b2")) "an endpoint is its own ancestor at distance 0"))
   (let [[gr db] (g-of dag) id (:id dag)]
-    (is (nil? (g/lowest-common-ancestor gr db (id "A") (id "E")))
-        "disjoint components have no common ancestor")))
+    (is (empty? (g/lowest-common-ancestors gr db (id "A") (id "E")))
+        "disjoint components share no ancestor"))
+  (let [[gr db] (g-of criss) id (:id criss) nm (:name criss)]
+    (is (= #{"a1" "a2"}
+           (set (map nm (g/lowest-common-ancestors gr db (id "ours") (id "theirs")))))
+        "a criss-cross has two genuine merge bases — both are returned")
+    (is (empty? (g/lowest-common-ancestors gr db (id "a1") (id "a2")))
+        "two roots share no ancestor")))


### PR DESCRIPTION
Follow-up to #890. Consuming `lowest-common-ancestor` from a real distributed VCS merge-base (Geschichte) surfaced two problems — the kind that only show up under a real workload, which is why the consumer was wired up.

1. **Wrong semantics.** It returned the *min-combined-distance* node — a heuristic, not the graph-theoretic LCA. A criss-cross (two genuine merge bases) was silently collapsed to one.
2. **It answered a question with no single answer.** A criss-cross genuinely has several lowest common ancestors; *which* to prefer is a caller policy, not a property of the graph. The old function hid that behind a `(str node)` order — for an `attr-graph` the local entity id, so two peers could pick different bases and diverge.

## Change

Replace the singular with **`lowest-common-ancestors`** (plural): the LCA **set** — common ancestors minimal in the ancestor order (none reachable from another). This is the true merge-base set and the query-composable primitive:

```clojure
[:where [(graph/lowest-common-ancestors ?g $ ?a ?b) [?base ...]]
        [?base :geschichte.commit/id ?id]]     ; bind the set, join freely
```

Pick one where you need one — join the set to a stable attribute in the query, or `sort-by` a stable key in Clojure. **No singular convenience:** it would only re-hide the multiplicity and re-introduce the unstable default, and since these functions are Datalog fn-clauses, a selection *function* can't be a parameter anyway. Selection is a caller policy, kept out of the primitive.

## Compatibility & tests

The #890 single-base expectations are preserved as set assertions (the older dominated ancestor is excluded; the single lowest is returned). New tests cover the criss-cross set (`#{a1 a2}`) and disjoint components. Graph suite: **99 tests / 348 assertions / 0 failures**. cljfmt clean; docs updated with the in-query example.

**Breaking (experimental ns):** removes `lowest-common-ancestor` (singular) shipped in 0.8.1742. Its semantics were the heuristic above, so any reliance was on incorrect behavior; this is the immediate next PR.