### PR TITLE
fix(cljdoc): make the datahike jar build on cljdoc + add a CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,20 @@ jobs:
             - .m2
             - .npm
             - replikativ
+  cljdoc-analysis:
+    executor: tools/clojurecli
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Analyze jar with cljdoc-analyzer (mirrors the cljdoc.org build)
+          command: bb cljdoc-check-installed
+          no_output_timeout: 10m
+      - save_cache:
+          key: deps-{{ checksum "deps.edn" }}
+          paths:
+            - /home/circleci/.m2
+            - /home/circleci/.deps.clj
   deploy:
     executor: tools/clojurecli
     steps:
@@ -394,6 +408,10 @@ workflows:
           requires:
             - build
       - java-examples-test:
+          context: ghcr-read-package
+          requires:
+            - build
+      - cljdoc-analysis:
           context: ghcr-read-package
           requires:
             - build

--- a/bb.edn
+++ b/bb.edn
@@ -10,6 +10,7 @@
                     [pod.borkdude.clj-kondo :as clj-kondo]
                     [tools.build :as build]
                     [tools.clj-kondo :as clj-kondo-tools]
+                    [tools.cljdoc :as cljdoc]
                     [tools.deploy :as deploy]
                     [tools.examples :as examples]
                     [tools.npm :as npm]
@@ -42,6 +43,13 @@
          lint {:doc "Run clj-kondo linter"
                :require [[pod.borkdude.clj-kondo :as clj-kondo]]
                :task (clj-kondo/print! (clj-kondo/run! {:lint "."}))}
