### PR TITLE
fix(secondary): Proximum bridge coerces :db.type/tuple vectors to float[]

### DIFF
--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -109,10 +109,13 @@ Proximum provides HNSW-based approximate nearest neighbor search. Requires Java 
                                                         :id (random-uuid)}}}])
 (Thread/sleep 1000)
 
-;; Add vector data
-(d/transact conn [{:person/embedding (float-array [1.0 0.0 0.0 0.0])}
-                  {:person/embedding (float-array [0.0 1.0 0.0 0.0])}
-                  {:person/embedding (float-array [0.9 0.1 0.0 0.0])}])
+;; Add vector data. A `:db.type/tuple` value is a plain Clojure vector — that
+;; is what datahike validates and stores in the primary index; the Proximum
+;; bridge coerces it to a float[] for the HNSW graph. (Query vectors passed to
+;; `-search` below are float[], the shape Proximum's search API takes.)
+(d/transact conn [{:person/embedding [1.0 0.0 0.0 0.0]}
+                  {:person/embedding [0.0 1.0 0.0 0.0]}
+                  {:person/embedding [0.9 0.1 0.0 0.0]}])
 ```
 
 ### KNN Search

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -22,6 +22,25 @@
    [replikativ.logging :as log]
    [clojure.core.async :as async]))
 
+(def ^:private float-array-class (Class/forName "[F"))
+
+(defn- ->float-array
+  "Coerce a datom value into the float[] Proximum indexes.
+
+   A `:db.type/tuple` value is a Clojure vector (datahike validates the type as
+   `vector?`), so that is the shape a schema-declared embedding attribute
+   actually carries. Accept a float[] verbatim, and coerce a vector/seq of
+   numbers; return nil for anything else so the caller can warn and skip.
+
+   The primary index keeps the immutable vector (which hashes by value);
+   Proximum needs the primitive array, so the conversion lives here at the
+   boundary rather than forcing callers to pick one representation for both."
+  ^floats [val]
+  (cond
+    (instance? float-array-class val) val
+    (and (sequential? val) (every? number? val)) (float-array val)
+    :else nil))
+
 (defn- make-proximum-index
   "Create an ISecondaryIndex backed by Proximum.
    Entity IDs are used as external keys in the Proximum index."
@@ -138,12 +157,13 @@
               eid (.-e datom)
               val (.-v datom)]
           (if added?
-            ;; Insert: val should be a float-array vector, eid is external key
-            (if (instance? (Class/forName "[F") val)
+            ;; Insert: coerce the datom value (a :db.type/tuple vector, or a raw
+            ;; float[]) to float[]; eid is the external key.
+            (if-let [fa (->float-array val)]
               (make-proximum-index
-               (prox/insert prox-idx val eid)
+               (prox/insert prox-idx fa eid)
                config)
-              (do (log/warn :datahike/non-float-array-vector {:eid eid :type (type val)})
+              (do (log/warn :datahike/non-vector-embedding {:eid eid :type (type val)})
                   (make-proximum-index prox-idx config)))
             ;; Retract: delete by external entity ID
             (make-proximum-index

--- a/test/datahike/test/secondary_integration_test.clj
+++ b/test/datahike/test/secondary_integration_test.clj
@@ -241,6 +241,44 @@
           (is (es/entity-bitset-contains? results 1))
           (is (es/entity-bitset-contains? results 2)))))))
 
+(deftest test-proximum-declarative-vector-values
+  ;; Regression: the fully declarative path (create-database → connect →
+  ;; schema-transact the index → transact embeddings) is what the docs show, and
+  ;; it went through datahike's write-time validation. A `:db.type/tuple` value
+  ;; validates as `vector?`, so an embedding attribute must carry a Clojure
+  ;; vector — but the bridge only indexed float[], so every validated value was
+  ;; silently skipped (0 indexed) while a float[] failed validation outright.
+  ;; The bridge now coerces the tuple vector to float[]; assert both index.
+  (when-not proximum-available?
+    (is (not proximum-available?) "SKIP: proximum requires Java 22+"))
+  (when proximum-available?
+    (testing "schema-declared :db.type/tuple embeddings are indexed from vector values"
+      (let [cfg {:store {:backend :memory :id (random-uuid)}
+                 :schema-flexibility :write}]
+        (d/create-database cfg)
+        (try
+          (let [conn (d/connect cfg)]
+            (d/transact conn [{:db/ident :person/embedding
+                               :db/valueType :db.type/tuple
+                               :db/cardinality :db.cardinality/one}])
+            (d/transact conn [{:db/ident :idx/vectors
+                               :db.secondary/type :proximum
+                               :db.secondary/attrs [:person/embedding]
+                               :db.secondary/config {:dim 4 :distance :cosine
+                                                     :store-config {:backend :memory
+                                                                    :id (random-uuid)}}}])
+            (Thread/sleep 1000)
+            ;; plain Clojure vectors — the shape a :db.type/tuple actually holds
+            (d/transact conn [{:person/embedding [1.0 0.0 0.0 0.0]}
+                              {:person/embedding [0.0 1.0 0.0 0.0]}
+                              {:person/embedding [0.9 0.1 0.0 0.0]}])
+            (Thread/sleep 500)
+            (let [vt (get-in (d/db conn) [:secondary-indices :idx/vectors])
+                  results (sec/-search vt {:vector (float-array [1.0 0.0 0.0 0.0]) :k 2} nil)]
+              ;; the two vectors nearest [1,0,0,0] — indexed, not skipped
+              (is (= 2 (es/entity-bitset-cardinality results)))))
+          (finally (d/delete-database cfg)))))))
+
 ;; ---------------------------------------------------------------------------
 ;; Stratum Entity-Filter Aggregate Tests
 


### PR DESCRIPTION
## Problem

The **declarative** path for a Proximum vector index — exactly what `doc/secondary-indices.md` documents — could not index anything.

A `:db.secondary/attrs` embedding attribute is declared `:db.type/tuple`, whose values datahike validates as `vector?`. But the Proximum bridge's `-transact` only inserted values that were already a `float[]`:

```clojure
(if (instance? (Class/forName "[F") val)
  (prox/insert prox-idx val eid)
  (log/warn :datahike/non-float-array-vector ...))   ; silently skipped
```

The two contracts have **no overlap**:

- a Clojure vector passes write-time validation → bridge skips it (warn, 0 indexed)
- a `float[]` is what the bridge wants → fails `:db.type/tuple` validation before it reaches the index

So a schema-declared Proximum index silently indexed nothing. The bug never surfaced because the existing tests all use the manual `sec/create-index` + `db/empty-db` path with raw `float[]`, bypassing validation.

Reproduced verbatim from the doc (only the value shape changed to a vector, since a `float[]` cannot validate):

```clojure
(d/transact conn [{:person/embedding [1.0 0.0 0.0 0.0]} ...])
;; before: 0 vectors indexed
```

## Fix

Coerce at the bridge boundary. `-transact` now accepts a `float[]` verbatim (unchanged for the manual path) and coerces a vector/seq of numbers to `float[]`. The primary index keeps the immutable vector (hashes by value); Proximum gets the primitive array it needs.

- `doc/secondary-indices.md`: the example transacted `(float-array …)`, which cannot validate against `:db.type/tuple` — corrected to plain vectors, with a note on why.
- Added a regression test exercising the full declarative path (create-database → connect → schema-transact index → transact vector embeddings). It **fails before this change** (0 indexed → cardinality assertion fails) and passes after.

## Validation

- Full `secondary-integration-test`: **12 tests, 59 assertions, 0 failures** (was 11/58; +1 regression test).
- Confirmed the new test catches the bug: reverting only the source change → **1 failure**.
- `float[]` passthrough, int/double-vector coercion, and non-numeric rejection all verified.

Found while building a semantic-code-search demo over a geschichte repository (Clojure's history), where the declarative Proximum index is the natural integration point.