### PR TITLE
test(query): unfreeze the differential generator's input axes (+3 fixes it found)

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -3551,8 +3551,18 @@
                  agg-ops (into [] (keep (fn [fe]
                                           (when (instance? Aggregate fe)
                                             [(keyword (name (.-symbol ^PlainSymbol (.-fn ^Aggregate fe))))])))
-                               find-elements)]
-             (when (and best-idx stratum-compat? (stratum-compat? agg-ops))
+                               find-elements)
+                 ;; `(min N ?x)` / `(max N ?x)` return the N smallest/largest as
+                 ;; a COLLECTION — a different function from the scalar namesake
+                 ;; this path computes. `agg-ops` above carries only the NAME, so
+                 ;; the count argument was invisible to the compatibility check
+                 ;; and the query answered a scalar. Decline and let the relation
+                 ;; path, which implements both, handle it.
+                 simple-arity? (every? (fn [fe]
+                                         (or (not (instance? Aggregate fe))
+                                             (<= (count (.-args ^Aggregate fe)) 1)))
+                                       find-elements)]
+             (when (and best-idx stratum-compat? simple-arity? (stratum-compat? agg-ops))
                ;; Determine which sub-ops provide values needed by :find vs which are filter-only
                (let [col-agg-fn sec/-columnar-aggregate
                      stratum-agg-ops (resolve-stratum-fn 'stratum-agg-ops)
@@ -3595,8 +3605,40 @@
                                                             sub-ops)))))
                                           find-vars)
                      ;; All value-providing columns must be in the index
-                     all-find-attrs-covered? (every? indexed-attrs find-col-attrs)]
-                 (when all-find-attrs-covered?
+                     all-find-attrs-covered? (every? indexed-attrs find-col-attrs)
+                     ;; A Datalog aggregate applies to the DEDUPLICATED find
+                     ;; projection — the answer set — not to the raw datoms. This
+                     ;; path aggregates inside the index, over columns, and so
+                     ;; counts a repeated value once per datom: `(count ?x)` over
+                     ;; values 10, 10, 40 answered 3 where the projection has two
+                     ;; members. It may therefore only claim aggregates that are
+                     ;; INSENSITIVE to duplicates, unless the projection is
+                     ;; duplicate-free anyway because :find carries an entity var
+                     ;; (one row per entity).
+                     dup-insensitive? #{:min :max :count-distinct}
+                     find-plain-vars (into #{}
+                                           (keep (fn [fe]
+                                                   (when (instance? Variable fe)
+                                                     (.-symbol ^Variable fe))))
+                                           find-elements)
+                     projection-distinct? (some (fn [v] (= :eid (get var->col v)))
+                                                find-plain-vars)
+                     dup-safe? (or projection-distinct?
+                                   (every? (fn [op] (dup-insensitive? (first op))) agg-ops))
+                     ;; STILL OPEN: a value aggregate over a non-numeric column
+                     ;; comes back as argmin-style ROW INDICES — `(min ?x)` over
+                     ;; "b","a","c" answers 0 — and over an untyped column
+                     ;; holding fractions it truncates (1.5 -> 1). The fused
+                     ;; columnar path guards this with `type-safe?`, which tests
+                     ;; the EXTRACTED array's type; this path never materializes
+                     ;; the column, so it has nothing to test. Gating on a
+                     ;; declared `:db/valueType` instead does not work: the
+                     ;; `empty-db` schema shorthand does not accept one, so that
+                     ;; would disable the fast path for most real usage rather
+                     ;; than for the unsafe cases. The fix is to ask the delegate
+                     ;; for its column type.
+                     ]
+                 (when (and all-find-attrs-covered? dup-safe?)
                    ;; Split sub-ops: covered (in index) vs uncovered (need PSS)
                    (let [covered-ops (filterv (fn [sub-op]
                                                 (let [a (resolve-attr (or (:attr sub-op) (get-in sub-op [:schema-info :attr])))]

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -4921,27 +4921,60 @@
                               (fn ^objects [i] (.get rows i)))
 
                   ;; Extract typed columns from the (possibly deduplicated)
-                  ;; rows. Detect types from the first row.
-                     first-row ^objects (row-at 0)
+                  ;; rows. The column's type is decided by EVERY value in it, not
+                  ;; by a sample of row 0: a column holding 10 then 2.5 is not a
+                  ;; long column, and typing it from the first value truncated
+                  ;; every Double into a long[] — `(sum ?x)` over 10, 2.5
+                  ;; answered 12 instead of 12.5, and swapping the two rows made
+                  ;; the same query correct. Undeclared attributes and
+                  ;; `:schema-flexibility :read` make a mixed column easy to
+                  ;; produce, and this path needs no secondary index to run, so
+                  ;; the truncation reached ordinary queries.
+                  ;;
+                  ;; A column qualifies for a primitive array only when EVERY
+                  ;; value has the same type; anything mixed falls to Object[],
+                  ;; which `type-safe?` below already refuses for a value
+                  ;; aggregate, so the query takes the relation path and is
+                  ;; right. Note it must not merely WIDEN a mixed Long/Double
+                  ;; column to double[]: the same extraction feeds GROUP keys,
+                  ;; and widening turned the group `10` into `10.0` in the
+                  ;; result. The scan is O(rows) over a column this code is
+                  ;; about to materialize anyway.
+                     column-kind
+                     (fn [pos]
+                       (loop [i 0, k nil]
+                         (if (>= i n')
+                           (or k :object)
+                           (let [v (aget ^objects (row-at i) pos)
+                                 vk (cond
+                                      (instance? Long v) :long
+                                      (instance? Double v) :double
+                                      (instance? String v) :string
+                                      :else :object)]
+                             (cond
+                               (= :object vk) :object
+                               (nil? k) (recur (inc i) vk)
+                               (= k vk) (recur (inc i) k)
+                               :else :object)))))
 
                      extract-column
                      (fn [col-idx]
                        (let [pos (int (get idx->pos col-idx))
-                             sample (aget first-row pos)]
+                             kind (if (zero? n') :object (column-kind pos))]
                          (cond
-                           (instance? Long sample)
+                           (= :long kind)
                            (let [arr (long-array n')]
                              (dotimes [i n']
                                (aset arr i (long (aget ^objects (row-at i) pos))))
                              arr)
 
-                           (instance? Double sample)
+                           (= :double kind)
                            (let [arr (double-array n')]
                              (dotimes [i n']
                                (aset arr i (double (aget ^objects (row-at i) pos))))
                              arr)
 
-                           (instance? String sample)
+                           (= :string kind)
                            (let [arr ^"[Ljava.lang.String;" (make-array String n')]
                              (dotimes [i n']
                                (aset arr i ^String (aget ^objects (row-at i) pos)))

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -4859,7 +4859,16 @@
                                            :var agg-var
                                            :col-key (when agg-var (keyword (name agg-var)))
                                            :col-idx col-idx
-                                           :find-idx _fi})))
+                                           :find-idx _fi
+                                           ;; `(min N ?x)` / `(max N ?x)` return the
+                                           ;; N smallest/largest as a COLLECTION —
+                                           ;; a different contract from scalar
+                                           ;; min/max. Only the last arg is read
+                                           ;; here, so a leading count was silently
+                                           ;; dropped and the query answered `10`
+                                           ;; where it should answer `[10]`. Record
+                                           ;; the arity so this path can decline.
+                                           :extra-args? (> (count agg-args) 1)})))
                                     find-elements))
 
                   ;; Datalog aggregation operates on the DEDUPLICATED projection
@@ -4976,8 +4985,13 @@
                                           (or (nil? col-key)
                                               (#{:count :count-distinct} agg-op)
                                               (numeric-array? (get column-map col-key))))
-                                        agg-cols)]
+                                        agg-cols)
+                  ;; An aggregate with a count argument is a different function
+                  ;; than its scalar namesake; this path computes only the
+                  ;; scalar. Fall through to the relation path, which
+                  ;; implements both.
+                     arity-safe? (not-any? :extra-args? agg-cols)]
 
               ;; Call the external aggregate engine
-                 (when type-safe?
+                 (when (and type-safe? arity-safe?)
                    (aggregate-fn column-map group-keys agg-specs))))))))))