+
+         cljdoc-check {:doc "Analyze the built jar with cljdoc-analyzer (mirrors the cljdoc.org build)"
+                       :depends [jar]
+                       :task (cljdoc/analyze config (-> config :build :clj))}
+
+         cljdoc-check-installed {:doc "cljdoc-check against the already-installed jar (CI; run after `bb install`)"
+                                 :task (cljdoc/analyze-installed config (-> config :build :clj))}
 
          test {:doc "Run all tests or restrict to 'native-image', 'back-compat' or a kaocha test id (see tests.edn)"
                :depends [jcompile]

--- a/bb/src/tools/cljdoc.clj
+++ b/bb/src/tools/cljdoc.clj
@@ -1,0 +1,88 @@
+(ns tools.cljdoc
+  "Run cljdoc.org's analyzer against the built jar, locally.
+
+   cljdoc builds documentation by *loading* every namespace shipped in the
+   published jar (clj) and statically analyzing it (cljs). That means a jar can
+   pass every unit test yet still fail on cljdoc.org — e.g. a namespace that
+   requires a dep which isn't in the published pom (only in a dev/test alias), or
+   a `.cljc` ns form the ClojureScript analyzer rejects. This task reproduces the
+   exact cljdoc analysis step so those failures surface in CI before a release,
+   instead of on cljdoc.org after it."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as p]
+   [clojure.string :as str]
+   [tools.build :refer [jar-path pom-path]]
+   [tools.version :as version]))
+
+(def analyzer-sha
+  "Commit of cljdoc/cljdoc-analyzer to run. Keep roughly in sync with the SHA
+   cljdoc.org's builder uses — read `CLJDOC_ANALYZER_DEP` from a recent build at
+   https://cljdoc.org/builds and bump this when it drifts. Pinned (rather than a
+   floating branch) so the check is reproducible."
+  "52a1281dff1a7d0421c58531f82eb29cf5a4ebfc")
+
+(defn- analyzer-args [repo-config project-config jarpath pompath]
+  ;; :languages nil -> cljdoc-analyzer auto-detects from the jar (clj + cljs when
+  ;; any .cljc/.cljs is present), matching a real cljdoc.org build. Local absolute
+  ;; paths for the jar/pom are used directly instead of downloading from Clojars.
+  (pr-str {:project   (str (:lib project-config))
+           :version   (version/string repo-config)
+           :jarpath   (str (fs/absolutize jarpath))
+           :pompath   (str (fs/absolutize pompath))
+           :languages nil
+           :repos     {"clojars" {:url "https://repo.clojars.org/"}
+                       "central" {:url "https://repo.maven.apache.org/maven2/"}}}))
+
+(defn- run-analyzer
+  "Analyze `jarpath` (+ `pompath`) exactly as cljdoc.org does; exit non-zero if it
+   fails."
+  [repo-config project-config jarpath pompath]
+  (when-not (fs/exists? jarpath)
+    (println "cljdoc-check: no jar at" (str jarpath))
+    (println "Build it first with `bb jar` (or run `bb cljdoc-check`, which does).")
+    (System/exit 1))
+  (let [dep  (format "{:deps {cljdoc/cljdoc-analyzer {:git/url \"https://github.com/cljdoc/cljdoc-analyzer.git\" :sha \"%s\"}}}"
+                     analyzer-sha)
+        args (analyzer-args repo-config project-config jarpath pompath)]
+    (println "Running cljdoc-analyzer" analyzer-sha "against" (str jarpath))
+    (let [{:keys [exit]} (p/shell {:continue true}
+                                  "clojure" "-Sdeps" dep
+                                  "-M" "-m" "cljdoc-analyzer.cljdoc-main" args)]
+      (if (zero? exit)
+        (println "cljdoc analysis succeeded — this jar would build on cljdoc.org.")
+        (do
+          (println)
+          (println "cljdoc analysis FAILED — this jar would fail to build on cljdoc.org.")
+          (println "See the exception above: a shipped namespace either can't be")
+          (println "loaded (clj) or can't be analyzed (cljs). Fix it, or exclude the")
+          (println "namespace with ^:no-doc, before releasing.")
+          (System/exit exit))))))
+
+(defn analyze
+  "Analyze the freshly built jar under target/. Assumes the jar + pom already
+   exist (run after `bb jar`)."
+  [repo-config project-config]
+  (run-analyzer repo-config project-config
+                (jar-path repo-config project-config)
+                (pom-path project-config)))
+
+(defn- m2-artifact
+  "Path of the jar/pom `bb install` places in the local Maven repo."
+  [repo-config {:keys [lib]} ext]
+  (let [version  (version/string repo-config)
+        artifact (name lib)
+        group    (str/replace (namespace lib) "." "/")]
+    (str (System/getProperty "user.home")
+         "/.m2/repository/" group "/" artifact "/" version "/"
+         artifact "-" version "." ext)))
+
+(defn analyze-installed
+  "Analyze the jar already installed to the local Maven repo by `bb install`,
+   instead of rebuilding it. Used by CI's cljdoc-analysis job, which runs after
+   the build job has built + installed + persisted the jar — so the artifact is
+   reused rather than recompiled."
+  [repo-config project-config]
+  (run-analyzer repo-config project-config
+                (m2-artifact repo-config project-config "jar")
+                (m2-artifact repo-config project-config "pom")))

