### PR TITLE
feat(migrate): robust, type-exact, verifiable, streaming export/import (rebased from @alekcz)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -88,6 +88,9 @@
                                org.replikativ/kabel          {:mvn/version "0.3.100"}
                                is.simm/distributed-scope     {:mvn/version "0.1.6"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.35"}
+
+                               ;; S3-compatible store integration test (migrate-s3-test, needs docker; runs Garage)
+                               org.replikativ/konserve-s3    {:mvn/version "0.1.35"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}

--- a/dev/migrate_scale.clj
+++ b/dev/migrate_scale.clj
@@ -1,0 +1,81 @@
+(ns migrate-scale
+  "Manual scale harness for datahike.migrate: build a file-backed database larger
+   than the JVM heap, then export and re-import it under that same capped heap to
+   demonstrate that export/import memory is bounded by the buffers, not the db size.
+
+   Run with a small heap so the target is reachable quickly, e.g.:
+
+     clojure -J-Xmx140m -M:dev -e \"(load-file \\\"dev/migrate_scale.clj\\\") (migrate-scale/run)\"
+
+   `run` grows the db until the (estimated) EDN dump is at least `:heap-multiple`x
+   the max heap (default 2x), exports (chunked), and imports into a fresh store —
+   printing sizes and timings. NOT a unit test; it writes GBs to /tmp."
+  (:require [datahike.api :as d]
+            [datahike.migrate :as m]
+            [clojure.java.io :as io]))
+
+(defn dir-size ^long [path]
+  (->> (file-seq (io/file path)) (filter #(.isFile ^java.io.File %))
+       (map #(.length ^java.io.File %)) (reduce + 0)))
+
+(defn- mb [b] (quot (long b) 1048576))
+
+(defn run
+  "Options:
+     :heap-multiple  2      dump must be >= this many x the max heap
+     :value-chars    1000   size of the padding string per entity (bigger = fewer
+                            datoms to reach the target = faster build)
+     :store-cache    32     :store-cache-size (small: the node cache is count-bounded)
+     :sort-buffer    5000   export run size
+     :chunk-size     25000  datoms per chunk file
+     :batch-size     10000  import batch"
+  ([] (run {}))
+  ([{:keys [heap-multiple value-chars store-cache sort-buffer chunk-size batch-size]
+     :or   {heap-multiple 2 value-chars 1000 store-cache 32
+            sort-buffer 5000 chunk-size 25000 batch-size 10000}}]
+   (let [maxheap (.maxMemory (Runtime/getRuntime))
+         target  (* heap-multiple maxheap)
+         stamp   (System/currentTimeMillis)
+         src-path (str "/tmp/dh-scale-src-" stamp)
+         cfg {:store {:backend :file :path src-path :id (java.util.UUID/randomUUID)}
+              :keep-history? true :schema-flexibility :write :attribute-refs? false
+              :store-cache-size store-cache :search-cache-size 0}
+         pad (apply str (repeat value-chars \x))
+         per-entity-bytes (+ value-chars 95)
+         need (long (/ target per-entity-bytes))
+         gen-batch 5000]
+     (println (format "heap max = %d MB ; target DUMP >= %d MB (%dx heap)"
+                      (mb maxheap) (mb target) heap-multiple))
+     (d/create-database cfg)
+     (let [conn (d/connect cfg)]
+       (d/transact conn [{:db/ident :k :db/valueType :db.type/long :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                         {:db/ident :s :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+       (println "building file-backed db ...")
+       (loop [i 0]
+         (when (< i need)
+           (when (zero? (mod i 50000))
+             (println (format "  %d / %d entities (store %d MB)" i need (mb (dir-size src-path)))))
+           (d/transact conn (mapv (fn [j] {:k (+ i j) :s (str pad "-" (+ i j))}) (range gen-batch)))
+           (recur (+ i gen-batch))))
+       (println (format "BUILT: %d MB store (%.1fx heap)"
+                        (mb (dir-size src-path)) (double (/ (dir-size src-path) maxheap))))
+       (let [dump (str "/tmp/dh-scale-dump-" stamp)
+             t0  (System/currentTimeMillis)
+             man (m/export-db conn dump {:format :chunked :history? true
+                                         :sort-buffer sort-buffer :chunk-size chunk-size})
+             t1  (System/currentTimeMillis)]
+         (println (format "EXPORT: %d datoms, %d chunks, DUMP = %d MB (%.2fx heap), %.1fs"
+                          (:count (:semantic-digest man)) (count (:chunks man))
+                          (mb (dir-size dump)) (double (/ (dir-size dump) maxheap))
+                          (/ (- t1 t0) 1000.0)))
+         (let [tcfg (-> cfg
+                        (assoc-in [:store :path] (str dump "-tgt"))
+                        (assoc-in [:store :id] (java.util.UUID/randomUUID)))]
+           (d/create-database tcfg)
+           (let [tconn (d/connect tcfg)
+                 t2  (System/currentTimeMillis)
+                 rep (m/import-db tconn dump {:batch-size batch-size})
+                 t3  (System/currentTimeMillis)]
+             (println (format "IMPORT: %.1fs %s" (/ (- t3 t2) 1000.0) (pr-str (dissoc rep :errors))))
+             (d/release conn) (d/release tconn)
+             (assoc rep :dump-mb (mb (dir-size dump)) :store-mb (mb (dir-size src-path))))))))))

--- a/doc/backup.md
+++ b/doc/backup.md
@@ -1,0 +1,294 @@
+# Backup & restore
+
+`datahike.migrate/export-db` and `import-db` write and read a portable, type-exact
+dump of a database. Use them for backups, moving a database between stores, or
+snapshotting before a risky change. For the format details and rationale see
+[import-export-design.md](import-export-design.md).
+
+## Flow
+
+The diagram renders on GitHub / cljdoc; the ASCII version below it reads anywhere
+(terminals, plain-text viewers).
+
+```mermaid
+flowchart TD
+  subgraph BACKUP["Backup — export-db(conn, target, opts)"]
+    E0["@conn → immutable db value"]
+    E1{":history?"}
+    E2["src = history db<br/>asserts + retracts + tx entities"]
+    E3["src = current db"]
+    E4{":sort?"}
+    E5["sorted (default): stream :eavt, encode by class,<br/>spill runs to /tmp, k-way merge<br/>(bounded memory, needs scratch)"]
+    E6["no-scratch (:sort? false): two :eavt passes —<br/>schema+tx-entity, then data<br/>(zero temp files, diskless)"]
+    E7["stream lines → chunks<br/>per-chunk SHA-256 + semantic digest"]
+    E8{"target"}
+    E9["filesystem<br/>datoms-NNNNNN.edn"]
+    E10["konserve store: chunk keys<br/>S3 / R2 / MinIO / JDBC / mem"]
+    E11(["manifest written LAST = commit marker"])
+    E0-->E1
+    E1-- true -->E2
+    E1-- false -->E3
+    E2-->E4
+    E3-->E4
+    E4-- "true" -->E5
+    E4-- "false" -->E6
+    E5-->E7
+    E6-->E7
+    E7-->E8
+    E8-- path -->E9
+    E8-- store -->E10
+    E9-->E11
+    E10-->E11
+  end
+
+  subgraph RESTORE["Restore — import-db(fresh-conn, source, opts)"]
+    I0["estimate-import-memory → recommended -Xmx"]
+    I1["open medium (filesystem OR store)"]
+    I2["read manifest + heap preflight"]
+    I3{"guards"}
+    I4["✗ import/format-version · config-mismatch ·<br/>non-empty-target · checksum-failed"]
+    I5{":attribute-refs?"}
+    I6["seed :migration system identity<br/>(#508 translate, not insert)"]
+    I7["stream lines → resolve #sysref →<br/>tx-aligned batcher"]
+    I8["@load-entities(batch)<br/>remap e/tx ids; id-map O(entities)"]
+    I9{":verify?"}
+    I10["✗ import/verify-failed"]
+    I11{":finalize?"}
+    I12["drop :migration id-map"]
+    I13(["report: datom-count, verified?, finalized?, ..."])
+    I0-->I1-->I2-->I3
+    I3-- fail -->I4
+    I3-- ok -->I5
+    I5-- yes -->I6-->I7
+    I5-- no -->I7
+    I7-->I8
+    I8-- "more batches" -->I7
+    I8-- done -->I9
+    I9-- ok -->I11
+    I9-- mismatch -->I10
+    I11-- true -->I12-->I13
+    I11-- false -->I13
+  end
+
+  E11 -. "dump on disk or in store" .-> I0
+```
+
+```
+╔══════════════════════════ BACKUP (export-db) ══════════════════════════╗
+  export-db(conn, TARGET, opts)
+        │
+  @conn ─► immutable db value          (consistent snapshot)
+        │
+  :history? ── true ─► src = history db (asserts + retracts + tx entities)
+        └── false ─► src = current db
+        │
+  ┌───────────────── choose ORDER (opts :sort?) ──────────────────┐
+  │  :sort? true (default)          :sort? false (no-scratch)     │
+  │  needs writable scratch         zero temp files               │
+  │        │                              │                       │
+  │  stream (datoms :eavt)          two lazy :eavt passes:        │
+  │  encode by CLASS (#633)          pass1 schema + tx-entity     │
+  │  spill runs → /tmp               pass2 data                   │
+  │  k-way merge (bounded)           (schema-before-data)         │
+  │  → t-ordered lines               → :eavt-ordered lines        │
+  │        └──────────────┬───────────────┘                       │
+  └───────────────────────┼───────────────────────────────────────┘
+                          ▼
+      stream lines → chunks, incremental per-chunk SHA-256 + digest
+                          │
+        ┌─────────────────┴──────────── choose TARGET ─────────────┐
+        ▼                                                          ▼
+   FILESYSTEM (path/dir)                       KONSERVE STORE {:store}/{:backend :s3}
+    datoms-000001.edn (tmp→rename)              key [.. prefix "datoms-000001"]
+    ...                                         ...  (S3 / R2 / MinIO / JDBC / mem)
+        │                                             │
+        ▼                                             ▼
+   manifest.edn written LAST ◄─ commit marker ─► manifest key written LAST
+   (stats+max-eid/max-tx, config, digest, chunk index+sha)
+        │
+        ▼
+   BACKUP COMPLETE   (no manifest = incomplete dump, by definition)
+╚═════════════════════════════════════════════════════════════════════════╝
+                          │
+                   dump (disk or store)
+                          │
+╔══════════════════════════ RESTORE (import-db) ═════════════════════════╗
+                          ▼
+  estimate-import-memory(SOURCE) ─► reads manifest only (no scan)
+        │                           {:entities :recommended-heap :sufficient?}
+        ▼   size -Xmx accordingly
+  import-db(fresh-conn, SOURCE, opts)
+        │
+  open medium (filesystem OR konserve store)  ── same code path
+        │
+  read manifest ; heap preflight warning if -Xmx looks too small
+        │
+  GUARDS (before touching the db):
+     format-version? · config-compat? · target-empty? · per-chunk SHA-256?
+        │  fail ─► throw :import/{format-version,config-mismatch,
+        │                         non-empty-target,checksum-failed}
+        ▼ ok
+  attribute-refs? ─ yes ─► seed :migration system identity  (#508 translate)
+        │
+        ▼
+  STREAM record lines  (fs: scoped readers │ store: whole-chunk values)
+        │   resolve #datahike/sysref → target system eid
+        ▼
+  tx-aligned batcher ─► @(load-entities conn batch)   remap e/tx ids; max-tx
+        │   ▲   (tx never split; a tx spanning chunks stays whole)
+        │   └── next batch      id-remap map O(entities), held until finalize
+        ▼ done
+  :verify?  ─► dump count == live count   else ► throw :import/verify-failed
+        │
+        ▼
+  :finalize? ─► drop :migration id-map (frees O(entities))
+        │
+        ▼
+  REPORT {:datom-count :tx-count :max-tx :verified? :finalized?
+          :recommended-heap :errors}
+╚═════════════════════════════════════════════════════════════════════════╝
+```
+
+## Export
+
+```clojure
+(require '[datahike.migrate :as m])
+
+;; snapshot of the current value (no history)
+(m/export-db conn "/backups/mydb")
+
+;; full history — every assertion, retraction, and tx entity
+(m/export-db conn "/backups/mydb" {:history? true})
+```
+
+A directory target writes the **chunked** format (`manifest.edn` +
+`datoms-NNNNNN.edn`); a plain-file target writes the **flat** format. The manifest
+is written last and is the commit marker — a dump directory without a
+`manifest.edn` is incomplete. Export holds an immutable db value, so it is
+consistent even under concurrent writes.
+
+### Export to an external store (S3 / S3-compatible / no local disk)
+
+For diskless deployments (e.g. Docker with no persistent volume), the dump target
+can be a **konserve store** instead of a path — the same storage abstraction
+datahike uses for its own data, so any backend works (S3, S3-compatible like MinIO
+/ R2 / B2 via `konserve-s3`, JDBC, Redis, in-memory). The dump chunks and manifest
+become keys under a prefix; the manifest key is written last as the commit marker,
+and per-chunk SHA-256 guards against partial/eventually-consistent reads.
+
+```clojure
+;; an already-open konserve store (you construct it with your bucket/endpoint)
+(m/export-db conn {:store my-store :prefix "backup-2026-07"} {:history? true})
+(m/import-db fresh-conn {:store my-store :prefix "backup-2026-07"})
+
+;; or a konserve store-config map (backend opened and released for you)
+(m/export-db conn {:backend :s3 :bucket "my-bucket" :region "..." :id #uuid "..."
+                   :prefix "backup-2026-07"} {:history? true})
+```
+
+`konserve-s3` accepts a custom `endpoint` + path-style addressing, which is how you
+target S3-compatible stores (MinIO, R2, B2, Wasabi, Ceph, Spaces) — nothing here is
+AWS-specific, and the S3 dependency is optional (loaded only when you use `:s3`).
+The bucket/store must already exist.
+
+### Hard read-only / zero-disk targets (`:sort? false`)
+
+By default only the **dump** lives in the store, but the export's sort **scratch**
+uses local temp files (ephemeral — fine in a normal container; point it at a RAM
+mount if needed). For a container with **no writable filesystem at all**, pass
+`:sort? false` to export with **no scratch**:
+
+```clojure
+(m/export-db conn {:store my-store :prefix "backup"} {:history? true :sort? false})
+```
+
+It streams schema/tx-entity datoms then data in `:eavt` order straight to the
+target — no temp files, bounded memory. This relaxes the global transaction
+ordering; it is safe for the common case (`load-entities` remaps ids and allocates
+forward refs on sight), but does **not** preserve a *same-transaction* card-one
+replacement (retract + re-assert of the same `[e a]` in one tx). If your history
+has those, keep the default sorted export and give it a writable scratch path.
+
+> **Do not run datahike GC during a long export** on a lazy-loading backend. GC
+> marks reachability from branch heads only and does not pin a reader-held
+> snapshot, so it can sweep index segments the in-flight export still needs.
+
+### Memory at scale
+
+Export orders the dump with an external merge sort and import streams it, so both
+run in memory bounded by `:sort-buffer` (export run size), `:chunk-size`, and
+`:batch-size` (import) — **not** by database size. A database many times larger
+than the JVM heap exports and imports fine (validated: a 1.2 GB / 8.5×-heap store
+exported to a 285 MB dump and re-imported, verified, under a 144 MB heap).
+
+Two knobs matter when the heap is tight relative to the data:
+
+- **`:store-cache-size` (connection config), for databases with large *values***.
+  This is the resident index-node cache and it is bounded by node **count**, not
+  bytes — so with large values (long strings, `bytes`, embedding arrays) a
+  thousand cached leaf nodes can dwarf the heap. Connect the source with a small
+  `:store-cache-size` (e.g. `32`) for a low-heap export; it is unrelated to the
+  export/import buffers below.
+- **`:sort-buffer` / `:batch-size`**, sized to your heap: peak export memory is
+  roughly `:sort-buffer` records plus the merge fan-in; peak import memory is one
+  `:batch-size` batch plus the O(entities) id-remap map (cleared by
+  `finalize-import!`). The id-remap map is the one part that grows with entity
+  count — budget for it on very large imports.
+
+**How much RAM to give an import.** You don't have to work this out by hand — call
+`estimate-import-memory` on the dump *before* importing:
+
+```clojure
+(datahike.migrate/estimate-import-memory "/backups/mydb")
+;; => {:datoms 41231884 :entities 8123402
+;;     :id-map-bytes 553_000_000 :batch-bytes 30_000_000
+;;     :recommended-heap-bytes .. :recommended-heap "1.2 GB"
+;;     :current-max-heap "512 MB" :sufficient? false}
+```
+
+It reads only the manifest (no scan) and returns the `-Xmx` to set. `import-db`
+runs the same check itself and prints a heap warning to stderr when the current
+`-Xmx` looks too small, and echoes `:recommended-heap` in its result. Pass the
+`:batch-size` you intend to use so the estimate matches (`estimate-import-memory
+source {:batch-size N}`).
+
+## Restore
+
+```clojure
+(def report (m/import-db fresh-conn "/backups/mydb"))
+;; => {:datom-count .. :tx-count .. :max-tx .. :verified? true :finalized? true :errors []}
+```
+
+Restore into a **freshly created, empty** database whose config is compatible with
+the dump's `:source-config` (the manifest records it). Import:
+
+- runs through `load-entities`, which **remaps** entity/tx ids — a restored
+  database is *semantically equivalent*, never id-identical;
+- **refuses a non-empty target** (`:import/non-empty-target`). Import is **not
+  resumable** (the id-remap is in-memory only); if an import is interrupted,
+  delete the target and start over;
+- verifies itself against the manifest by default (`:verify? true`) and clears its
+  bookkeeping on success (`:finalize? true`).
+
+Options: `:batch-size`, `:verify?`, `:finalize?`, `:on-error :abort|:collect`,
+`:progress-fn`. Failures are `ex-info` with a namespaced `:error` (e.g.
+`:import/config-mismatch`, `:import/checksum-failed`, `:import/bad-chunk-path`).
+
+Old flat **CBOR** dumps (produced by pre-1.0 datahike) still import through the
+legacy path automatically.
+
+## Data protection (PII / right-to-erasure)
+
+**A `:history? true` export resurrects retracted data.** Retraction is not erasure
+in an immutable database, so every value ever asserted — including "deleted"
+personal data — is written into the dump. If a dump may leave your trust boundary,
+export with `:history? false`. The manifest records `:history?` so a receiving
+system can tell which kind it holds. Datahike has no history-excision primitive.
+
+## Integrity & signing
+
+Each chunk carries a SHA-256 in the manifest; `import-db`/`verify` recompute them
+before touching the database. Exports are deterministic (identical source db ⇒
+byte-identical chunks), so a dump can be signed by external tooling (GPG, cosign,
+KMS). The manifest's semantic digest is for order-independent content comparison,
+not tamper-evidence.

--- a/doc/import-export-design.md
+++ b/doc/import-export-design.md
@@ -316,13 +316,13 @@ maintainers.
 
 ---
 
-## 13. Open questions for maintainers
+## 13. Open question for maintainers
 
-1. **Codec: CBOR-fixed vs EDN-lines** (§5.3) — the main fork.
-2. Chunked-directory format acceptable, or prefer single-file only?
-3. Is `datahike.migrate` the right home, or should this land under the Wanderung
-   umbrella whilo mentioned for 1.0?
-4. Target branch — `development` vs `main` (docs disagree in places).
+**Codec: EDN-lines vs CBOR** (§5.3) — the one real fork. EDN-lines as
+implemented is type-exact by construction, deterministic (byte-identical
+re-export ⇒ signable dumps), and drops the clj-cbor write dependency; CBOR is
+more compact and faster to parse at scale. Either plugs into the same
+`write-record`/`read-record` seam.
 
 ---
 

--- a/doc/import-export-design.md
+++ b/doc/import-export-design.md
@@ -1,0 +1,387 @@
+# Robust Export / Import — design proposal
+
+**Status:** Draft for discussion (targets Datahike 1.0's import/export revisit).
+**Namespace:** `datahike.migrate` (today `^:no-doc`, "temporary solution, pending
+Wanderung").
+**Scope:** full-history, type-exact, verifiable dump/restore that round-trips a
+real database — not just a toy EAVT snapshot.
+
+This document is written to be checked against the live source. Every claim about
+internals carries a `file:line` citation so a maintainer can verify it before any
+code lands. Where an earlier private spec (v2) was wrong about the code, this doc
+says so explicitly — the goal is to *not* ship a PR built on a stale mental model.
+
+---
+
+## 1. Why
+
+`datahike.migrate/export-db`/`import-db` today is a ~45-line CBOR dump of the
+current EAVT snapshot (`src/datahike/migrate.clj:8-45`). It works for small
+databases and breaks on real ones, in ways that are already filed:
+
+| Issue | State | Problem |
+|---|---|---|
+| [#262](https://github.com/replikativ/datahike/issues/262) | open | EAVT order interleaves schema after data → re-import fails when a data datom precedes its attribute's definition. |
+| [#377](https://github.com/replikativ/datahike/issues/377) | open | tx-log / history not represented; no way to round-trip `history`/`as-of`/`since`. |
+| [#508](https://github.com/replikativ/datahike/issues/508) | open | `:attribute-refs? true` dumps depend on the source's system-entity numbering staying stable across versions. |
+| [#531](https://github.com/replikativ/datahike/issues/531) | open | restore into a schema-bearing / bootstrapped target collides on `:db/ident`. |
+| [#633](https://github.com/replikativ/datahike/issues/633) | open | `:db.type/double` round-trips back as `float` — **a CBOR float-encoding bug** (the issue title says so). |
+| [#552](https://github.com/replikativ/datahike/issues/552) | open | dumps carry no format version; cross-version import fails opaquely. |
+| [#287](https://github.com/replikativ/datahike/issues/287) | **closed** | max-tx after import — fixed by batching ([#845]). |
+| [#386](https://github.com/replikativ/datahike/issues/386) | **closed** | memory leak — closed. |
+
+The current import path also uses `api/transact` with fresh tx-ids
+(`migrate.clj:32-45`), so it *cannot* reproduce history even in principle. The
+right primitive is `load-entities`, which remaps ids while preserving the
+`[e a v t op]` structure — see §4.
+
+---
+
+## 2. Corrections to the v2 spec (read this first)
+
+A prior spec (v2) drove this work. Grounding it against `main` invalidated
+several load-bearing parts. These corrections are normative here:
+
+1. **There is no `read-string` RCE to fix.** v2's headline "PR-A closes a latent
+   remote-code-execution hole" assumed the importer `read-string`s dump lines. It
+   does not — it uses `clj-cbor` (`migrate.clj:14,37`). That eval vector was
+   removed when the format moved to CBOR ([#496]). Any EDN-lines codec we
+   introduce (§5) still uses a **closed** reader map as basic hygiene, but this is
+   defense-in-depth, not a fix for a live vuln — and the PR must not claim
+   otherwise.
+
+2. **The sort key must not put retractions first.** v2 mandated
+   `(t, added, e, a, v)` with `added=false` before `true`, calling retract-first
+   "the safe replay order." The direct transactor is **order-sensitive and does
+   not reorder within a tx**: a card-one *add* upserts (replaces the prior `[e a]`
+   value; `db/transaction.cljc:524`), and a *retract* matches an exact `[e a v]`
+   and is a **no-op if that value was already replaced** (`:426`, `upsert?` at
+   `:1511`). So forcing retract-before-add can silently drop a same-tx
+   replacement's retraction. Correct rule (§6): order by `t`, force
+   `:db/txInstant` (and other tx-entity `meta-attr?` datoms) **first** within a
+   tx, and otherwise **preserve source datom order**. This matches the existing
+   test's live `TODO` (`test/datahike/test/migrate_test.clj:307`).
+
+3. **No core fix is needed for forward refs.** v2 proposed a separate core PR
+   ("PR-B") to allocate a target eid when a ref value points at a not-yet-seen
+   entity. `transact-entities-directly` **already does this**
+   (`db/transaction.cljc:1499-1500`: on `(and (ref? …) (nil? (get-in
+   migration-state [:eids v])))` it `allocate-eid`s and recurs on the same
+   input). PR-B is dropped.
+
+4. **Import is not resumable; don't design as if it were.** v2 made resume
+   "conditional on the `:migration` id-map being durable." It is **not durable**:
+   `db->stored` omits `:migration` and `stored->db` never restores it
+   (`src/datahike/writing.cljc:56-58,227-281`) — it lives only on the in-memory db
+   value and is dropped on reconnect. So a partially-imported target cannot be
+   resumed correctly; the honest recovery is **recreate-and-restart**, and
+   `import-db` refuses a non-empty target rather than double-applying. (Export
+   *is* resumable — completed chunks are content-addressed.)
+
+5. **The value-type table was incomplete.** Current builtin types
+   (`src/datahike/schema.cljc:48-71`) include `:db.type/float-array` and
+   `:db.type/double-array` (added in [#896]) and `:db.type/store-ref`, which v2's
+   §7.4 table omits. A type-exact codec must cover them (§5.3).
+
+6. **`migration-state` is O(entities) and rides in the db value** — clearing it
+   after a verified import (`finalize-import!`) is still warranted (§8).
+
+Stale incidentals also corrected: the file is `migrate.clj` (not `.cljc`); tests
+live at `test/datahike/test/migrate_test.clj` and run via kaocha
+(`ns-patterns ["datahike.test."]`), not `./bin/run-unittests`; cljfmt is `0.9.2`.
+
+---
+
+## 3. Goals / non-goals
+
+**Goals.** (G1) complete — every datom needed to reconstruct the db; (G2)
+full-history round-trip under `:history? true` (`history`/`as-of`/`since`
+equivalent at every `t`); (G3) type-exact (fixes #633 and covers every builtin
+value type incl. the array types); (G4) correct replay order (#262 + §2.2);
+(G5) bounded memory independent of db size except the stated O(entities)
+`migration-state`; (G6) verifiable + tamper-evident (per-chunk SHA-256 +
+order-independent semantic digest); (G7) cross-version portable (dump
+format-version, #552); (G8) resumable export, honest recreate-and-restart import;
+(G9) backward-compatible 2-arity surface; (G10) secure-by-default (closed reader,
+path validation, secret allowlist, tight file perms).
+
+**Non-goals.** Incremental/differential backup (format leaves room); encryption
+(dumps are *signable*, signing is external); on-disk store-format changes;
+Datahike→Datomic bridging; history excision (Datahike has none — see §9 PII note).
+
+---
+
+## 4. How import actually works (grounding for the format)
+
+Path: `datahike.api/load-entities` → `datahike.writer/load-entities` →
+`datahike.writing/load-entities` (`writing.cljc:840`) →
+`datahike.core/load-entities-with` (`core.cljc:149`) →
+`db/transaction.cljc/transact-entities-directly` (`:1451`). `load-entities` is
+`[connection entities]`, `:stability :stable` (`specification.cljc:232-242`),
+returns a throwable-promise delivered from a `go` block (`writer.cljc:299-307`) —
+so callers `@`-deref to block. `entities` is a seq of `[e a v t op]` 5-tuples
+(a `Datom` `seq`s to exactly that, `datom.cljc:111-112`).
+
+Consequences that drive the format:
+
+- **Input is `[e a v t op]`** — exactly `(seq datom)` plus the added/retracted
+  boolean. Export writes these tuples.
+- **Ids are remapped, not preserved.** A per-import `migration-state` maps each
+  source id to a freshly allocated target id and reuses it on later sight
+  (`:1490-1492`, `:1499-1500`, `:else` at `:1502`). A round-tripped db is
+  *semantically equivalent*, never byte-identical in ids → verification (§7)
+  compares structure, never raw eids.
+- **tx entities** are recognized via `meta-attr?`
+  (`= #{:db/txInstant :db/retracted :db/noCommit :db.valid/from :db.valid/to}`,
+  `schema.cljc:123`); their datom uses the remapped tx id as both `e` and tx, and
+  populates `[:tids t]` (`db/transaction.cljc:1482-1492`). `max-tx` is maintained
+  here — the old file-scan heuristic is unnecessary (fixes #287).
+- **Attributes resolve against the *target* schema** via `-ident-for`/`-ref-for`
+  (`db.cljc:344-354`). Keyword idents are valid in both ref and non-ref configs;
+  numeric attr ids only in ref configs → **export always writes keyword idents**
+  (§5.2, fixes #508 correctly: translate, never re-insert system datoms).
+- **History `:eavt` includes retractions.** `(d/datoms (d/history db) :eavt [])`
+  enumerates the full temporal set incl. `added=false`
+  (`db.cljc:248,509-512`; `interface.cljc:65-70`) — so a history export is
+  feasible directly.
+
+---
+
+## 5. Dump format
+
+### 5.1 Layout (chunked, primary)
+
+```
+my-backup/
+  manifest.edn            ; metadata + digests + chunk index (written LAST = commit marker)
+  datoms-000001.edn       ; EDN-lines: one datom record per line, ordered
+  datoms-000002.edn
+  ...
+```
+
+In-progress chunks are `*.edn.tmp`, renamed on completion; a directory without
+`manifest.edn` is incomplete by definition. A single-file **flat** format remains
+for small dbs and the legacy 2-arity path.
+
+### 5.2 Record
+
+One EDN 5-vector per line: `[e a v t added]`. `a` is **always a keyword ident**
+(even for `:attribute-refs? true` sources). Ref values to *system* entities are
+written as `#datahike/sysref :the/ident` and resolved by ident lookup in the
+target's own system table on import (translation, not insertion). `e`/`t` are
+source longs, retained for ordering + verification, remapped on import.
+
+### 5.3 Value encoding (fixes #633; covers all builtin types)
+
+Encoded by declared `:db/valueType` when a schema exists, else by runtime class;
+imported by coercing to the **target's** declared type, else the manifest schema,
+else the tag. Full builtin set per `schema.cljc:48-71`:
+
+| valueType | encoding | import coercion |
+|---|---|---|
+| keyword/string/boolean/long | native EDN | native / `long` |
+| `double` | `pr-str` shortest round-trip | **force** `double` |
+| `float` | `#datahike/float "…"` (string, no double-rounding) | **force** `float` |
+| `float-array` / `double-array` | `#datahike/farray [..]` / `#datahike/darray [..]` | rebuild primitive array |
+| `ref` | source long / `#datahike/sysref :ident` | remap / translate |
+| `instant` | `#inst` | `java.util.Date` |
+| `uuid` | `#uuid` | `UUID` |
+| `bigint` | `123N` | `BigInt` |
+| `bigdec` | `1.50M` | `BigDecimal` (scale kept) |
+| `bytes` | `#datahike/bytes "base64"` | `byte[]` |
+| `symbol` | `#datahike/symbol "ns/name"` | `symbol` |
+| `tuple` | vector, element-wise per tupleType(s) | element-wise |
+| `store-ref` | (uuid form) | as uuid |
+
+Reader map is **closed**: the `#datahike/*` tags above + EDN `#inst`/`#uuid`;
+unknown tag ⇒ `:import/unknown-tag`. (This is the #633 fix at root: EDN tagged
+literals carry the exact type, so `double` never silently narrows to `float` the
+way CBOR's float encoding does.)
+
+> **Open question for maintainers (codec):** keep **CBOR** and fix its
+> float handling, or move to **EDN-lines** as above? EDN-lines makes type-exactness,
+> determinism (byte-identical re-export → signable), and closed-reader safety
+> clean, and it *removes* the `clj-cbor` dependency; CBOR is more compact and
+> faster to parse at 40M-datom scale. This doc implements EDN-lines behind a
+> pluggable codec seam so CBOR can remain a variant. **This is the main thing to
+> settle before the big PR.**
+
+### 5.4 `manifest.edn`
+
+Fixed key order (determinism). Carries: `format-version`, informational
+`datahike-version`/`created-at`, `history?`, `serialization`, an **allowlisted**
+`source-config` (`#{:attribute-refs? :keep-history? :schema-flexibility :index}`
++ backend keyword only — never the store map), `schema` (ident→attr),
+`system-idents` (source system eid→ident, for `#datahike/sysref`), `stats`,
+`semantic-digest` `{:xor :sum :count}`, and `chunks` (each `{:file :count :sha256
+:first-t :last-t}`). Chunk `:file` validated as `^datoms-\d{6}\.edn$`, resolved
+strictly under the dump dir — no `..`, no absolute, no symlink (`:import/bad-chunk-path`).
+
+---
+
+## 6. Ordering rule (corrected)
+
+Emit **schema/ident datoms first** (small pass), then data. Within the stream,
+order by `t` ascending (guarantees an attribute's defining tx precedes its use —
+#262 — and causal history replay). **Within a single `t`**, force tx-entity
+`meta-attr?` datoms (esp. `:db/txInstant`) first, then **preserve source order**
+of the remaining datoms. Do **not** globally sort `added=false` before `true`
+(§2.2). `e,a,v` break ties only among datoms with no inherent source order, to
+keep bytes deterministic (§7 signing). Snapshot mode (`:history? false`): all
+`added=true`; same pipeline.
+
+---
+
+## 7. Verification (fixes #728 direction)
+
+Two digests, two threat models: **per-chunk SHA-256** (in the manifest;
+tamper-evidence; checked before import touches the db) and an **order-independent
+semantic digest** (`{:xor :sum :count}` over normalized records; compares a dump
+to a live, id-remapped db; explicitly *not* a security control — it is linear,
+hence forgeable). `verify` returns a tiered report: tier0 (hashes/paths), tier1
+(counts total/per-attr/per-tx), tier2 (id-independent multiset digest over
+`[a v added]`, refs excluded and covered by per-attr ref-counts + out-degree
+histograms), tier3 (sampled `pull '[*]` diff on entities keyed by
+`:db.unique/identity`). Honest limit, stated in the docstring: tier2 can't verify
+ref topology without graph isomorphism; tier3 sampling + degree histograms is the
+practical bound.
+
+---
+
+## 8. Finalization
+
+`migration-state`'s `:eids` map is O(entities); for millions of entities that is
+hundreds of MB riding inside the db value. `finalize-import!` removes `:migration`
+after `verify` passes; on by default (`:finalize? true`), idempotent, and a
+precondition for reporting `:finalized? true`.
+
+---
+
+## 9. Security & data protection (normative)
+
+- **Closed EDN reader**, no `*read-eval*`, no `clojure.core/read-string` anywhere
+  in the namespace (§5.3).
+- **Path validation** for chunk files (§5.4); **record-line cap** (default 64
+  MiB, `:import/record-too-large`); dump files/dirs created owner-only
+  (`rw-------`/`rwx------`) where the platform supports it.
+- **Secret allowlist** for `:source-config` (§5.4) — never emit the store map.
+- **PII / right-to-erasure:** a `:history? true` export *resurrects retracted
+  data* — retraction is not erasure in an immutable db, and "deleted" values are
+  written into a portable file. Docstrings + the backup guide must say this
+  prominently; operators under erasure obligations should use `:history? false`
+  for data crossing a trust boundary. Datahike has no excision primitive and this
+  PR does not add one.
+
+---
+
+## 10. Public API (additive; legacy 2-arities retained)
+
+`export-db` (`[db target]` legacy | `[db target opts]`), `import-db`
+(`[conn source]` legacy | `[conn source opts]`), `verify` (`[source]` |
+`[conn-or-db source]`), `finalize-import!` `[conn]`, and low-level reusable pieces
+`datom-reducible`, `write-dump`, `read-dump`, `semantic-digest`. Streaming
+producers/consumers are **reducibles** (`IReduceInit`), not lazy seqs, so file
+handles stay scoped to the reduction. `update-max-tx`/`update-max-tx-from-file`
+deprecated (warn), not removed (G9).
+
+Error taxonomy: every failure is `ex-info` with namespaced `:error` ∈
+`#{:import/format-version :import/config-mismatch :import/non-empty-target
+:import/bad-chunk-path :import/checksum-failed :import/unknown-tag
+:import/record-too-large :import/corrupt-datom :import/cannot-resume
+:import/verify-failed :export/target-exists :export/io}` plus precise `ex-data`.
+Corruption policy: `:on-error :abort` (default, halt with the offending datom +
+`t` + chunk + line) vs `:collect` (skip, itemize in the report; `verify` then
+fails on counts, correctly). Never silently skip.
+
+---
+
+## 11. GC-during-export hazard
+
+Exporting holds an immutable db value and streams its indices. Datahike GC marks
+reachability only from branch heads back to a cutoff and does **not** pin
+reader-held snapshots (`src/datahike/gc.cljc:229-254`) — so running GC during a
+long export on a lazy-loading backend can sweep index segments the held value
+still needs. The docstring warns; the backup guide states it as a rule.
+
+---
+
+## 12. Sequencing
+
+One feature branch, commits ordered for review: format + digests → `datom-reducible`
+→ `export-db` → `import-db` (+ emptiness/config/taxonomy/on-error) → `verify` +
+`finalize-import!` → export resumability → docs/CHANGELOG. Because the corrections
+in §2 removed the RCE "PR-A" and the forward-ref "PR-B", this is a single
+coherent PR, best opened *after* the §5.3 codec question is settled with the
+maintainers.
+
+---
+
+## 13. Open questions for maintainers
+
+1. **Codec: CBOR-fixed vs EDN-lines** (§5.3) — the main fork.
+2. Chunked-directory format acceptable, or prefer single-file only?
+3. Is `datahike.migrate` the right home, or should this land under the Wanderung
+   umbrella whilo mentioned for 1.0?
+4. Target branch — `development` vs `main` (docs disagree in places).
+
+---
+
+## 14. Implementation status (what has landed vs. what this doc designs)
+
+The committed implementation delivers the correctness core AND bounded-memory
+streaming end-to-end — flat and chunked EDN formats, type-exact codec (fixing
+#633), history + attribute-refs round-trip, manifest + per-chunk SHA-256 + semantic
+digest, `verify`, `finalize-import!`, config/emptiness/format guards, closed-reader
++ path-validation + owner-only perms, and legacy-CBOR read compatibility — with a
+green kaocha suite (`test/datahike/test/migrate_test.clj`) across the persistent-set
+and hitchhiker-tree indices and under spec instrumentation.
+
+**Streaming is implemented (G5).** Export orders via an external merge sort
+(`datahike.migrate.sort`): datoms stream from the index, spill into sorted runs of
+`:sort-buffer` records, and k-way merge into the chunk writer, which computes each
+chunk's SHA-256 and the semantic digest incrementally. Import verifies chunk hashes
+by streaming each file, then feeds a tx-aligned batcher that flushes to
+`load-entities` at `t`-boundaries (a transaction spanning chunk files is kept whole
+because batch state carries across files); readers are scoped to their reduction
+(reducible, not an escaping lazy seq). Peak memory is bounded by `:sort-buffer`,
+`:chunk-size`, and `:batch-size`, independent of database size — demonstrated by a
+180k-datom history round-trip under a **120 MB heap** and by `streaming-scale-test`
+(tiny buffers forcing many runs + chunks).
+
+**External stores are supported (`datahike.migrate.store`).** Besides a filesystem
+path, `export-db`/`import-db`/`estimate-import-memory` accept a **konserve store**
+target (an open store `{:store s :prefix ..}` or a `{:backend :s3 ..}` config), so a
+diskless container can dump straight to S3 / S3-compatible / JDBC / etc. — the same
+storage layer datahike itself uses, no new hard dependency. Chunks + manifest are
+store keys, manifest-last is the commit marker, and per-chunk SHA-256 covers
+partial/eventually-consistent reads. Round-trip (incl. every value type + the
+memory estimate) is tested against an in-memory konserve store, and an
+integration test (`test/datahike/integration_test/migrate_s3_test.clj`) round-trips
+over the **real S3 wire protocol** against Garage in docker (endpoint override +
+path-style + SigV4, via `konserve-s3`; self-skips without docker — Garage chosen
+over MinIO because it is actively maintained open source). Store chunks are held
+in memory as one value each, so the store-target `:chunk-size` defaults lower
+(50k) than the filesystem's (1M).
+
+**No-scratch streaming export (`:sort? false`).** For a container with no writable
+filesystem at all (hard read-only), export can skip the external sort entirely:
+two lazy `:eavt` passes emit schema/tx-entity datoms then data, streamed straight
+to the target with zero temp files. It relaxes global tx ordering (kept:
+schema-before-data and tx-entity-before-data; the one shape it drops is a same-tx
+card-one replacement). Tested round-trip on filesystem and store targets, non-ref
+and attribute-refs. The default remains the sorted export (uses ephemeral local
+scratch).
+
+The verification and error-handling described in §§7–10 are fully implemented:
+
+- **`verify` tiers 0–3 (§7).** Tier 0 = chunk-path + SHA-256 (validated on open),
+  tier 1 = counts, tier 2 = an id-independent multiset digest over `[a v op]` plus
+  per-attribute ref counts and an out-degree histogram (so two databases with
+  fully remapped ids compare equal), tier 3 = a sampled structural diff of
+  `:db.unique` entities that reconstructs each entity's *net current* state from
+  the dump (asserts add, retracts remove) and diffs it against `pull '[*]'` on the
+  live db.
+- **`:on-error :collect` is per-datom (§8.10).** On a batch failure the importer
+  narrows to per-transaction, then per-datom, so exactly the offending datoms are
+  recorded and skipped while everything else lands — id-consistency holds because
+  the `:migration` id-map persists in the db value across `load-entities` calls.

--- a/doc/import-export-design.md
+++ b/doc/import-export-design.md
@@ -206,6 +206,62 @@ way CBOR's float encoding does.)
 > pluggable codec seam so CBOR can remain a variant. **This is the main thing to
 > settle before the big PR.**
 
+### 5.3.1 Codec evidence (measured, not preference)
+
+The §5.3 note above says EDN tags fix #633 "the way CBOR's float encoding does
+[not]". That is true of *shortest-form* float encoding — which RFC 8949's own
+deterministic profile prescribes — but it is an **encoder policy, not a property
+of CBOR**. Measured against `clj-cbor` 1.1.1, which encodes floats by class
+(`codec.clj`: `(instance? Float n)` → `writeFloat`, else `writeDouble`):
+
+| value | bytes | note |
+|---|---|---|
+| `(double 1.5)` | `fb 3ff8000000000000` | f64 |
+| `(double 2.0)` | `fb 4000000000000000` | f64 **even though 2.0 fits f32 exactly** — shortest-form would narrow it here |
+| `(float 1.5)` | `fa 3fc00000` | f32 |
+| `(bigint 1234…890)` | `c2 4d …` | tag 2, arbitrary precision |
+| `1.50M` | `c4 82 21 1896` | tag 4 = `[-2 150]` — **scale preserved** |
+| `1.5M` | `c4 82 20 0f` | tag 4 = `[-1 15]` — distinct from `1.50M` |
+| `#inst "2026-01-01"` | `c1 1a 6955b900` | tag 1, epoch |
+| `#uuid "…0001"` | `d825 50 …` | tag 37 |
+| `(byte-array [0 1 127 -1])` | `44 00017fff` | major type 2, no base64 wrapper |
+
+**Cross-language check.** Those exact bytes were read with Python `cbor2`:
+
+```
+bigdec  → Decimal('1.50')                      scale intact
+instant → datetime(2026,1,1, tzinfo=utc)        native
+uuid    → UUID('…0001')                         native
+bytes   → b'\x00\x01\x7f\xff'                native
+bigint  → 123456789012345678901234567890        exact
+```
+
+This is the argument for CBOR that size and speed do not make: **a foreign reader
+produces native values while knowing nothing about datahike.** The EDN encoding
+in §5.3 routes every non-trivial type through a `#datahike/*` tag, which is
+portable in principle and Clojure-only in practice — and the scenario a dump
+exists for is precisely the one where datahike is unavailable or not trusted.
+
+**One measured gap, and it is narrow.** `clj-cbor` encodes zero, NaN and
+±Infinity as f16 regardless of class, and f16 decodes to `Float` — so a `Double`
+0.0 round-trips as a `Float`. That is #633 surviving for exactly three values. It
+does **not** affect the dump as implemented (EDN-lines): a full export/import of
+`:db.type/double` values 0.0, 1.5 and 2.0 restores all three as `Double`. It is
+the one thing a move to CBOR must address, with a width-preserving float policy.
+
+All of the above is pinned as byte-level vectors in
+`test/datahike/test/migrate_codec_test.clj`, so it is a contract rather than a
+finding: any codec — `clj-cbor`, a cross-platform successor — has to satisfy the
+same octets, which makes the *format* the commitment and the *library* an
+implementation detail.
+
+**Recommendation.** Freeze the format (tag table, float policy, canonical map
+ordering) in this document and in those vectors; keep the codec behind the
+pluggable seam §5.3 already provides. Then the library can be swapped on
+evidence, and a dump written today stays readable by anything conformant.
+
+---
+
 ### 5.4 `manifest.edn`
 
 Fixed key order (determinism). Carries: `format-version`, informational

--- a/doc/walkthrough.md
+++ b/doc/walkthrough.md
@@ -1,0 +1,306 @@
+# Reviewer walkthrough — robust export/import (`import-export` branch)
+
+*This file is a guide for an AI assistant (or a human) conducting a code
+walkthrough of this branch with a reviewer. It gives the reading order, the
+thinking behind each piece, and the questions worth pressing on. It is not
+user documentation — that's [backup.md](backup.md); the design rationale is
+[import-export-design.md](import-export-design.md).*
+
+**If you are the assistant:** walk one stop at a time, in order. For each stop:
+open the file, summarize what it does in 2–3 sentences, state the *decision*
+embedded in it and why, then raise the review questions listed. Let the reviewer
+steer — these notes are a map, not a script. Where the reviewer disagrees with a
+decision, the design doc records the alternatives that were considered; bring
+those in rather than defending the current choice.
+
+---
+
+## 0. Orientation (5 minutes)
+
+One commit on top of `main`. Everything lives under `datahike.migrate`:
+
+| File | Role |
+|---|---|
+| `src/datahike/migrate.clj` | Orchestrator: `export-db`, `import-db`, `verify`, `finalize-import!`, `estimate-import-memory` |
+| `src/datahike/migrate/edn.clj` | Type-exact EDN codec + closed reader map |
+| `src/datahike/migrate/digest.clj` | SHA-256 + order-independent semantic digest |
+| `src/datahike/migrate/sort.clj` | External merge sort (bounded memory + bounded fan-in) |
+| `src/datahike/migrate/store.clj` | Konserve-store dump medium (S3 / S3-compatible / any backend) |
+| `test/datahike/test/migrate_test.clj` | 20 unit tests / 78 assertions |
+| `test/datahike/integration_test/migrate_s3_test.clj` | Real-S3-wire round-trip vs Garage in docker |
+| `dev/migrate_scale.clj` | Manual harness: build a db larger than heap, dump/restore under the cap |
+
+Issues addressed: #633, #377, #262, #508/#531, #552-adjacent (format versioning);
+#287 was already fixed upstream by batching.
+
+Suggested first move: run the suite so everything after is discussed against
+green tests:
+
+```
+clojure -M:test -m kaocha.runner :clj-pss --focus datahike.test.migrate-test
+```
+
+---
+
+## 1. The design doc — read §2 before any code
+
+**File:** `doc/import-export-design.md`
+
+**Thinking:** this feature was first specified from memory of the codebase, and
+several load-bearing assumptions were wrong. §2 lists each corrected assumption
+with `file:line` evidence. Reading it first prevents re-litigating settled
+questions and shows which behaviors are *load-bearing constraints of datahike
+core*, not choices this branch made:
+
+- The direct transactor is **order-sensitive** (upsert vs exact-match retract) —
+  this is why the sort key preserves source order within a tx rather than
+  sorting retractions first.
+- `transact-entities-directly` **already allocates on a forward-ref miss** — no
+  core change was needed.
+- The `:migration` id-map is **memory-only** — which forces the
+  "import is not resumable, recreate-and-restart" policy.
+
+**Review questions**
+- §13 lists the three calls that belong to the maintainer: codec (EDN vs CBOR),
+  home (`datahike.migrate` vs Wanderung), target branch. These are genuinely
+  open — the branch implements one defensible answer to each.
+- §14 is the claims-vs-implementation ledger. Check it against the code as you
+  go; anything overclaimed there is a review finding.
+
+---
+
+## 2. The codec — `migrate/edn.clj`
+
+**What it is:** one datom = one EDN line `[e a v t added]`. Values encode by
+**runtime class**, with a small closed tag set (`#datahike/float`, `/bytes`,
+`/farray`, `/darray`, `/sysref`). Reading uses `clojure.edn` with exactly those
+readers and a throwing `:default`.
+
+**Thinking:**
+- **#633's root cause is class loss**, not precision loss: clj-cbor routes
+  zero/NaN/±Inf doubles through float16 and decodes them as `java.lang.Float`;
+  datahike's schema predicates (`double?`) have no coercion, so the flipped
+  class fails validation. Keying the encoder on the class makes the bug
+  impossible rather than handled.
+- **Closed readers** are defense-in-depth (there was never an eval hole — the
+  old importer is CBOR), but a dump is untrusted input, so unknown tags error
+  and `read-string`/`*read-eval*` never appear.
+- `#datahike/float` carries a *string* to avoid double-rounding on read.
+- `BigInteger` is coerced to `clojure.lang.BigInt` before printing so it reads
+  back as a bigint rather than a long.
+
+**Review questions**
+- Is the tag set complete against `datahike.schema/builtin-value-types`? (Tuples
+  ride as plain vectors, element-encoded; `store-ref` rides as `#uuid`.)
+- The codec is EDN — **this is the main fork**. CBOR would be smaller (~40–60%)
+  and faster to parse; EDN is type-exact by construction, deterministic
+  (byte-identical re-export ⇒ signable dumps), human-readable, and drops the
+  clj-cbor write dependency. The seam (`write-record`/`read-record`) is where a
+  CBOR variant would plug in if you prefer it.
+
+---
+
+## 3. Digests — `migrate/digest.clj`
+
+**Thinking:** two mechanisms, two threat models, deliberately not conflated:
+- **Per-chunk SHA-256** = tamper evidence. Cryptographic, recorded in the
+  manifest, checked before import touches the db, and (because dumps are
+  deterministic) externally signable.
+- **`{:xor :sum :count}` semantic digest** = order-independent comparison of a
+  dump against a live *id-remapped* database. Linear, hence forgeable — the
+  docstring says so explicitly. It is a comparison tool, not a security control.
+
+**Review question:** confirm you're comfortable that the semantic digest is
+*labelled* non-cryptographic; a reviewer skimming could mistake it for
+integrity.
+
+---
+
+## 4. External sort — `migrate/sort.clj`
+
+**What it is:** spill sorted runs of `:sort-buffer` records to temp files,
+k-way merge with a priority queue, multi-pass when runs exceed a 64-file
+fan-in.
+
+**Thinking:**
+- EAVT is ordered by `e`, not `t`; a dump must replay in transaction order
+  (#262), so a sort is unavoidable *in the default mode* — and it must not hold
+  the database in memory (the old exporter's `sort-by` OOM'd a 98M-datom
+  export).
+- **The sort key is `(t, txInstant-first, e, a)` — NOT retract-before-assert.**
+  The first spec version mandated retract-first; grounding showed the direct
+  transactor upserts on card-one adds and no-ops a retract whose value was
+  already replaced, so reordering within a tx can silently drop datoms. Within
+  a tx the key only forces the tx-entity datom first (matching the pre-existing
+  `TODO` in the old test file).
+- Bounded fan-in (64) keeps the merge under conservative OS fd limits.
+
+**Review questions**
+- The merge re-parses each line to recover its key (a known CPU cost, traded
+  for simplicity). Acceptable, or should the key ride alongside the line?
+- Temp-file hygiene: runs live in a `Files/createTempDirectory` dir deleted in
+  a `finally`.
+
+---
+
+## 5. The store medium — `migrate/store.clj`
+
+**What it is:** the dump can target a **konserve store** instead of a
+filesystem: chunks and manifest become store keys under a prefix.
+
+**Thinking:**
+- Konserve is *datahike's own storage abstraction* — so S3, S3-compatible
+  (endpoint override + path-style via konserve-s3), JDBC, etc. all work with no
+  new hard dependency, reusing whatever credentials the deployment already has.
+  This is what makes diskless/container deployments work.
+- **Manifest-written-last is the commit marker** — deliberately *not* a rename,
+  because object stores have no atomic rename. A dump without its manifest key
+  is incomplete by definition.
+- Per-chunk SHA-256 on read covers partial/eventually-consistent object reads.
+- A store chunk is one konserve value, materialized as a string — hence the
+  store-target `:chunk-size` default is 50k (vs 1M for files, which stream).
+
+**Review questions**
+- Is the key layout (`["datahike.migrate" prefix "datoms-NNNNNN"]`) acceptable
+  as a de-facto format commitment?
+- Would you rather chunk values be byte arrays (smaller, but loses greppability
+  in store browsers)?
+
+---
+
+## 6. The orchestrator — `migrate.clj`
+
+Walk it in this order:
+
+### 6a. `export-records` / `export-records-streaming` and `export-db`
+- Only user datoms (`tx > tx0`) are emitted — the bootstrap is never dumped, so
+  attribute-refs targets can never collide on `:db/ident` (#531).
+- Two orderings: the default external sort, and **`:sort? false`** — a
+  zero-scratch two-pass stream (schema + tx-entity datoms, then data) for hard
+  read-only containers. **Press on this trade-off:** it does not preserve a
+  same-transaction card-one replacement (retract + re-assert of the same
+  `[e a]` in one tx). That edge is documented, not detected. Is doc-level
+  protection enough, or should export scan for the pattern and refuse?
+
+### 6b. `datom->record` and the `#sysref` scheme (#508)
+- Attributes are always written as **keyword idents**; ref values pointing at
+  *system* entities are written as `#datahike/sysref :the/ident` and resolved
+  by ident lookup **in the target's own system table** on import — translation,
+  never insertion. This makes dumps independent of system-entity numbering
+  across datahike versions, which is precisely the #508 hazard.
+- Import seeds the target's `:migration` id-map with system-entity identity so
+  `load-entities` reuses rather than re-allocates them. Verified empirically
+  (`swap!` on the connection reaches the transactor's seed — see design doc).
+
+### 6c. `run-import` — guards, batcher, report
+- All guards run **before touching the db**: format-version, config
+  compatibility, target emptiness, chunk checksums. Every failure is `ex-info`
+  with a namespaced `:error`.
+- The batcher is a single streaming reduction; a transaction is never split
+  across a `load-entities` call, and batch state carries across chunk files.
+- Non-empty targets are refused because **import is not resumable** — the
+  id-map is memory-only, so resuming would double-apply. Recreate-and-restart
+  is the honest recovery. (A future durable id-map could change this; that is a
+  core-datahike question, not a migrate one.)
+
+### 6d. `collect-apply!` — the `:on-error :collect` path
+- On batch failure it narrows batch → transaction → datom, so exactly the bad
+  datoms are recorded and skipped.
+- **The safety argument matters:** a failed `load-entities` call applies
+  nothing — the writer builds the new db value purely and only a successful
+  result reaches the commit queue / `reset! connection`
+  (`writer.cljc:105-112`, commit at `:140-143`). The test pins this by
+  asserting every good datom landed *exactly once* after a mid-tx failure.
+- **Review question:** confirm the writer's atomicity reading — this is the one
+  place the feature leans on a core invariant that isn't in core's docstrings.
+
+### 6e. `verify` — tiers 0–3
+- Tier 2 is id-independent: multiset digest over non-ref `[a v op]` + per-attr
+  ref counts + out-degree histogram. Tier 3 samples `:db.unique` entities,
+  reconstructs their **net current state** from the dump (asserts add, retracts
+  remove), and diffs against `pull '[*]'`.
+- Honest limitation, stated in the docstring: tier 2/3 cannot fully verify ref
+  *topology* without graph isomorphism; degree histograms + sampling are the
+  practical bound.
+- Subtle bug fixed during development worth knowing about: `pull` returns a
+  vector for card-many **and** for tuple values — the comparator disambiguates
+  by declared cardinality, never value shape.
+
+### 6f. `estimate-import-memory`
+- The one memory term that grows with data is the id-remap map
+  (`~64 bytes × (entities + txs)`, held until `finalize-import!`). The manifest
+  carries `:max-eid`/`:max-tx` so the estimate needs no scan. `import-db` runs
+  it as a preflight and warns on stderr when `-Xmx` looks too small.
+- **Review question:** the constants are calibrated against one workload; treat
+  the estimate as an order-of-magnitude guide. Fine, or should it be labelled
+  more conservatively?
+
+---
+
+## 7. Tests — what covers what
+
+**Unit (`migrate_test.clj`):** round-trip of every builtin value type incl.
+tuple, flat + chunked (#633 class assertions); attribute-refs round-trip with a
+ref-resolution query (#508/#531); schema-evolution mid-history; schema-on-read;
+no-scratch mode (file + store); store-target round-trip; tiered-verify positive
+and tamper cases; per-datom collect with the exactly-once assertion; security
+(unknown tag, `#=(...)` refusal, path traversal, chunk tamper, non-empty
+target); determinism (byte-identical re-export); legacy CBOR import; memory
+estimator. Runs on both index backends and under spec instrumentation.
+
+**Integration (`migrate_s3_test.clj`):** provisions Garage v2.3.0 in docker
+(config via `docker cp`, no volume mounts), creates bucket + access key through
+Garage's CLI, and round-trips over the real S3 wire (SigV4, endpoint override,
+path-style). Self-skips without docker. Garage was chosen over MinIO because
+MinIO's community edition stopped receiving releases in 2025.
+
+**Scale evidence (manual, `dev/migrate_scale.clj`):** a 1.2 GB file-backed
+store (8.5× a 144 MB heap) exported to a 285 MB dump and re-imported +
+verified under the same cap. One operational finding worth flagging to users:
+`:store-cache-size` is **count-bounded, not byte-bounded** — with large values
+it must be kept small on the exporting connection (documented in backup.md).
+
+**What is *not* tested:** warm-heap throughput (the one benchmark is a
+worst-case cold run); cljs (the namespace is JVM-only, as the old one was);
+persistent backends in the unit suite (memory only; file/S3 covered by the
+manual harness and integration test respectively).
+
+---
+
+## 8. The decisions that are yours (recap)
+
+1. **Codec** — EDN-lines (implemented) vs CBOR (smaller/faster; loses
+   determinism-for-signing and type-exactness-by-construction). Seam exists
+   either way.
+2. **Home** — `datahike.migrate` (implemented, additive, `^:no-doc` today) vs
+   the Wanderung umbrella for 1.0.
+3. **Target branch** — `development` vs `main`.
+4. **`:sort? false` guard level** — documentation (current) vs detect-and-refuse.
+5. **Chunk-key layout / value type** in the store medium, before it becomes a
+   de-facto format.
+
+If the preferred outcome is a reimplementation rather than a merge, the pieces
+with the highest reuse value are: the §2 grounding facts (transactor order
+sensitivity, memory-only id-map, forward-ref allocation), the class-keyed codec
+approach with its closed reader, the manifest-last + per-chunk-SHA object-store
+pattern, the sysref translation scheme, and the test suite — most of which is
+implementation-independent.
+
+---
+
+## 9. Verification commands
+
+```
+# unit suite, both index backends
+clojure -M:test -m kaocha.runner :clj-pss --focus datahike.test.migrate-test
+clojure -M:test -m kaocha.runner :clj-hht --focus datahike.test.migrate-test
+
+# real-S3 integration (needs docker; ~30s)
+clojure -M:test -m kaocha.runner :integration --focus datahike.integration-test.migrate-s3-test
+
+# formatting
+clojure -M:format src/datahike/migrate.clj src/datahike/migrate test/datahike/test/migrate_test.clj
+
+# capped-heap scale demonstration (writes ~1.5 GB under /tmp, several minutes)
+clojure -J-Xmx140m -M:dev -e "(load-file \"dev/migrate_scale.clj\")(migrate-scale/run)"
+```

--- a/doc/walkthrough.md
+++ b/doc/walkthrough.md
@@ -61,9 +61,9 @@ core*, not choices this branch made:
   "import is not resumable, recreate-and-restart" policy.
 
 **Review questions**
-- §13 lists the three calls that belong to the maintainer: codec (EDN vs CBOR),
-  home (`datahike.migrate` vs Wanderung), target branch. These are genuinely
-  open — the branch implements one defensible answer to each.
+- §13 states the one call that belongs to the maintainer: the codec (EDN-lines
+  vs CBOR). It is genuinely open — the branch implements one defensible answer,
+  behind a seam that accepts the other.
 - §14 is the claims-vs-implementation ledger. Check it against the code as you
   go; anything overclaimed there is a review finding.
 
@@ -267,17 +267,13 @@ manual harness and integration test respectively).
 
 ---
 
-## 8. The decisions that are yours (recap)
+## 8. The open question (recap)
 
-1. **Codec** — EDN-lines (implemented) vs CBOR (smaller/faster; loses
-   determinism-for-signing and type-exactness-by-construction). Seam exists
-   either way.
-2. **Home** — `datahike.migrate` (implemented, additive, `^:no-doc` today) vs
-   the Wanderung umbrella for 1.0.
-3. **Target branch** — `development` vs `main`.
-4. **`:sort? false` guard level** — documentation (current) vs detect-and-refuse.
-5. **Chunk-key layout / value type** in the store medium, before it becomes a
-   de-facto format.
+**Codec** — EDN-lines (implemented) vs CBOR (smaller/faster; loses
+determinism-for-signing and type-exactness-by-construction). Seam exists either
+way. This is the one design fork; the smaller review-level questions
+(`:sort? false` guard level, store chunk-key layout, merge re-parse cost) are
+raised inline at their stops above (§4, §5, §6a).
 
 If the preferred outcome is a reimplementation rather than a merge, the pieces
 with the highest reuse value are: the §2 grounding facts (transactor order

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -1,42 +1,807 @@
 (ns ^:no-doc datahike.migrate
+  "Robust, type-exact, verifiable export/import for datahike databases.
+
+   The 3-arity `export-db`/`import-db` produce and consume a *type-exact* EDN-lines
+   dump (see `doc/import-export-design.md`) that round-trips full history, every
+   builtin value type (fixing #633), schema ordering (#262), the tx log (#377), and
+   attribute-refs databases (#508) without re-inserting system datoms (#531).
+
+   The legacy 2-arity remains for backward compatibility and additionally still
+   *reads* old CBOR dumps on import. New dumps are EDN. Import runs through
+   `load-entities`, which remaps entity/tx ids while preserving `[e a v t op]`
+   structure — a restored db is semantically equivalent, never id-identical.
+
+   Import is NOT resumable: the id-remap (`:migration`) is memory-only and dropped
+   on reconnect, so a partial import must be recreated-and-restarted rather than
+   resumed. Export IS resumable (completed chunks are content-addressed). A
+   `:history? true` export resurrects retracted data — see the data-protection note
+   in `import-db`/the backup guide."
   (:require [datahike.api :as api]
             [datahike.constants :as c]
             [datahike.datom :as d]
-            [datahike.db :as db]
-            [clj-cbor.core :as cbor]))
+            [datahike.db.interface :as dbi]
+            [datahike.db.utils :as dbu]
+            [datahike.schema :as ds]
+            [datahike.migrate.edn :as medn]
+            [datahike.migrate.digest :as dig]
+            [datahike.migrate.sort :as msort]
+            [datahike.migrate.store :as mstore]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clj-cbor.core :as cbor])
+  (:import [datahike.migrate.edn SysRef]
+           [java.io File BufferedReader]
+           [java.security MessageDigest]
+           [java.nio.charset StandardCharsets]
+           [java.nio.file Files]
+           [java.nio.file.attribute PosixFilePermissions]))
+
+(def format-version 1)
+(def ^:private manifest-key :datahike.migrate/format-version)
+
+(def ^:private source-config-allowlist
+  #{:attribute-refs? :keep-history? :schema-flexibility :index})
+
+;; ---------------------------------------------------------------------------
+;; small helpers
+
+(defn- ->db [x] (if (dbu/db? x) x @x))
+
+(defn- attribute-refs? [db] (boolean (:attribute-refs? (dbi/-config db))))
+
+(defn- a-ident
+  "Attribute as a keyword ident (resolve numeric refs in attribute-refs dbs)."
+  [db a]
+  (if (and (number? a) (attribute-refs? db)) (dbi/-ident-for db a) a))
+
+(defn- system-idents
+  "Map of source system-entity eid -> ident, for attribute-refs dumps (else {})."
+  [db]
+  (if (attribute-refs? db)
+    (into (sorted-map)
+          (keep (fn [e] (when-let [i (dbi/-ident-for db e)] [e i])))
+          (dbi/-system-entities db))
+    {}))
+
+(defn- posix? []
+  (-> (java.nio.file.FileSystems/getDefault) .supportedFileAttributeViews (.contains "posix")))
+
+(defn- restrict-perms! [^File f dir?]
+  (when (posix?)
+    (try
+      (Files/setPosixFilePermissions
+       (.toPath f)
+       (PosixFilePermissions/fromString (if dir? "rwx------" "rw-------")))
+      (catch Throwable _ nil))))
+
+;; ---------------------------------------------------------------------------
+;; export
+
+(defn- datom->record
+  "Convert a datom to an EDN-encodable record vector [e a v t added]. `a` becomes a
+   keyword ident; ref values pointing at a system entity become #datahike/sysref."
+  [db sys-ents sys-idents datom]
+  (let [e (nth datom 0)
+        a (a-ident db (nth datom 1))
+        v (nth datom 2)
+        t (nth datom 3)
+        op (nth datom 4)
+        sysref? (fn [val] (when (and (dbu/ref? db a) (contains? sys-ents val))
+                            (get sys-idents val)))]
+    [e a (medn/encode-value v sysref?) t op]))
+
+(defn- export-records
+  "Lazy seq of encoded record vectors for `db` (UNSORTED — the external merge sort
+   in `export-db` imposes the `(t, txInstant-first, e, a)` order). Emits only
+   user-transaction datoms (tx > tx0): this drops the bootstrap in attribute-refs
+   dbs — system entities are already present in the target, so refs to them are
+   translated (#508/#531) rather than re-inserted — and is a no-op for plain dbs,
+   whose bootstrap never appears in :eavt."
+  [db {:keys [history?]}]
+  (let [src      (if history? (api/history db) db)
+        sys-ents (if (attribute-refs? db) (dbi/-system-entities db) #{})
+        sidents  (system-idents db)]
+    (->> (api/datoms src :eavt)
+         (filter (fn [dm] (> (d/datom-tx dm) c/tx0)))
+         (map (fn [dm] (datom->record db sys-ents sidents dm))))))
+
+(defn- export-records-streaming
+  "Lazy seq of encoded records for `db` in a load-safe order WITHOUT sorting (so
+   export needs no scratch space — for hard read-only / diskless targets). Two lazy
+   passes over `:eavt`: first schema/ident and tx-entity (`meta-attr?`) datoms — so
+   schema precedes the data that uses it (#262) and every tx entity (with its
+   `:db/txInstant`) exists before any data datom — then the data datoms. Emits only
+   user-transaction datoms (tx > tx0).
+
+   Load-entities tolerates the remaining EAVT ordering: cross-tx and intra-tx
+   forward refs allocate on first sight, and ids remap consistently. The one shape
+   this does NOT preserve is a *same-transaction* card-one replacement (retract +
+   re-assert of the same [e a] in one tx), which the sorting exporter orders
+   explicitly; if a history has those, use the default (sorted) export."
+  [db {:keys [history?]}]
+  (let [src      (if history? (api/history db) db)
+        sys-ents (if (attribute-refs? db) (dbi/-system-entities db) #{})
+        sidents  (system-idents db)
+        user?    (fn [dm] (> (d/datom-tx dm) c/tx0))
+        schema-or-meta? (fn [dm]
+                          (let [a (a-ident db (nth dm 1))]
+                            (or (ds/schema-attr? a) (ds/meta-attr? a))))
+        make     (fn [dm] (datom->record db sys-ents sidents dm))]
+    (concat
+     (->> (api/datoms src :eavt) (filter user?) (filter schema-or-meta?) (map make))
+     (->> (api/datoms src :eavt) (filter user?) (remove schema-or-meta?) (map make)))))
+
+(defn- ident-schema
+  "The user schema as an ident->attr-map, keyed by keyword ident only (drops the
+   numeric-eid mirror that attribute-refs dbs keep)."
+  [db]
+  (into {} (filter (fn [[k v]] (and (keyword? k) (map? v))) (:schema db))))
+
+(defn- build-manifest [db {:keys [history?] :as _opts} digest chunks]
+  (let [cfg (dbi/-config db)]
+    (array-map
+     manifest-key                    format-version
+     :datahike-version               (try (System/getProperty "datahike.version") (catch Throwable _ nil))
+     :history?                       (boolean history?)
+     :serialization                  :edn-lines
+     :source-config                  (into (array-map :store-backend (get-in cfg [:store :backend]))
+                                           (map (fn [k] [k (get cfg k)]))
+                                           (sort source-config-allowlist))
+     :schema                         (ident-schema db)
+     :system-idents                  (system-idents db)
+     ;; :max-eid / :max-tx let an importer estimate the O(entities) id-remap map
+     ;; (and thus the heap to give the import) without scanning the dump.
+     :stats                          {:datom-count (:count digest)
+                                      :max-eid     (:max-eid db)
+                                      :max-tx      (:max-tx db)}
+     :semantic-digest                digest
+     :chunks                         (vec chunks))))
+
+(def chunk-re #"^datoms-\d{6}\.edn$")
+
+(defn- chunk-name [n] (format "datoms-%06d.edn" n))
+
+(defn- write-chunk-stream!
+  "Write up to `limit` lines from the (lazy) seq `lines` to `f`, updating the
+   semantic-digest accumulator `dacc` and computing the chunk SHA-256
+   incrementally — O(1) memory regardless of chunk size. Returns
+   [remaining-lines count sha256-hex dacc']."
+  [^File f lines limit dacc]
+  (let [md (MessageDigest/getInstance "SHA-256")
+        nl (byte-array 1 (byte 10))]
+    (with-open [w (io/writer f)]
+      (loop [ls (seq lines) c 0 da dacc]
+        (if (and ls (< c limit))
+          (let [^String line (first ls)]
+            (.write w line)
+            (.write w "\n")
+            (.update md (.getBytes line StandardCharsets/UTF_8))
+            (.update md nl)
+            (recur (next ls) (inc c) (dig/add-line da line)))
+          [ls c (dig/hex (.digest md)) da])))))
+
+(defn- write-flat! [db opts ^File f sorted-lines progress]
+  (let [tmp (File/createTempFile "dh-flat-" ".edn"
+                                 (.getAbsoluteFile (or (.getParentFile (.getAbsoluteFile f))
+                                                       (io/file "."))))
+        [_ cnt sha dacc] (write-chunk-stream! tmp sorted-lines Long/MAX_VALUE (dig/accumulator))
+        digest   (dig/finalize dacc)
+        manifest (build-manifest db opts digest
+                                 [{:file (.getName f) :count cnt :bytes (.length tmp) :sha256 sha}])]
+    (with-open [w (io/writer f)]
+      (.write w (pr-str manifest))
+      (.write w "\n")
+      (with-open [r (io/reader tmp)] (io/copy r w)))
+    (.delete tmp)
+    (restrict-perms! f false)
+    (progress {:phase :done :datoms cnt})
+    manifest))
+
+(defn- write-chunked! [db opts ^File dir sorted-lines chunk-size progress]
+  (.mkdirs dir)
+  (restrict-perms! dir true)
+  (loop [ls (seq sorted-lines) n 1 chunks [] dacc (dig/accumulator)]
+    (if (nil? ls)
+      (let [manifest (build-manifest db opts (dig/finalize dacc) chunks)]
+        (spit (io/file dir "manifest.edn") (pr-str manifest))
+        (restrict-perms! (io/file dir "manifest.edn") false)
+        (progress {:phase :done :datoms (:count (dig/finalize dacc))})
+        manifest)
+      (let [fname (chunk-name n)
+            tmp   (io/file dir (str fname ".tmp"))
+            final (io/file dir fname)
+            [rem cnt sha dacc'] (write-chunk-stream! tmp ls chunk-size dacc)]
+        (.renameTo tmp final)
+        (restrict-perms! final false)
+        (progress {:phase :chunk :datoms cnt})
+        (recur (seq rem) (inc n)
+               (conj chunks {:file fname :count cnt :bytes (.length final) :sha256 sha})
+               dacc')))))
 
 (defn export-db
-  "Export the database in a flat-file of datoms at path.
-  Intended as a temporary solution, pending developments in Wanderung."
-  [conn path]
-  (let [db @conn
-        cfg (:config db)]
-    (cbor/spit-all path (cond->> (sort-by
-                                  (juxt d/datom-tx :e)
-                                  (api/datoms (if (:keep-history? cfg) (api/history db) db) :eavt))
-                          (:attribute-refs? cfg) (remove #(= (d/datom-tx %) c/tx0))
-                          true (map seq)))))
+  "Export a database (or connection) to `target`.
 
-(defn update-max-tx
-  "Find bigest tx in datoms and update max-tx of db.
-  Note: the last tx might not be the biggest if the db
-  has been imported before."
+   2-arity keeps the legacy surface but writes the type-exact EDN format. 3-arity
+   opts:
+     :history?     false        include full history (asserts+retracts+tx entities)
+     :format       :chunked|:flat  (:chunked when target is a directory, else :flat)
+     :chunk-size   1000000      datoms per chunk file (50000 for store targets —
+                                a store chunk is held in memory as one value)
+     :sort-buffer  1000000      datoms per in-memory external-sort run
+     :sort?        true         false ⇒ no-scratch streaming order (see below)
+     :progress-fn  nil          (fn [{:keys [phase datoms]}])
+   `target` may be a filesystem path/dir OR a konserve store (S3 / S3-compatible /
+   JDBC / mem). Returns the manifest map.
+
+   By default ordering uses an external merge sort, so peak memory is bounded by
+   :sort-buffer, independent of database size — but it spills sorted runs to local
+   temp files. With `:sort? false` the export uses **no scratch at all** (for hard
+   read-only / diskless targets): it streams schema/tx-entity datoms then data in
+   `:eavt` order straight to the target. This relaxes the global tx ordering — it is
+   safe for the common case (load-entities remaps ids and allocates forward refs),
+   but does not preserve a *same-transaction* card-one replacement; keep the default
+   sort if your history has those.
+
+   The manifest is written LAST as the commit marker.
+
+   NOTE: with :history? true this dump contains every value ever asserted,
+   including retracted (\"deleted\") data — treat it as sensitive."
+  ([db-or-conn target] (export-db db-or-conn target {}))
+  ([db-or-conn target opts]
+   (let [db       (->db db-or-conn)
+         opts     (merge {:history? (boolean (:keep-history? (dbi/-config db)))
+                          ;; A store chunk is one konserve value, materialized as a
+                          ;; single string — so the store default is much smaller
+                          ;; than the filesystem default (which streams line by
+                          ;; line and never holds a chunk in memory).
+                          :chunk-size (if (mstore/store-target? target) 50000 1000000)
+                          :sort-buffer 1000000
+                          :sort? true}
+                         opts)
+         progress (or (:progress-fn opts) (constantly nil))
+         write-to! (fn [lines]
+                     (cond
+                       ;; external store (konserve): S3 / S3-compatible / JDBC / ...
+                       (mstore/store-target? target)
+                       (let [m (mstore/open target)]
+                         (try
+                           (mstore/write-chunks! m lines (:chunk-size opts)
+                                                 (fn [digest chunks] (build-manifest db opts digest chunks))
+                                                 progress)
+                           (finally (mstore/close m))))
+
+                       :else
+                       (let [fmt (cond
+                                   (:format opts)                  (:format opts)
+                                   (.isDirectory (io/file target)) :chunked
+                                   :else                           :flat)]
+                         (if (= :flat fmt)
+                           (write-flat! db opts (io/file target) lines progress)
+                           (write-chunked! db opts (io/file target) lines (:chunk-size opts) progress)))))]
+     (if (:sort? opts)
+       (let [records (export-records db opts)
+             ^File tmp-dir (.toFile (Files/createTempDirectory
+                                     "dh-export"
+                                     (make-array java.nio.file.attribute.FileAttribute 0)))]
+         (try
+           (write-to! (msort/external-sort records (:sort-buffer opts) tmp-dir))
+           (finally
+             (doseq [^File f (.listFiles tmp-dir)] (.delete f))
+             (.delete tmp-dir))))
+       ;; no-scratch streaming: no temp dir, no sort
+       (write-to! (map medn/write-record (export-records-streaming db opts)))))))
+
+;; ---------------------------------------------------------------------------
+;; reading dumps
+
+(defn- read-manifest-map [^String s]
+  (edn/read-string {:readers medn/readers :default (fn [t v] (tagged-literal t v))} s))
+
+(defn- looks-like-edn-manifest? [^File f]
+  (with-open [r (io/reader f)]
+    (let [c (.read r)] (= (int \{) c))))
+
+(defn- validate-chunk-file [^File dir fname]
+  (when-not (re-matches chunk-re fname)
+    (throw (ex-info (str "Illegal chunk file name in manifest: " fname)
+                    {:error :import/bad-chunk-path :file fname})))
+  (let [f (io/file dir fname)
+        canon (.getCanonicalFile f)
+        base  (.getCanonicalFile dir)]
+    (when-not (= base (.getParentFile canon))
+      (throw (ex-info (str "Chunk path escapes dump directory: " fname)
+                      {:error :import/bad-chunk-path :file fname})))
+    f))
+
+(defn- manifest-of
+  "Return {:manifest m :legacy? bool :flat? bool :files [File...]} WITHOUT hashing —
+   reads the manifest and validates chunk paths only. Cheap enough for estimation."
+  [source]
+  (let [^File f (io/file source)]
+    (cond
+      (.isDirectory f)
+      (let [manifest (read-manifest-map (slurp (io/file f "manifest.edn")))
+            files    (mapv #(validate-chunk-file f (:file %)) (:chunks manifest))]
+        {:manifest manifest :legacy? false :flat? false :files files})
+
+      (looks-like-edn-manifest? f)
+      (let [manifest (with-open [^BufferedReader r (io/reader f)]
+                       (read-manifest-map (.readLine r)))]
+        {:manifest manifest :legacy? false :flat? true :files [f]})
+
+      :else
+      {:manifest {manifest-key 0 :serialization :cbor :legacy? true}
+       :legacy? true :flat? false :files []})))
+
+(defn- open-dump
+  "Like `manifest-of`, but for a chunked directory dump additionally validates chunk
+   paths and verifies per-chunk SHA-256 by STREAMING each file (bounded memory)
+   before any import touches the database. Flat dumps have no separate chunk files
+   to validate (their single 'chunk' is the file itself)."
+  [source]
+  (let [dump (manifest-of source)]
+    (when (and (not (:legacy? dump)) (not (:flat? dump)))
+      (doseq [{:keys [file sha256]} (:chunks (:manifest dump))
+              :when sha256
+              :let [cf (validate-chunk-file (io/file source) file)]]
+        (when (not= sha256 (dig/sha256-file-hex cf))
+          (throw (ex-info (str "Checksum mismatch for chunk " file)
+                          {:error :import/checksum-failed :file file})))))
+    dump))
+
+;; ---------------------------------------------------------------------------
+;; memory estimation — tell the user how much heap to give an import
+
+(defn- bytes->human [b]
+  (let [b (double b)]
+    (cond
+      (>= b 1073741824) (format "%.1f GB" (/ b 1073741824.0))
+      (>= b 1048576)    (format "%.0f MB" (/ b 1048576.0))
+      :else             (format "%.0f KB" (/ b 1024.0)))))
+
+(def ^:private idmap-bytes-per-entry
+  "Conservative heap cost of one source->target id-map entry (boxed longs + Clojure
+   persistent-map node overhead)."
+  64)
+
+(defn- estimate-from-manifest
+  "Estimate from a manifest and the dump's total byte size (medium-agnostic)."
+  [manifest total-bytes batch-size]
+  (let [stats    (:stats manifest)
+        datoms   (long (or (:datom-count stats) 0))
+        entities (long (or (:max-eid stats) datoms 0))
+        txs      (long (max 0 (- (long (or (:max-tx stats) c/tx0)) c/tx0)))
+        avg-rec  (if (pos? datoms) (/ (double total-bytes) datoms) 64.0)
+        idmap    (long (* (+ entities txs) idmap-bytes-per-entry))
+        ;; a batch plus the tx-report / index-delta churn it drives (~3x)
+        batch    (long (* batch-size avg-rec 3))
+        recommend (max (* 512 1024 1024) (long (* 1.6 (+ idmap batch))))
+        maxheap  (.maxMemory (Runtime/getRuntime))]
+    {:datoms datoms
+     :entities entities
+     :id-map-bytes idmap
+     :batch-bytes batch
+     :recommended-heap-bytes recommend
+     :recommended-heap (bytes->human recommend)
+     :current-max-heap-bytes maxheap
+     :current-max-heap (bytes->human maxheap)
+     :sufficient? (>= maxheap recommend)}))
+
+(defn- manifest-total-bytes
+  "Total dump bytes from the manifest's chunk `:bytes` (present in v1 dumps); falls
+   back to on-disk file sizes for a filesystem dump that predates `:bytes`."
+  [manifest files]
+  (let [from-manifest (reduce + 0 (keep :bytes (:chunks manifest)))]
+    (if (pos? from-manifest)
+      from-manifest
+      (reduce + 0 (map #(.length ^File %) (or files []))))))
+
+(defn estimate-import-memory
+  "Estimate the JVM heap an `import-db` of `source` needs, so you can size `-Xmx`
+   before running it. Reads only the dump's manifest (no scan, no hashing).
+   `source` may be a filesystem path/dir OR a konserve store target.
+
+   The dominant, unavoidable term is the O(entities) id-remap map that
+   `load-entities` holds until `finalize-import!`; the rest is one `:batch-size`
+   worth of records. Returns e.g.
+     {:datoms .. :entities .. :id-map-bytes .. :batch-bytes ..
+      :recommended-heap-bytes .. :recommended-heap \"2.1 GB\"
+      :current-max-heap-bytes .. :current-max-heap \"512 MB\" :sufficient? bool}"
+  ([source] (estimate-import-memory source {}))
+  ([source opts]
+   (let [batch-size (:batch-size (merge {:batch-size 100000} opts))]
+     (if (mstore/store-target? source)
+       (let [m (mstore/open source)]
+         (try
+           (let [manifest (mstore/read-manifest m)]
+             (estimate-from-manifest manifest (manifest-total-bytes manifest nil) batch-size))
+           (finally (mstore/close m))))
+       (let [{:keys [manifest files]} (manifest-of source)]
+         (estimate-from-manifest manifest (manifest-total-bytes manifest files) batch-size))))))
+
+(defn- reduce-dump-lines
+  "Reduce `rf` over every record-line of the dump, with each file's reader scoped to
+   its inner reduction (no lazy seq escapes an open handle). Flat dumps skip the
+   manifest header line. Returns the final accumulator."
+  [{:keys [files flat?]} rf init]
+  (reduce (fn [acc ^File file]
+            (with-open [r (io/reader file)]
+              (let [lines (line-seq r)
+                    lines (if flat? (rest lines) lines)]
+                (reduce rf acc lines))))
+          init
+          files))
+
+;; ---------------------------------------------------------------------------
+;; import
+
+(defn- resolve-sysrefs
+  "Replace any SysRef value in a record with the target's system-entity eid."
+  [db record]
+  (let [v (nth record 2)]
+    (if (instance? SysRef v)
+      (assoc record 2 (dbi/-ref-for db (:ident v)))
+      record)))
+
+(defn- system-eid-seed
+  "Identity seed {eid eid} for every target system entity, so refs resolved to a
+   system entity are not re-allocated by load-entities (#508)."
+  [db]
+  (into {} (map (fn [e] [e e])) (dbi/-system-entities db)))
+
+(defn- user-datom-count
+  "Count user-transaction datoms (tx > tx0), i.e. everything an export writes. With
+   `history?` the full temporal set is enumerated, matching a :history? true dump."
+  ([db] (user-datom-count db false))
+  ([db history?]
+   (let [src (if history? (api/history db) db)]
+     (count (filter #(> (d/datom-tx %) c/tx0) (api/datoms src :eavt))))))
+
+(defn- collect-apply!
+  "Apply a tx-aligned batch under :on-error :collect. Fast path applies the whole
+   batch; on failure it narrows to per-transaction, then per-datom, so exactly the
+   offending datoms are recorded and skipped while everything else still lands
+   (id-consistency holds because the :migration id-map persists in the db value
+   across load-entities calls).
+
+   The narrowing retry is safe because a FAILED load-entities call applies
+   nothing: the writer's transaction loop builds the new db value purely and only
+   a successful result reaches the commit queue / `(reset! connection ...)` — on
+   Exception it recurs with the old db (src/datahike/writer.cljc:105-112, commit
+   at :140-143). So re-attempting a tx/datom after a failed batch cannot
+   double-apply anything. Returns the errors collected."
+  [conn batch progress]
+  (try
+    @(api/load-entities conn batch)
+    (progress {:phase :batch :datoms (count batch)})
+    []
+    (catch Exception _batch-ex
+      (vec
+       (mapcat
+        (fn [tx-group]
+          (let [tx-group (vec tx-group)]
+            (try
+              @(api/load-entities conn tx-group)
+              []
+              (catch Exception _tx-ex
+                (reduce (fn [errs d]
+                          (try @(api/load-entities conn [d]) errs
+                               (catch Exception ex
+                                 (conj errs {:error (or (:error (ex-data ex)) :import/corrupt-datom)
+                                             :datom d :message (ex-message ex)}))))
+                        [] tx-group)))))
+        (partition-by #(nth % 3) batch))))))
+
+(defn- flush-batch!
+  "Apply one tx-aligned batch via load-entities. Under :on-error :abort a failure
+   throws; under :collect the offending datoms are skipped and returned as errors
+   (per-datom granularity, see `collect-apply!`)."
+  [conn batch on-error progress]
+  (if (seq batch)
+    (if (= :collect on-error)
+      (collect-apply! conn batch progress)
+      (try
+        @(api/load-entities conn batch)
+        (progress {:phase :batch :datoms (count batch)})
+        []
+        (catch Exception ex
+          (throw (ex-info (str "Import aborted: " (ex-message ex))
+                          (merge (ex-data ex) {:error :import/corrupt-datom}) ex)))))
+    []))
+
+(defn- config-compat! [manifest conn]
+  (let [tgt (dbi/-config @conn)
+        src (:source-config manifest)]
+    (doseq [k [:attribute-refs? :keep-history? :schema-flexibility]]
+      (when (and (contains? src k) (not= (get src k) (get tgt k)))
+        (throw (ex-info (str "Config mismatch on " k
+                             ": dump=" (get src k) " target=" (get tgt k))
+                        {:error :import/config-mismatch :key k
+                         :expected (get src k) :actual (get tgt k)}))))))
+
+(declare import-db-legacy finalize-import!)
+
+(defn- run-import
+  "Medium-agnostic import core. `reduce-lines` is (fn [rf init] -> acc) that streams
+   the dump's record lines with resource scoping (filesystem or store). `mem` is the
+   memory estimate. Handles guards, attribute-refs seeding, the tx-aligned batcher,
+   verification, finalization, and the report."
+  [conn manifest mem reduce-lines opts]
+  (let [opts     (merge {:batch-size 100000 :verify? true :on-error :abort :finalize? true} opts)
+        progress (or (:progress-fn opts) (constantly nil))
+        batch-size (:batch-size opts)
+        on-error (:on-error opts)]
+    ;; ---- heap preflight: tell the operator how much RAM to give this ----
+    (when-not (:sufficient? mem)
+      (binding [*out* *err*]
+        (println (format "[datahike.migrate] heap warning: importing %d datoms (~%d entities) needs about %s; this JVM's -Xmx is %s. Raise -Xmx (the id-remap map is held until finalize) or expect OutOfMemoryError."
+                         (:datoms mem) (:entities mem)
+                         (:recommended-heap mem) (:current-max-heap mem)))))
+    ;; ---- guard rails (all before touching the db) ----
+    (when-let [fv (get manifest manifest-key)]
+      (when (> fv format-version)
+        (throw (ex-info (str "Unsupported dump format-version " fv)
+                        {:error :import/format-version :version fv}))))
+    (config-compat! manifest conn)
+    (when (pos? (user-datom-count @conn))
+      (throw (ex-info "Target database is not empty; import is not resumable — recreate and restart."
+                      {:error :import/non-empty-target})))
+    ;; ---- attribute-refs: seed system-entity identity so refs to system
+    ;; entities are translated, not re-allocated (#508) ----
+    (when (attribute-refs? @conn)
+      (swap! conn update :migration
+             (fn [m] (update (or m {}) :eids merge (system-eid-seed @conn)))))
+    ;; ---- stream records through a tx-aligned batcher (bounded memory) ----
+    ;; System-entity idents are stable across the import, so resolve #sysref against
+    ;; a captured db value. A transaction is never split across a batch flush; a tx
+    ;; spanning chunk boundaries is still kept whole, because the batcher state
+    ;; carries across chunks/files.
+    (let [sref-db @conn
+          final (reduce-lines
+                 (fn [acc line]
+                   (let [rec (resolve-sysrefs sref-db (medn/read-record line))
+                         t   (nth rec 3)
+                         acc (if (and (>= (long (:n acc)) batch-size)
+                                      (not= t (:last-t acc)))
+                               (-> acc
+                                   (update :errors into
+                                           (flush-batch! conn (:batch acc) on-error progress))
+                                   (assoc :batch [] :n 0))
+                               acc)]
+                     (-> acc
+                         (update :batch conj rec)
+                         (update :n inc)
+                         (update :tx-count + (if (= t (:last-t acc)) 0 1))
+                         (assoc :last-t t))))
+                 {:batch [] :n 0 :last-t ::start :tx-count 0 :errors []})
+          errors (into (:errors final)
+                       (flush-batch! conn (:batch final) on-error progress))
+          hist?  (boolean (:history? manifest))
+          live   (long (user-datom-count @conn hist?))
+          verified? (when (:verify? opts)
+                      (let [ok? (= (:count (:semantic-digest manifest)) live)]
+                        (when (and (not ok?) (not= :collect on-error))
+                          (throw (ex-info "Post-import verification failed (datom count mismatch)"
+                                          {:error :import/verify-failed
+                                           :dump-count (:count (:semantic-digest manifest))
+                                           :live-count live})))
+                        ok?))]
+      (when (and (:finalize? opts) verified?)
+        (finalize-import! conn))
+      {:datom-count live
+       :tx-count    (:tx-count final)
+       :max-tx      (:max-tx @conn)
+       :verified?   verified?
+       :finalized?  (boolean (and (:finalize? opts) verified?))
+       :recommended-heap (:recommended-heap mem)
+       :errors      errors})))
+
+(defn import-db
+  "Import a dump produced by `export-db` into connection `conn`.
+
+   `source` may be a filesystem path/dir OR a konserve store target (an open store
+   `{:store s :prefix ..}` or a `{:backend :s3 ..}`-style config). The target db
+   SHOULD be freshly created with a config compatible with the dump's
+   :source-config. 2-arity keeps the legacy surface; 3-arity opts:
+     :batch-size   100000   datoms per load-entities call (tx-aligned, never split)
+     :verify?      true      run verify after import; throw on mismatch
+     :on-error     :abort    :abort | :collect  (never silently skip)
+     :finalize?    true      clear the :migration id-map after a verified import
+     :progress-fn  nil
+   Returns {:datom-count .. :tx-count .. :max-tx .. :verified? .. :errors [..]
+            :recommended-heap ..}. Prints a heap warning if the current -Xmx looks
+   too small for the id-remap map (see `estimate-import-memory`).
+   Refuses a non-empty target (import is not resumable — recreate and restart)."
+  ([conn source] (import-db conn source {}))
+  ([conn source opts]
+   (let [batch-size (:batch-size (merge {:batch-size 100000} opts))]
+     (if (mstore/store-target? source)
+       (let [m (mstore/open source)]
+         (try
+           (let [manifest (mstore/read-manifest m)
+                 mem (estimate-from-manifest manifest (manifest-total-bytes manifest nil) batch-size)]
+             (run-import conn manifest mem
+                         (fn [rf init] (mstore/reduce-lines m manifest rf init)) opts))
+           (finally (mstore/close m))))
+       (let [dump (open-dump source)]
+         (if (:legacy? dump)
+           (import-db-legacy conn source)
+           (let [manifest (:manifest dump)
+                 mem (estimate-from-manifest manifest (manifest-total-bytes manifest (:files dump)) batch-size)]
+             (run-import conn manifest mem
+                         (fn [rf init] (reduce-dump-lines dump rf init)) opts))))))))
+
+(defn finalize-import!
+  "Clear import bookkeeping (:migration id map) from the db after a successful,
+   verified import. Idempotent. The map is O(entities) and rides in the db value."
+  [conn]
+  (swap! conn dissoc :migration)
+  :finalized)
+
+;; ---------------------------------------------------------------------------
+;; verify
+
+(defn- norm-val
+  "Stably hashable form of a value: array/bytes values compare structurally rather
+   than by identity, while keeping their class distinct."
+  [v]
+  (cond
+    (bytes? v)                              [:bytes (vec v)]
+    (instance? (Class/forName "[F") v)      [:farray (vec v)]
+    (instance? (Class/forName "[D") v)      [:darray (vec v)]
+    :else                                   v))
+
+;; Tier-2 fingerprint: an id-independent multiset digest over non-ref [a v op]
+;; tuples, plus per-attribute ref counts and an out-degree histogram for refs — so
+;; two databases with the same content compare equal despite fully remapped ids.
+(defn- fp-init [] {:acc (dig/accumulator) :refc {} :outd {}})
+(defn- fp-step [fp [e a v op] ref?]
+  (if (ref? a)
+    (-> fp (update-in [:refc a] (fnil inc 0)) (update-in [:outd e] (fnil inc 0)))
+    (update fp :acc dig/add-line (pr-str [a (norm-val v) op]))))
+(defn- fp-final [fp]
+  {:digest (dig/finalize (:acc fp))
+   :ref-counts (:refc fp)
+   :out-degree (frequencies (vals (:outd fp)))})
+
+(defn- with-source-lines
+  "Call `(f manifest reduce-lines)` where `reduce-lines` is `(fn [rf init] -> acc)`
+   streaming the dump's record lines, for either medium (filesystem or store).
+   `reduce-lines` may be invoked several times (each pass re-opens/re-reads)."
+  [source f]
+  (if (mstore/store-target? source)
+    (let [m (mstore/open source)]
+      (try (let [manifest (mstore/read-manifest m)]
+             (f manifest (fn [rf init] (mstore/reduce-lines m manifest rf init))))
+           (finally (mstore/close m))))
+    (let [dump (open-dump source)]
+      (f (:manifest dump) (fn [rf init] (reduce-dump-lines dump rf init))))))
+
+(defn- verify-sample
+  "Tier 3 — sampled structural diff. Pick up to `n` entities by a `:db.unique`
+   attribute, reconstruct their non-ref attributes from the dump, and diff against
+   `pull '[*]'` on the live db."
+  [manifest reduce-lines db ref? n]
+  (let [schema (:schema manifest)
+        uniq   (set (for [[a m] schema
+                          :when (#{:db.unique/identity :db.unique/value} (:db/unique m))] a))]
+    (if (empty? uniq)
+      {:sampled 0 :ok? true :note "no :db.unique attrs — content covered by tiers 1–2"}
+      (let [picks (reduce-lines
+                   (fn [acc line]
+                     (let [[e a v _t op] (medn/read-record line)]
+                       (if (and op (uniq a) (< (count acc) n) (not (contains? acc [a v])))
+                         (assoc acc [a v] e) acc)))
+                   {})
+            pick-es (set (vals picks))
+            ;; net *current* state per picked entity: asserts add, retracts remove,
+            ;; so a fully-retracted entity nets to empty (and is not compared).
+            recon (reduce-lines
+                   (fn [acc line]
+                     (let [[e a v _t op] (medn/read-record line)]
+                       (if (and (contains? pick-es e) (not (ref? a)))
+                         (update-in acc [e a] (fnil (if op conj disj) #{}) (norm-val v))
+                         acc)))
+                   {})
+            recon (into {} (for [[e am] recon
+                                 :let [am (into {} (remove (comp empty? val) am))]
+                                 :when (seq am)] [e am]))
+            diffs (reduce
+                   (fn [ds [[a v] e]]
+                     (if-let [cur (get recon e)]
+                       (let [live (api/q '[:find (pull ?e [*]) . :in $ ?a ?v :where [?e ?a ?v]] db a v)]
+                         (if (nil? live)
+                           (conj ds {:unique [a v] :error :missing-in-live})
+                           ;; pull returns a vector for card-many AND for a tuple
+                           ;; value — disambiguate by declared cardinality, never
+                           ;; by value shape (a tuple is ONE value).
+                           (let [many? (fn [la] (= :db.cardinality/many
+                                                   (:db/cardinality (get schema la))))
+                                 live-attrs (into {} (for [[la lv] (dissoc live :db/id)
+                                                           :when (not (ref? la))]
+                                                       [la (if (many? la)
+                                                             (set (map norm-val lv))
+                                                             #{(norm-val lv)})]))]
+                             (if (= live-attrs cur) ds
+                                 (conj ds {:unique [a v] :error :field-mismatch})))))
+                       ds)) ;; entity net-retracted — not current, not a failure
+                   [] picks)]
+        {:sampled (count picks) :ok? (empty? diffs) :diffs (vec (take 5 diffs))}))))
+
+(defn verify
+  "Compare a dump against its own manifest (integrity) and, given a live db/conn,
+   against that database (id-independent semantic equivalence). Returns a tiered
+   report: tier0 = checksums/paths (validated on open), tier1 = counts,
+   tier2 = multiset digest over `[a v op]` + ref-topology counts, tier3 = sampled
+   structural diff of unique entities. `source` may be a path or a konserve store."
+  ([source]
+   (let [{:keys [manifest]} (if (mstore/store-target? source)
+                              (let [m (mstore/open source)]
+                                (try {:manifest (mstore/read-manifest m)} (finally (mstore/close m))))
+                              (open-dump source))]
+     {:ok? true
+      :tier0 {:checksums :ok :format (get manifest manifest-key)}
+      :tier1 {:manifest-count (:count (:semantic-digest manifest))}}))
+  ([conn-or-db source]
+   (let [db    (->db conn-or-db)]
+     (with-source-lines source
+       (fn [manifest reduce-lines]
+         (let [schema (:schema manifest)
+               ref?   (fn [a] (= :db.type/ref (:db/valueType (get schema a))))
+               hist?  (boolean (:history? manifest))
+               ;; tier 1 — counts
+               dump-count (long (or (:count (:semantic-digest manifest)) 0))
+               live-count (long (user-datom-count db hist?))
+               ;; tier 2 — id-independent fingerprint, dump vs live
+               dump-fp (fp-final (reduce-lines
+                                  (fn [fp line]
+                                    (let [[e a v _t op] (medn/read-record line)]
+                                      (fp-step fp [e a v op] ref?)))
+                                  (fp-init)))
+               src     (if hist? (api/history db) db)
+               live-fp (fp-final (reduce (fn [fp dm]
+                                           (if (> (d/datom-tx dm) c/tx0)
+                                             (fp-step fp [(nth dm 0) (a-ident db (nth dm 1)) (nth dm 2) (nth dm 4)] ref?)
+                                             fp))
+                                         (fp-init) (api/datoms src :eavt)))
+               t2-ok  (and (= (:digest dump-fp) (:digest live-fp))
+                           (= (:ref-counts dump-fp) (:ref-counts live-fp))
+                           (= (:out-degree dump-fp) (:out-degree live-fp)))
+               ;; tier 3 — sampled structural diff
+               t3     (verify-sample manifest reduce-lines db ref? 25)]
+           {:ok? (and (= dump-count live-count) t2-ok (:ok? t3))
+            :tier0 {:checksums :ok :format (get manifest manifest-key)}
+            :tier1 {:manifest-count dump-count :live-count live-count :match? (= dump-count live-count)}
+            :tier2 {:match? t2-ok
+                    :value-digest-match? (= (:digest dump-fp) (:digest live-fp))
+                    :ref-counts-match? (= (:ref-counts dump-fp) (:ref-counts live-fp))
+                    :out-degree-match? (= (:out-degree dump-fp) (:out-degree live-fp))}
+            :tier3 t3}))))))
+
+;; ---------------------------------------------------------------------------
+;; legacy CBOR path (backward compatibility for old dumps)
+
+(def ^:dynamic *import-batch-size* 10000)
+
+(defn ^:deprecated update-max-tx
+  "DEPRECATED. max-tx is maintained by load-entities; retained for old dumps."
   [db datoms]
   (assoc db :max-tx (reduce #(max %1 (nth %2 3)) (:max-tx db 0) datoms)))
+
+(defn ^:deprecated update-max-tx-from-file
+  "DEPRECATED no-op wrapper retained for backward compatibility."
+  [db _file]
+  db)
 
 (defn- instance-to-date [v]
   (if (instance? java.time.Instant v) (java.util.Date/from v) v))
 
-(def ^:dynamic *import-batch-size* 10000)
-
-(defn import-db
-  "Import a flat-file of datoms at path into your database.
-  Intended as a temporary solution, pending developments in Wanderung."
+(defn- import-db-legacy
+  "Legacy import of an old flat CBOR dump via api/transact (unchanged behaviour)."
   [conn path]
-  (println "Preparing import of" path "in batches of" *import-batch-size*)
+  (println "Preparing legacy CBOR import of" path "in batches of" *import-batch-size*)
   (let [datoms (->> (cbor/slurp-all path)
                     (map #(-> (apply d/datom %) (update :v instance-to-date))))]
-    (print "Importing ")
     (reduce (fn [_last-tx batch]
               (let [batch (vec batch)]
                 (swap! conn update-max-tx batch)

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -912,6 +912,44 @@
                    [] picks)]
         {:sampled (count picks) :ok? (empty? diffs) :diffs (vec (take 5 diffs))}))))
 
+(defn- verify-blobs
+  "Check that a dump holds every blob it declares, and that each one's bytes hash
+   to the id it is filed under.
+
+   Blobs are verified at the SAME tier as the datom chunks, not reported
+   alongside: a dump whose `store-refs/` is short is incomplete, and a
+   verification that says `:ok? true` about it would be exactly the reassurance
+   nobody should get. Because the file name IS the content hash, this needs
+   nothing from the manifest beyond the id — and it catches a truncated or torn
+   object, which a count could not.
+
+   `:external` ids are counted, never checked: those bytes were never ours to
+   carry (see `datahike.migrate.blobs`). They make a dump not self-contained,
+   which the manifest states, and it is the operator who must place them."
+  [manifest source]
+  (if-let [store-refs (:store-refs manifest)]
+    (let [read-blob (blob-reader source)
+          declared  (vec (:carried store-refs))
+          results   (mapv (fn [id]
+                            (let [bytes (read-blob id)]
+                              (cond
+                                (nil? bytes)                    [:missing id]
+                                (not (mblobs/verify-blob id bytes)) [:corrupt id]
+                                :else                           [:ok id])))
+                          declared)
+          missing   (mapv second (filter #(= :missing (first %)) results))
+          corrupt   (mapv second (filter #(= :corrupt (first %)) results))]
+      {:ok?            (and (empty? missing) (empty? corrupt))
+       :declared       (count declared)
+       :verified       (count (filter #(= :ok (first %)) results))
+       :missing        missing
+       :corrupt        corrupt
+       :external       (count (:external store-refs))
+       :self-contained? (boolean (:self-contained? store-refs))})
+    ;; no store-refs section: either no blobs, or a dump predating blob carriage
+    {:ok? true :declared 0 :verified 0 :missing [] :corrupt []
+     :external 0 :self-contained? true}))
+
 (defn verify
   "Compare a dump against its own manifest (integrity) and, given a live db/conn,
    against that database (id-independent semantic equivalence). Returns a tiered
@@ -923,9 +961,11 @@
                               (let [m (mstore/open source)]
                                 (try {:manifest (mstore/read-manifest m)} (finally (mstore/close m))))
                               (open-dump source))]
-     {:ok? true
-      :tier0 {:checksums :ok :format (get manifest manifest-key)}
-      :tier1 {:manifest-count (:count (:semantic-digest manifest))}}))
+     (let [blobs (verify-blobs manifest source)]
+       {:ok? (:ok? blobs)
+        :tier0 {:checksums :ok :format (get manifest manifest-key)}
+        :tier1 {:manifest-count (:count (:semantic-digest manifest))}
+        :blobs blobs})))
   ([conn-or-db source]
    (let [db    (->db conn-or-db)]
      (with-source-lines source
@@ -952,15 +992,18 @@
                            (= (:ref-counts dump-fp) (:ref-counts live-fp))
                            (= (:out-degree dump-fp) (:out-degree live-fp)))
                ;; tier 3 — sampled structural diff
-               t3     (verify-sample manifest reduce-lines db ref? 25)]
-           {:ok? (and (= dump-count live-count) t2-ok (:ok? t3))
+               t3     (verify-sample manifest reduce-lines db ref? 25)
+               ;; blobs — same tier as the chunks, and part of :ok?
+               blobs  (verify-blobs manifest source)]
+           {:ok? (and (= dump-count live-count) t2-ok (:ok? t3) (:ok? blobs))
             :tier0 {:checksums :ok :format (get manifest manifest-key)}
             :tier1 {:manifest-count dump-count :live-count live-count :match? (= dump-count live-count)}
             :tier2 {:match? t2-ok
                     :value-digest-match? (= (:digest dump-fp) (:digest live-fp))
                     :ref-counts-match? (= (:ref-counts dump-fp) (:ref-counts live-fp))
                     :out-degree-match? (= (:out-degree dump-fp) (:out-degree live-fp))}
-            :tier3 t3}))))))
+            :tier3 t3
+            :blobs blobs}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; legacy CBOR path (backward compatibility for old dumps)

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -26,8 +26,12 @@
             [datahike.migrate.digest :as dig]
             [datahike.migrate.sort :as msort]
             [datahike.migrate.store :as mstore]
+            [datahike.migrate.blobs :as mblobs]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
+            [clojure.core.async :as async]
+            [konserve.core :as k]
+            [superv.async :refer [<?? S]]
             [clj-cbor.core :as cbor])
   (:import [datahike.migrate.edn SysRef]
            [java.io File BufferedReader]
@@ -155,6 +159,15 @@
                                       :max-eid     (:max-eid db)
                                       :max-tx      (:max-tx db)}
      :semantic-digest                digest
+     ;; Which `:db.type/store-ref` blobs this dump carries, and which it could
+     ;; not. A store-ref names an object without saying where the bytes live, so
+     ;; a dump is self-contained only for blobs that were IN the source store;
+     ;; anything held in a raw bucket the browser PUT to never transits our JVM
+     ;; and cannot be copied. Recording both halves means an import can refuse a
+     ;; dump whose referents it cannot place, instead of restoring datoms that
+     ;; name objects which are not there.
+     :store-refs                     (when-let [p (::blob-plan _opts)]
+                                       (mblobs/manifest-entry p))
      :chunks                         (vec chunks))))
 
 (def chunk-re #"^datoms-\d{6}\.edn$")
@@ -218,6 +231,58 @@
                (conj chunks {:file fname :count cnt :bytes (.length final) :sha256 sha})
                dacc')))))
 
+(defn- blob-dir
+  "The directory carried blobs live in for a filesystem dump.
+
+   Only a DIRECTORY dump can carry blobs: a flat single-file dump has nowhere to
+   put them, and silently dropping them would produce a dump whose datoms name
+   objects it does not contain."
+  ^File [target]
+  (io/file target mblobs/dir-name))
+
+(defn- blob-writer
+  "`(fn [id bytes])` writing one blob into `target`'s blob area."
+  [target opts]
+  (cond
+    (mstore/store-target? target)
+    (let [m (mstore/open target)]
+      (fn [id bytes]
+        (try (<?? S (k/bassoc (:store m) [mblobs/dir-name id] bytes))
+             (finally nil))))
+
+    (= :flat (:format opts))
+    (fn [_ _]
+      (throw (ex-info (str "This database has :db.type/store-ref blobs, which a flat "
+                           "single-file dump cannot carry. Export to a directory so the "
+                           "bytes can be written under " mblobs/dir-name "/.")
+                      {:error :export/flat-with-blobs})))
+
+    :else
+    (let [dir (doto (blob-dir target) (.mkdirs))]
+      (fn [id bytes]
+        (with-open [out (io/output-stream (io/file dir (str id)))]
+          (.write out ^bytes bytes))))))
+
+(defn- blob-reader
+  "`(fn [id]) -> bytes-or-nil` reading one blob back out of a dump."
+  [source]
+  (if (mstore/store-target? source)
+    (let [m (mstore/open source)]
+      (fn [id]
+        (<?? S (k/bget (:store m) [mblobs/dir-name id]
+                       (fn [{:keys [input-stream]}]
+                         (async/go
+                           (when input-stream
+                             (let [bos (java.io.ByteArrayOutputStream.)]
+                               (io/copy input-stream bos)
+                               (.toByteArray bos)))))))))
+    (fn [id]
+      (let [f (io/file (blob-dir source) (str id))]
+        (when (.exists f)
+          (let [bos (java.io.ByteArrayOutputStream.)]
+            (with-open [in (io/input-stream f)] (io/copy in bos))
+            (.toByteArray bos)))))))
+
 (defn export-db
   "Export a database (or connection) to `target`.
 
@@ -258,6 +323,20 @@
                           :sort-buffer 1000000
                           :sort? true}
                          opts)
+         ;; Only walk for blobs when the schema can actually have them. Two
+         ;; reasons, and the second is not an optimisation:
+         ;;   * `reachable-store-refs` is a full reachability mark — pointless
+         ;;     when no attribute is a `:db.type/store-ref`;
+         ;;   * it walks index ADDRESSES, so it requires a flushed index and
+         ;;     raises "Index needs to be properly flushed before marking" on an
+         ;;     unflushed in-memory db. Plenty of legitimate exports are of such
+         ;;     a db (`db-with`, a `:memory` store mid-test), and those cannot
+         ;;     hold in-store blobs anyway.
+         blob-plan (when (mblobs/schema-has-store-refs? db)
+                     (mblobs/plan db (:store db)))
+         opts     (cond-> opts
+                    (seq (:carried blob-plan)) (assoc ::blob-plan blob-plan)
+                    (seq (:external blob-plan)) (assoc ::blob-plan blob-plan))
          progress (or (:progress-fn opts) (constantly nil))
          write-to! (fn [lines]
                      (cond
@@ -278,6 +357,13 @@
                          (if (= :flat fmt)
                            (write-flat! db opts (io/file target) lines progress)
                            (write-chunked! db opts (io/file target) lines (:chunk-size opts) progress)))))]
+     ;; Blob carriage. Planned BEFORE anything is written so the manifest can
+     ;; declare it, and the bytes are written before the manifest — which is the
+     ;; commit marker — so a dump that has a manifest has its blobs. Same
+     ;; ordering the konserve-sync walker needs when it ships blobs ahead of the
+     ;; branch head: nothing may name an object that is not there yet.
+     (when-let [plan (::blob-plan opts)]
+       (mblobs/copy-out! (:store db) plan (blob-writer target opts)))
      (if (:sort? opts)
        (let [records (export-records db opts)
              ^File tmp-dir (.toFile (Files/createTempDirectory
@@ -596,6 +682,26 @@
        :recommended-heap (:recommended-heap mem)
        :errors      errors})))
 
+(defn- restore-blobs!
+  "Put the dump's carried `:db.type/store-ref` bytes into the target store, before
+   any datom that names them is loaded.
+
+   Order matters and is the same rule the sync walker follows: a reference must
+   never exist without its referent, or a reader between the two steps sees a
+   dangling pointer. Blobs are content-addressed, so restoring one twice is
+   idempotent and a re-run cannot corrupt anything.
+
+   A dump that declares blobs it could NOT carry (`:external` — bytes that lived
+   outside the source store, e.g. a bucket a browser PUT to directly) is refused
+   unless the caller passes `:accept-external-blobs? true`. The restored database
+   would name objects this import did not place, and that has to be a decision
+   rather than something discovered later by a failing read."
+  [conn manifest source opts]
+  (when-let [store-refs (:store-refs manifest)]
+    (mblobs/check-importable store-refs opts)
+    (when (seq (:carried store-refs))
+      (mblobs/copy-in! (:store @conn) store-refs (blob-reader source)))))
+
 (defn import-db
   "Import a dump produced by `export-db` into connection `conn`.
 
@@ -620,6 +726,7 @@
          (try
            (let [manifest (mstore/read-manifest m)
                  mem (estimate-from-manifest manifest (manifest-total-bytes manifest nil) batch-size)]
+             (restore-blobs! conn manifest source opts)
              (run-import conn manifest mem
                          (fn [rf init] (mstore/reduce-lines m manifest rf init)) opts))
            (finally (mstore/close m))))
@@ -628,6 +735,7 @@
            (import-db-legacy conn source)
            (let [manifest (:manifest dump)
                  mem (estimate-from-manifest manifest (manifest-total-bytes manifest (:files dump)) batch-size)]
+             (restore-blobs! conn manifest source opts)
              (run-import conn manifest mem
                          (fn [rf init] (reduce-dump-lines dump rf init)) opts))))))))
 

--- a/src/datahike/migrate.clj
+++ b/src/datahike/migrate.clj
@@ -22,6 +22,7 @@
             [datahike.db.interface :as dbi]
             [datahike.db.utils :as dbu]
             [datahike.schema :as ds]
+            [datahike.tools :as dt]
             [datahike.migrate.edn :as medn]
             [datahike.migrate.digest :as dig]
             [datahike.migrate.sort :as msort]
@@ -141,6 +142,71 @@
   [db]
   (into {} (filter (fn [[k v]] (and (keyword? k) (map? v))) (:schema db))))
 
+(def ^:private base-capabilities
+  "Capabilities every dump reader is assumed to have. Anything beyond these must
+   be declared, so an older reader can refuse precisely."
+  #{:datahike.migrate/edn-lines})
+
+(defn- dump-requires
+  "The capability set needed to INTERPRET this dump.
+
+   Version alone is too blunt for a dump. `connector/version-check` refuses a
+   STORE written by a newer datahike, and that is right — the on-disk index is
+   not forward compatible. A dump is different: it is logical, and a v3 dump that
+   happens to use no v3-only feature is perfectly readable by v2. Refusing it on
+   the version stamp would work against datahike's own commitment to backwards
+   compatibility, while accepting a dump whose features we cannot represent would
+   silently drop data. So the dump declares what it NEEDS, and the reader
+   compares that against what it HAS.
+
+   Value-type capabilities are derived from the schema rather than hand-listed:
+   a type added in a later version appears here automatically, and an older
+   reader — whose `ds/builtin-value-types` does not contain it — refuses by
+   construction rather than by anyone remembering to update a table."
+  [db {:keys [history?]} blob-plan]
+  (into base-capabilities
+        cat
+        [(when history? [:datahike.migrate/history])
+         (when (seq (:carried blob-plan)) [:datahike.migrate/store-ref-blobs])
+         (when (seq (:external blob-plan)) [:datahike.migrate/external-blobs])
+         (when (:attribute-refs? (dbi/-config db)) [:datahike.migrate/attribute-refs])
+         ;; every declared value type in play
+         (into #{}
+               (keep (fn [[_ attr]] (:db/valueType attr)))
+               (dbi/-schema db))]))
+
+(def ^:private supported-capabilities
+  "What THIS version can interpret. Derived, so it tracks the schema."
+  (into (conj base-capabilities
+              :datahike.migrate/history
+              :datahike.migrate/store-ref-blobs
+              :datahike.migrate/external-blobs
+              :datahike.migrate/attribute-refs)
+        ds/builtin-value-types))
+
+(defn check-capabilities!
+  "Raise unless every capability the dump declares is one we can honour.
+
+   Names the specific missing capabilities: \"this dump requires
+   :db.type/double-array\" is actionable, where \"version mismatch\" is not. A
+   dump with no `:requires` predates the declaration and is read as before."
+  [manifest]
+  (when-let [required (:requires manifest)]
+    (let [missing (remove supported-capabilities required)]
+      (when (seq missing)
+        (throw (ex-info (str "This dump requires capabilities this version of datahike "
+                             "cannot interpret: " (pr-str (vec (sort missing)))
+                             ". It was written by datahike "
+                             (or (get-in manifest [:datahike/meta :datahike/version])
+                                 (:datahike-version manifest) "?")
+                             "; upgrade to import it, or re-export from a database that "
+                             "does not use these features.")
+                        {:error :import/unsupported-capabilities
+                         :missing (vec (sort missing))
+                         :required (vec (sort required))
+                         :supported (vec (sort supported-capabilities))})))))
+  nil)
+
 (defn- build-manifest [db {:keys [history?] :as _opts} digest chunks]
   (let [cfg (dbi/-config db)]
     (array-map
@@ -148,6 +214,14 @@
      :datahike-version               (try (System/getProperty "datahike.version") (catch Throwable _ nil))
      :history?                       (boolean history?)
      :serialization                  :edn-lines
+     ;; Provenance in the SAME shape the store carries (`datahike.tools/meta-data`,
+     ;; which `connector/version-check` enforces), so a dump and a store can be
+     ;; reasoned about with one vocabulary.
+     :datahike/meta                  (dt/meta-data)
+     ;; …and, separately, what is needed to READ this dump. See `dump-requires`:
+     ;; provenance is for diagnostics, capabilities are for the accept/reject
+     ;; decision, and conflating them is what makes a version stamp too blunt.
+     :requires                       (vec (sort (dump-requires db _opts (::blob-plan _opts))))
      :source-config                  (into (array-map :store-backend (get-in cfg [:store :backend]))
                                            (map (fn [k] [k (get cfg k)]))
                                            (sort source-config-allowlist))
@@ -726,6 +800,7 @@
          (try
            (let [manifest (mstore/read-manifest m)
                  mem (estimate-from-manifest manifest (manifest-total-bytes manifest nil) batch-size)]
+             (check-capabilities! manifest)
              (restore-blobs! conn manifest source opts)
              (run-import conn manifest mem
                          (fn [rf init] (mstore/reduce-lines m manifest rf init)) opts))
@@ -735,6 +810,7 @@
            (import-db-legacy conn source)
            (let [manifest (:manifest dump)
                  mem (estimate-from-manifest manifest (manifest-total-bytes manifest (:files dump)) batch-size)]
+             (check-capabilities! manifest)
              (restore-blobs! conn manifest source opts)
              (run-import conn manifest mem
                          (fn [rf init] (reduce-dump-lines dump rf init)) opts))))))))

--- a/src/datahike/migrate/blobs.cljc
+++ b/src/datahike/migrate/blobs.cljc
@@ -1,0 +1,187 @@
+(ns datahike.migrate.blobs
+  "Carrying `:db.type/store-ref` BYTES in a dump.
+
+   A store-ref datom holds a `hasch` content id (`datahike.blob/blob-id`), which
+   is both the value in the datom and the key the bytes live under. Exporting the
+   datom therefore exports the *reference* and not the referent: restore it into a
+   fresh store and you get datoms naming objects that are not there. A backup that
+   loses the blobs is not a backup, so the dump has to carry them.
+
+   THE PART THAT CANNOT BE ASSUMED AWAY: datahike does not always have the bytes.
+   `:db.type/store-ref` deliberately says *what* an object is, never *where* it
+   lives (see `datahike.gc/reachable-store-refs`). Two cases, and only the first
+   is ours:
+
+     - IN THIS STORE — written with `k/bassoc`, readable with `k/bget`. We copy
+       these into the dump, and the dump is self-contained with respect to them.
+
+     - ANYWHERE ELSE — a raw S3 prefix a browser PUT to with a presigned URL, a
+       CDN, another bucket. The bytes never transit our JVM by design; that is
+       the whole point of the feature. We cannot copy what we cannot read.
+
+   So `plan` splits the live set into `:carried` and `:external`, the manifest
+   records both, and a dump that has externals is honestly labelled as not
+   self-contained rather than quietly appearing complete. That mirrors the
+   division of labour the GC already states: datahike owns the mark (what is
+   still referenced, across branches and through retained history), the operator
+   owns the sweep — and here, the copy.
+
+   ORDERING. Bytes must be present before anything names them, the same
+   constraint the konserve-sync walker met by shipping blobs ahead of the branch
+   head, and the same one the dump meets by writing the manifest last. On import
+   we restore blobs BEFORE the datoms that reference them; on export we write
+   them before the manifest, so a dump without a manifest is incomplete by
+   definition and a dump with one has its blobs."
+  (:require [clojure.core.async :refer [go]]
+            [datahike.db.interface :as dbi]
+            #?(:clj [clojure.java.io :as io])
+            [datahike.blob :as blob]
+            [datahike.gc :as gc]
+            [konserve.core :as k]
+            [superv.async :refer [<?? S]]))
+
+(def ^:const dir-name
+  "Subdirectory (filesystem) / key segment (store) the blobs live under.
+
+   Each blob is one object named by its content id, so the name IS the checksum:
+   verification is recomputing `blob-id` over the bytes, identical content
+   deduplicates for free, and nothing needs a side table mapping names to
+   hashes."
+  "store-refs")
+
+(defn- blob-bytes
+  "The bytes for `id` in `store`, or nil when this store does not hold them.
+
+   `k/bget` hands the callback a platform-specific handle — a wrapped
+   `InputStream` on the JVM, a `Blob` in JS — and the callback IS the scope in
+   which that handle is valid: konserve still owns the backing object, and a
+   streaming view is only live until the callback (or the channel it returns)
+   completes. So the read has to finish inside it. Called asynchronously, as
+   datahike's stores are, the callback must synchronously return a CHANNEL;
+   returning the bytes directly makes `bget` hand back a byte array where the
+   caller expects something to take from, which is a confusing failure precisely
+   because it looks like a working call.
+
+   nil is the ordinary answer for a blob that lives outside this store (see the
+   ns docstring), so it must mean exactly that. No catch-all here: reporting a
+   store error as \"external\" would turn a broken store into a dump that looks
+   fine and carries nothing."
+  [store id]
+  (<?? S (k/bget store id
+                 (fn [{:keys [input-stream]}]
+                   (go
+                     (when input-stream
+                       #?(:clj (let [bos (java.io.ByteArrayOutputStream.)]
+                                 (io/copy input-stream bos)
+                                 (.toByteArray bos))
+                          ;; cljs receives a Blob; reading it is async and not
+                          ;; needed until import runs on cljs.
+                          :cljs input-stream)))))))
+
+(defn schema-has-store-refs?
+  "True when any attribute in `db` is declared `:db.type/store-ref`.
+
+   The cheap precondition for planning blobs at all: with no such attribute there
+   can be no blobs, and the full reachability walk `plan` performs — which also
+   requires a flushed index — would be both pointless and, on an unflushed
+   in-memory db, an error."
+  [db]
+  (boolean
+   (some (fn [[_ attr]]
+           (= :db.type/store-ref (:db/valueType attr)))
+         (dbi/-schema db))))
+
+(defn plan
+  "Split the database's live store-refs into what this dump can carry and what it
+   cannot.
+
+   Returns `{:carried [id …] :external [id …] :self-contained? bool}`, with ids
+   sorted so the manifest stays deterministic. `:external` is not a failure — it
+   is the operator's half of the contract, and it has to be visible."
+  [db store]
+  (let [live (sort (<?? S (gc/reachable-store-refs db)))
+        {carried true external false} (group-by #(some? (blob-bytes store %)) live)]
+    {:carried (vec (sort carried))
+     :external (vec (sort external))
+     :self-contained? (empty? external)}))
+
+(defn manifest-entry
+  "The `:store-refs` section for the manifest.
+
+   Records the count and the ids rather than only a total: an importer must be
+   able to say *which* blob is missing, and a verifier must be able to check the
+   dump holds exactly these. Sizes are omitted deliberately — the id is the
+   content hash, so it already pins the bytes."
+  [{:keys [carried external self-contained?]}]
+  (array-map :self-contained? self-contained?
+             :carried-count (count carried)
+             :carried (vec carried)
+             :external (vec external)))
+
+(defn verify-blob
+  "True when `bytes` hash to `id`.
+
+   The name is the checksum, so verification needs nothing from the manifest
+   beyond the name itself — and it detects a torn or truncated object, which a
+   count alone would not."
+  [id bytes]
+  (= id (blob/blob-id bytes)))
+
+(defn copy-out!
+  "Copy the carried blobs from the source store to `write-blob!`.
+
+   `write-blob!` is `(fn [id bytes])` and owns the medium — a file under
+   `store-refs/`, a key in a konserve target, an object in a bucket. Returns the
+   number copied.
+
+   A blob that has vanished between `plan` and here (a concurrent GC, say) is
+   reported rather than skipped: the dump would otherwise be short by one object
+   and still look complete."
+  [store {:keys [carried]} write-blob!]
+  (reduce (fn [n id]
+            (if-let [bytes (blob-bytes store id)]
+              (do (write-blob! id bytes) (inc n))
+              (throw (ex-info "Blob disappeared during export; the dump would be incomplete"
+                              {:error :export/blob-vanished :blob-id id}))))
+          0
+          carried))
+
+(defn copy-in!
+  "Restore blobs into the target store, verifying each against its own name.
+
+   `read-blob` is `(fn [id]) -> bytes-or-nil`. Called BEFORE the datoms are
+   loaded, so nothing ever names an object that is not yet there.
+
+   A blob whose bytes do not hash to its id is a corrupt dump and raises: writing
+   it anyway would put a wrong object under a content-addressed key, where every
+   later reader would trust it."
+  [store {:keys [carried]} read-blob]
+  (reduce (fn [n id]
+            (let [bytes (read-blob id)]
+              (when (nil? bytes)
+                (throw (ex-info "Dump is missing a blob it declares"
+                                {:error :import/blob-missing :blob-id id})))
+              (when-not (verify-blob id bytes)
+                (throw (ex-info "Blob content does not match its content id — dump is corrupt"
+                                {:error :import/blob-corrupt :blob-id id})))
+              (<?? S (k/bassoc store id bytes))
+              (inc n)))
+          0
+          carried))
+
+(defn check-importable
+  "Raise unless a dump's blobs can be honoured by this import.
+
+   A dump carrying externals is importable only if the caller says so: the
+   restored database will name objects this import did not place, and that has to
+   be a decision rather than a discovery. Same rule as a partial dump — best
+   effort is fine, silence is not."
+  [{:keys [external] :as _store-refs} {:keys [accept-external-blobs?] :as _opts}]
+  (when (and (seq external) (not accept-external-blobs?))
+    (throw (ex-info (str "This dump is not self-contained: " (count external)
+                         " store-ref blob(s) live outside the source store and were "
+                         "not carried. Copy them to the target's blob location and "
+                         "re-run with :accept-external-blobs? true, or export from a "
+                         "database whose blobs are in-store.")
+                    {:error :import/external-blobs :external external})))
+  nil)

--- a/src/datahike/migrate/digest.clj
+++ b/src/datahike/migrate/digest.clj
@@ -1,0 +1,79 @@
+(ns ^:no-doc datahike.migrate.digest
+  "Two independent integrity mechanisms for dumps, with distinct threat models.
+
+   * `sha256` — per-chunk cryptographic hash recorded in the manifest. This is the
+     tamper-evidence control: `verify` recomputes it, and because a dump is
+     deterministic it can be signed by external tooling.
+
+   * semantic digest `{:xor :sum :count}` — an order-independent fold over the
+     record lines, so a dump can be compared against a live, *id-remapped* database
+     without solving id equality. It is **not** a security control (it is linear,
+     hence forgeable); its only job is cheap structural comparison."
+  (:require [clojure.java.io :as io])
+  (:import [java.security MessageDigest]
+           [java.nio.charset StandardCharsets]))
+
+(defn sha256-bytes ^bytes [^bytes bs]
+  (.digest (MessageDigest/getInstance "SHA-256") bs))
+
+(defn ^String hex [^bytes bs]
+  (let [sb (StringBuilder. (* 2 (alength bs)))]
+    (dotimes [i (alength bs)]
+      (let [b (bit-and (aget bs i) 0xff)]
+        (when (< b 16) (.append sb \0))
+        (.append sb (Integer/toHexString b))))
+    (.toString sb)))
+
+(defn sha256-hex
+  "Hex SHA-256 of a UTF-8 string or a byte array."
+  [x]
+  (hex (sha256-bytes (if (string? x) (.getBytes ^String x StandardCharsets/UTF_8) x))))
+
+(defn sha256-file-hex
+  "Streaming hex SHA-256 of a file's bytes — bounded memory, for large chunks."
+  [file]
+  (let [md (MessageDigest/getInstance "SHA-256")
+        buf (byte-array 65536)]
+    (with-open [in (io/input-stream file)]
+      (loop []
+        (let [n (.read in buf)]
+          (when (pos? n) (.update md buf 0 n) (recur)))))
+    (hex (.digest md))))
+
+(defn- record-hash8
+  "First 8 bytes (big-endian) of SHA-256(line-bytes) as a raw 64-bit long (the sign
+   bit is just the top data bit; all arithmetic below treats it as unsigned)."
+  ^long [^String line]
+  (let [d (sha256-bytes (.getBytes line StandardCharsets/UTF_8))]
+    (areduce d i acc (long 0)
+             (if (< i 8) (bit-or (bit-shift-left acc 8) (bit-and (aget d i) 0xff)) acc))))
+
+;; Semantic digest as a stateful accumulator so it composes with a streaming
+;; reduction (one pass, bounded memory, order-independent). Everything is a 64-bit
+;; long: two's-complement wraparound IS addition mod 2^64, and `%016x` renders a
+;; long as unsigned hex.
+
+(defn accumulator
+  "Return a fresh accumulator {:xor long :sum long :count long}."
+  [] {:xor 0 :sum 0 :count 0})
+
+(defn add-line
+  "Fold one record line into the accumulator."
+  [acc ^String line]
+  (let [h (record-hash8 line)]
+    {:xor   (bit-xor (long (:xor acc)) h)
+     :sum   (unchecked-add (long (:sum acc)) h)
+     :count (unchecked-inc (long (:count acc)))}))
+
+(defn finalize
+  "Render an accumulator to the manifest shape: unsigned hex xor + hex sum + count."
+  [acc]
+  {:algo  :xor64+sum64
+   :xor   (format "%016x" (long (:xor acc)))
+   :sum   (format "%016x" (long (:sum acc)))
+   :count (:count acc)})
+
+(defn digest-lines
+  "Convenience: fold a seq/reducible of record lines to a finalized digest."
+  [lines]
+  (finalize (reduce add-line (accumulator) lines)))

--- a/src/datahike/migrate/edn.clj
+++ b/src/datahike/migrate/edn.clj
@@ -1,0 +1,127 @@
+(ns ^:no-doc datahike.migrate.edn
+  "Type-exact EDN-lines codec for datahike dumps.
+
+   One datom is one line: an EDN 5-vector `[e a v t added]`. Values are encoded so
+   that the *runtime class* round-trips exactly — the core reason this exists is
+   #633, where the CBOR codec routes zero/NaN/Inf `double`s through half-precision
+   and reads them back as `java.lang.Float`, silently changing a `:db.type/double`
+   value's class (datahike's schema is a bare `double?`/`float?` predicate with no
+   coercion, so the flipped class fails validation / compares unequal).
+
+   Encoding is by runtime class (so schema-on-read databases round-trip too), with
+   a small, **closed** set of reader tags:
+
+     #datahike/float   \"3.14\"     ; java.lang.Float, exact via Float/toString
+     #datahike/bytes   \"<b64>\"    ; byte[]
+     #datahike/farray  \"<b64>\"    ; float[]  (IEEE-754 big-endian)
+     #datahike/darray  \"<b64>\"    ; double[]
+     #datahike/sysref  :db/ident   ; ref value pointing at a system entity (#508)
+
+   plus EDN built-ins `#inst`/`#uuid`. `clojure.core/read-string` and `*read-eval*`
+   are never used; parsing is `clojure.edn/read` with this closed `:readers` map and
+   a throwing `:default`, so a dump can never execute code on import."
+  (:require [clojure.edn :as edn])
+  (:import [java.util Base64]
+           [java.nio ByteBuffer]))
+
+;; ---------------------------------------------------------------------------
+;; system-entity references (#508): translate, never re-insert
+
+(defrecord SysRef [ident])
+
+(defmethod print-method SysRef [^SysRef r ^java.io.Writer w]
+  (.write w "#datahike/sysref ")
+  (print-method (.-ident r) w))
+
+;; ---------------------------------------------------------------------------
+;; primitive-array <-> base64 (exact IEEE-754 bytes, order-preserving)
+
+(def ^:private ^Class float-array-class (class (float-array 0)))
+(def ^:private ^Class double-array-class (class (double-array 0)))
+
+(defn- b64-encode ^String [^bytes bs]
+  (.encodeToString (Base64/getEncoder) bs))
+
+(defn- b64-decode ^bytes [^String s]
+  (.decode (Base64/getDecoder) s))
+
+(defn- floats->b64 [^floats fs]
+  (let [bb (ByteBuffer/allocate (* 4 (alength fs)))]
+    (dotimes [i (alength fs)] (.putFloat bb (aget fs i)))
+    (b64-encode (.array bb))))
+
+(defn- b64->floats [^String s]
+  (let [bb (ByteBuffer/wrap (b64-decode s))
+        n  (quot (.remaining bb) 4)
+        fs (float-array n)]
+    (dotimes [i n] (aset fs i (.getFloat bb)))
+    fs))
+
+(defn- doubles->b64 [^doubles ds]
+  (let [bb (ByteBuffer/allocate (* 8 (alength ds)))]
+    (dotimes [i (alength ds)] (.putDouble bb (aget ds i)))
+    (b64-encode (.array bb))))
+
+(defn- b64->doubles [^String s]
+  (let [bb (ByteBuffer/wrap (b64-decode s))
+        n  (quot (.remaining bb) 8)
+        ds (double-array n)]
+    (dotimes [i n] (aset ds i (.getDouble bb)))
+    ds))
+
+;; ---------------------------------------------------------------------------
+;; value encoding — dispatch on runtime class, tag only what native EDN can't
+;; round-trip class-exactly.
+
+(defn encode-value
+  "Return an EDN-printable representation of value `v` whose reader round-trips to
+   the identical runtime class. `sysref?` is a predicate `(fn [v] -> truthy)` that
+   returns the target *ident* when `v` is a ref pointing at a system entity, else
+   nil (the caller supplies db context)."
+  ([v] (encode-value v (constantly nil)))
+  ([v sysref?]
+   (if-let [ident (sysref? v)]
+     (->SysRef ident)
+     (condp instance? v
+       Float                (tagged-literal 'datahike/float (Float/toString v))
+       ;; BigInteger prints without the `N` suffix and would read back as Long;
+       ;; coerce to clojure.lang.BigInt so it prints `123N` and reads as bigint.
+       java.math.BigInteger (bigint v)
+       (cond
+         (instance? float-array-class v)  (tagged-literal 'datahike/farray (floats->b64 v))
+         (instance? double-array-class v) (tagged-literal 'datahike/darray (doubles->b64 v))
+         (bytes? v)                       (tagged-literal 'datahike/bytes (b64-encode v))
+         ;; tuples: encode element-wise, keep the surrounding native vector
+         (vector? v)                      (mapv #(encode-value % sysref?) v)
+         ;; native EDN handles: keyword string boolean long double bigint bigdec
+         ;; symbol, #inst (Date), #uuid
+         :else                            v)))))
+
+;; ---------------------------------------------------------------------------
+;; closed reader map — the ONLY tags accepted on import
+
+(def readers
+  {'datahike/float  (fn [^String s] (Float/parseFloat s))
+   'datahike/bytes  (fn [^String s] (b64-decode s))
+   'datahike/farray (fn [^String s] (b64->floats s))
+   'datahike/darray (fn [^String s] (b64->doubles s))
+   'datahike/sysref (fn [ident] (->SysRef ident))})
+
+(defn- unknown-tag [tag value]
+  (throw (ex-info (str "Unknown reader tag in dump: #" tag)
+                  {:error :import/unknown-tag :tag tag :value value})))
+
+(def ^:private read-opts
+  {:readers readers :default unknown-tag :eof ::eof})
+
+(defn read-record
+  "Parse one EDN record line into `[e a v t added]`, resolving only the closed tag
+   set. Never evaluates code."
+  [^String line]
+  (edn/read-string read-opts line))
+
+(defn write-record
+  "Render a datom tuple `[e a v t added]` as one EDN line string (no newline).
+   `v` must already be run through `encode-value`."
+  [record]
+  (pr-str record))

--- a/src/datahike/migrate/sort.clj
+++ b/src/datahike/migrate/sort.clj
@@ -1,0 +1,98 @@
+(ns ^:no-doc datahike.migrate.sort
+  "External merge sort for the export path, so ordering a dump uses memory bounded
+   by `:sort-buffer` rather than by the database size. `(api/datoms db :eavt)` is
+   lazy over the index but ordered by `e`, not `t`; a dump must be ordered by
+   transaction, so we spill sorted runs to temp files and k-way merge them.
+
+   Records are `[e a v t op]` vectors; run files hold one EDN record per line."
+  (:require [clojure.java.io :as io]
+            [datahike.migrate.edn :as medn])
+  (:import [java.io File BufferedReader]
+           [java.util PriorityQueue Comparator]))
+
+(defn sort-key
+  "Ordering key: transaction first (schema/refs before use, causal history),
+   `:db/txInstant` first within a tx (tx entity established before its datoms),
+   then `e`,`a` for a deterministic total order."
+  [record]
+  [(nth record 3) (if (= (nth record 1) :db/txInstant) 0 1) (nth record 0) (str (nth record 1))])
+
+(defn spill-runs
+  "Consume a (lazy) seq of records in windows of `run-size`, sort each window by
+   `sort-key`, and write it to a temp run file under `tmp-dir`. Returns the vector
+   of run `File`s. Memory is bounded by one window."
+  [records run-size ^File tmp-dir]
+  (loop [rs (seq records) files []]
+    (if (nil? rs)
+      files
+      (let [window (into [] (take run-size) rs)
+            f (File/createTempFile "dh-run-" ".edn" tmp-dir)]
+        (with-open [w (io/writer f)]
+          (doseq [r (sort-by sort-key window)]
+            (.write w ^String (medn/write-record r))
+            (.write w "\n")))
+        (recur (seq (drop run-size rs)) (conj files f))))))
+
+(defn- line-seq-closing
+  "Lazy seq of lines from `f` that closes the reader when exhausted."
+  [^File f]
+  (let [^BufferedReader r (io/reader f)]
+    ((fn step []
+       (lazy-seq
+        (if-let [line (.readLine r)]
+          (cons line (step))
+          (do (.close r) nil)))))))
+
+(defn merge-runs
+  "K-way merge of sorted run files into a single lazy seq of record-line strings,
+   globally ordered by `sort-key`. Memory is bounded by the number of runs."
+  [run-files]
+  (let [cmp (reify Comparator
+              (compare [_ a b] (compare (:key a) (:key b))))
+        cursors (keep (fn [f]
+                        (let [ls (seq (line-seq-closing f))]
+                          (when ls
+                            {:key (sort-key (medn/read-record (first ls)))
+                             :line (first ls)
+                             :rest (rest ls)})))
+                      run-files)
+        pq (PriorityQueue. (max 1 (count run-files)) cmp)]
+    (doseq [c cursors] (.add pq c))
+    ((fn step []
+       (lazy-seq
+        (when-not (.isEmpty pq)
+          (let [{:keys [line rest]} (.poll pq)]
+            (when-let [nl (first rest)]
+              (.add pq {:key (sort-key (medn/read-record nl))
+                        :line nl
+                        :rest (next rest)}))
+            (cons line (step)))))))))
+
+(def ^:private max-fanin
+  "Maximum run files merged at once, so a run never opens more file descriptors than
+   a conservative OS limit — bounding fan-in rather than assuming a high `ulimit`."
+  64)
+
+(defn- merge-into-file
+  "Merge a group of sorted run files into one new sorted run file, deleting the
+   inputs. Opens at most (count run-files) descriptors."
+  [run-files ^File tmp-dir]
+  (let [out (File/createTempFile "dh-merge-" ".edn" tmp-dir)]
+    (with-open [w (io/writer out)]
+      (doseq [^String line (merge-runs run-files)]
+        (.write w line)
+        (.write w "\n")))
+    (doseq [^File f run-files] (.delete f))
+    out))
+
+(defn external-sort
+  "Given a lazy seq of records, return a lazy seq of record-line strings globally
+   ordered by `sort-key`, using external merge sort bounded by `run-size`. When the
+   number of runs exceeds `max-fanin`, they are merged in passes so no single merge
+   opens more than `max-fanin` files. Spill files are created under `tmp-dir`; the
+   caller cleans up `tmp-dir` after the returned seq is fully consumed."
+  [records run-size ^File tmp-dir]
+  (loop [runs (spill-runs records run-size tmp-dir)]
+    (if (<= (count runs) max-fanin)
+      (merge-runs runs)
+      (recur (mapv #(merge-into-file % tmp-dir) (partition-all max-fanin runs))))))

--- a/src/datahike/migrate/store.clj
+++ b/src/datahike/migrate/store.clj
@@ -1,0 +1,87 @@
+(ns ^:no-doc datahike.migrate.store
+  "Konserve-store medium for dumps, so export/import can target an external store
+   (S3 / S3-compatible via konserve-s3, JDBC, Redis, in-memory, ...) with no local
+   disk for the dump itself — the same storage abstraction datahike uses for its
+   own data. A diskless container writes straight to its configured store.
+
+   A dump target/source may be:
+     - an already-open konserve store:   {:store <store> :prefix \"my-backup\"}
+     - a konserve store-config map:       {:backend :s3 :bucket .. :id .. :prefix ..}
+   Chunks and the manifest are stored under keys `[\"datahike.migrate\" prefix X]`;
+   the manifest key is written LAST as the commit marker. Only the store transport
+   differs — the format, per-chunk SHA-256, and semantic digest are identical to
+   the filesystem dump.
+
+   The external-sort scratch still uses local temp files (ephemeral, fine in a
+   normal container); only the dump lives in the store."
+  (:require [konserve.core :as k]
+            [konserve.store :as ks]
+            [datahike.migrate.digest :as dig]
+            [clojure.string :as str])
+  (:import [java.nio.charset StandardCharsets]))
+
+(def ^:private ns-tag "datahike.migrate")
+
+(defn store-target?
+  "True if `x` designates a konserve store medium (open store or backend config),
+   as opposed to a filesystem path/File."
+  [x]
+  (and (map? x) (or (:store x) (:backend x))))
+
+(defn open
+  "Open a medium from a target spec. Returns {:store :prefix :owned?}; call `close`."
+  [target]
+  (let [prefix (or (:prefix target) "dump")]
+    (if-let [s (:store target)]
+      {:store s :prefix prefix :owned? false}
+      {:store (ks/connect-store (dissoc target :prefix) {:sync? true})
+       :prefix prefix :owned? true :config (dissoc target :prefix)})))
+
+(defn close [{:keys [store owned? config]}]
+  (when owned?
+    (try (ks/release-store config store {:sync? true}) (catch Throwable _ nil))))
+
+(defn- ckey [prefix x] [ns-tag prefix x])
+
+(defn- chunk-key [prefix n] (ckey prefix (format "datoms-%06d" n)))
+
+(defn write-chunks!
+  "Stream `sorted-lines` into the store as chunk values of at most `chunk-size`
+   lines each, computing per-chunk SHA-256 and the semantic digest incrementally.
+   `manifest-fn` is (fn [finalized-digest chunks] -> manifest-map). Writes the
+   manifest key LAST. Returns the manifest."
+  [{:keys [store prefix]} sorted-lines chunk-size manifest-fn progress]
+  (loop [ls (seq sorted-lines) n 1 chunks [] dacc (dig/accumulator)]
+    (if (nil? ls)
+      (let [manifest (manifest-fn (dig/finalize dacc) chunks)]
+        (k/assoc store (ckey prefix "manifest") manifest {:sync? true})
+        (progress {:phase :done :datoms (:count (dig/finalize dacc))})
+        manifest)
+      (let [part    (into [] (take chunk-size) ls)
+            content (str (str/join "\n" part) "\n")
+            bytes   (alength (.getBytes content StandardCharsets/UTF_8))]
+        (k/assoc store (chunk-key prefix n) content {:sync? true})
+        (progress {:phase :chunk :datoms (count part)})
+        (recur (seq (drop chunk-size ls)) (inc n)
+               (conj chunks {:file (format "datoms-%06d" n) :count (count part)
+                             :bytes bytes :sha256 (dig/sha256-hex content)})
+               (reduce dig/add-line dacc part))))))
+
+(defn read-manifest [{:keys [store prefix]}]
+  (k/get store (ckey prefix "manifest") nil {:sync? true}))
+
+(defn reduce-lines
+  "Reduce `rf` over every record line of the dump, verifying each chunk's SHA-256
+   (streaming a whole chunk value at a time — bounded by chunk-size) before use."
+  [{:keys [store prefix]} manifest rf init]
+  (reduce (fn [acc {:keys [file sha256]}]
+            (let [content (k/get store (ckey prefix file) nil {:sync? true})]
+              (when (nil? content)
+                (throw (ex-info (str "Missing chunk in store: " file)
+                                {:error :import/checksum-failed :file file})))
+              (when (and sha256 (not= sha256 (dig/sha256-hex content)))
+                (throw (ex-info (str "Checksum mismatch for chunk " file)
+                                {:error :import/checksum-failed :file file})))
+              (reduce rf acc (str/split-lines content))))
+          init
+          (:chunks manifest)))

--- a/test/datahike/integration_test/migrate_s3_test.clj
+++ b/test/datahike/integration_test/migrate_s3_test.clj
@@ -1,0 +1,138 @@
+(ns datahike.integration-test.migrate-s3-test
+  "Round-trips a dump through a REAL S3-compatible store — Garage in docker — so
+   the store target is exercised over the actual S3 wire protocol (endpoint
+   override + path-style addressing + SigV4), not the in-memory konserve
+   stand-in.
+
+   Garage (garagehq.deuxfleurs.fr) is chosen over MinIO because it is actively
+   maintained open source; nothing below is Garage-specific beyond the
+   provisioning CLI — any S3-compatible target works. The config file is
+   injected with `docker cp` (no volume mounts), so the test runs on any docker
+   host. Skips cleanly when docker is unavailable."
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.java.shell :refer [sh]]
+            [clojure.java.io :as io]
+            [datahike.api :as d]
+            [datahike.migrate :as m]
+            [konserve-s3.core]  ;; registers the :s3 konserve backend
+            [konserve.store :as ks]))
+
+(def ^:private s3-port 3910)
+(def ^:private container "dh-migrate-garage-test")
+;; Pinned to the exact release this test was validated against.
+(def ^:private image "dxflrs/garage:v2.3.0")
+(def ^:private bucket "dh-migrate-test")
+
+(def ^:private garage-toml
+  (str "metadata_dir = \"/var/lib/garage/meta\"\n"
+       "data_dir = \"/var/lib/garage/data\"\n"
+       "db_engine = \"sqlite\"\n"
+       "replication_factor = 1\n"
+       "rpc_bind_addr = \"[::]:3901\"\n"
+       ;; fixed test-only secret (any 32 bytes of hex)
+       "rpc_secret = \"a3298f1d5b94b5bfae25f31e5cdd63b06b2b3b7d3e1f0a52c7d94d3e1f0a52c7\"\n"
+       "[s3_api]\n"
+       ;; a real AWS region name so the client's region enum resolves
+       "s3_region = \"us-east-1\"\n"
+       "api_bind_addr = \"[::]:3900\"\n"
+       "root_domain = \".s3.garage.localhost\"\n"))
+
+(defn- docker? []
+  (try (zero? (:exit (sh "docker" "info"))) (catch Exception _ false)))
+
+(defn- garage! [& args]
+  (apply sh "docker" "exec" container "/garage" args))
+
+(defn- wait-until
+  "Poll `f` (a fn returning truthy on success) every 500ms, up to `n` times."
+  [n f]
+  (loop [n n]
+    (when (pos? n)
+      (or (f) (do (Thread/sleep 500) (recur (dec n)))))))
+
+(defn- start-garage! []
+  (sh "docker" "rm" "-f" container)
+  (let [cfg (io/file (System/getProperty "java.io.tmpdir") "dh-garage-test.toml")]
+    (spit cfg garage-toml)
+    (when-not (zero? (:exit (sh "docker" "create" "--name" container
+                                "-p" (str s3-port ":3900") image)))
+      (throw (ex-info "could not create garage container" {})))
+    (sh "docker" "cp" (str cfg) (str container ":/etc/garage.toml"))
+    (sh "docker" "start" container)
+    (when-not (wait-until 60 #(zero? (:exit (garage! "status"))))
+      (throw (ex-info "garage did not become healthy" {})))))
+
+(defn- provision!
+  "Assign the single-node layout, create bucket + key, grant access.
+   Returns {:access-key .. :secret ..}."
+  []
+  (let [node-id (some->> (:out (garage! "status"))
+                         (re-find #"(?m)^([0-9a-f]{8,})\s")
+                         second)]
+    (when-not node-id (throw (ex-info "could not parse garage node id" {})))
+    (garage! "layout" "assign" "-z" "dc1" "-c" "1G" node-id)
+    (garage! "layout" "apply" "--version" "1")
+    (when-not (wait-until 20 #(zero? (:exit (garage! "bucket" "list"))))
+      (throw (ex-info "garage layout did not settle" {})))
+    (garage! "bucket" "create" bucket)
+    (let [out (:out (garage! "key" "create" "dh-test-key"))
+          kid (second (re-find #"Key ID:\s*(\S+)" out))
+          sec (second (re-find #"Secret key:\s*(\S+)" out))]
+      (when-not (and kid sec)
+        (throw (ex-info "could not parse garage key" {:out out})))
+      (garage! "bucket" "allow" "--read" "--write" bucket "--key" "dh-test-key")
+      {:access-key kid :secret sec})))
+
+(defn- stop-garage! []
+  (sh "docker" "rm" "-f" container))
+
+(defn- fresh-db []
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :keep-history? true :schema-flexibility :write}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(deftest migrate-via-garage-test
+  (if-not (docker?)
+    (do (println "[migrate-s3-test] docker unavailable — skipping Garage integration test")
+        (is true "skipped: no docker"))
+    (try
+      (start-garage!)
+      (let [{:keys [access-key secret]} (provision!)
+            s3-spec {:backend :s3
+                     :bucket bucket
+                     :region "us-east-1"
+                     :access-key access-key
+                     :secret secret
+                     :endpoint-override {:protocol :http :hostname "localhost" :port s3-port}
+                     :path-style-access? true}]
+        (testing "export → estimate → import → verify through a real S3 API"
+          (let [store  (ks/create-store (assoc s3-spec :id (java.util.UUID/randomUUID))
+                                        {:sync? true})
+                target {:store store :prefix "backup-it"}
+                src    (fresh-db)]
+            (d/transact src [{:db/ident :name :db/valueType :db.type/string
+                              :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                             {:db/ident :score :db/valueType :db.type/double
+                              :db/cardinality :db.cardinality/one}
+                             {:db/ident :pal :db/valueType :db.type/ref
+                              :db/cardinality :db.cardinality/many}])
+            (d/transact src [{:db/id "a" :name "Alice" :score 0.0}
+                             {:db/id "b" :name "Bob" :score 3.14 :pal "a"}])
+            (d/transact src [[:db/retractEntity [:name "Bob"]]])
+            (let [man (m/export-db src target {:history? true :chunk-size 5})
+                  est (m/estimate-import-memory target)
+                  tgt (fresh-db)
+                  rep (m/import-db tgt target {})
+                  ver (m/verify tgt target)]
+              (is (> (count (:chunks man)) 1) "wrote multiple chunk objects to garage")
+              (is (string? (:recommended-heap est)) "estimate reads the manifest from S3")
+              (is (:verified? rep) "import from S3 verifies")
+              (is (:ok? ver) "full tiered verify against the S3 dump passes")
+              (is (get-in ver [:tier2 :match?]))
+              (is (= Double (class (d/q '[:find ?v . :where [?e :name "Alice"] [?e :score ?v]] @tgt)))
+                  "#633 type-exactness holds over the S3 wire")
+              (d/release src)
+              (d/release tgt)))))
+      (finally
+        (stop-garage!)))))

--- a/test/datahike/test/migrate_codec_test.clj
+++ b/test/datahike/test/migrate_codec_test.clj
@@ -1,0 +1,115 @@
+(ns datahike.test.migrate-codec-test
+  "Byte-level conformance for the dump's value encoding.
+
+   WHY BYTES AND NOT ROUND-TRIPS. A round-trip test proves the library agrees
+   with itself; it cannot tell you whether another language could read the dump,
+   which is the entire reason for choosing a standard codec. So the assertions
+   here pin the exact octets, against the tag numbers RFC 8949 registers. Any
+   conformant decoder — `cbor2`, `serde_cbor`, `cbor-java`, a future rune — must
+   read these, and the vectors are the contract a codec swap has to satisfy.
+
+   Verified once out-of-band with Python `cbor2` on these very bytes: `bigdec`
+   arrives as `Decimal('1.50')` with its scale, `instant` as a tz-aware
+   `datetime`, `uuid` as a `UUID`, `bytes` as `bytes`, and the bignum exactly.
+   That is the property that justifies CBOR over an EDN-tagged encoding, where
+   every value would need a Clojure reader.
+
+   NOTE the dump currently encodes values as EDN-lines; CBOR is the open
+   alternative (see `doc/import-export-design.md` §5.3) and the legacy reader for
+   pre-existing dumps. These vectors are therefore the CONTRACT a move to CBOR
+   would have to satisfy, and the evidence for making that move — not a
+   description of today's dump."
+  (:require [clojure.test :refer [deftest testing is]]
+            [clj-cbor.core :as cbor]))
+
+(defn- hex [x]
+  (apply str (map #(format "%02x" %) (cbor/encode x))))
+
+(deftest float-width-is-preserved-test
+  ;; #633 at root: a `:db.type/double` must not come back as a Float. The trap is
+  ;; an encoder that picks the shortest float that round-trips — RFC 8949's own
+  ;; deterministic profile prescribes exactly that, and it would silently narrow
+  ;; every double whose value happens to fit in f32.
+  ;;
+  ;; clj-cbor encodes by CLASS instead (`codec.clj`: `(instance? Float n)` →
+  ;; writeFloat, else writeDouble), so the distinction survives. Pinned here
+  ;; because it is a policy, not a format guarantee: a codec that "optimises"
+  ;; floats reintroduces #633.
+  (testing "a double encodes as f64 (0xfb) even when exactly f32-representable"
+    (is (= "fb3ff8000000000000" (hex (double 1.5))))
+    (is (= "fb4000000000000000" (hex (double 2.0)))
+        "2.0 fits f32 exactly — shortest-form encoding would narrow it here"))
+  (testing "a float encodes as f32 (0xfa)"
+    (is (= "fa3fc00000" (hex (float 1.5)))))
+  (testing "and the class survives a round trip"
+    (is (instance? Double (cbor/decode (cbor/encode (double 2.0)))))
+    (is (instance? Float (cbor/decode (cbor/encode (float 1.5)))))))
+
+(deftest zero-and-special-floats-lose-their-width-test
+  ;; KNOWN GAP, asserted so it cannot drift unnoticed. clj-cbor encodes zero,
+  ;; NaN and ±Infinity as f16 (0xf9) regardless of class, and f16 decodes to
+  ;; Float — so a `Double` 0.0 comes back a `Float`. That is #633 surviving for
+  ;; exactly three values.
+  ;;
+  ;; It does NOT affect the dump as it stands: the dump encodes values as
+  ;; EDN-lines, and a full export/import of `:db.type/double` values 0.0, 1.5 and
+  ;; 2.0 restores all three as `Double` (measured). So this is a property of the
+  ;; CBOR codec, recorded here because the codec choice is still open — if the
+  ;; dump moves to CBOR, this is the one case that needs a width-preserving float
+  ;; policy rather than clj-cbor's default, and a codec swap must decide it
+  ;; consciously instead of inheriting it.
+  (testing "zero collapses to f16 for both classes"
+    (is (= "f90000" (hex (double 0.0))))
+    (is (= "f90000" (hex (float 0.0))))
+    (is (instance? Float (cbor/decode (cbor/encode (double 0.0))))
+        "a Double zero decodes as Float — the residue"))
+  (testing "NaN and infinity likewise"
+    (is (instance? Float (cbor/decode (cbor/encode (double ##NaN)))))
+    (is (instance? Float (cbor/decode (cbor/encode (double ##Inf)))))))
+
+(deftest standard-tags-are-used-test
+  ;; The reason a dump is readable elsewhere. Each of these is a tag REGISTERED
+  ;; with IANA, so a foreign decoder produces a native value without knowing
+  ;; anything about datahike. An EDN-tagged encoding (`#datahike/bytes "base64"`)
+  ;; is portable in principle and Clojure-only in practice.
+  (testing "tag 2 — positive bignum, arbitrary precision preserved"
+    (is (= "c24d018ee90ff6c373e0ee4e3f0ad2"
+           (hex (bigint 123456789012345678901234567890N))))
+    (is (= 123456789012345678901234567890N
+           (cbor/decode (cbor/encode (bigint 123456789012345678901234567890N))))))
+  (testing "tag 4 — decimal fraction, and SCALE is part of the value"
+    ;; 1.50M and 1.5M are different values for us; the encoding must distinguish
+    ;; them, or a restored bigdec silently changes precision.
+    (is (= "c482211896" (hex 1.50M)) "[-2 150]")
+    (is (= "c482200f" (hex 1.5M)) "[-1 15]")
+    (is (not= (hex 1.50M) (hex 1.5M)))
+    (is (= 1.50M (cbor/decode (cbor/encode 1.50M))))
+    (is (= 2 (.scale ^java.math.BigDecimal (cbor/decode (cbor/encode 1.50M))))))
+  (testing "tag 1 — epoch instant"
+    (is (= "c11a6955b900" (hex #inst "2026-01-01T00:00:00.000-00:00"))))
+  (testing "tag 37 — uuid"
+    (is (= "d8255000000000000000000000000000000001"
+           (hex #uuid "00000000-0000-0000-0000-000000000001"))))
+  (testing "major type 2 — byte strings are native, no base64 wrapper"
+    (is (= "4400017fff" (hex (byte-array [0 1 127 -1]))))
+    (is (= [0 1 127 -1] (vec (cbor/decode (cbor/encode (byte-array [0 1 127 -1]))))))))
+
+(deftest integers-and-scalars-test
+  (testing "small integers are compact"
+    (is (= "182a" (hex (long 42)))))
+  (testing "scalars survive"
+    (is (= "text" (cbor/decode (cbor/encode "text"))))
+    (is (= true (cbor/decode (cbor/encode true))))
+    (is (nil? (cbor/decode (cbor/encode nil))))))
+
+(deftest encoding-is-deterministic-test
+  ;; Same input, identical bytes — what makes a dump signable and a re-export
+  ;; diffable. Asserted for the whole fixture at once, since determinism is a
+  ;; property of the encoder as a whole and not of any single value.
+  (let [fixture {"d" (double 1.5) "f" (float 1.5) "n" (long 42)
+                 "bi" (bigint 123456789012345678901234567890N) "bd" 1.50M
+                 "i" #inst "2026-01-01T00:00:00.000-00:00"
+                 "u" #uuid "00000000-0000-0000-0000-000000000001"
+                 "s" "text" "b" true}]
+    (is (= (hex fixture) (hex fixture)))
+    (is (= (seq (cbor/encode fixture)) (seq (cbor/encode fixture))))))

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -1,11 +1,25 @@
 (ns datahike.test.migrate-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.java.io :as io]
             [clj-cbor.core :as cbor]
             [datahike.api :as d]
+            [datahike.constants :as c]
             [datahike.datom :as datom]
-            [datahike.migrate :as m]
+            [datahike.db.interface :as dbi]
             [datahike.db.utils :as dbu]
+            [datahike.migrate :as m]
+            [datahike.migrate.edn :as medn]
+            [clojure.string :as str]
+            [konserve.store :as ks]
             [datahike.test.utils :as utils]))
+
+;; ---------------------------------------------------------------------------
+;; core `load-entities` behaviour (independent of the dump format)
+
+(defn- teardown [conn]
+  (let [cfg (:config @conn)]
+    (d/release conn)
+    (d/delete-database cfg)))
 
 (def tx-data [[:db/add 1 :db/cardinality :db.cardinality/one 536870913 true]
               [:db/add 1 :db/ident :name 536870913 true]
@@ -20,223 +34,6 @@
               [:db/add 4 :age 35 536870913 true]
               [:db/add 4 :name "Bob" 536870913 true]])
 
-(def tx-meta [[:db/ident :db.install/attribute 536870912 true]
-              [:db/doc "An attribute's cardinality" 536870912 true]
-              [:db/valueType 28 536870912 true]
-              [:db/ident :db.type/instant 536870912 true]
-              [:db/ident :db.type/bigint 536870912 true]
-              [:db/cardinality 11 536870912 true]
-              [:db/ident :db/txInstant 536870912 true]
-              [:db/ident :db/isComponent 536870912 true]
-              [:db/ident :db/unique 536870912 true]
-              [:db/ident :db/valueType 536870912 true]
-              [:db/valueType 26 536870912 true]
-              [:db/ident :db.type/valueType 536870912 true]
-              [:db/ident :db.type/unique 536870912 true]
-              [:db/ident :db.part/tx 536870912 true]
-              [:db/ident :db/tupleAttrs 536870912 true]
-              [:db/doc "An attribute's unique selection" 536870912 true]
-              [:db/doc "An attribute's history selection" 536870912 true]
-              [:db/txInstant #inst "1970-01-01T00:00:00.000-00:00" 536870912 true]
-              [:db/ident :db.type/boolean 536870912 true]
-              [:db/valueType 31 536870912 true]
-              [:db/ident :db/noHistory 536870912 true]
-              [:db/valueType 17 536870912 true]
-              [:db/ident :db.type/float 536870912 true]
-              [:db/ident :db.part/sys 536870912 true]
-              [:db/ident :db/index 536870912 true]
-              [:db/noHistory true 536870912 true]
-              [:db/ident :db.part/user 536870912 true]
-              [:db/ident :db.type/tuple 536870912 true]
-              [:db/ident :db/doc 536870912 true]
-              [:db/ident :db/tupleType 536870912 true]
-              [:db/doc
-               "An attribute's or specification's identifier"
-               536870912
-               true]
-              [:db/ident :db.type/uuid 536870912 true]
-              [:db/doc "Only for interoperability with Datomic" 536870912 true]
-              [:db/ident :db.type/cardinality 536870912 true]
-              [:db/valueType 30 536870912 true]
-              [:db/ident :db/cardinality 536870912 true]
-              [:db/ident :db.cardinality/one 536870912 true]
-              [:db/ident :db.unique/identity 536870912 true]
-              [:db/valueType 23 536870912 true]
-              [:db/ident :db.type/number 536870912 true]
-              [:db/unique 33 536870912 true] [:db/ident :db/ident 536870912 true]
-              [:db/ident :db.type/ref 536870912 true]
-              [:db/ident :db.type/bigdec 536870912 true]
-              [:db/ident :db/tupleTypes 536870912 true]
-              [:db/ident :db.type/symbol 536870912 true]
-              [:db/valueType 22 536870912 true]
-              [:db/doc "An attribute's index selection" 536870912 true]
-              [:db/doc "A transaction's time-point" 536870912 true]
-              [:db/index true 536870912 true]
-              [:db/ident :db.type.install/attribute 536870912 true]
-              [:db/ident :db.unique/value 536870912 true]
-              [:db/valueType 19 536870912 true]
-              [:db/ident :db.type/long 536870912 true]
-              [:db/ident :db.cardinality/many 536870912 true]
-              [:db/ident :db.type/string 536870912 true]
-              [:db/ident :db.type/double 536870912 true]
-              [:db/doc "An attribute's value type" 536870912 true]
-              [:db/doc "An attribute's documentation" 536870912 true]
-              [:db/ident :db.type/keyword 536870912 true]
-              ;; Bitemporal valid-time tx-meta — system-schema (commit 1 of
-              ;; feature/bitemporal-v1). Two new idents + two doc strings;
-              ;; the valueType (22 = :db.type/instant), cardinality (11),
-              ;; and `:db/index true` ref-datoms collapse with existing
-              ;; entries when materialised through `into #{}`.
-              [:db/ident :db.valid/from 536870912 true]
-              [:db/ident :db.valid/to 536870912 true]
-              [:db/doc
-               "A transaction's valid-time lower bound (inclusive).\n             Every datom in the tx inherits this vt-from. When\n             absent the transaction's `:db/txInstant` is used.\n             See `doc/valid_time.md` for usage."
-               536870912 true]
-              [:db/doc
-               "A transaction's valid-time upper bound (exclusive).\n             When absent the interval is open-ended (treated as +∞).\n             May be written retroactively on a prior tx-entity to\n             close that tx's window; the write is a normal commit,\n             the prior tx's hash is unchanged, and the transactor\n             enforces a cross-tx `vf < vt` check on the combined\n             state. See `doc/valid_time.md` for usage."
-               536870912 true]
-              ;; Secondary-index schema attrs — the :db.secondary/* family
-              ;; graduated into system-schema with fixed IDs. Added as bare
-              ;; idents (value-types stay in schema/implicit-schema-spec), so
-              ;; each contributes exactly one :db/ident datom here.
-              [:db/ident :db.secondary/type 536870912 true]
-              [:db/ident :db.secondary/attrs 536870912 true]
-              [:db/ident :db.secondary/config 536870912 true]
-              [:db/ident :db.secondary/status 536870912 true]
-              [:db/ident :db.secondary/building-since-tx 536870912 true]
-              [:db/ident :db.secondary/only 536870912 true]
-              ;; Cross-database reference attrs — the :dh.ref/* family
-              ;; graduated into system-schema (datahike.reference), full
-              ;; declarations like :db.valid/*. Five idents + four doc
-              ;; strings + ONE new distinct valueType ref-datom
-              ;; (29 = :db.type/uuid); the keyword/string valueTypes,
-              ;; cardinality (11) and `:db/index true` ref-datoms collapse
-              ;; with existing entries when materialised through `into #{}`.
-              [:db/ident :dh.ref/db 536870912 true]
-              [:db/ident :dh.ref/attr 536870912 true]
-              [:db/ident :dh.ref/value 536870912 true]
-              [:db/ident :dh.ref/temporal 536870912 true]
-              [:db/ident :dh.ref/type 536870912 true]
-              ;; :db.type/store-ref — a builtin value type needs a system entity so
-              ;; that :db/valueType (a REF under :attribute-refs?) can resolve to it
-              [:db/ident :db.type/store-ref 536870912 true]
-              [:db/valueType 29 536870912 true]
-              [:db/doc "Cross-db reference: target database (store :id)" 536870912 true]
-              [:db/doc "Cross-db reference: unique attribute of the target lookup ref" 536870912 true]
-              [:db/doc "Cross-db reference: lookup-ref value, canonically encoded" 536870912 true]
-              [:db/doc "Cross-db reference: temporal qualifier (tx:/date:/valid:/branch:); absent = live head" 536870912 true]
-              [:db/doc "Cross-db reference: link predicate (application vocabulary)" 536870912 true]
-              ;; Attribute-value constraints — :db/maxLength / :db.attr/preds
-              ;; graduated into system-schema (ids 53/54 after rebase onto main)
-              ;; with full specs inline. New idents; :db.attr/preds also
-              ;; contributes symbol valueType (27) and cardinality-many (10).
-              ;; :db/maxLength's long valueType and cardinality-one collapse
-              ;; with existing entries via `into #{}`.
-              [:db/ident :db/maxLength 536870912 true]
-              [:db/ident :db.attr/preds 536870912 true]
-              [:db/valueType 24 536870912 true]
-              [:db/valueType 27 536870912 true]
-              [:db/cardinality 10 536870912 true]])
-
-(deftest export-import-test
-  (let [os-prefix (case (System/getProperty "os.name")
-                    "Windows 10" (System/getProperty "java.io.tmpdir")
-                    "/tmp/")
-        old-path (str os-prefix "old-db")
-        new-path (str os-prefix "new-db")
-        export-path (str os-prefix "eavt-dump")
-        base-config {:store {:backend :file}
-                     :schema-flexibility :write
-                     :keep-history? false
-                     :attribute-refs? false}
-        add-uuid (fn [cfg] (assoc-in cfg [:store :id] (java.util.UUID/randomUUID)))
-        schema [{:db/ident       :name
-                 :db/cardinality :db.cardinality/one
-                 :db/index       true
-                 :db/unique      :db.unique/identity
-                 :db/valueType   :db.type/string}
-                {:db/ident       :parents
-                 :db/cardinality :db.cardinality/many
-                 :db/valueType   :db.type/ref}
-                {:db/ident       :age
-                 :db/cardinality :db.cardinality/one
-                 :db/valueType   :db.type/long}]
-        tx-data {:tx-data [{:name "Alice" :age  25}
-                           {:name "Bob" :age  35}
-                           {:name    "Charlie"
-                            :age     5
-                            :parents [[:name "Alice"] [:name "Bob"]]}
-                           {:name "Daisy" :age 20}
-                           {:name "Erhard" :age 20}]}]
-
-    (testing "Same configuration roundtrip for exporting and importing."
-      (doseq [hist [true false]
-              attr-ref [true false]]
-        (let [cfg (merge base-config
-                         {:keep-history? hist
-                          :attribute-refs? attr-ref})
-              old-cfg (add-uuid (assoc-in cfg [:store :path] (str old-path (utils/get-time))))
-              old-conn (utils/setup-db old-cfg)
-              new-cfg (add-uuid (assoc-in cfg [:store :path] (str new-path (utils/get-time))))
-              new-conn (utils/setup-db new-cfg)]
-          (d/transact old-conn schema)
-          (d/transact old-conn tx-data)
-          (d/transact old-conn {:tx-data [[:db/retractEntity [:name "Erhard"]]]})
-          (m/export-db old-conn export-path)
-          (m/import-db new-conn export-path)
-          (is (= (d/datoms (if (:keep-history? cfg) (d/history @old-conn) @old-conn) :eavt)
-                 (filter #(< (:e %) (:max-tx @new-conn))
-                         (d/datoms (if (:keep-history? cfg) (d/history @new-conn) @new-conn) :eavt))))
-          (d/release old-conn)
-          (d/release new-conn)
-          (d/delete-database old-cfg)
-          (d/delete-database new-cfg))))
-
-    (testing "Export history database, import non-history database"
-      (let [old-cfg (-> base-config
-                        (assoc-in [:store :path] (str old-path (utils/get-time)))
-                        (assoc :keep-history? true)
-                        add-uuid)
-            old-conn (utils/setup-db old-cfg)
-            new-cfg (-> base-config
-                        (assoc-in [:store :path] (str new-path (utils/get-time)))
-                        (assoc :keep-history? false)
-                        add-uuid)
-            new-conn (utils/setup-db new-cfg)]
-        (d/transact old-conn schema)
-        (d/transact old-conn tx-data)
-        (m/export-db old-conn export-path)
-        (m/import-db new-conn export-path)
-        (is (= (d/datoms @old-conn :eavt)
-               (d/datoms @new-conn :eavt)))
-        (d/release old-conn)
-        (d/release new-conn)
-        (d/delete-database old-cfg)
-        (d/delete-database new-cfg)))
-
-    (testing "Export non-history database, import history database"
-      (let [old-cfg (-> base-config
-                        (assoc-in [:store :path] (str old-path (utils/get-time)))
-                        (assoc :keep-history? false)
-                        add-uuid)
-            old-conn (utils/setup-db old-cfg)
-            new-cfg (-> base-config
-                        (assoc-in [:store :path] (str new-path (utils/get-time)))
-                        (assoc :keep-history? true)
-                        add-uuid)
-            new-conn (utils/setup-db new-cfg)]
-        (d/transact old-conn schema)
-        (d/transact old-conn tx-data)
-        (m/export-db old-conn export-path)
-        (m/import-db new-conn export-path)
-        (is (= (d/datoms @old-conn :eavt)
-               (filter #(< (:e %) (:max-tx @new-conn))
-                       (d/datoms @new-conn :eavt))))
-        (d/release old-conn)
-        (d/release new-conn)
-        (d/delete-database old-cfg)
-        (d/delete-database new-cfg)))))
-
 (deftest load-entities-test
   (testing "Test migrate simple datoms without attribute refs"
     (let [source-datoms (->> tx-data
@@ -250,129 +47,487 @@
       @(d/load-entities conn source-datoms)
       (is (= (into #{} source-datoms)
              (d/q '[:find ?e ?a ?v ?t ?op :where [?e ?a ?v ?t ?op]] @conn)))
-      (d/release conn)))
-  (testing "Test migrate simple datoms with attribute refs"
-    (let [source-datoms (->> tx-data
-                             (mapv #(-> % rest vec))
-                             (concat [[536870913 :db/txInstant #inst "2020-03-11T14:54:27.979-00:00" 536870913 true]]))
-          cfg           {:store         {:backend :memory
-                                         :id      #uuid "001e0000-0000-0000-0000-00000000001e"}
-                         :keep-history? true
-                         :attribute-refs? true
-                         :schema-flexibility :write}
-          conn (utils/setup-db cfg)]
-      @(d/load-entities conn source-datoms)
-      (is (= (into #{} (->> source-datoms
-                            (mapv (comp vec rest))
-                            (concat tx-meta)))
-             (d/q '[:find ?a ?v ?t ?op
-                    :where
-                    [?e ?attr ?v ?t ?op]
-                    [?attr :db/ident ?a]] @conn)))
-      (d/release conn))))
+      (teardown conn))))
+
+;; ---------------------------------------------------------------------------
+;; helpers for semantic (id-independent) comparison of two databases
+
+(defn- normv
+  "Normalise a value so array/bytes values compare structurally rather than by
+   identity, while keeping enough to distinguish class (float vs double)."
+  [v]
+  (cond
+    (bytes? v)                              [:bytes (vec v)]
+    (= (class v) (class (float-array 0)))   [:farray (mapv float (vec v))]
+    (= (class v) (class (double-array 0)))  [:darray (vec v)]
+    :else                                   v))
+
+(defn- a->ident [db a] (if (number? a) (dbi/-ident-for db a) a))
+
+(defn- user-triples
+  "Set of [attr-ident normalised-value op] over user-transaction datoms of a
+   database's full history — an id-independent fingerprint of its content."
+  [conn]
+  (let [hdb (d/history @conn)]
+    (set (for [dm (d/datoms hdb :eavt)
+               :when (> (datom/datom-tx dm) c/tx0)]
+           [(a->ident hdb (nth dm 1)) (normv (nth dm 2)) (nth dm 4)]))))
+
+(defn- mem-cfg [{:keys [history? attribute-refs?]}]
+  {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+   :keep-history?      (boolean history?)
+   :schema-flexibility :write
+   :attribute-refs?    (boolean attribute-refs?)})
+
+(def rich-schema
+  [{:db/ident :name   :db/valueType :db.type/string  :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+   {:db/ident :score  :db/valueType :db.type/double  :db/cardinality :db.cardinality/one}
+   {:db/ident :ratio  :db/valueType :db.type/float   :db/cardinality :db.cardinality/one}
+   {:db/ident :big    :db/valueType :db.type/bigdec  :db/cardinality :db.cardinality/one}
+   {:db/ident :huge   :db/valueType :db.type/bigint  :db/cardinality :db.cardinality/one}
+   {:db/ident :when   :db/valueType :db.type/instant :db/cardinality :db.cardinality/one}
+   {:db/ident :id     :db/valueType :db.type/uuid    :db/cardinality :db.cardinality/one}
+   {:db/ident :sym    :db/valueType :db.type/symbol  :db/cardinality :db.cardinality/one}
+   {:db/ident :blob   :db/valueType :db.type/bytes   :db/cardinality :db.cardinality/one}
+   {:db/ident :vec    :db/valueType :db.type/float-array  :db/cardinality :db.cardinality/one}
+   {:db/ident :dvec   :db/valueType :db.type/double-array :db/cardinality :db.cardinality/one}
+   {:db/ident :pos    :db/valueType :db.type/tuple   :db/cardinality :db.cardinality/one
+    :db/tupleTypes [:db.type/long :db.type/long :db.type/keyword]}
+   {:db/ident :friend :db/valueType :db.type/ref     :db/cardinality :db.cardinality/many}])
+
+(defn- populate-rich! [conn]
+  (d/transact conn rich-schema)
+  (d/transact conn [{:db/id "a" :name "Alice" :score 0.0 :ratio (float 0.5) :big 1.50M
+                     :huge 123456789012345678901234567890N
+                     :when #inst "2020-01-01" :id #uuid "00000000-0000-0000-0000-0000000000aa"
+                     :sym 'ns/foo :blob (byte-array [0 1 2 127 -1])
+                     :vec (float-array [1.0 -2.5 3.25]) :dvec (double-array [9.0 8.5])
+                     :pos [7 11 :north]}
+                    {:db/id "b" :name "Bob" :score 3.14 :friend "a"}])
+  (d/transact conn [[:db/retractEntity [:name "Bob"]]]))
+
+;; ---------------------------------------------------------------------------
+;; T-ROUND / T-TYPE — full round-trip of every value type, flat and chunked
+
+(deftest roundtrip-all-value-types-test
+  (doseq [fmt [:flat :chunked]]
+    (testing (str "round-trip every value type, history, format " fmt)
+      (let [src (utils/setup-db (mem-cfg {:history? true}))
+            _   (populate-rich! src)
+            dir (str (System/getProperty "java.io.tmpdir") "/dh-rt-" (name fmt) "-" (utils/get-time))
+            manifest (m/export-db src dir {:format fmt :history? true :chunk-size 4})
+            tgt (utils/setup-db (mem-cfg {:history? true}))
+            report (m/import-db tgt dir {})]
+        (is (:verified? report) "post-import verification passes")
+        (is (true? (:finalized? report)) "migration state cleared")
+        (is (nil? (:migration @tgt)) "finalize-import! removed :migration")
+        (is (= (user-triples src) (user-triples tgt))
+            "id-independent content is identical after round-trip")
+        (testing "#633: double/float classes preserved exactly"
+          (let [q (fn [conn a] (d/q [:find (list 'pull '?e [a]) '. :where ['?e :name "Alice"]] @conn))]
+            (is (= Double (class (:score (q src :score)))))
+            (is (= Double (class (:score (q tgt :score)))) ":db.type/double stays Double (was Float via CBOR)")
+            (is (= Float  (class (:ratio (q tgt :ratio)))) ":db.type/float stays Float")))
+        (teardown src)
+        (teardown tgt)))))
+
+(deftest double-zero-regression-test ;; T-TYPE, #633 minimal
+  (testing "double 0.0 / NaN round-trip as Double, float stays Float"
+    (let [rt (fn [v] (nth (medn/read-record (medn/write-record [1 :x (medn/encode-value v) 2 true])) 2))]
+      (is (= Double (class (rt 0.0))))
+      (is (= 0.0 (rt 0.0)))
+      (is (Double/isNaN ^double (rt (Double/NaN))))
+      (is (= Double (class (rt (/ 1.0 0.0)))))
+      (is (= Float (class (rt (float 0.5)))))
+      (is (= (float 0.5) (rt (float 0.5)))))))
+
+;; ---------------------------------------------------------------------------
+;; T-REFS — attribute-refs database, translate-not-insert (#508 / #531)
+
+(deftest attribute-refs-roundtrip-test
+  (testing "attribute-refs db round-trips; refs to system entities are translated"
+    (let [src (utils/setup-db (mem-cfg {:history? true :attribute-refs? true}))
+          _   (d/transact src [{:db/ident :name :db/valueType :db.type/string
+                                :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                               {:db/ident :pal :db/valueType :db.type/ref :db/cardinality :db.cardinality/many}])
+          _   (d/transact src [{:db/id "a" :name "Alice"} {:db/id "b" :name "Bob" :pal "a"}])
+          path (str (System/getProperty "java.io.tmpdir") "/dh-ar-" (utils/get-time))
+          _   (m/export-db src path {:format :flat :history? true})
+          tgt (utils/setup-db (mem-cfg {:history? true :attribute-refs? true}))
+          report (m/import-db tgt path {})]
+      (is (:verified? report))
+      (is (= (user-triples src) (user-triples tgt)))
+      (is (= #{["Alice"]}
+             (d/q '[:find ?pn :where [?b :name "Bob"] [?b :pal ?p] [?p :name ?pn]] (d/history @tgt)))
+          "ref resolves to the same target entity (no :db/ident collision, no re-inserted system datom)")
+      (teardown src)
+      (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; T-ORDER — schema replays before the data that uses it (#262)
+
+(deftest empty-target-import-order-test
+  (testing "import into a fresh empty target succeeds (schema-before-data by tx order)"
+    (let [src (utils/setup-db (mem-cfg {:history? false}))
+          _   (do (d/transact src [{:db/ident :name :db/valueType :db.type/string
+                                    :db/cardinality :db.cardinality/one}])
+                  (d/transact src [{:name "x"} {:name "y"}]))
+          path (str (System/getProperty "java.io.tmpdir") "/dh-order-" (utils/get-time))
+          _   (m/export-db src path {:format :flat})
+          tgt (utils/setup-db (mem-cfg {:history? false}))]
+      (is (:verified? (m/import-db tgt path {})))
+      (is (= #{["x"] ["y"]} (d/q '[:find ?n :where [?e :name ?n]] @tgt)))
+      (teardown src)
+      (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; Security & integrity
+
+(deftest security-eval-and-unknown-tag-test ;; §4.1
+  (testing "unknown reader tag fails safely, no evaluation"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown reader tag"
+                          (medn/read-record "[1 :a #evil/tag \"x\" 2 true]")))
+    (is (= :import/unknown-tag
+           (try (medn/read-record "[1 :a #evil/tag \"x\" 2 true]")
+                (catch clojure.lang.ExceptionInfo ex (:error (ex-data ex))))))
+    (testing "the #=(...) eval probe is refused (never evaluated)"
+      (is (thrown? Exception
+                   (medn/read-record "[1 :a #=(java.lang.System/exit 1) 2 true]"))))))
+
+(deftest security-bad-chunk-path-test ;; T-SEC-PATH, §4.2
+  (testing "a manifest chunk path outside the dump dir is refused before any read"
+    (let [src (utils/setup-db (mem-cfg {}))
+          _   (do (d/transact src [{:db/ident :n :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+                  (d/transact src [{:n "a"}]))
+          dir (str (System/getProperty "java.io.tmpdir") "/dh-path-" (utils/get-time))
+          manifest (m/export-db src dir {:format :chunked})
+          mf (io/file dir "manifest.edn")
+          poisoned (assoc-in (read-string (slurp mf)) [:chunks 0 :file] "../evil.edn")]
+      (spit mf (pr-str poisoned))
+      (let [tgt (utils/setup-db (mem-cfg {}))]
+        (is (= :import/bad-chunk-path
+               (try (m/import-db tgt dir {}) nil
+                    (catch clojure.lang.ExceptionInfo ex (:error (ex-data ex))))))
+        (teardown tgt))
+      (teardown src))))
+
+(deftest tamper-detection-test ;; T-TAMPER, §9
+  (testing "flipping a byte in a chunk is caught by sha256 before import"
+    (let [src (utils/setup-db (mem-cfg {}))
+          _   (do (d/transact src [{:db/ident :n :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+                  (d/transact src [{:n "alpha"} {:n "beta"}]))
+          dir (str (System/getProperty "java.io.tmpdir") "/dh-tamper-" (utils/get-time))
+          _   (m/export-db src dir {:format :chunked})
+          chunk (io/file dir "datoms-000001.edn")
+          content (slurp chunk)]
+      (spit chunk (clojure.string/replace-first content "alpha" "alphX"))
+      (let [tgt (utils/setup-db (mem-cfg {}))]
+        (is (= :import/checksum-failed
+               (try (m/import-db tgt dir {}) nil
+                    (catch clojure.lang.ExceptionInfo ex (:error (ex-data ex))))))
+        (teardown tgt))
+      (teardown src))))
+
+(deftest non-empty-target-refused-test ;; §8.7 recreate-and-restart
+  (testing "import into a non-empty target is refused (import is not resumable)"
+    (let [src (utils/setup-db (mem-cfg {}))
+          _   (do (d/transact src [{:db/ident :n :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+                  (d/transact src [{:n "a"}]))
+          path (str (System/getProperty "java.io.tmpdir") "/dh-nonempty-" (utils/get-time))
+          _   (m/export-db src path {:format :flat})
+          tgt (utils/setup-db (mem-cfg {}))]
+      (d/transact tgt [{:db/ident :n :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+      (d/transact tgt [{:n "pre-existing"}])
+      (is (= :import/non-empty-target
+             (try (m/import-db tgt path {}) nil
+                  (catch clojure.lang.ExceptionInfo ex (:error (ex-data ex))))))
+      (teardown src)
+      (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; Determinism (§12) & backward compatibility (G9)
+
+(deftest determinism-test ;; T-DETERMINISM
+  (testing "exporting the same db twice yields byte-identical chunks + digests"
+    (let [src (utils/setup-db (mem-cfg {:history? true}))
+          _   (populate-rich! src)
+          d1  (str (System/getProperty "java.io.tmpdir") "/dh-det1-" (utils/get-time))
+          d2  (str (System/getProperty "java.io.tmpdir") "/dh-det2-" (utils/get-time))
+          m1  (m/export-db src d1 {:format :chunked :history? true :chunk-size 5})
+          m2  (m/export-db src d2 {:format :chunked :history? true :chunk-size 5})]
+      (is (= (:semantic-digest m1) (:semantic-digest m2)))
+      (is (= (mapv :sha256 (:chunks m1)) (mapv :sha256 (:chunks m2))))
+      (is (= (slurp (io/file d1 "datoms-000001.edn"))
+             (slurp (io/file d2 "datoms-000001.edn"))))
+      (teardown src))))
+
+(deftest legacy-cbor-import-test ;; T-LEGACY, G9
+  (testing "an old flat CBOR dump still imports via the legacy path"
+    (let [datoms (mapv #(vec (rest %)) tx-data)
+          path (str (System/getProperty "java.io.tmpdir") "/dh-legacy-" (utils/get-time))
+          conn (utils/setup-db {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+                                :schema-flexibility :read :keep-history? false})]
+      (cbor/spit-all path datoms)
+      (binding [m/*import-batch-size* 5]
+        (m/import-db conn path))
+      (is (= (set (map #(apply datom/datom %) datoms))
+             (set (filter #(< (:e %) (:max-tx @conn)) (d/datoms @conn :eavt)))))
+      (teardown conn)
+      (.delete (io/file path)))))
+
+;; ---------------------------------------------------------------------------
+;; core `load-entities` reconstructs history (lower-level than the dump format)
 
 (deftest load-entities-history-test
   (testing "Migrate predefined set with historical data"
-    (let [source-cfg {:store              {:backend :memory
-                                           :id      #uuid "001f0000-0000-0000-0000-00000000001f"}
-                      :name               "load-entities-history-test-source"
-                      :keep-history?      true
-                      :schema-flexibility :write
-                      :search-cache-size  0
-                      :store-cache-size   1
-                      :attribute-refs?    false}
-          schema      [{:db/ident       :name
-                        :db/cardinality :db.cardinality/one
-                        :db/index       true
-                        :db/unique      :db.unique/identity
-                        :db/valueType   :db.type/string}]
+    (let [source-cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+                      :keep-history? true :schema-flexibility :write :attribute-refs? false}
+          schema     [{:db/ident :name :db/cardinality :db.cardinality/one :db/index true
+                       :db/unique :db.unique/identity :db/valueType :db.type/string}]
           source-conn (utils/setup-db source-cfg)
-          txs         [schema
-                       [{:name "Alice"} {:name "Bob"}]
-                       [{:name "Charlie"} {:name "Daisy"}]
-                       [[:db/retractEntity [:name "Alice"]]]]
-          _           (doseq [tx-data txs]
-                        (d/transact source-conn {:tx-data tx-data}))
+          txs        [schema
+                      [{:name "Alice"} {:name "Bob"}]
+                      [{:name "Charlie"} {:name "Daisy"}]
+                      [[:db/retractEntity [:name "Alice"]]]]
+          _          (doseq [tx-data txs] (d/transact source-conn {:tx-data tx-data}))
           datoms-to-export (d/datoms (d/history @source-conn) :eavt)
-
-          ;; The datoms to export must primarily
-          ;; be sorted by transaction entity id
-          ;; and secondarily so that datoms with attribute `:db/txInstant`
-          ;; come before other datoms
           export-data (->> datoms-to-export
                            (map (comp vec seq))
-                           (sort-by (fn [[e a v tx]]
-                                      [tx
-
-                                       ;; TODO: It seems as if :db/txInstant
-                                       ;; datoms must come first. Is this a bug
-                                       ;; in load-entities?
-                                       (case a
-                                         :db/txInstant 0
-                                         1)]))
+                           (sort-by (fn [[_e a _v tx]] [tx (case a :db/txInstant 0 1)]))
                            (into []))
-          target-cfg  (-> source-cfg
-                          (assoc-in [:store :id] #uuid "00200000-0000-0000-0000-000000000020")
-                          (assoc-in [:name] "load-entities-history-test-target"))
-          target-conn (utils/setup-db target-cfg)
-          _           @(d/load-entities target-conn export-data)
-          current-q   (fn [conn] (d/q
-                                  '[:find ?n
-                                    :where
-                                    [?e :name ?n]]
-                                  @conn))
-          history-q   (fn [conn] (d/q '[:find ?n ?t ?op
-                                        :where
-                                        [?e :name ?n ?t ?op]]
-                                      (d/history @conn)))]
+          target-conn (utils/setup-db (assoc-in source-cfg [:store :id] (java.util.UUID/randomUUID)))
+          _          @(d/load-entities target-conn export-data)
+          current-q  (fn [conn] (d/q '[:find ?n :where [?e :name ?n]] @conn))
+          history-q  (fn [conn] (d/q '[:find ?n ?t ?op :where [?e :name ?n ?t ?op]] (d/history @conn)))]
       (is (dbu/distinct-sorted-datoms? :eavt datoms-to-export))
-      (is (= (current-q source-conn)
-             (current-q target-conn)))
-      (is (= (history-q source-conn)
-             (history-q target-conn)))
-      (d/release source-conn)
-      (d/release target-conn))))
+      (is (= (current-q source-conn) (current-q target-conn)))
+      (is (= (history-q source-conn) (history-q target-conn)))
+      (teardown source-conn)
+      (teardown target-conn))))
 
-(deftest test-binary-support
-  (let [config {:store {:backend :memory
-                        :id #uuid "00210000-0000-0000-0000-000000000021"}
-                :schema-flexibility :read
-                :keep-history? false}
-        export-path "/tmp/test-export-binary-support"
-        conn (utils/setup-db config)
-        import-conn (utils/setup-db)]
-    (d/transact conn [{:db/id 1, :name "Jiayi", :payload (byte-array [0 2 3])}
-                      {:db/id 2, :name "Peter", :payload (byte-array [1 2 3])}])
-    (m/export-db conn export-path)
-    (m/import-db import-conn export-path)
-    (is (utils/all-true? (map #(or (= %1 %2) (utils/all-eq? (nth %1 2) (nth %2 2)))
-                              (d/datoms @conn :eavt)
-                              (filter #(< (datom/datom-tx %) (:max-tx @import-conn))
-                                      (d/datoms @import-conn :eavt)))))
-    (d/release conn)
-    (d/release import-conn)))
+;; ---------------------------------------------------------------------------
+;; Schema that evolved over time — new attributes added across transactions
+;; must round-trip, because history mode replays schema datoms in tx order.
 
-(deftest import-db-batches-with-dynamic-size
-  (let [export-path (str "/tmp/import-batch-test-" (utils/get-time))
-        datoms (mapv #(vec (rest %)) tx-data)
-        imported-tx (apply max (map #(nth % 3) datoms))
-        config {:store {:backend :memory
-                        :id #uuid "00210000-0000-0000-0000-000000000022"}
-                :schema-flexibility :read
-                :keep-history? false}
-        conn (utils/setup-db config)
-        batch-size 5]
-    (try
-      (cbor/spit-all export-path datoms)
-      (binding [m/*import-batch-size* batch-size]
-        (is (= {:tx-data (mapv #(apply datom/datom %) (last (partition-all batch-size datoms)))}
-               (select-keys (m/import-db conn export-path) [:tx-data])))
-        (is (= (+ imported-tx (count (partition-all batch-size datoms)))
-               (:max-tx @conn))))
-      (is (= (set (map #(apply datom/datom %) datoms))
-             (set (filter #(< (:e %) (:max-tx @conn))
-                          (d/datoms @conn :eavt)))))
-      (finally
-        (d/release conn)
-        (d/delete-database config)
-        (.delete (java.io.File. export-path))))))
+(deftest schema-evolution-test
+  (testing "attributes added at later txs round-trip under history replay"
+    (let [src (utils/setup-db (mem-cfg {:history? true}))]
+      ;; tx1: schema v1 (just :a)
+      (d/transact src [{:db/ident :a :db/valueType :db.type/long :db/cardinality :db.cardinality/one}])
+      ;; tx2: data under v1
+      (d/transact src [{:db/id "e1" :a 1}])
+      ;; tx3: schema grows — add a ref attr :b (card-many) mid-history
+      (d/transact src [{:db/ident :b :db/valueType :db.type/ref :db/cardinality :db.cardinality/many}])
+      ;; tx4: data using the new attr
+      (d/transact src [{:db/id "e2" :a 2 :b "e1"}])
+      ;; tx5: schema grows again — add a unique string attr :c
+      (d/transact src [{:db/ident :c :db/valueType :db.type/string
+                        :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}])
+      ;; tx6: data using the new unique attr + a retraction
+      (d/transact src [{:db/id "e3" :a 3 :c "hello"}])
+      (d/transact src [[:db/retractEntity [:c "hello"]]])
+      (let [path (str (System/getProperty "java.io.tmpdir") "/dh-schema-evo-" (utils/get-time))
+            _   (m/export-db src path {:format :flat :history? true})
+            tgt (utils/setup-db (mem-cfg {:history? true}))
+            report (m/import-db tgt path {})]
+        (is (:verified? report))
+        (is (= (user-triples src) (user-triples tgt))
+            "content identical despite schema added across history")
+        ;; the target's final schema knows all three attributes
+        (is (= #{[:a] [:b] [:c]}
+               (d/q '[:find ?id :where [?e :db/ident ?id]
+                      [(contains? #{:a :b :c} ?id)]] @tgt)))
+        (teardown src)
+        (teardown tgt)))))
+
+;; ---------------------------------------------------------------------------
+;; Scale / streaming — tiny :sort-buffer and :chunk-size force many spill runs
+;; and many chunks, exercising external-sort + streaming import end to end.
+
+(deftest streaming-scale-test
+  (testing "many-run external sort + multi-chunk streaming import round-trips"
+    (let [src (utils/setup-db (mem-cfg {:history? true}))
+          n   4000]
+      (d/transact src [{:db/ident :k :db/valueType :db.type/long
+                        :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                       {:db/ident :s :db/valueType :db.type/string :db/cardinality :db.cardinality/one}])
+      ;; several transactions so history has many tx entities too
+      (doseq [batch (partition-all 500 (range n))]
+        (d/transact src (mapv (fn [i] {:k i :s (str "v" i)}) batch)))
+      (let [dir (str (System/getProperty "java.io.tmpdir") "/dh-scale-" (utils/get-time))
+            manifest (m/export-db src dir {:format :chunked :history? true
+                                           :sort-buffer 300 :chunk-size 250})
+            tgt (utils/setup-db (mem-cfg {:history? true}))
+            report (m/import-db tgt dir {:batch-size 200})]
+        (is (> (count (:chunks manifest)) 1) "produced multiple chunks")
+        (is (:verified? report) "streamed import verifies")
+        (is (= (:count (:semantic-digest manifest)) (:datom-count report)))
+        (is (= n (count (d/q '[:find ?i :where [?e :k ?i]] @tgt))) "all entities present")
+        (is (= (user-triples src) (user-triples tgt)) "content identical at scale")
+        (teardown src)
+        (teardown tgt)))))
+
+;; ---------------------------------------------------------------------------
+;; Memory estimation — tell the operator how much heap to give an import
+
+(deftest estimate-import-memory-test
+  (testing "estimate reports a recommended heap that scales with entity count"
+    (let [make (fn [n]
+                 (let [c (utils/setup-db (mem-cfg {:history? true}))]
+                   (d/transact c [{:db/ident :k :db/valueType :db.type/long
+                                   :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}])
+                   (doseq [b (partition-all 500 (range n))]
+                     (d/transact c (mapv (fn [i] {:k i}) b)))
+                   c))
+          small (make 200)
+          big   (make 2000)
+          ps    (str (System/getProperty "java.io.tmpdir") "/dh-est-s-" (utils/get-time))
+          pb    (str (System/getProperty "java.io.tmpdir") "/dh-est-b-" (utils/get-time))
+          _     (m/export-db small ps {:format :flat :history? true})
+          man-b (m/export-db big pb {:format :flat :history? true})
+          es    (m/estimate-import-memory ps)
+          eb    (m/estimate-import-memory pb)]
+      (is (pos? (:recommended-heap-bytes es)))
+      (is (string? (:recommended-heap es)) "human-readable heap string present")
+      (is (contains? es :sufficient?))
+      (is (>= (:entities eb) (:entities es)) "more entities reported for the bigger db")
+      (is (> (:id-map-bytes eb) (:id-map-bytes es)) "id-map estimate grows with entities")
+      ;; the manifest carries the stats the estimate relies on (no scan needed)
+      (is (number? (:max-eid (:stats man-b))) "manifest :stats has :max-eid")
+      (is (number? (:max-tx (:stats man-b))) "manifest :stats has :max-tx")
+      (teardown small)
+      (teardown big))))
+
+;; ---------------------------------------------------------------------------
+;; External store target — export/import through a konserve store (stands in for
+;; S3 / S3-compatible; the only difference in prod is the backend config).
+
+(deftest store-target-roundtrip-test
+  (testing "export/import through a konserve store, all value types + history"
+    (let [store  (ks/create-store {:backend :memory :id (java.util.UUID/randomUUID)} {:sync? true})
+          target {:store store :prefix "backup-1"}
+          src    (utils/setup-db (mem-cfg {:history? true}))
+          _      (populate-rich! src)
+          man    (m/export-db src target {:history? true :chunk-size 4})
+          est    (m/estimate-import-memory target)
+          tgt    (utils/setup-db (mem-cfg {:history? true}))
+          rep    (m/import-db tgt target {})]
+      (is (> (count (:chunks man)) 1) "wrote multiple chunk keys")
+      (is (:verified? rep) "store import verifies")
+      (is (= (:count (:semantic-digest man)) (:datom-count rep)))
+      (is (= (user-triples src) (user-triples tgt)) "content identical via store round-trip")
+      (is (string? (:recommended-heap est)) "estimate works against a store target")
+      (teardown src)
+      (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; No-scratch streaming export (:sort? false) — for hard read-only / diskless
+;; targets. Two lazy :eavt passes, no temp files, straight to the target.
+
+(deftest no-scratch-streaming-export-test
+  (testing ":sort? false round-trips (file + store) with no scratch"
+    ;; filesystem, every value type + history
+    (let [src (utils/setup-db (mem-cfg {:history? true}))
+          _   (populate-rich! src)
+          path (str (System/getProperty "java.io.tmpdir") "/dh-nosort-" (utils/get-time))
+          _   (m/export-db src path {:format :flat :history? true :sort? false})
+          tgt (utils/setup-db (mem-cfg {:history? true}))
+          rep (m/import-db tgt path {})]
+      (is (:verified? rep) "no-scratch export verifies")
+      (is (= (user-triples src) (user-triples tgt)) "content identical, unsorted order")
+      (teardown src)
+      (teardown tgt))
+    ;; straight to a konserve store with no scratch (the diskless path)
+    (let [store  (ks/create-store {:backend :memory :id (java.util.UUID/randomUUID)} {:sync? true})
+          target {:store store :prefix "diskless"}
+          src (utils/setup-db (mem-cfg {:history? true :attribute-refs? true}))
+          _   (d/transact src [{:db/ident :name :db/valueType :db.type/string
+                                :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                               {:db/ident :pal :db/valueType :db.type/ref :db/cardinality :db.cardinality/many}])
+          _   (d/transact src [{:db/id "a" :name "Alice"} {:db/id "b" :name "Bob" :pal "a"}])
+          _   (m/export-db src target {:history? true :sort? false :chunk-size 4})
+          tgt (utils/setup-db (mem-cfg {:history? true :attribute-refs? true}))
+          rep (m/import-db tgt target {})]
+      (is (:verified? rep) "no-scratch export to store, attribute-refs, verifies")
+      (is (= (user-triples src) (user-triples tgt)))
+      (teardown src)
+      (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; Tiered verify (0–3) and per-datom :on-error :collect
+
+(deftest verify-tiers-test
+  (testing "verify confirms a faithful import (tiers 1–3) and catches divergence"
+    (let [src  (utils/setup-db (mem-cfg {:history? true}))
+          _    (populate-rich! src)
+          path (str (System/getProperty "java.io.tmpdir") "/dh-verify-" (utils/get-time))
+          _    (m/export-db src path {:format :flat :history? true})
+          tgt  (utils/setup-db (mem-cfg {:history? true}))
+          _    (m/import-db tgt path {:verify? false})
+          ok   (m/verify tgt path)]
+      (is (:ok? ok))
+      (is (get-in ok [:tier1 :match?]))
+      (is (get-in ok [:tier2 :match?]) "id-independent value digest + ref topology match")
+      (is (:ok? (:tier3 ok)) "sampled structural diff clean")
+      (d/transact tgt [{:name "extra-entity" :score 1.0}])
+      (let [bad (m/verify tgt path)]
+        (is (not (:ok? bad)))
+        (is (not (get-in bad [:tier2 :match?])) "tier2 catches the extra content"))
+      (teardown src)
+      (teardown tgt))))
+
+(deftest on-error-collect-test
+  (testing ":collect skips exactly the bad datom and lands the rest; :abort throws"
+    (let [src  (utils/setup-db (mem-cfg {:history? true}))
+          _    (d/transact src [{:db/ident :age :db/valueType :db.type/long :db/cardinality :db.cardinality/one}])
+          _    (d/transact src [{:db/id "a" :age 30}])
+          path (str (System/getProperty "java.io.tmpdir") "/dh-collect-" (utils/get-time))
+          man  (m/export-db src path {:format :flat :history? true})
+          good-count (:count (:semantic-digest man))
+          ;; inject a datom load-entities rejects — a numeric attribute in a
+          ;; non-ref db — INTO the same tx as the good data datoms, so the
+          ;; per-tx/per-datom narrowing re-attempts good datoms after the failed
+          ;; batch attempt (exercising the writer's failure-atomicity).
+          lines (vec (line-seq (io/reader path)))
+          _    (spit path (str/join "\n" (conj lines "[9999 42 \"x\" 536870914 true]")))]
+      (testing ":abort halts with the offending datom"
+        (let [t1 (utils/setup-db (mem-cfg {:history? true}))]
+          (is (= :import/corrupt-datom
+                 (try (m/import-db t1 path {:on-error :abort :verify? false}) nil
+                      (catch clojure.lang.ExceptionInfo ex (:error (ex-data ex))))))
+          (teardown t1)))
+      (testing ":collect records only the bad datom, imports everything else"
+        (let [t2  (utils/setup-db (mem-cfg {:history? true}))
+              rep (m/import-db t2 path {:on-error :collect :verify? false})]
+          (is (= 1 (count (:errors rep))) "exactly one datom collected")
+          (is (= [9999 42 "x" 536870914 true] (:datom (first (:errors rep)))))
+          (is (= 30 (d/q '[:find ?a . :where [?e :age ?a]] @t2)) "good data still imported")
+          (is (= good-count
+                 (count (filter #(> (datom/datom-tx %) c/tx0)
+                                (d/datoms (d/history @t2) :eavt))))
+              "every good datom landed EXACTLY once — a failed load-entities call applies nothing, so the narrowing retry cannot double-apply")
+          (teardown t2)))
+      (teardown src))))
+
+;; ---------------------------------------------------------------------------
+;; Schema-on-read databases (no declared schema; codec keys on runtime class)
+
+(deftest schema-on-read-roundtrip-test
+  (testing "a :schema-flexibility :read db round-trips with exact value classes"
+    (let [cfg  (fn [] {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+                       :keep-history? true :schema-flexibility :read})
+          src  (utils/setup-db (cfg))
+          _    (d/transact src [{:db/id 1 :name "Alice" :score 0.0 :ratio (float 0.5)
+                                 :blob (byte-array [3 1 4])}
+                                {:db/id 2 :name "Bob" :score 2.5}])
+          path (str (System/getProperty "java.io.tmpdir") "/dh-sor-" (utils/get-time))
+          _    (m/export-db src path {:format :flat :history? true})
+          tgt  (utils/setup-db (cfg))
+          rep  (m/import-db tgt path {})]
+      (is (:verified? rep))
+      (is (= (user-triples src) (user-triples tgt)))
+      (let [v (fn [conn n a] (d/q [:find '?v '. :where ['?e :name n] ['?e a '?v]] @conn))]
+        (is (= Double (class (v tgt "Alice" :score))) "double stays Double without schema")
+        (is (= Float  (class (v tgt "Alice" :ratio))) "float stays Float without schema"))
+      (teardown src)
+      (teardown tgt))))

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -678,3 +678,35 @@
   (testing "a dump predating capability declaration reads as before"
     (is (nil? (m/check-capabilities! {})))
     (is (nil? (m/check-capabilities! {:requires []})))))
+
+(deftest verify-covers-blobs-test
+  ;; Blobs verify at the SAME tier as the datom chunks. The case that matters is
+  ;; a dump whose datoms are perfect and whose `store-refs/` is short: counts
+  ;; match, the semantic digest matches, every pre-existing tier passes — and the
+  ;; dump is unrestorable. Reporting :ok? true there is exactly the reassurance
+  ;; nobody should get.
+  (let [{:keys [conn id]} (blob-fixture)
+        dump (str "/tmp/dh-verify-blob-" (java.util.UUID/randomUUID))]
+    (.mkdirs (io/file dump))
+    (m/export-db @conn dump {})
+    (testing "an intact dump verifies, and says what it checked"
+      (let [v (m/verify dump)]
+        (is (:ok? v))
+        (is (= 1 (:declared (:blobs v))))
+        (is (= 1 (:verified (:blobs v))))
+        (is (empty? (:missing (:blobs v)))))
+      (is (:ok? (m/verify @conn dump))))
+    (testing "a missing blob fails verification even though every other tier passes"
+      (io/delete-file (io/file dump mblobs/dir-name (str id)))
+      (let [v (m/verify @conn dump)]
+        (is (false? (:ok? v)))
+        (is (true? (:match? (:tier1 v))) "datom counts still match")
+        (is (true? (:match? (:tier2 v))) "the semantic digest still matches")
+        (is (false? (:ok? (:blobs v))) "…and the blob tier is what fails")
+        (is (= [id] (:missing (:blobs v))))))
+    (testing "a blob with the right name and the wrong bytes is corrupt"
+      ;; only detectable because the file NAME is the content hash
+      (spit (io/file dump mblobs/dir-name (str id)) "tampered")
+      (let [v (m/verify dump)]
+        (is (false? (:ok? v)))
+        (is (= [id] (:corrupt (:blobs v))))))))

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -630,3 +630,51 @@
   (let [db (d/db-with (datahike.db/empty-db {:name {:db/cardinality :db.cardinality/one}})
                       [{:name "no blobs here"}])]
     (is (false? (mblobs/schema-has-store-refs? db)))))
+
+;; ---------------------------------------------------------------------------
+;; provenance + capabilities
+
+(deftest dump-declares-capabilities-test
+  ;; A version stamp is the right check for a STORE — `connector/version-check`
+  ;; refuses one written by a newer datahike, because the on-disk index is not
+  ;; forward compatible. A dump is logical, so a v3 dump using no v3-only feature
+  ;; IS readable by v2, and refusing it on the stamp would work against
+  ;; datahike's backwards-compat commitment. So the dump declares what it NEEDS,
+  ;; and the reader compares against what it HAS.
+  (let [{:keys [conn id]} (blob-fixture)
+        dump (str "/tmp/dh-cap-dump-" (java.util.UUID/randomUUID))]
+    (d/transact conn [{:db/ident :doc/vec :db/valueType :db.type/double-array
+                       :db/cardinality :db.cardinality/one}])
+    (d/transact conn [{:doc/name "vec" :doc/vec (double-array [1.5 2.5])}])
+    (.mkdirs (io/file dump))
+    (let [manifest (m/export-db @conn dump {})
+          requires (set (:requires manifest))]
+      (testing "provenance rides in the same shape the store uses"
+        (is (contains? (:datahike/meta manifest) :datahike/version))
+        (is (contains? (:datahike/meta manifest) :konserve/version)))
+      (testing "capabilities are derived from what the dump actually uses"
+        (is (contains? requires :datahike.migrate/history))
+        (is (contains? requires :datahike.migrate/store-ref-blobs))
+        ;; value types come from the schema, not a hand-maintained list — so a
+        ;; type added later shows up here automatically
+        (is (contains? requires :db.type/double-array))
+        (is (contains? requires :db.type/store-ref)))
+      (testing "and this version can honour its own dump"
+        (is (nil? (m/check-capabilities! manifest)))
+        (is (= [id] (:carried (:store-refs manifest))))))))
+
+(deftest unsupported-capability-is-refused-precisely-test
+  ;; The point of a capability set over a version number: say WHICH feature is
+  ;; missing. "requires :db.type/double-array" is actionable; "newer version" is
+  ;; not — and silently importing everything else would drop that attribute.
+  (testing "an unknown capability is named"
+    (let [e (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo #"cannot interpret"
+                 (m/check-capabilities!
+                  {:requires [:db.type/string :datahike.migrate/quantum-index]
+                   :datahike/meta {:datahike/version "99.0"}})))]
+      (is (= [:datahike.migrate/quantum-index] (:missing (ex-data e)))
+          "only the unknown capability is reported, not the ones we support")))
+  (testing "a dump predating capability declaration reads as before"
+    (is (nil? (m/check-capabilities! {})))
+    (is (nil? (m/check-capabilities! {:requires []})))))

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -9,6 +9,12 @@
             [datahike.db.utils :as dbu]
             [datahike.migrate :as m]
             [datahike.migrate.edn :as medn]
+            [datahike.migrate.blobs :as mblobs]
+            [datahike.blob :as blob]
+            [datahike.db]
+            [konserve.core :as k]
+            [clojure.core.async :refer [go]]
+            [superv.async :refer [<?? S]]
             [clojure.string :as str]
             [konserve.store :as ks]
             [datahike.test.utils :as utils]))
@@ -531,3 +537,96 @@
         (is (= Float  (class (v tgt "Alice" :ratio))) "float stays Float without schema"))
       (teardown src)
       (teardown tgt))))
+
+;; ---------------------------------------------------------------------------
+;; store-ref blobs
+
+(defn- blob-fixture
+  "A file-backed db with one in-store blob, plus one store-ref whose bytes were
+   never written here — i.e. a blob living outside this store, which is the case
+   a dump cannot carry."
+  []
+  (let [path (str "/tmp/dh-blob-test-" (java.util.UUID/randomUUID))
+        cfg  {:store {:backend :file :path path :id (java.util.UUID/randomUUID)}
+              :schema-flexibility :write :keep-history? true}
+        _    (d/create-database cfg)
+        conn (d/connect cfg)]
+    (d/transact conn [{:db/ident :doc/name :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :doc/file :db/valueType :db.type/store-ref
+                       :db/cardinality :db.cardinality/one}])
+    (let [payload (.getBytes "the actual blob payload" "UTF-8")
+          id      (blob/blob-id payload)
+          ext-id  (blob/blob-id (.getBytes "lives in a raw bucket" "UTF-8"))]
+      (<?? S (k/bassoc (:store @conn) id payload))
+      (d/transact conn [{:doc/name "carried" :doc/file id}])
+      {:conn conn :cfg cfg :payload payload :id id :ext-id ext-id})))
+
+(defn- read-blob-from-store [store id]
+  (<?? S (k/bget store id
+                 (fn [{:keys [input-stream]}]
+                   (go (when input-stream
+                         (let [bos (java.io.ByteArrayOutputStream.)]
+                           (io/copy input-stream bos)
+                           (.toByteArray bos))))))))
+
+(deftest store-ref-blobs-are-carried-test
+  ;; A store-ref datom holds a content id; exporting it exports the REFERENCE.
+  ;; Without carrying the bytes the datom restores perfectly and names an object
+  ;; that is not in the target store — a backup that silently lost its blobs.
+  (let [{:keys [conn payload id]} (blob-fixture)
+        dump (str "/tmp/dh-blob-dump-" (java.util.UUID/randomUUID))]
+    (.mkdirs (io/file dump))
+    (let [manifest (m/export-db @conn dump {})]
+      (testing "the manifest declares what it carries"
+        (is (= true (:self-contained? (:store-refs manifest))))
+        (is (= 1 (:carried-count (:store-refs manifest))))
+        (is (= [id] (:carried (:store-refs manifest)))))
+      (testing "the bytes are in the dump, named by their content id"
+        ;; the file name IS the checksum, so verification needs no side table
+        (is (.exists (io/file dump mblobs/dir-name (str id))))))
+    (let [path2 (str "/tmp/dh-blob-target-" (java.util.UUID/randomUUID))
+          cfg2  {:store {:backend :file :path path2 :id (java.util.UUID/randomUUID)}
+                 :schema-flexibility :write :keep-history? true}
+          _     (d/create-database cfg2)
+          conn2 (d/connect cfg2)
+          rep   (m/import-db conn2 dump {})]
+      (testing "datoms and blobs both arrive"
+        (is (:verified? rep))
+        (is (= #{["carried" id]}
+               (d/q '[:find ?n ?f :where [?e :doc/name ?n] [?e :doc/file ?f]] (d/db conn2))))
+        (is (= (seq payload) (seq (read-blob-from-store (:store @conn2) id)))
+            "the referent must be present, not merely the reference")))))
+
+(deftest store-ref-blobs-outside-the-store-test
+  ;; `:db.type/store-ref` says WHAT an object is, never where it lives: bytes in a
+  ;; raw bucket a browser PUT to never transit this JVM. We cannot copy those, so
+  ;; the dump must say so rather than appear complete.
+  (let [{:keys [conn ext-id]} (blob-fixture)]
+    (d/transact conn [{:doc/name "external" :doc/file ext-id}])
+    (let [plan (mblobs/plan @conn (:store @conn))]
+      (is (= [ext-id] (:external plan)))
+      (is (false? (:self-contained? plan)))
+      (testing "import refuses a dump it cannot fully honour"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not self-contained"
+                              (mblobs/check-importable plan {}))))
+      (testing "…unless the operator accepts it explicitly"
+        (is (nil? (mblobs/check-importable plan {:accept-external-blobs? true})))))))
+
+(deftest store-ref-blob-corruption-is-detected-test
+  ;; Blobs are content-addressed, so a wrong object under a content-addressed key
+  ;; would be trusted by every later reader. Verify on the way in.
+  (let [{:keys [conn id]} (blob-fixture)]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not match its content id"
+                          (mblobs/copy-in! (:store @conn) {:carried [id]}
+                                           (fn [_] (.getBytes "tampered" "UTF-8")))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"missing a blob it declares"
+                          (mblobs/copy-in! (:store @conn) {:carried [id]} (fn [_] nil))))))
+
+(deftest store-ref-walk-is-skipped-without-store-ref-attrs-test
+  ;; The reachability walk needs a FLUSHED index, and plenty of legitimate
+  ;; exports are of an unflushed in-memory db. Gating on the schema keeps those
+  ;; working — and makes the common case pay nothing.
+  (let [db (d/db-with (datahike.db/empty-db {:name {:db/cardinality :db.cardinality/one}})
+                      [{:name "no blobs here"}])]
+    (is (false? (mblobs/schema-has-store-refs? db)))))


### PR DESCRIPTION
Rebases [**alekcz/datahike#5**](https://github.com/alekcz/datahike/pull/5) onto current `main` so it can be reviewed and CI-checked here. **All implementation and design work is by [@alekcz](https://github.com/alekcz) (Alex Oloo)** — his two commits are preserved with original authorship; anything we add lands as separate commits on top with `Co-authored-by` trailers.

It came out of a real ~98M-datom production migration that the current exporter could not survive.

## Why rebase rather than review in place

His PR was opened against his fork's `main` at `e4e26c68` (#905), which is 8 commits behind. That made the diff show `query.cljc` +268/−83, `lower.cljke` +150/−1, `execute.cljc`, `relation.cljc` and four query test files — **all of which is already-merged upstream work** (#908–#917), carried along as artifact. Reviewing it linearly would have wasted real effort, and merging as-is risked reverting recent query-engine fixes.

Against current `main` his actual change is **12 files, +2880/−360, zero query-engine files**.

## Verified on this branch, against current main

- his migrate suite: **20 tests, 78 assertions, 0 failures**
- full `clj-pss`: **862 tests, 7207 assertions, 0 failures**
- `bb format` clean

## What it does

Reworks `datahike.migrate` from the flat CBOR snapshot — marked *"temporary solution, pending developments in Wanderung"* in the source — into a full-history, type-exact, verifiable, bounded-memory dump & restore targeting local disk, any konserve store (S3 / S3-compatible / JDBC), or a diskless container.

| issue | fix |
|---|---|
| #633 | `:db.type/double` no longer round-trips as `Float`; values encode by runtime class, every builtin type incl. `float-array`/`double-array`/tuple |
| #377 | full history — asserts + retracts + tx entities; `history`/`as-of` match at every `t` |
| #262 | schema replays before the data that uses it |
| #508 / #531 | attribute-refs dumps translate refs to system entities by ident, never re-inserted |
| #552 | dumps carry a format version; old CBOR dumps still import via the legacy path |

Bounded memory at any scale (external merge sort out, streaming tx-aligned import in — validated 1.2 GB store → 285 MB dump → re-imported and verified under a **144 MB heap**), tiered verification, `estimate-import-memory`, and a `:sort? false` zero-scratch mode.

## Read `doc/import-export-design.md` §2 first

Its §2 grounds a prior spec against live source and **invalidates several load-bearing parts of it**. Two are worth calling out because they are the kind of thing a fresh implementation would get wrong:

- **The sort key must not put retractions first.** The direct transactor is order-sensitive and does not reorder within a tx: a card-one *add* upserts (`transaction.cljc:524`), and a *retract* matches an exact `[e a v]` and is a **no-op if that value was already replaced** (`:426`, `upsert?` at `:1511`). Retract-before-add — the intuitive choice — therefore silently drops a same-tx replacement's retraction.
- **Import is not resumable and cannot be**: the `:migration` id-map is not durable (`writing.cljc:56-58,227-281`), so it lives only on the in-memory db value. Honest recovery is recreate-and-restart, and `import-db` refuses a non-empty target. *Export* is resumable, because chunks are content-addressed.

It also correctly drops two things that prior spec demanded — a `read-string` RCE fix (the importer uses `clj-cbor`; no live vuln) and a core change for forward refs (`transact-entities-directly` already allocates eids at `transaction.cljc:1499-1500`).

## Known gaps, to be addressed as separate commits here

1. **The dump is not self-contained for `store-ref`.** `store-ref` is covered as a *value type* (rides as `#uuid`) but the referent **bytes are not carried**, so restoring a database that uses blobs yields datoms pointing at objects absent from the target store. `gc/reachable-store-refs` is the enumeration hook, and `gc/record-store-refs` already solved the identical ordering constraint for the konserve-sync walker (blobs must arrive *before* the reference that names them — the same discipline as manifest-last).
2. **Provenance + capabilities.** Carry `datahike.tools/meta-data` (the map `connector/version-check` already enforces for stores) **plus** a `:requires` capability set. A bare version is too blunt for a dump: a v3 dump using no v3-only features is readable by v2, and refusing it would work against datahike's backwards-compat stance. Capabilities make **downgrade** well-defined — fail precisely, never silently drop.
3. **Blob verification tier.** Blobs should verify at the same tier as datom chunks, so a dump cannot verify OK with a short `store-refs/`.
4. **Codec** — his one deliberately open question. Leaning canonical CBOR for the datom stream (RFC 8949, readers in every language — the scenario a dump exists for is the one where datahike is unavailable), EDN manifest, raw bytes for blobs.

## Where this sits in the migration story

Four axes, and this is the one that was missing:

| tool | axis |
|---|---|
| **konserve-sync** | physical, online, incremental replication (format-coupled) |
| **pg-datahike** | relational interchange, both directions incl. `pg_dump` / `COPY` |
| **wanderung** | Datomic (datom-shaped, lossy) — incomplete; harvest its adapter knowledge |
| **this** | datahike's own format: faithful, offline, self-contained, version-declaring |

None substitutes for another for structural reasons: konserve-sync ships the index format so it cannot cross an incompatible version; a logical dump re-derives ids so it cannot give cheap incremental replication.