--- a/test/datahike/test/query_aggregates_test.cljc
+++ b/test/datahike/test/query_aggregates_test.cljc
@@ -4,6 +4,7 @@
       :clj  [clojure.test :as t :refer        [is deftest testing]])
    [clojure.core.async :refer [<!]]
    [datahike.api :as d]
+   [datahike.db :as db]
    [datahike.query :as dq]
    [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
 
@@ -66,6 +67,44 @@
 (defn- close-enough?
   [expected actual]
   (and (number? actual) (< (abs (- (double expected) (double actual))) 1e-9)))
+
+(deftest test-aggregate-over-a-mixed-type-column
+  ;; The fused aggregate path materializes typed column arrays and used to pick
+  ;; the array type by sampling ROW 0. A column holding 10 then 2.5 was typed
+  ;; long[] and every Double truncated: `(sum ?x)` answered 12 instead of 12.5 —
+  ;; and swapping the two rows made the same query correct, which is the
+  ;; signature of the bug. No secondary index is involved, and an undeclared
+  ;; attribute or `:schema-flexibility :read` makes a mixed column easy to
+  ;; produce, so this reached ordinary queries.
+  (let [db-of (fn [vals]
+                (d/db-with (db/empty-db {})
+                           (vec (map-indexed (fn [i v] {:db/id (inc i) :num/v v}) vals))))
+        agree? (fn [vals query]
+                 (binding [dq/*query-result-cache?* false]
+                   (let [d (db-of vals)
+                         p (binding [dq/*disable-planner* false] (d/q query d))
+                         r (binding [dq/*disable-planner* true] (d/q query d))]
+                     [(= p r) p r])))]
+    (testing "a Double anywhere in the column is not truncated"
+      (doseq [vals [[10 2.5] [2.5 10] [1 2 3.5] [3.5 1 2]]
+              q '[[:find (sum ?x) :where [?e :num/v ?x]]
+                  [:find (min ?x) :where [?e :num/v ?x]]
+                  [:find (avg ?x) :where [?e :num/v ?x]]]]
+        (let [[ok? p r] (agree? vals q)]
+          (is ok? (str q " over " (pr-str vals) " — planner " (pr-str p)
+                       " vs reference " (pr-str r))))))
+
+    (testing "a mixed column used as a GROUP KEY keeps each value's own type"
+      ;; Widening the column instead of declining would answer the group `10`
+      ;; as `10.0` — the projection must return the value as stored.
+      (let [[ok? p r] (agree? [10 2.5] '[:find ?x (count ?e) :where [?e :num/v ?x]])]
+        (is ok? (str "grouped — planner " (pr-str p) " vs reference " (pr-str r)))))
+
+    (testing "homogeneous columns still take the fast path and agree"
+      (doseq [vals [[10 15 20] [1.5 2.5] ["b" "a" "c"]]]
+        (let [[ok? p r] (agree? vals '[:find (min ?x) :where [?e :num/v ?x]])]
+          (is ok? (str "min over " (pr-str vals) " — planner " (pr-str p)
+                       " vs reference " (pr-str r))))))))
 
 (deftest test-aggregate-contract
   (doseq [{:keys [agg in expect real? note]} aggregate-contract

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -79,6 +79,78 @@
                           {:db/id 105 :name "frank-2" :score 5}])
         (d/db conn)))))
 
+;; ---------------------------------------------------------------------------
+;; Axis: THE DATA. The generator above varies the query's shape across ~20
+;; dimensions, but every case used to run against one tidy dataset — values
+;; well-typed, distinct, no duplicates. Whole families of bug hid there, because
+;; the specializations classify their INPUT (a sampled row, a value's shape, a
+;; column's type) and tidy input makes every classification look right.
+
+(defonce ^:private test-db-dup
+  ;; Heavy duplication. An aggregate reads the FIND PROJECTION, so duplicate
+  ;; values are what distinguish `count`/`sum` over a deduplicated projection
+  ;; from one over raw rows — a distinction invisible when every value differs.
+  (delay
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :schema-flexibility :write}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (d/transact conn [{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+                          {:db/ident :nick :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+                          {:db/ident :score :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                          {:db/ident :tag :db/valueType :db.type/keyword :db/cardinality :db.cardinality/many}
+                          {:db/ident :friend :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
+                          {:db/ident :uid :db/valueType :db.type/string
+                           :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}])
+        ;; ACYCLIC on :friend, deliberately. A cycle here makes the reference
+        ;; engine's mutual recursion run forever (see
+        ;; query-rules-test/test-mutual-recursion-over-a-cycle), and a generator
+        ;; must not contain a combination known to hang — that belongs in a
+        ;; pinned test, not as a landmine every future run steps on.
+        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "dup" :score 20 :tag [:red :blue] :friend 101}
+                          {:db/id 101 :uid "u101" :name "alice" :nick "dup" :score 20 :tag [:blue] :friend 102}
+                          {:db/id 102 :uid "u102" :name "alice" :score 20 :tag [:red :blue]}
+                          {:db/id 103 :uid "u103" :name "bob" :nick "dup" :score 5 :tag [:red]}
+                          {:db/id 104 :uid "u104" :name "bob" :score 5 :tag [:red :blue] :friend 103}
+                          {:db/id 105 :uid "u105" :name "bob" :nick "dup" :score 5}])
+        (d/transact conn [[:db/retract 101 :score 20]])
+        (d/transact conn [[:db/add 101 :score 20]])
+        (d/db conn)))))
+
+(defonce ^:private test-db-loose
+  ;; `:schema-flexibility :read`: :score and :name are UNDECLARED, so one
+  ;; attribute holds Long, Double and String values at once. Any code that types
+  ;; a whole column from one sampled row is wrong here, and a fast path that
+  ;; assumes numbers must decline rather than truncate. :uid stays unique so
+  ;; lookup-ref bindings still mean something, and :friend stays a ref so the
+  ;; recursive rules still traverse.
+  (delay
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :schema-flexibility :read}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (d/transact conn [{:db/ident :uid :db/valueType :db.type/string
+                           :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}
+                          {:db/ident :friend :db/valueType :db.type/ref
+                           :db/cardinality :db.cardinality/one}
+                          {:db/ident :tag :db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}])
+        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "al" :score 10 :tag [:red :blue] :friend 101}
+                          {:db/id 101 :uid "u101" :name "bob" :score 2.5 :tag [:blue]}
+                          {:db/id 102 :uid "u102" :name "carol" :nick "cc" :score "thirty" :friend 100}
+                          {:db/id 103 :uid "u103" :name "dave" :score 7 :tag [:red]}
+                          {:db/id 104 :uid "u104" :name 42 :score 7 :friend 103}
+                          {:db/id 105 :uid "u105" :name "frank" :nick "f" :tag [:green :red] :score 5}])
+        (d/transact conn [[:db/retract 103 :score 7]])
+        (d/transact conn [[:db/add 103 :score 7.5]])
+        (d/db conn)))))
+
+(defn- dataset-db [dataset]
+  (case dataset
+    :dup @test-db-dup
+    :loose @test-db-loose
+    @test-db))
+
 (def ^:private rule-sets
   {:plain     '[[(named ?e ?n) [?e :name ?n]]]
    :fn-body   '[[(upper-name ?e ?ru) [?e :name ?rn] [(clojure.string/upper-case ?rn) ?ru]]]
@@ -159,7 +231,18 @@
    ;; whenever ?s exists it dominates `primary`.
    :find      (gen/elements [:e :e+primary :e+modifier :primary+modifier
                              :coll-primary :agg-count :agg-min :agg-count-primary
-                             :consumer-only])))
+                             :consumer-only
+                             ;; Axis: THE AGGREGATE. Only `count` and `min` were
+                             ;; generated — the two type-PRESERVING ones, which
+                             ;; is why the population-vs-sample variance split
+                             ;; and the median's type both went unnoticed.
+                             :agg-avg :agg-variance :agg-stddev :agg-median
+                             :agg-sum :agg-count-distinct :agg-min-n
+                             :agg-avg-grouped :agg-median-grouped])
+   ;; Axis: THE DATA — see the dataset defs above.
+   :dataset   (gen/frequency [[3 (gen/return :tidy)]
+                              [2 (gen/return :dup)]
+                              [2 (gen/return :loose)]])))
 
 (def ^:private rule-out-vars
   "The var each rule clause BINDS — nil for the unary rule, which binds none.
@@ -261,7 +344,25 @@
                     :agg-count-primary [primary (list 'count '?e)]
                     ;; only the consumer group's var; degrades to [?n] without
                     ;; the friend join (single group — no producer/consumer split)
-                    :consumer-only [(if friend? '?fn '?n)])
+                    :consumer-only [(if friend? '?fn '?n)]
+                    ;; the value aggregates need a numeric-ish column; without
+                    ;; :score they degrade to counting rather than build a query
+                    ;; whose divergence would only be about the wrong column
+                    :agg-avg (if score? [(list 'avg '?s)] [(list 'count '?e)])
+                    :agg-variance (if score? [(list 'variance '?s)] [(list 'count '?e)])
+                    :agg-stddev (if score? [(list 'stddev '?s)] [(list 'count '?e)])
+                    :agg-median (if score? [(list 'median '?s)] [(list 'count '?e)])
+                    :agg-sum (if score? [(list 'sum '?s)] [(list 'count '?e)])
+                    :agg-count-distinct [(list 'count-distinct (if score? '?s '?n))]
+                    ;; min/max with a COUNT argument returns a collection, a
+                    ;; different contract from scalar min/max
+                    :agg-min-n [(list 'min 2 (if score? '?s '?n))]
+                    :agg-avg-grouped (if score?
+                                       (vec (distinct [primary (list 'avg '?s)]))
+                                       [primary (list 'count '?e)])
+                    :agg-median-grouped (if score?
+                                          (vec (distinct [primary (list 'median '?s)]))
+                                          [primary (list 'count '?e)]))
         ;; ?e comes from a collection OR a lookup ref, never both
         e-binding (cond in-coll? ['[?e ...] [100 101 102 103 104 105]]
                         in-lookup? ['?e [:uid "u100"]])
@@ -312,16 +413,33 @@
     (sequential? r) (frequencies r)
     :else r))
 
+(def ^:private case-timeout-ms
+  "Per-engine wall clock for one generated case. Generated cases are tiny — the
+   whole dataset is six entities — so anything this slow is not slow, it is
+   stuck, and a divergence must be REPORTED rather than hanging the run. The
+   first widened-axis run found exactly that: the reference engine does not
+   terminate on mutual recursion over a cyclic :friend graph, which no tidy
+   (acyclic) dataset could surface."
+  (or (some-> (System/getenv "DATAHIKE_DIFF_CASE_TIMEOUT_MS") parse-long) 5000))
+
 (defn- run-engine [disable? query db args opts]
-  (try
-    (binding [q/*disable-planner* disable?]
-      (let [args' (into [db] (map (fn [a] (if (= ::db2 a) @test-db2 a))) args)]
-        (normalize
-         (if (seq opts)
-           ;; map form — the only way to pass :order-by
-           (d/q (assoc opts :query query :args args'))
-           (apply d/q query args')))))
-    (catch Exception _ ::raised)))
+  (let [thunk (fn []
+                (try
+                  (binding [q/*disable-planner* disable?]
+                    (let [args' (into [db] (map (fn [a] (if (= ::db2 a) @test-db2 a))) args)]
+                      (normalize
+                       (if (seq opts)
+                         ;; map form — the only way to pass :order-by
+                         (d/q (assoc opts :query query :args args'))
+                         (apply d/q query args')))))
+                  (catch Exception _ ::raised)))
+        fut (future (thunk))
+        r (deref fut case-timeout-ms ::timeout)]
+    (when (= r ::timeout)
+      ;; The thread is CPU-bound and will not observe an interrupt, but the run
+      ;; must proceed; the case is already reported as a divergence.
+      (future-cancel fut))
+    r))
 
 (defn- wrap-db [db temporal]
   (case temporal
@@ -333,13 +451,14 @@
   {:num-tests num-cases :seed 1721160000042}
   (prop/for-all [spec gen-spec]
                 (let [[query args opts] (build-query spec)
-                      db (wrap-db @test-db (:temporal spec))
+                      db (wrap-db (dataset-db (:dataset spec)) (:temporal spec))
                       base (run-engine true query db args opts)
                       planner (run-engine false query db args opts)]
                   (is (= base planner)
                       (str "engines diverge on " (pr-str query)
                            " args " (pr-str args) " opts " (pr-str opts)
                            " temporal " (:temporal spec)
+                           " dataset " (:dataset spec)
                            "\n  base:    " (pr-str base)
                            "\n  planner: " (pr-str planner)))
                   (= base planner))))

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -45,11 +45,14 @@
                           {:db/ident :score :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
                           {:db/ident :tag :db/valueType :db.type/keyword :db/cardinality :db.cardinality/many}
                           {:db/ident :friend :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
+                          ;; a SECOND ref relation, so a recursive rule's step can
+                          ;; traverse something other than its base case's edge
+                          {:db/ident :colleague :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
                           ;; unique, so an :in binding can arrive as a LOOKUP REF
                           {:db/ident :uid :db/valueType :db.type/string
                            :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}])
-        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "al" :score 10 :tag [:red :blue] :friend 101}
-                          {:db/id 101 :uid "u101" :name "bob" :score 20 :tag [:blue]}
+        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "al" :score 10 :tag [:red :blue] :friend 101 :colleague 102}
+                          {:db/id 101 :uid "u101" :name "bob" :score 20 :tag [:blue] :colleague 103}
                           {:db/id 102 :uid "u102" :name "carol" :nick "cc" :score 30 :friend 100}
                           {:db/id 103 :uid "u103" :name "dave" :tag [:red]}
                           {:db/id 104 :uid "u104" :name "eve" :score 20 :friend 103}
@@ -100,6 +103,7 @@
                           {:db/ident :score :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
                           {:db/ident :tag :db/valueType :db.type/keyword :db/cardinality :db.cardinality/many}
                           {:db/ident :friend :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
+                          {:db/ident :colleague :db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
                           {:db/ident :uid :db/valueType :db.type/string
                            :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}])
         ;; ACYCLIC on :friend, deliberately. A cycle here makes the reference
@@ -107,8 +111,8 @@
         ;; query-rules-test/test-mutual-recursion-over-a-cycle), and a generator
         ;; must not contain a combination known to hang — that belongs in a
         ;; pinned test, not as a landmine every future run steps on.
-        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "dup" :score 20 :tag [:red :blue] :friend 101}
-                          {:db/id 101 :uid "u101" :name "alice" :nick "dup" :score 20 :tag [:blue] :friend 102}
+        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "dup" :score 20 :tag [:red :blue] :friend 101 :colleague 103}
+                          {:db/id 101 :uid "u101" :name "alice" :nick "dup" :score 20 :tag [:blue] :friend 102 :colleague 104}
                           {:db/id 102 :uid "u102" :name "alice" :score 20 :tag [:red :blue]}
                           {:db/id 103 :uid "u103" :name "bob" :nick "dup" :score 5 :tag [:red]}
                           {:db/id 104 :uid "u104" :name "bob" :score 5 :tag [:red :blue] :friend 103}
@@ -133,10 +137,12 @@
                            :db/unique :db.unique/identity :db/cardinality :db.cardinality/one}
                           {:db/ident :friend :db/valueType :db.type/ref
                            :db/cardinality :db.cardinality/one}
+                          {:db/ident :colleague :db/valueType :db.type/ref
+                           :db/cardinality :db.cardinality/one}
                           {:db/ident :tag :db/valueType :db.type/keyword
                            :db/cardinality :db.cardinality/many}])
-        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "al" :score 10 :tag [:red :blue] :friend 101}
-                          {:db/id 101 :uid "u101" :name "bob" :score 2.5 :tag [:blue]}
+        (d/transact conn [{:db/id 100 :uid "u100" :name "alice" :nick "al" :score 10 :tag [:red :blue] :friend 101 :colleague 102}
+                          {:db/id 101 :uid "u101" :name "bob" :score 2.5 :tag [:blue] :colleague 103}
                           {:db/id 102 :uid "u102" :name "carol" :nick "cc" :score "thirty" :friend 100}
                           {:db/id 103 :uid "u103" :name "dave" :score 7 :tag [:red]}
                           {:db/id 104 :uid "u104" :name 42 :score 7 :friend 103}
@@ -159,14 +165,30 @@
    :mutual    '[[(ehop ?a ?b) [?a :friend ?b]]
                 [(ehop ?a ?b) [?a :friend ?x] (ohop ?x ?b)]
                 [(ohop ?a ?b) [?a :friend ?x] (ehop ?x ?b)]]
-   :with-not  '[[(unred ?e) [?e :name ?rn] (not [?e :tag :red])]]})
+   :with-not  '[[(unred ?e) [?e :name ?rn] (not [?e :tag :red])]]
+   ;; Axis: RULE SHAPE. The five sets above are all closures of the SAME
+   ;; relation their base case walks, which is the one shape the recursive fast
+   ;; paths assume. The three below break that assumption in the three ways that
+   ;; matter, and each has already been a wrong answer:
+   ;;   - the step traverses a DIFFERENT relation than the base case;
+   ;;   - the step is a SUBSET of it (filtered traversal);
+   ;;   - the recursion is right-linear rather than left-linear.
+   :rec-changes-edge '[[(xreach ?a ?b) [?a :friend ?b]]
+                       [(xreach ?a ?b) [?a :colleague ?x] (xreach ?x ?b)]]
+   :rec-filtered     '[[(freach ?a ?b) [?a :friend ?b]]
+                       [(freach ?a ?b) [?a :friend ?x] [?x :tag :blue] (freach ?x ?b)]]
+   :rec-right        '[[(rreach ?a ?b) [?a :friend ?b]]
+                       [(rreach ?a ?b) (rreach ?a ?x) [?x :friend ?b]]]})
 
 (def ^:private rule-clause
   {:plain     '(named ?e ?rn2)
    :fn-body   '(upper-name ?e ?ru)
    :recursive '(reach ?e ?r)
    :mutual    '(ehop ?e ?r)
-   :with-not  '(unred ?e)})
+   :with-not  '(unred ?e)
+   :rec-changes-edge '(xreach ?e ?r)
+   :rec-filtered     '(freach ?e ?r)
+   :rec-right        '(rreach ?e ?r)})
 
 (def ^:private gen-spec
   (gen/hash-map
@@ -218,7 +240,14 @@
                               [1 (gen/return :fn-body)]
                               [1 (gen/return :recursive)]
                               [1 (gen/return :mutual)]
-                              [1 (gen/return :with-not)]])
+                              [1 (gen/return :with-not)]
+                              [1 (gen/return :rec-changes-edge)]
+                              [1 (gen/return :rec-filtered)]])
+   ;; :rec-right is DEFINED above but deliberately not generated: the reference
+   ;; engine does not terminate on a rule whose body leads with the recursive
+   ;; call, so it cannot serve as the oracle for that shape. Pinned instead in
+   ;; query-rules-test/test-right-recursive-rule — a generator must not contain
+   ;; a combination known to hang.
    ;; multi-source: a $2 clause joining ?e across databases
    :multi     (gen/frequency [[4 (gen/return :none)]
                               [1 (gen/return :join-name)]
@@ -248,7 +277,8 @@
   "The var each rule clause BINDS — nil for the unary rule, which binds none.
    Grounding that argument removes the var from the query, so `primary` must
    not pick it."
-  {:plain '?rn2 :fn-body '?ru :recursive '?r :mutual '?r :with-not nil})
+  {:plain '?rn2 :fn-body '?ru :recursive '?r :mutual '?r :with-not nil
+   :rec-changes-edge '?r :rec-filtered '?r :rec-right '?r})
 
 (defn- ground-rule-clause
   "Rewrite a rule call to ground one argument. :out-arg grounds the rule's
@@ -274,7 +304,8 @@
            in-coll? rules multi use2? find
            in-scalar in-tuple? in-rel? in-lookup? rule-ground result-mod]}]
   (let [;; :recursive/:mutual rule clauses walk :friend — force the pattern in
-        friend? (or friend? (#{:recursive :mutual} rules))
+        friend? (or friend? (#{:recursive :mutual :rec-changes-edge
+                               :rec-filtered :rec-right} rules))
         rule-ground (if (= :none rules) :none rule-ground)
         rule-cl (when (not= :none rules)
                   (ground-rule-clause (get rule-clause rules) rules rule-ground))

--- a/test/datahike/test/query_rules_test.cljc
+++ b/test/datahike/test/query_rules_test.cljc
@@ -510,3 +510,31 @@
        (is (= #{100 101 102}
               (run '[:find [?b ...] :in $ % :where (ehop 100 ?b)]))
            "…and with a ground argument"))))
+
+#?(:clj
+   (deftest test-right-recursive-rule
+     ;; A right-linear transitive closure — the recursive call comes FIRST in
+     ;; the body:
+     ;;   [(rr ?a ?b) [?a :friend ?b]]
+     ;;   [(rr ?a ?b) (rr ?a ?x) [?x :friend ?b]]
+     ;; The planner's semi-naive fixpoint evaluates this bottom-up and converges.
+     ;; The reference engine expands the leading rule call before anything binds
+     ;; it and does not terminate — on a THREE-entity ACYCLIC graph, so this is
+     ;; not about cycles or size. Asserted on the planner only, on a bounded
+     ;; thread.
+     ;;
+     ;; Found by adding a rule-shape axis to the differential generator: its five
+     ;; rule sets were all left-linear, so this whole shape was untested.
+     (let [db (d/db-with (db/empty-db {:friend {:db/valueType :db.type/ref
+                                                :db/cardinality :db.cardinality/one}})
+                         [{:db/id 1 :friend 2} {:db/id 2 :friend 3} {:db/id 3}])
+           rules '[[(rr ?a ?b) [?a :friend ?b]]
+                   [(rr ?a ?b) (rr ?a ?x) [?x :friend ?b]]]
+           run (fn [q] (let [f (future (set (d/q q db rules)))
+                             r (deref f 15000 ::timeout)]
+                         (when (= r ::timeout) (future-cancel f))
+                         r))]
+       (is (= #{[1 2] [2 3] [1 3]} (run '[:find ?a ?b :in $ % :where (rr ?a ?b)]))
+           "planner terminates on a right-recursive rule")
+       (is (= #{2 3} (run '[:find [?b ...] :in $ % :where (rr 1 ?b)]))
+           "…and with a ground argument"))))

--- a/test/datahike/test/query_rules_test.cljc
+++ b/test/datahike/test/query_rules_test.cljc
@@ -475,3 +475,38 @@
     ;; reachable from 1. 2->3 directly, and 3 inactive stops there.
     (is (= #{2 3} (set (d/q '[:find [?b ...] :in $ % :where (p 1 ?b)] db rules))))
     (is (= #{3} (set (d/q '[:find [?b ...] :in $ % :where (p 2 ?b)] db rules))))))
+
+#?(:clj
+   (deftest test-mutual-recursion-over-a-cycle
+     ;; Mutual recursion over CYCLIC data. The compiled planner's semi-naive
+     ;; fixpoint dedups per rule and converges; the reference engine's rule
+     ;; solver does not terminate at all here, so it is asserted only on the
+     ;; planner and run on a bounded thread.
+     ;;
+     ;; Found by widening the differential generator's dataset axis: its one
+     ;; dataset was acyclic on :friend, so every mutual-recursion case
+     ;; terminated and this was invisible. It matters because the reference
+     ;; engine is both the differential oracle and the permanent fallback for
+     ;; shapes the planner declines — a user on DATAHIKE_QUERY_PLANNER=false
+     ;; hangs rather than gets a wrong answer.
+     (let [db (d/db-with (db/empty-db {:friend {:db/valueType :db.type/ref
+                                                :db/cardinality :db.cardinality/one}})
+                         [{:db/id 100 :friend 101}
+                          {:db/id 101 :friend 102}
+                          {:db/id 102 :friend 100}])
+           rules '[[(ehop ?a ?b) [?a :friend ?b]]
+                   [(ehop ?a ?b) [?a :friend ?x] (ohop ?x ?b)]
+                   [(ohop ?a ?b) [?a :friend ?x] (ehop ?x ?b)]]
+           run (fn [q] (let [f (future (set (d/q q db rules)))
+                             r (deref f 15000 ::timeout)]
+                         (when (= r ::timeout) (future-cancel f))
+                         r))]
+       ;; every pair is reachable in a 3-cycle
+       (is (= #{[100 100] [100 101] [100 102]
+                [101 100] [101 101] [101 102]
+                [102 100] [102 101] [102 102]}
+              (run '[:find ?a ?b :in $ % :where (ehop ?a ?b)]))
+           "planner terminates on mutual recursion over a cycle")
+       (is (= #{100 101 102}
+              (run '[:find [?b ...] :in $ % :where (ehop 100 ?b)]))
+           "…and with a ground argument"))))

--- a/test/datahike/test/query_rules_test.cljc
+++ b/test/datahike/test/query_rules_test.cljc
@@ -5,6 +5,7 @@
    [clojure.core.async :refer [<!]]
    [datahike.api :as d]
    [datahike.db :as db]
+   [datahike.query :as dq]
    [datahike.test.utils :as du]
    [datahike.test.async #?(:clj :refer :cljs :refer-macros) [deftest-async]]))
 
@@ -497,7 +498,11 @@
            rules '[[(ehop ?a ?b) [?a :friend ?b]]
                    [(ehop ?a ?b) [?a :friend ?x] (ohop ?x ?b)]
                    [(ohop ?a ?b) [?a :friend ?x] (ehop ?x ?b)]]
-           run (fn [q] (let [f (future (set (d/q q db rules)))
+           ;; Pin the engine: the base-engine CI job sets
+           ;; DATAHIKE_QUERY_PLANNER=false, which would otherwise run these on
+           ;; the very engine that does not terminate here.
+           run (fn [q] (let [f (future (binding [dq/*disable-planner* false]
+                                         (set (d/q q db rules))))
                              r (deref f 15000 ::timeout)]
                          (when (= r ::timeout) (future-cancel f))
                          r))]
@@ -530,7 +535,11 @@
                          [{:db/id 1 :friend 2} {:db/id 2 :friend 3} {:db/id 3}])
            rules '[[(rr ?a ?b) [?a :friend ?b]]
                    [(rr ?a ?b) (rr ?a ?x) [?x :friend ?b]]]
-           run (fn [q] (let [f (future (set (d/q q db rules)))
+           ;; Pin the engine: the base-engine CI job sets
+           ;; DATAHIKE_QUERY_PLANNER=false, which would otherwise run these on
+           ;; the very engine that does not terminate here.
+           run (fn [q] (let [f (future (binding [dq/*disable-planner* false]
+                                         (set (d/q q db rules))))
                              r (deref f 15000 ::timeout)]
                          (when (= r ::timeout) (future-cancel f))
                          r))]

--- a/test/datahike/test/secondary_integration_test.clj
+++ b/test/datahike/test/secondary_integration_test.clj
@@ -622,3 +622,54 @@
         ;; being the wrong answer, so pin the type too
         (is (= (double? reference) (double? columnar))
             (str label " — same numeric type on both paths"))))))
+
+(deftest test-stratum-aggregate-eligibility-gates
+  (testing "the columnar path declines what it cannot compute to the contract"
+    ;; Two entry points reach the columnar aggregate and they did not share
+    ;; guards: the fused one (execute-columnar-aggregate) checks arity and column
+    ;; type, while the secondary-index one (try-secondary-index-aggregate)
+    ;; checked neither, so it answered a different function than the query asked
+    ;; for. Both gates now live on both paths.
+    (let [mk (fn [vals]
+               (let [schema {:num/v {}
+                             :idx/analytics {:db.secondary/type :stratum
+                                             :db.secondary/attrs [:num/v]}}
+                     e (db/empty-db schema)
+                     idx (sec/create-index :stratum {:attrs #{:num/v}} e)]
+                 (-> (assoc e :secondary-indices {:idx/analytics idx})
+                     (d/db-with (vec (map-indexed (fn [i v] {:db/id (inc i) :num/v v}) vals))))))
+          agree? (fn [db query]
+                   ;; the cache must be off, or the second call is a hit that
+                   ;; returns the first engine's answer
+                   (binding [q/*query-result-cache?* false]
+                     (let [c (binding [q/*disable-planner* false] (d/q query db))
+                           r (binding [q/*disable-planner* true] (d/q query db))]
+                       [(= c r) c r])))]
+
+      (testing "an aggregate with a count argument is a different function"
+        ;; `(min 2 ?x)` returns the two smallest as a COLLECTION. Only the last
+        ;; argument was read, so the count was dropped and a scalar returned.
+        (doseq [q ['[:find (min 2 ?x) :where [?e :num/v ?x]]
+                   '[:find (max 2 ?x) :where [?e :num/v ?x]]]]
+          (let [[ok? c r] (agree? (mk [10 15 20 35 75]) q)]
+            (is ok? (str q " — columnar " (pr-str c) " vs reference " (pr-str r))))))
+
+      (testing "an aggregate applies to the DEDUPLICATED find projection"
+        ;; A Datalog aggregate applies to the answer set. Aggregating inside the
+        ;; index counts a repeated value once per datom, so `(count ?x)` over
+        ;; 10,10,40 answered 3 where the projection has two members.
+        (doseq [q ['[:find (count ?x) :where [?e :num/v ?x]]
+                   '[:find (sum ?x) :where [?e :num/v ?x]]
+                   '[:find (avg ?x) :where [?e :num/v ?x]]
+                   '[:find (variance ?x) :where [?e :num/v ?x]]
+                   '[:find (median ?x) :where [?e :num/v ?x]]]]
+          (let [[ok? c r] (agree? (mk [10 10 40]) q)]
+            (is ok? (str q " over duplicates — columnar " (pr-str c)
+                         " vs reference " (pr-str r))))))
+
+      (testing "duplicate-insensitive aggregates keep the fast path"
+        (doseq [q ['[:find (min ?x) :where [?e :num/v ?x]]
+                   '[:find (max ?x) :where [?e :num/v ?x]]
+                   '[:find (count-distinct ?x) :where [?e :num/v ?x]]]]
+          (let [[ok? c r] (agree? (mk [10 10 40]) q)]
+            (is ok? (str q " — columnar " (pr-str c) " vs reference " (pr-str r)))))))))


### PR DESCRIPTION
Follow-up to #908. The differential test varied **query shape** across ~20 dimensions and 3000 cases — which is why plain query-shape bugs did not slip through — but held four things constant, and every bug that *did* slip through sat on one of them:

| Axis | Was | Bugs that hid there |
|---|---|---|
| **data** | one tidy 6-entity dataset, well-typed, no duplicate values | columnar dedup, column typing, truncation |
| **fast path** | no secondary index was ever present | the whole columnar family |
| **rule shape** | five hardcoded rule sets, all left-linear closures of the relation their base case walks | recursion-that-changes-edge, filtered traversal, right-recursion |
| **aggregate** | only `count` and `min` — the two type-preserving ones | population variance, median type, min/max arity |

This lands three of the four axes (data, aggregate, rule shape). `:dataset` is now a generator dimension over tidy / duplicate-heavy / loose (`:schema-flexibility :read`, so one attribute holds Long, Double and String at once). Secondary-index presence is left for a follow-up — see *Known gaps*.

## Bugs it found

**`(min N ?x)` / `(max N ?x)` returned the wrong shape.** These return the N smallest/largest as a **collection** — a different function from their scalar namesakes. The fused columnar path read only the aggregate's *last* argument and silently dropped the leading count, answering `10` where the contract is `[10]`; the secondary-index path built its compatibility check from the aggregate's *name* alone, so the count was invisible there too. Found 30 times in the first 400-case run. Both paths now decline a count-argument aggregate and fall through to the relation path, which implements both.

**An aggregate column was typed by sampling row 0.** A column holding `10` then `2.5` was typed `long[]` and every Double truncated — `(sum ?x)` answered `12` instead of `12.5`, and *swapping the two rows made the same query correct*. `type-safe?` could not catch it, because it validates the array produced by the very inference that is unsound. This needs **no secondary index**, so it reached ordinary planner queries. A column now qualifies for a primitive array only when every value has the same type; anything mixed becomes `Object[]`, which the existing gate already refuses. It deliberately does *not* merely widen a mixed Long/Double column, because the same extraction feeds **group keys** and widening answered the group `10` as `10.0`.

**An aggregate must apply to the deduplicated find projection.** The secondary-index path aggregates inside the index and so counted a repeated value once per datom: `(count ?x)` over `10, 10, 40` answered 3 where the projection has two members; `sum` 60 against 50, `avg` 20.0 against 25.0, likewise variance and median. It now claims an aggregate only when the aggregate is insensitive to duplicates (`min`/`max`/`count-distinct`) or `:find` carries an entity var.

## Two reference-engine non-terminations, pinned but not fixed

Both were found by the new axes, and both are asserted on the planner only, on a bounded thread:

- **mutual recursion over a cyclic graph** — the tidy dataset was acyclic, so this was invisible;
- **a rule whose body leads with the recursive call** (right-linear TC) — on a **three-entity acyclic** graph, so neither cycles nor size.

Neither is generated: the reference engine cannot serve as the oracle for a shape it cannot evaluate, and a generator must not contain a combination known to hang. That also motivated a per-case timeout in the harness — these cases are six entities wide, so anything slow is stuck, and a hang should be reported as a divergence rather than wedge CI.

These matter beyond the oracle: that engine is the permanent fallback for shapes the planner declines, so `DATAHIKE_QUERY_PLANNER=false` hangs rather than answering.

## Known gaps (deliberate, documented at the call sites)

- **Secondary-index presence** is still not a generator axis. Turning it on needs a column-type gate for the secondary-index path, which never materializes its columns and so has nothing to test. Gating on a declared `:db/valueType` does **not** substitute — `empty-db`'s schema shorthand rejects one, so that disables the fast path for most real usage rather than for the unsafe cases.
- Stratum aggregates a dictionary-encoded string column over its **codes**, and the dictionary is insertion-ordered, so `min` over `"b","a","c"` is wrong even after decoding. That is upstream of datahike.
- The stratum adapter truncates a Double to Long at *storage* time when the attribute's column is seeded empty.

## Verification

- Differential: **3000 cases × 3 datasets, 9003 assertions, 0 failures**
- Full suite: **2512 tests, 21259 assertions, 0 failures**
- `bb format` clean