--- a/src-kabel/datahike/kabel/walker.cljc
+++ b/src-kabel/datahike/kabel/walker.cljc
@@ -22,10 +22,13 @@
   (:require [datahike.gc :as gc]
             [konserve.core :as k]
             [org.replikativ.persistent-sorted-set.arrays :as arrays]
+            ;; cljs: go is a MACRO → :refer-macros in the same clojure.core.async
+            ;; spec. A separate :require-macros [clojure.core.async ...] would make
+            ;; two require specs for one namespace and trip the cljdoc cljs
+            ;; analyzer's duplicate-alias check.
             #?@(:clj [[superv.async :refer [go-try- <?-]]]
-                :cljs [[clojure.core.async :refer [<!]]]))
-  #?(:cljs (:require-macros [clojure.core.async :refer [go]]
-                            [superv.async :refer [go-try- <?-]]))
+                :cljs [[clojure.core.async :refer [<!] :refer-macros [go]]]))
+  #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]))
   #?(:clj (:import [org.replikativ.persistent_sorted_set PersistentSortedSet Branch])))
 
 ;; ============================================================================

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -1,4 +1,4 @@
-(ns datahike.index.secondary.proximum
+(ns ^:no-doc datahike.index.secondary.proximum
   "Proximum (vector similarity search) integration with Datahike secondary indices.
 
    Require this namespace to register the :proximum index type:

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -1,4 +1,4 @@
-(ns datahike.index.secondary.scriptum
+(ns ^:no-doc datahike.index.secondary.scriptum
   "Scriptum (Lucene full-text search) integration with Datahike secondary indices.
 
    Require this namespace to register the :scriptum index type:

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -1,4 +1,4 @@
-(ns datahike.index.secondary.stratum
+(ns ^:no-doc datahike.index.secondary.stratum
   "Stratum (columnar analytics) integration with Datahike.
 
    Two integration paths:

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -19,9 +19,12 @@
             [datahike.versioning :as dv]
             [datahike.bitemporal.predicate :as bp.pred]
             [replikativ.logging :as log]
-            #?(:cljs [clojure.core.async :as async :refer [<! >! chan put! close!]]))
-  #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]
-                            [clojure.core.async :refer [go]]))
+            ;; go is a MACRO referred via :refer-macros in the same spec — a
+            ;; separate :require-macros [clojure.core.async ...] would make two
+            ;; require specs for one namespace and trip the cljdoc cljs analyzer's
+            ;; duplicate-alias check.
+            #?(:cljs [clojure.core.async :as async :refer [<! >! chan put! close!] :refer-macros [go]]))
+  #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]))
   #?(:clj
      (:import [datahike.db HistoricalDB AsOfDB SinceDB FilteredDB]
               [datahike.impl.entity Entity])))

--- a/src/datahike/audit.cljc
+++ b/src/datahike/audit.cljc
@@ -20,10 +20,12 @@
             [konserve.utils :refer [#?(:clj async+sync) *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
             ;; cljs: superv.async/go-try- expands to clojure.core.async/go, so the `go`
-            ;; MACRO must be required here or it falls back to the JVM macro and fails to
-            ;; compile (vary-meta on keyword in go-impl). Mirrors datahike.versioning.
-            #?(:cljs [clojure.core.async :refer [<!]]))
-  #?(:cljs (:require-macros [clojure.core.async :refer [go]])))
+            ;; MACRO must be referred here or it falls back to the JVM macro and fails to
+            ;; compile (vary-meta on keyword in go-impl). It's referred via :refer-macros
+            ;; in the same spec: a separate :require-macros [clojure.core.async ...] makes
+            ;; two require specs for one namespace and trips the cljdoc cljs analyzer's
+            ;; duplicate-alias check. Mirrors datahike.versioning.
+            #?(:cljs [clojure.core.async :refer [<!] :refer-macros [go]])))
 
 (defn- audit-grade-stored?
   "Mirror of writing/audit-grade? but for already-stored commits we're

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -13,12 +13,15 @@
             [replikativ.logging :as log]
             [superv.async :refer [<? S go-try <<?]]
             ;; go-loop drives start-background-gc!'s scheduler; it's a MACRO, so
-            ;; cljs needs it via :require-macros (mirrors datahike.versioning).
+            ;; cljs refers it via :refer-macros in the same spec. Folding it into
+            ;; the require (rather than a separate :require-macros) keeps a single
+            ;; clojure.core.async require spec per platform — two specs for the same
+            ;; namespace make the cljdoc cljs analyzer fail with a duplicate-alias
+            ;; error. Mirrors the superv.async :refer/:refer-macros spec below.
             #?(:clj  [clojure.core.async :as async :refer [go-loop]]
-               :cljs [clojure.core.async :as async])
+               :cljs [clojure.core.async :as async :refer-macros [go-loop]])
             [datahike.schema-cache :as sc])
-  #?(:clj  (:import [java.util Date])
-     :cljs (:require-macros [clojure.core.async :refer [go-loop]])))
+  #?(:clj (:import [java.util Date])))
 
 ;; meta-data does not get passed in macros
 (defn get-time [d]

--- a/src/datahike/json.clj
+++ b/src/datahike/json.clj
@@ -10,11 +10,10 @@
             [datahike.schema :as s]
             [jsonista.core :as j]
             [jsonista.tagged :as jt])
