### PR TITLE
fix(tuples): derive and validate composite tuples under :attribute-refs?

### DIFF
--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -548,13 +548,18 @@
          report' (-> report
                      (update-in [:db-after] update-fn datom)
                      (update-in [:tx-data] conj datom))]
-     (if (dbu/tuple-source? db a)
-       (let [e      (:e datom)
-             v      (if (datom-added datom) (:v datom) nil)
-             queue  (or (-> report' ::queued-tuples (get e)) {})
-             tuples (get (dbi/-attrs-by db :db/attrTuples) a)
-             queue' (queue-tuples queue tuples db e v)]
-         (update report' ::queued-tuples assoc e queue'))
+     ;; ONE resolving lookup, not a resolving predicate plus a raw lookup.
+     ;; `tuple-source?` resolved `a` ref→ident and answered yes; the `get` that
+     ;; followed did not, so under `:attribute-refs?` (where `a` is a numeric
+     ;; ref and `:db/attrTuples` is ident-keyed) it found nil and `queue-tuples`
+     ;; reduced over nothing — composite tuples were silently never derived,
+     ;; and with them uniqueness on the composite silently unenforced. Asking
+     ;; once for the value cannot disagree with itself.
+     (if-let [tuples (dbu/attr-props db a :db/attrTuples)]
+       (let [e     (:e datom)
+             v     (if (datom-added datom) (:v datom) nil)
+             queue (or (-> report' ::queued-tuples (get e)) {})]
+         (update report' ::queued-tuples assoc e (queue-tuples queue tuples db e v)))
        report'))))
 
 (defn- check-upsert-conflict [entity acc]
@@ -1018,7 +1023,16 @@
 
 (defn check-tuple [db op-vec]
   (let [[op _ a v] op-vec
-        attr-schema (-> db dbi/-schema (get a))]
+        ;; By IDENT. `schema` is dual-keyed under `:attribute-refs?`, but the ref
+        ;; key holds a POINTER — `update-schema` stores `[:schema e] → v-ident` —
+        ;; so a raw numeric `a` returned a keyword here, every branch below was
+        ;; false, and tuple validation silently did nothing: a composite could be
+        ;; written by hand past the guard at the bottom, and an arity- or
+        ;; type-invalid heterogeneous tuple was accepted. Resolving first is also
+        ;; why `attr-schema` must be a MAP; anything else means the lookup missed.
+        a-ident (dbu/attr-ident db a)
+        attr-schema (let [s (-> db dbi/-schema (get a-ident))]
+                      (when (map? s) s))]
     (cond (:db/tupleType attr-schema)
           (cond (> (count v) 8)
                 (log/raise "Cannot store more than 8 values for homogeneous tuple: " op-vec
@@ -1028,7 +1042,9 @@
                 (log/raise "Cannot store homogeneous tuple with values of different type: " op-vec
                            {:error :transact/syntax, :tx-data op-vec})
 
-                (not (s/valid? (-> db dbi/-schema a :db/tupleType) (first v)))
+                ;; `attr-schema` already IS this lookup; the re-fetch used the raw
+                ;; `a` AS A FUNCTION, which throws outright on a numeric ref.
+                (not (s/valid? (:db/tupleType attr-schema) (first v)))
                 (log/raise "Cannot store homogeneous tuple. Values are of wrong type: " op-vec
                            {:error :transact/syntax, :tx-data op-vec}))
           (:db/tupleTypes attr-schema)

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -13,13 +13,31 @@
   #?(:cljs (:require-macros [datahike.datom :refer [datom]]))
   #?(:clj (:import [datahike.datom Datom])))
 
+(defn attr-ident
+  "`attr` as an IDENT. Under `:attribute-refs?` a datom's `a` is a numeric ref,
+   while `rschema` and `schema` are keyed by ident — so anything looking an
+   attribute up in either has to resolve first."
+  [db attr]
+  (if (and (:attribute-refs? (dbi/-config db))
+           (number? attr))
+    (dbi/ident-for db attr :error-on-missing)
+    attr))
+
 (defn #?@(:clj [^Boolean is-attr?]
           :cljs [^boolean is-attr?]) [db attr property]
-  (let [a-ident (if (and (:attribute-refs? (dbi/-config db))
-                         (number? attr))
-                  (dbi/ident-for db attr :error-on-missing)
-                  attr)]
-    (contains? (dbi/-attrs-by db property) a-ident)))
+  (contains? (dbi/-attrs-by db property) (attr-ident db attr)))
+
+(defn attr-props
+  "Value of `rschema` `property` for `attr` — the MAP-valued counterpart of
+   `is-attr?`, which only answers whether an entry exists.
+
+   The pair matters: without this, a caller needing the value hand-rolls
+   `(get (dbi/-attrs-by db property) attr)` and silently loses the ident
+   resolution `is-attr?` does. That is exactly how composite `:db/tupleAttrs`
+   came to be dropped under `:attribute-refs?` — the guard resolved and said
+   yes, then the lookup did not and found nothing."
+  [db attr property]
+  (get (dbi/-attrs-by db property) (attr-ident db attr)))
 
 (defn #?@(:clj [^Boolean multival?]
           :cljs [^boolean multival?]) [db attr]

--- a/test/datahike/test/attribute_refs/tuples_test.cljc
+++ b/test/datahike/test/attribute_refs/tuples_test.cljc
@@ -1,0 +1,148 @@
+(ns datahike.test.attribute-refs.tuples-test
+  "Composite `:db/tupleAttrs` and tuple validation under `:attribute-refs?`.
+
+   DIFFERENTIAL by construction: every test runs the same schema and the same
+   data through both modes and asserts they agree. That shape is deliberate —
+   the bug these pin was not a wrong answer but a MISSING one, and only a
+   comparison against the default mode makes an absence visible. Each assertion
+   below passed with `:attribute-refs? false` and failed with it true.
+
+   Root cause, common to both halves: a datom's `a` is a numeric ref in this
+   mode, while `rschema` and `schema` are keyed by ident. Code that resolved
+   before looking up was correct; code that did not silently found nothing.
+   `datahike.test.tuples-test` covers the same ground in default mode only,
+   which is why this went unnoticed."
+  (:require
+   #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
+      :clj  [clojure.test :as t :refer        [is deftest testing]])
+   [datahike.api :as d]))
+
+#?(:cljs (def Throwable js/Error))
+
+(def composite-schema
+  [{:db/ident :t/a :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :t/b :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :t/ab :db/valueType :db.type/tuple
+    :db/tupleAttrs [:t/a :t/b]
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}])
+
+(def hetero-schema
+  [{:db/ident :t/ht :db/valueType :db.type/tuple
+    :db/tupleTypes [:db.type/keyword :db.type/keyword]
+    :db/cardinality :db.cardinality/one}])
+
+(defn- conn-with [schema attribute-refs?]
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write
+             :keep-history? false
+             :attribute-refs? attribute-refs?}]
+    (d/create-database cfg)
+    (doto (d/connect cfg) (d/transact schema))))
+
+(defn- both-modes
+  "`(f conn)` under both modes, as `{false … true …}`, so a test can simply
+   assert the two agree."
+  [schema f]
+  (into {} (for [refs? [false true]]
+             [refs? (f (conn-with schema refs?))])))
+
+(defn- attr-ref
+  "The numeric entity id of an attribute — Datahike has no `entid`, and the ref
+   IS what a datom's `a` looks like in this mode, so the tests need it to write
+   the form that used to slip past validation."
+  [db attr]
+  (:db/id (d/entity db attr)))
+
+(defn- eid-of-x
+  "The entity carrying `:t/a :x`, resolved by QUERY rather than from `:tempids`
+   — the tempid map is keyed by the tempid, and a wrong extraction there yields
+   nil, which reads as a missing composite and would frame a passing fix as
+   broken."
+  [db]
+  (d/q '[:find ?e . :where [?e :t/a :x]] db))
+
+(defn- composite-of [db e]
+  ;; by ident: `:components` accepts either representation, so one call works
+  ;; in both modes
+  (:v (first (d/datoms db {:index :eavt :components [e :t/ab]}))))
+
+;; ---------------------------------------------------------------------------
+
+(deftest composite-tuples-are-derived
+  (let [r (both-modes composite-schema
+                      (fn [conn]
+                        (d/transact conn [{:t/a :x :t/b :y}])
+                        (let [db (d/db conn)]
+                          {:composite (composite-of db (eid-of-x db))
+                           :in-avet (count (d/datoms (d/db conn)
+                                                     {:index :avet :components [:t/ab]}))})))]
+    (is (= (get r false) (get r true))
+        "the whole point: attribute-refs must derive what the default mode derives")
+    (is (= [:x :y] (:composite (get r true)))
+        "the composite datom was never written at all in this mode")
+    (is (= 1 (:in-avet (get r true)))
+        "and so nothing was indexed for it, which is what a lookup ref needs")))
+
+(deftest a-derived-composite-is-addressable-as-a-lookup-ref
+  (let [r (both-modes composite-schema
+                      (fn [conn]
+                        (d/transact conn [{:t/a :x :t/b :y}])
+                        (try (some? (d/pull (d/db conn) '[*] [:t/ab [:x :y]]))
+                             (catch Throwable _ :unresolvable))))]
+    (is (= (get r false) (get r true)))
+    (is (true? (get r true)))))
+
+(deftest uniqueness-on-a-composite-is-enforced
+  ;; The half that loses data rather than merely omitting it: with no composite
+  ;; datom there is nothing for :db.unique/identity to match, so a second write
+  ;; of the same component values made a SECOND entity instead of upserting.
+  (let [r (both-modes composite-schema
+                      (fn [conn]
+                        (d/transact conn [{:t/a :x :t/b :y}])
+                        (d/transact conn [{:t/a :x :t/b :y}])
+                        (count (d/q '[:find ?e :where [?e :t/a :x]] (d/db conn)))))]
+    (is (= (get r false) (get r true)))
+    (is (= 1 (get r true))
+        "two entities here means the uniqueness constraint was never applied")))
+
+(deftest retracting_a_component_updates_the_composite
+  (let [r (both-modes composite-schema
+                      (fn [conn]
+                        (d/transact conn [{:t/a :x :t/b :y}])
+                        (let [e (eid-of-x (d/db conn))]
+                          (d/transact conn [[:db/retract e :t/b :y]])
+                          (composite-of (d/db conn) e))))]
+    (is (= (get r false) (get r true)))
+    (is (= [:x nil] (get r true))
+        "the composite has to track its components in both directions")))
+
+(deftest a-composite-cannot-be-written-by-hand
+  ;; Guarded by `check-tuple`, which resolved nothing and so guarded nothing:
+  ;; addressing the attribute by its numeric ref walked straight past it.
+  (doseq [refs? [false true]]
+    (testing (str ":attribute-refs? " refs?)
+      (let [conn (conn-with composite-schema refs?)
+            db (d/db conn)
+            _ (d/transact conn [{:t/a :x :t/b :y}])
+            e (eid-of-x (d/db conn))]
+        (is (thrown-with-msg? Throwable #"Can.t modify tuple attrs directly"
+                              (d/transact conn [[:db/add e :t/ab [:p :q]]]))
+            "by ident")
+        (when refs?
+          (is (thrown-with-msg? Throwable #"Can.t modify tuple attrs directly"
+                                (d/transact conn [[:db/add e (attr-ref db :t/ab) [:p :q]]]))
+              "and by numeric ref — the form that used to be accepted"))))))
+
+(deftest heterogeneous-tuple-arity-is-validated
+  (doseq [refs? [false true]]
+    (testing (str ":attribute-refs? " refs?)
+      (let [conn (conn-with hetero-schema refs?)
+            db (d/db conn)]
+        (is (thrown-with-msg? Throwable #"Cannot store heterogeneous tuple"
+                              (d/transact conn [{:t/ht [:only-one]}]))
+            "too few values, addressed by ident in an entity map")
+        (when refs?
+          (is (thrown-with-msg? Throwable #"Cannot store heterogeneous tuple"
+                                (d/transact conn [[:db/add -1 (attr-ref db :t/ht) [:a :b :c :d]]]))
+              "too many values, addressed by numeric ref"))))))


### PR DESCRIPTION
## What's broken

With `:attribute-refs? true`, a datom's `a` is a numeric ref while `rschema` and `schema` are keyed by ident. Two places look an attribute up in one of those maps **without resolving first**, and both fail silently.

Identical schema and data, one config flag apart:

```clojure
{:attribute-refs? false → composite datom [[:x :y]] present, :avet count 1}
{:attribute-refs? true  → no composite datom at all,          :avet count 0}
```

### 1. `transact-report` never derives composite `:db/tupleAttrs`

`tuple-source?` resolves internally and answers **yes**; the `get` on `:db/attrTuples` that follows uses the raw `a`, finds `nil`, and `queue-tuples` reduces over nothing. So the guard says "derive" and the derivation quietly does nothing.

Consequences beyond the missing datom:

- nothing is indexed for it, so `(d/pull db '[*] [:t/ab [:x :y]])` cannot resolve
- **`:db.unique/identity` on the composite is silently unenforced** — re-transacting the same component values creates a *second* entity instead of upserting

All four `transact-report` call sites are affected, including the datom-import loop (`:1487`, `:1513`), so bulk loads drop composites too.

### 2. `check-tuple` skips every tuple check

`schema` *is* dual-keyed in this mode, but the ref key holds a **pointer** — `update-schema` stores `[:schema e] → v-ident` — so a raw numeric `a` returns a *keyword* where a map is expected, every `cond` branch is false, and validation does nothing. Measured:

- a composite written by hand walks straight past "Can't modify tuple attrs directly"
- a 2-slot `:db/tupleTypes` accepts 4 values
- a 2-slot `:db/tupleTypes` accepts 1 value via an entity map (raises correctly with refs off)

One inner re-fetch also used `a` **as a function**, which throws outright on a number.

## The fix

Follow the convention already codified in `is-attr?` (`db/utils.cljc:16-22`): resolve ref→ident, *then* consult rschema.

- `dbu/attr-ident` — names that resolution
- `dbu/attr-props` — the **map-valued counterpart** to `is-attr?`'s boolean

The missing counterpart is why the call site hand-rolled the lookup wrong. With it there is only one lookup, so the guard and the value can no longer disagree — the failure mode becomes structurally unrepresentable rather than merely fixed.

## Performance

Not a slowdown — the old code paid the resolution *inside* `tuple-source?` and then a redundant raw `get`. Min-of-5 over 2M iterations, in-memory store:

| | before | after |
|---|---|---|
| refs on, attr is a tuple source | 135.5 ns | **84.3 ns** |
| refs off | 51.2 ns | **44.5 ns** |

Absolutes ±15%, ordering repeatable. At ~44 µs/datom end-to-end this is noise either way; measured only because it is a per-datom path.

## Tests

`test/datahike/test/attribute_refs/tuples_test.cljc` is **differential by construction** — same schema, same data, one flag apart, asserting the modes agree. The bug was a *missing* datom rather than a wrong one, and only comparison against the default mode makes an absence visible.

**12 of the 15 new assertions fail without this change.**

Why it was never caught: `datahike.test.tuples-test` (13 deftests, 564 lines) never sets `:attribute-refs? true`, and `test/datahike/test/attribute_refs/` had no composite `:db/tupleAttrs` test at all.

Suite: **1733 / 851 / 16** tests across the three phases, **0 failures**. (`bb test` exits 1 in my environment for missing native-image binaries — `bb ni-cli` / `ni-compile` — unrelated.)

## Follow-ups, deliberately not bundled

- `dbi/-ref-for` returning `nil` plus a log warning is the generic silent-failure generator behind this class.
- `rschema` is serialized and restored verbatim rather than recomputed in `stored->db`, so a stale or buggy stored copy survives a reconnect. (This is also why fixing the *keying* instead of the *lookup* would not have repaired existing databases.)
- Existing databases keep the composite datoms they already failed to write; a repair pass is separate.

## Provenance

Found while getting [EACL](https://github.com/theronic/eacl) (ReBAC authorization, Datomic-backed) running on Datahike. EACL v7's engine traverses relationship indices directly and its schema is built on composite tuple attributes; `:attribute-refs?` is the mode that makes a datom's `a` match Datomic's representation, so it is the natural compatibility mode — and this bug made it unusable.