-  #?(:clj
-     (:import [datahike.datom Datom]
-              [datahike.impl.entity Entity]
-              [com.fasterxml.jackson.core JsonGenerator]
-              [datahike.db HistoricalDB AsOfDB SinceDB])))
+  (:import [datahike.datom Datom]
+           [datahike.impl.entity Entity]
+           [com.fasterxml.jackson.core JsonGenerator]
+           [datahike.db HistoricalDB AsOfDB SinceDB]))
 
 (defn config->store-id [config]
   [(store-identity (:store config))

--- a/src/datahike/remote.clj
+++ b/src/datahike/remote.clj
@@ -7,13 +7,12 @@
             [clojure.edn :as edn]
             [datahike.json :refer [json-base-handlers]]
             [datahike.datom :as dd])
-  #?(:clj
-     (:import [clojure.lang IDeref]
-              [datahike.datom Datom]
-              [com.fasterxml.jackson.core JsonGenerator])))
+  (:import [clojure.lang IDeref]
+           [datahike.datom Datom]
+           [com.fasterxml.jackson.core JsonGenerator]))
 
 ;; https://github.com/thi-ng/color/issues/10
-;; fixes lein repl / Cloure 1.10.0 
+;; fixes lein repl / Cloure 1.10.0
 (prefer-method print-method java.util.Map clojure.lang.IDeref)
 
 ;; fixes lein repl / Clojure 1.10.1
@@ -38,20 +37,18 @@
 (defn remote-peer [obj] (-remote-peer obj))
 
 (defrecord RemoteConnection [store-id remote-peer]
-  #?@(:clj
-      [IDeref
-       (deref [conn] (remote-deref conn))
-       PRemotePeer
-       (-remote-peer [_] remote-peer)]))
+  IDeref
+  (deref [conn] (remote-deref conn))
+  PRemotePeer
+  (-remote-peer [_] remote-peer))
 
 (defn remote-connection [store-id]
   (RemoteConnection. store-id *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteConnection
-     [^RemoteConnection conn ^java.io.Writer w]
-     (.write w "#datahike/RemoteConnection")
-     (.write w (pr-str (:store-id conn)))))
+(defmethod print-method RemoteConnection
+  [^RemoteConnection conn ^java.io.Writer w]
+  (.write w "#datahike/RemoteConnection")
+  (.write w (pr-str (:store-id conn))))
 
 (defrecord RemoteDB [store-id max-tx max-eid commit-id remote-peer]
   PRemotePeer
@@ -60,11 +57,10 @@
 (defn remote-db [m]
   (assoc (map->RemoteDB m) :remote-peer *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteDB
-     [^RemoteDB db ^java.io.Writer w]
-     (.write w "#datahike/RemoteDB")
-     (.write w (pr-str  (into {} (dissoc db :remote-peer))))))
+(defmethod print-method RemoteDB
+  [^RemoteDB db ^java.io.Writer w]
+  (.write w "#datahike/RemoteDB")
+  (.write w (pr-str  (into {} (dissoc db :remote-peer)))))
 
 (defrecord RemoteHistoricalDB [origin remote-peer]
   PRemotePeer
@@ -73,11 +69,10 @@
 (defn remote-historical-db [m]
   (assoc (map->RemoteHistoricalDB m) :remote-peer *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteHistoricalDB
-     [^RemoteDB db ^java.io.Writer w]
-     (.write w "#datahike/RemoteHistoricalDB")
-     (.write w (pr-str  (into {} (dissoc db :remote-peer))))))
+(defmethod print-method RemoteHistoricalDB
+  [^RemoteDB db ^java.io.Writer w]
+  (.write w "#datahike/RemoteHistoricalDB")
+  (.write w (pr-str  (into {} (dissoc db :remote-peer)))))
 
 (defrecord RemoteSinceDB [origin time-point remote-peer]
   PRemotePeer
@@ -86,11 +81,10 @@
 (defn remote-since-db [m]
   (assoc (map->RemoteSinceDB m) :remote-peer *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteSinceDB
-     [^RemoteDB db ^java.io.Writer w]
-     (.write w "#datahike/RemoteSinceDB")
-     (.write w (pr-str  (into {} (dissoc db :remote-peer))))))
+(defmethod print-method RemoteSinceDB
+  [^RemoteDB db ^java.io.Writer w]
+  (.write w "#datahike/RemoteSinceDB")
+  (.write w (pr-str  (into {} (dissoc db :remote-peer)))))
 
 (defrecord RemoteAsOfDB [origin time-point remote-peer]
   PRemotePeer
@@ -99,11 +93,10 @@
 (defn remote-as-of-db [m]
   (assoc (map->RemoteAsOfDB m) :remote-peer *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteAsOfDB
-     [^RemoteDB db ^java.io.Writer w]
-     (.write w "#datahike/RemoteAsOfDB")
-     (.write w (pr-str  (into {} (dissoc db :remote-peer))))))
+(defmethod print-method RemoteAsOfDB
+  [^RemoteDB db ^java.io.Writer w]
+  (.write w "#datahike/RemoteAsOfDB")
+  (.write w (pr-str  (into {} (dissoc db :remote-peer)))))
 
 (defrecord RemoteEntity [db eid remote-peer]
   PRemotePeer
@@ -112,11 +105,10 @@
 (defn remote-entity [m]
   (assoc (map->RemoteEntity m) :remote-peer *remote-peer*))
 
-#?(:clj
-   (defmethod print-method RemoteEntity
-     [^RemoteEntity e ^java.io.Writer w]
-     (.write w "#datahike/RemoteEntity")
-     (.write w (pr-str (dissoc (into {} e) :remote-peer)))))
+(defmethod print-method RemoteEntity
+  [^RemoteEntity e ^java.io.Writer w]
+  (.write w "#datahike/RemoteEntity")
+  (.write w (pr-str (dissoc (into {} e) :remote-peer))))
 
 (defn edn-replace-remote-literals [s]
   (reduce (fn [^String s [^String from ^String to]]

--- a/src/datahike/versioning.cljc
+++ b/src/datahike/versioning.cljc
@@ -20,8 +20,11 @@
             [replikativ.logging :as log]
             [konserve.utils :refer [#?(:clj async+sync) multi-key-capable? *default-sync-translation*]
              #?@(:cljs [:refer-macros [async+sync]])]
-            #?(:cljs [clojure.core.async :refer [<!]]))
-  #?(:cljs (:require-macros [clojure.core.async :refer [go]])))
+            ;; go is a MACRO → :refer-macros in the same spec. A separate
+            ;; :require-macros [clojure.core.async ...] would make two require
+            ;; specs for one namespace and trip the cljdoc cljs analyzer's
+            ;; duplicate-alias check.
+            #?(:cljs [clojure.core.async :refer [<!] :refer-macros [go]])))
 
 (defn- branch-check [branch]
   (when-not (keyword? branch)


### PR DESCRIPTION
Fixes the cljdoc build for datahike (was failing at [build #107748](https://cljdoc.org/builds/107748)) and adds a CI check so it can't silently regress.

## Why it was failing

cljdoc builds docs by **loading every namespace in the published jar (clj)** and **statically analyzing it (cljs)**. A jar can pass every unit test yet still fail on cljdoc. Testing against cljdoc's own analyzer (the exact pinned SHA its builder uses) surfaced three independent blockers:

1. **Optional secondary-index namespaces** — since #844 shipped `src-secondary` in the jar, `datahike.index.secondary.{proximum,scriptum,stratum}` are loaded during analysis, but they require optional libs (`proximum`/`scriptum`/`stratum`) that live only in the `:test` alias, not the pom. clj analysis dies loading `proximum.core`.
2. **core.async macro requires** — `gc`, `versioning`, `audit`, `api.impl` and the kabel `walker` each had a `:require [clojure.core.async …]` **and** a separate `:require-macros [clojure.core.async …]`. Two require specs for one namespace register the implicit `clojure.core.async` alias twice → the cljs analyzer aborts with *"as alias must be unique"*.
3. **JVM-only namespaces with a `.cljc` extension** — `datahike.json` and `datahike.remote` unconditionally require `jsonista` (Jackson, JVM-only) and have **no** `:cljs` branches. They never worked under ClojureScript, yet cljdoc still tried to cljs-analyze them.

cljdoc **always** analyzes both clj and cljs when a jar ships any `.cljc`/`.cljs` (no repo-side override), and a cljs error fails the whole build — so all three had to be fixed.

## The fixes (3 commits)

- **`fix(cljdoc): mark optional secondary-index namespaces :no-doc`** — the analyzer excludes `:no-doc` namespaces *before* loading them, matching how `src-hitchhiker-tree` and the kabel integrations are already tagged.
- **`fix(cljdoc): make the published jar analyzable for ClojureScript`** — fold the core.async macro into the require spec with `:refer-macros` (one spec, like the existing `superv.async` usage); and rename `json.cljc`/`remote.cljc` → `.clj` (cljs analyzer skips them, clj docs keep them), unwrapping their now-pointless `#?(:clj …)` reader conditionals. Nothing in cljs/cljc requires these two namespaces, so nothing downstream breaks.
- **`ci(cljdoc): add cljdoc-analysis presubmit …`** — `bb cljdoc-check` builds the jar and runs cljdoc's own analyzer against it, failing on non-zero exit; wired into CircleCI as a `cljdoc-analysis` job on every branch/PR. The CI job requires `build` and runs `bb cljdoc-check-installed`, reusing the jar the `build` job already installed to `~/.m2` instead of recompiling.

## Verification

Ran cljdoc's analyzer (pinned SHA `52a1281`, the one cljdoc.org uses) against a locally built jar — **clj + cljs both succeed: 63 clj / 47 cljs namespaces**, with `datahike.json` kept in the Clojure docs and the secondary namespaces excluded. Confirmed pass both with and without `--add-modules jdk.incubator.vector` (the real cljdoc env has no JVM opts). `cljfmt` clean; `clj-kondo` shows no new findings (fewer errors than before). `remote.clj` records/print-methods/JSON mapper smoke-tested at runtime.

## Notes

- Takes effect on cljdoc only after the next Clojars release (cljdoc re-analyzes the published jar; re-running the build for `0.8.1742` would re-analyze the old jar).
- No CHANGELOG entry: doc-tooling + CI only, no library behavior/API change (the two renamed namespaces never worked on cljs).
- **Maintainer decision — should this gate release?** The `cljdoc-analysis` job runs on every branch/PR (so it flags a regression before merge), but it is **not** in the `requires:` of `deploy`/`release-jar`. As-is, a jar that fails cljdoc analysis can still be deployed to Clojars and released (cljdoc then fails post-release). Adding `cljdoc-analysis` to those two jobs' `requires:` would hard-block such a release — that's a release-policy call for the maintainers, so I've left it out. One-line change if you want it.
- The analyzer SHA is pinned in `bb/src/tools/cljdoc.clj` with a comment on when/how to bump it to track cljdoc's builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
