### PR TITLE
test(query): a third engine, composable plan checks, and two axes that find bugs

### DIFF
--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -993,8 +993,44 @@
 
    Note the check fires on plan CREATION, and `datahike.query` caches plans, so
    a caller enabling it must also clear that cache or it will silently examine
-   nothing. `datahike.test.query-eqcheck/with-plan-checks` does both."
+   nothing. `datahike.test.query-eqcheck/with-plan-checks` does both.
+
+   Install through `add-plan-check!`, never by `alter-var-root` with
+   `constantly`: this is ONE slot, so a second `constantly` install silently
+   evicts the first and both checkers then report a clean sweep while one of
+   them examines nothing."
   nil)
+
+(def plan-check-stats
+  "How many plans the installed checks have actually seen, as {:plans n}.
+
+   A checker's failure mode is SILENCE: an install that was evicted, a warm
+   plan cache, or a suite that never builds a plan all look exactly like `no
+   violations`. CI asserts this counter is non-zero, which is what tells the
+   two apart. Only touched when a check is installed, so production pays
+   nothing for it."
+  (atom {:plans 0}))
+
+(defn add-plan-check!
+  "Install `f` (a function of one plan) alongside any check already installed,
+   and return the composed function now in the slot.
+
+   Composition is folded at install time rather than kept in a list, so the
+   hot path stays exactly what it was before any checker existed: one var
+   deref and one nil test."
+  [f]
+  (alter-var-root
+   #'*check-plan*
+   (fn [installed]
+     (if installed
+       (fn [plan] (installed plan) (f plan))
+       (fn [plan] (swap! plan-check-stats update :plans inc) (f plan))))))
+
+(defn clear-plan-checks!
+  "Remove every installed plan check and reset the coverage counter."
+  []
+  (alter-var-root #'*check-plan* (constantly nil))
+  (reset! plan-check-stats {:plans 0}))
 
 (defn- maybe-check!
   "Hand `plan` to the installed checker, if any. Returns `plan` either way."

--- a/test/datahike/oracle.clj
+++ b/test/datahike/oracle.clj
@@ -1,0 +1,631 @@
+(ns datahike.oracle
+  "A NAIVE REFERENCE EVALUATOR (\"oracle\") for datahike Datalog queries.
+
+   Purpose: differential testing between the planner and the relational base
+   engine has a systematic blind spot — when both share a wrong assumption they
+   agree, and the test passes. This namespace is a THIRD implementation, written
+   to be obviously correct by reading rather than fast:
+
+     * no indexes    — every pattern scans the full datom sequence;
+     * no planner    — clauses are taken in written order (with one deferral
+                       loop so that a function clause whose inputs are not yet
+                       bound simply waits);
+     * no fusion, no caching, no specialization, no fast paths;
+     * one uniform notion of a partial answer: an ENVIRONMENT, a map from
+       query variable to value. Everything is `unify`.
+
+   The one non-negotiable rule, and the source of its oracle value:
+
+       BINDING A VARIABLE THAT IS ALREADY BOUND IS UNIFICATION, NOT ASSIGNMENT.
+
+   Both engines violate this in at least one place (see `bind` and the notes in
+   plan-oracle.md). Because there is exactly ONE binding function here, the rule
+   cannot be violated in one clause type and honoured in another.
+
+   Deliberately UNSUPPORTED (throws ex-info {:oracle/unsupported ...} so a
+   differential harness can skip rather than mis-report):
+     pull, :keys/:syms/:strs return-maps, :order-by/:limit/:offset,
+     :attribute-refs? true databases, nested `q` calls, and any clause form
+     not listed in `eval-clause`."
+  (:require
+   [datahike.api :as d]
+   [datahike.db.interface :as dbi]
+   [datahike.db.utils :as dbu]
+   [datahike.query :as dq]))
+
+;; ---------------------------------------------------------------------------
+;; Syntax predicates
+
+(defn- qvar? [x] (and (symbol? x) (= \? (first (name x)))))
+(defn- src-var? [x] (and (symbol? x) (= \$ (first (name x)))))
+(defn- rules-var? [x] (= '% x))
+(defn- blank? [x] (= '_ x))
+
+(defn- unsupported! [what form]
+  (throw (ex-info (str "oracle does not support " what)
+                  {:oracle/unsupported what :form form})))
+
+(defn- fail! [msg data]
+  (throw (ex-info msg (assoc data :oracle/error true))))
+
+;; ---------------------------------------------------------------------------
+;; Query parsing (deliberately independent of datahike.parser — a shared parser
+;; would be a shared assumption)
+
+(def ^:private query-sections #{:find :with :in :where :keys :syms :strs})
+
+(defn- parse-query
+  "[:find ... :in ... :where ...] or the equivalent map -> a map of sections."
+  [q]
+  (let [m (if (map? q)
+            q
+            (loop [acc {} section nil items q]
+              (if-let [x (first items)]
+                (if (query-sections x)
+                  (recur (assoc acc x []) x (rest items))
+                  (recur (update acc section (fnil conj []) x) section (rest items)))
+                acc)))]
+    (when (some m [:keys :syms :strs])
+      (unsupported! ":keys/:syms/:strs return maps" q))
+    m))
+
+(defn- parse-find
+  "-> {:kind :rel|:coll|:scalar|:tuple, :elements [...]}
+   An element is a symbol, or an aggregate call (agg ?v) / (agg n ?v)."
+  [find]
+  (let [check (fn [els]
+                (doseq [e els]
+                  (cond
+                    (symbol? e) nil
+                    (and (seq? e) (= 'pull (first e))) (unsupported! "pull" e)
+                    (seq? e) nil
+                    :else (unsupported! (str "find element " (pr-str e)) e)))
+                (vec els))]
+    (cond
+      (and (= 2 (count find)) (= '. (second find)))
+      {:kind :scalar :elements (check [(first find)])}
+
+      (and (= 1 (count find)) (vector? (first find)))
+      (let [inner (first find)]
+        (if (and (= 2 (count inner)) (= '... (second inner)))
+          {:kind :coll :elements (check [(first inner)])}
+          {:kind :tuple :elements (check inner)}))
+
+      :else
+      {:kind :rel :elements (check find)})))
+
+(defn- aggregate-element? [e] (seq? e))
+
+;; ---------------------------------------------------------------------------
+;; Datom access. The oracle's ONLY view of a database is the flat sequence of
+;; its datoms, in whatever order the index hands them over. Nothing downstream
+;; may depend on that order.
+
+(defn- all-datoms [db]
+  (when (:attribute-refs? (dbi/-config db))
+    (unsupported! ":attribute-refs? true database" nil))
+  (mapv (fn [d] [(:e d) (:a d) (:v d)]) (d/datoms db :eavt)))
+
+;; ---------------------------------------------------------------------------
+;; Environments and unification. THE core of the oracle: three lines that every
+;; clause type goes through, so no clause type can have its own binding rule.
+
+(def ^:private no-match ::no-match)
+
+(defn- bind
+  "Unify pattern position `x` against value `v` in environment `env`.
+   Returns the extended env, or nil if unification fails.
+     _        matches anything, binds nothing
+     ?var     binds if free, CHECKS FOR EQUALITY if already bound
+     constant matches iff equal"
+  [env x v]
+  (cond
+    (blank? x)  env
+    (qvar? x)   (if-some [[_ bound] (find env x)]
+                  (when (= bound v) env)
+                  (assoc env x v))
+    :else       (when (= x v) env)))
+
+(defn- bind-form
+  "Unify a :in / function-output BINDING FORM against a value.
+   Returns a seq of envs (a collection binding fans out).
+     ?x        scalar        [?a ?b]  tuple
+     [?x ...]  collection    [[?a ?b]] relation"
+  [env form value]
+  (cond
+    (or (blank? form) (qvar? form))
+    (when-let [e (bind env form value)] [e])
+
+    (and (vector? form) (= 2 (count form)) (= '... (second form)))
+    (let [inner (first form)]
+      (when-not (or (nil? value) (seqable? value))
+        (fail! "Cannot bind non-collection to a collection binding"
+               {:form form :value value}))
+      (mapcat #(bind-form env inner %) value))
+
+    (and (vector? form) (= 1 (count form)) (vector? (first form)))
+    (let [inner (first form)]
+      (mapcat #(bind-form env inner %) value))
+
+    (vector? form)
+    (when (and (seqable? value) (>= (count value) (count form)))
+      (reduce (fn [envs [f v]] (mapcat #(bind-form % f v) envs))
+              [env]
+              (map vector form value)))
+
+    :else (unsupported! (str "binding form " (pr-str form)) form)))
+
+;; ---------------------------------------------------------------------------
+;; Constants in pattern positions
+
+(defn- lookup-ref? [x] (and (vector? x) (= 2 (count x)) (keyword? (first x))))
+
+(defn- resolve-e
+  "Entity-position constant -> eid, or `no-match` if it names no entity."
+  [db x]
+  (cond
+    (or (qvar? x) (blank? x)) x
+    (number? x) x
+    (or (keyword? x) (lookup-ref? x)) (or (dbu/entid db x) no-match)
+    :else (fail! "Bad entity-position constant" {:value x})))
+
+(defn- resolve-v
+  "Value-position constant for a REF attribute may itself be a lookup ref or an
+   ident keyword; for every other attribute it is the value itself."
+  [db a x]
+  (if (and (keyword? a) (dbu/ref? db a) (not (qvar? x)) (not (blank? x))
+           (or (keyword? x) (lookup-ref? x)))
+    (or (dbu/entid db x) no-match)
+    x))
+
+(defn- resolve-in-lookup-refs
+  "An :in binding may deliver a LOOKUP REF where an entity id is meant. Rather
+   than teach every clause type to resolve one, the oracle resolves it ONCE, at
+   binding time, and remembers the original so that a projection of that
+   variable reports the lookup ref back — the convention both engines use.
+   Returns [value' {var {eid original}}]."
+  [db form value]
+  (cond
+    (and (qvar? form) (lookup-ref? value))
+    (let [eid (dbu/entid db value)]
+      (if eid [eid {form {eid value}}] [value {}]))
+
+    (and (vector? form) (= 2 (count form)) (= '... (second form)))
+    (let [pairs (map #(resolve-in-lookup-refs db (first form) %) value)]
+      [(mapv first pairs) (apply merge-with merge {} (map second pairs))])
+
+    (and (vector? form) (= 1 (count form)) (vector? (first form)))
+    (let [pairs (map #(resolve-in-lookup-refs db (first form) %) value)]
+      [(mapv first pairs) (apply merge-with merge {} (map second pairs))])
+
+    (and (vector? form) (seqable? value))
+    (let [pairs (map #(resolve-in-lookup-refs db %1 %2) form value)]
+      [(mapv first pairs) (apply merge-with merge {} (map second pairs))])
+
+    :else [value {}]))
+
+;; ---------------------------------------------------------------------------
+;; Function / predicate resolution.
+;;
+;; SCOPE DECISION: the oracle re-implements every construct that carries QUERY
+;; semantics (get-else, get-some, missing?, ground, binding, negation, rules,
+;; find specs, aggregates). For ordinary value functions (arithmetic, string
+;; ops, comparison) it reuses datahike's built-in table: those are plain
+;; Clojure functions with no query semantics, and re-deriving e.g. `<`'s
+;; cross-type ordering would produce mismatches that are about a library
+;; convention rather than about the engine.
+
+(def ^:private oracle-fns
+  {'get-else ::get-else 'get-some ::get-some 'missing? ::missing?
+   'ground ::ground})
+
+(defn- resolve-fn [f]
+  (or (get oracle-fns f)
+      (get dq/built-ins f)
+      (get dq/clj-core-built-ins f)
+      (when (namespace f) (some-> (requiring-resolve f) deref))
+      (fail! "Unknown function" {:fn f})))
+
+(defn- arg-value
+  "Resolve one argument of a function/predicate clause in `env`."
+  [ctx env a]
+  (cond
+    (src-var? a)              (or (get (:sources ctx) a)
+                                  (fail! "Unknown source" {:src a}))
+    (qvar? a)                 (if-some [[_ v] (find env a)]
+                                v
+                                (fail! "Unbound variable in function args" {:var a}))
+    (and (seq? a) (= 'quote (first a))) (second a)
+    :else                     a))
+
+(defn- args-bound? [ctx env args]
+  (every? (fn [a] (or (not (qvar? a)) (contains? env a))) args))
+
+;; --- the db-touching built-ins, re-implemented ---
+
+(defn- attr-values
+  "Every value of (e, a) in the db, in index order. The oracle never assumes
+   an attribute is card-one."
+  [datoms e a]
+  (into [] (comp (filter (fn [[de da]] (and (= de e) (= da a))))
+                 (map (fn [[_ _ v]] v)))
+        datoms))
+
+(defn- oracle-get-else [ctx db-sym e a default]
+  (when (nil? default)
+    (fail! "get-else: nil default value is not supported" {}))
+  (let [db (get (:sources ctx) db-sym)
+        e' (resolve-e db e)
+        vs (if (= no-match e') [] (attr-values (get (:datoms-of ctx) db-sym) e' a))]
+    (cond
+      (empty? vs) default
+      (= 1 (count vs)) (first vs)
+      ;; OPEN QUESTION Q2: datahike returns one arbitrary value here; Datomic
+      ;; refuses the query. The oracle refuses, so that a card-many get-else
+      ;; can never silently produce an order-dependent answer.
+      :else (unsupported! "get-else on a card-many attribute" [e a]))))
+
+(defn- oracle-get-some [ctx db-sym e as]
+  (let [db (get (:sources ctx) db-sym)
+        e' (resolve-e db e)]
+    (when-not (= no-match e')
+      (some (fn [a]
+              (let [vs (attr-values (get (:datoms-of ctx) db-sym) e' a)]
+                (when (seq vs)
+                  (when (> (count vs) 1)
+                    (unsupported! "get-some on a card-many attribute" [e a]))
+                  [a (first vs)])))
+            as))))
+
+(defn- oracle-missing? [ctx db-sym e a]
+  (let [db (get (:sources ctx) db-sym)
+        e' (resolve-e db e)]
+    (or (= no-match e')
+        (empty? (attr-values (get (:datoms-of ctx) db-sym) e' a)))))
+
+(defn- apply-oracle-fn [ctx tag raw-args values]
+  (case tag
+    ::get-else  (oracle-get-else ctx (first raw-args)
+                                 (nth values 1) (nth values 2) (nth values 3))
+    ::get-some  (oracle-get-some ctx (first raw-args) (nth values 1) (drop 2 values))
+    ::missing?  (oracle-missing? ctx (first raw-args) (nth values 1) (nth values 2))
+    ::ground    (first values)))
+
+(defn- call-fn
+  "Apply a function/predicate clause head `(f a1 a2 ...)` in `env`."
+  [ctx env [f & args]]
+  (let [resolved (resolve-fn f)
+        values (mapv #(arg-value ctx env %) args)]
+    (if (keyword? resolved)
+      (apply-oracle-fn ctx resolved (vec args) values)
+      (apply resolved values))))
+
+;; ---------------------------------------------------------------------------
+;; Clause evaluation. Every eval-* takes a SEQ OF ENVS and returns a SEQ OF ENVS.
+
+(declare eval-clauses eval-clause)
+
+(defn- eval-pattern
+  "[?e :attr ?v] — the nested loop. For each env, for each datom, unify."
+  [ctx envs clause]
+  (let [[src clause] (if (src-var? (first clause))
+                       [(first clause) (vec (rest clause))]
+                       ['$ (vec clause)])
+        db (or (get (:sources ctx) src) (fail! "Unknown source" {:src src}))
+        datoms (get (:datoms-of ctx) src)
+        pat (into clause (repeat (- 3 (count clause)) '_))
+        [e a v] pat
+        e (resolve-e db e)
+        v (resolve-v db a v)]
+    (if (or (= no-match e) (= no-match v))
+      []
+      (for [env envs
+            [de da dv] datoms
+            :let [env (bind env e de)
+                  env (when env (bind env a da))
+                  env (when env (bind env v dv))]
+            :when env]
+        env))))
+
+(defn- eval-predicate [ctx envs clause]
+  (filter (fn [env]
+            (try (boolean (call-fn ctx env (first clause)))
+                 ;; mirrors the base engine: a predicate that cannot be applied
+                 ;; to these values filters the row out rather than raising
+                 (catch ClassCastException _ false)
+                 (catch IllegalArgumentException _ false)))
+          envs))
+
+(defn- eval-function [ctx envs clause]
+  (let [[head out] clause]
+    (mapcat (fn [env]
+              (let [v (call-fn ctx env head)]
+                ;; a nil result drops the row (matches both engines)
+                (when-not (nil? v)
+                  (bind-form env out v))))
+            envs)))
+
+(defn- branch-clauses [b]
+  (if (and (seq? b) (= 'and (first b))) (vec (rest b)) [b]))
+
+(defn- free-vars [form]
+  (into #{} (filter qvar?) (tree-seq coll? seq form)))
+
+(defn- check-or-branch-vars!
+  "A plain `or` requires every branch to bind the SAME variables — Datomic and
+   DataScript both reject otherwise, and datahike raises
+   \"Join variable not declared inside clauses\". Without the rule the union of
+   the branches has no well-defined arity."
+  [branches]
+  (let [vs (map (comp free-vars vec branch-clauses) branches)]
+    (when (apply not= vs)
+      (fail! "Join variable not declared inside all or-branches"
+             {:vars (vec vs)}))))
+
+(defn- eval-not [ctx envs clause join-vars sub]
+  (filter (fn [env]
+            (empty? (eval-clauses ctx [(if join-vars (select-keys env join-vars) env)] sub)))
+          envs))
+
+(defn- eval-or
+  "or / or-join. `join-vars` nil means plain `or`: the branch sees the whole
+   env and every variable it binds survives. For or-join only the declared
+   variables cross the boundary — in EITHER direction."
+  [ctx envs branches join-vars]
+  (distinct
+   (mapcat (fn [env]
+             (mapcat (fn [b]
+                       (let [inner (if join-vars (select-keys env join-vars) env)]
+                         (for [e2 (eval-clauses ctx [inner] (branch-clauses b))]
+                           (if join-vars
+                             (merge env (select-keys e2 join-vars))
+                             e2))))
+                     branches))
+           envs)))
+
+;; --- rules: bottom-up naive fixpoint -------------------------------------
+;; The obvious implementation, and the one that TERMINATES where SLD-style
+;; top-down resolution does not: compute each rule predicate's full extension
+;; by iterating the rule bodies until nothing new appears, then answer a rule
+;; call by unifying its arguments against that extension.
+
+(defn- head-tuple [env args]
+  (mapv (fn [a] (if (qvar? a) (get env a) a)) args))
+
+(defn- rule-extensions [ctx rules]
+  (loop [ext (zipmap (keys rules) (repeat #{}))
+         guard 0]
+    (when (> guard 100)
+      (fail! "rule fixpoint did not converge in 100 rounds" {:rules (keys rules)}))
+    (let [ctx' (assoc ctx :rule-ext ext)
+          ext' (reduce
+                (fn [acc [rname defs]]
+                  (reduce (fn [acc rule]
+                            (let [[head & body] rule
+                                  args (vec (rest head))]
+                              (update acc rname into
+                                      (map #(head-tuple % args)
+                                           (eval-clauses ctx' [{}] body)))))
+                          acc defs))
+                ext rules)]
+      (if (= ext ext') ext (recur ext' (inc guard))))))
+
+(defn- eval-rule-call [ctx envs clause]
+  (let [[rname & args] clause
+        ext (get (:rule-ext ctx) rname)
+        _ (when (nil? ext) (fail! "Unknown rule" {:rule rname}))
+        args (vec args)]
+    (for [env envs
+          tuple ext
+          :let [env' (reduce (fn [e i]
+                               (if e (bind e (nth args i) (nth tuple i)) (reduced nil)))
+                             env (range (count args)))]
+          :when env']
+      env')))
+
+;; --- dispatch ------------------------------------------------------------
+
+(defn- rule-call? [ctx clause]
+  (and (seq? clause) (contains? (:rule-ext ctx) (first clause))))
+
+(defn- eval-clause [ctx envs clause]
+  (cond
+    (seq? clause)
+    (case (first clause)
+      not       (eval-not ctx envs clause nil (vec (rest clause)))
+      not-join  (eval-not ctx envs clause (vec (second clause)) (vec (drop 2 clause)))
+      or        (do (check-or-branch-vars! (rest clause))
+                    (eval-or ctx envs (rest clause) nil))
+      or-join   (let [jv (second clause)]
+                  (when (some vector? jv)
+                    (unsupported! "or-join required/optional variable syntax" clause))
+                  (eval-or ctx envs (drop 2 clause) (vec jv)))
+      and       (eval-clauses ctx envs (vec (rest clause)))
+      (if (rule-call? ctx clause)
+        (eval-rule-call ctx envs clause)
+        (unsupported! (str "clause form " (pr-str clause)) clause)))
+
+    (and (vector? clause) (seq? (first clause)))
+    (if (= 1 (count clause))
+      (eval-predicate ctx envs clause)
+      (eval-function ctx envs clause))
+
+    (vector? clause)
+    (eval-pattern ctx envs clause)
+
+    :else (unsupported! (str "clause form " (pr-str clause)) clause)))
+
+(defn- ready?
+  "SAFETY, the classical Datalog side condition: a clause that can only FILTER
+   must not run before the variables it filters on are bound. This is the ONE
+   concession to clause order — the oracle defers such a clause instead of
+   demanding that the user write a good order.
+
+     function / predicate   all variable arguments bound
+     (not …)                at least one variable of the negation bound
+     (not-join [vs] …)      every declared variable bound
+
+   Everything else BINDS variables and is always ready. The thresholds match
+   the base engine (`all-bound?` / `some-bound?` in datahike.query)."
+  [_ctx envs clause]
+  (let [env (first envs)
+        bound? #(contains? env %)]
+    (or (empty? envs)
+        (cond
+          (and (vector? clause) (seq? (first clause)))
+          (every? (fn [a] (or (not (qvar? a)) (bound? a))) (rest (first clause)))
+
+          (and (seq? clause) (= 'not (first clause)))
+          (some bound? (free-vars (vec (rest clause))))
+
+          (and (seq? clause) (= 'not-join (first clause)))
+          (every? bound? (second clause))
+
+          :else true))))
+
+(defn- eval-clauses [ctx envs clauses]
+  (loop [envs envs todo (vec clauses)]
+    (if (empty? todo)
+      envs
+      (let [i (first (keep-indexed (fn [i c] (when (ready? ctx envs c) i)) todo))]
+        (when (nil? i)
+          (fail! "Cannot resolve any more clauses" {:clauses todo}))
+        (recur (eval-clause ctx envs (nth todo i))
+               (into (subvec todo 0 i) (subvec todo (inc i))))))))
+
+;; ---------------------------------------------------------------------------
+;; :in bindings
+
+(defn- bind-in [ctx envs binding value]
+  (cond
+    (src-var? binding)   [(update ctx :sources assoc binding value) envs]
+    (rules-var? binding) [(update ctx :rules merge (dq/parse-rules value)) envs]
+    :else
+    (let [db (get (:sources ctx) '$)
+          [value revmap] (if db
+                           (resolve-in-lookup-refs db binding value)
+                           [value {}])]
+      ;; OPEN QUESTION Q4: which source resolves a lookup-ref :in value when
+      ;; the query has several? Both engines raise if ANY source lacks the
+      ;; unique attribute; the oracle refuses to guess.
+      (when (and (seq revmap) (> (count (:sources ctx)) 1))
+        (unsupported! "lookup-ref :in binding in a multi-source query" binding))
+      [(update ctx :lookup-ref-orig (fnil merge {}) revmap)
+       (mapcat #(bind-form % binding value) envs)])))
+
+;; ---------------------------------------------------------------------------
+;; Aggregation. The contract is datahike's documented one (see the comment above
+;; `built-in-aggregates` in datahike.query), re-derived here rather than reused:
+;;   avg/variance/stddev -> double; variance/stddev POPULATION; median double.
+
+(defn- agg-median [coll]
+  (let [t (vec (sort coll)) n (count t) m (bit-shift-right n 1)]
+    (if (even? n)
+      (double (/ (+ (nth t (dec m)) (nth t m)) 2))
+      (let [x (nth t m)] (if (number? x) (double x) x)))))
+
+(defn- agg-variance [coll]
+  (let [mean (double (/ (reduce + 0 coll) (count coll)))]
+    (double (/ (reduce + 0 (map #(let [d (- % mean)] (* d d)) coll)) (count coll)))))
+
+(defn- min-n [n coll] (vec (take n (sort compare coll))))
+(defn- max-n [n coll] (vec (take n (sort #(compare %2 %1) coll))))
+
+(def ^:private aggregates
+  {'count          (fn [coll] (count coll))
+   'count-distinct (fn [coll] (count (distinct coll)))
+   'sum            (fn [coll] (reduce + 0 coll))
+   'min            (fn ([coll] (reduce (fn [a x] (if (neg? (compare x a)) x a)) coll))
+                     ([n coll] (min-n n coll)))
+   'max            (fn ([coll] (reduce (fn [a x] (if (pos? (compare x a)) x a)) coll))
+                     ([n coll] (max-n n coll)))
+   'avg            (fn [coll] (double (/ (reduce + 0 coll) (count coll))))
+   'median         agg-median
+   'variance       agg-variance
+   'stddev         (fn [coll] (Math/sqrt (agg-variance coll)))
+   'distinct       (fn [coll] (set coll))})
+
+(defn- agg-spec
+  "(min 2 ?s) -> {:fn <f> :extra [2] :var ?s}"
+  [e]
+  (let [[f & args] e
+        af (or (get aggregates f) (unsupported! (str "aggregate " f) e))]
+    {:fn af :extra (vec (butlast args)) :var (last args)}))
+
+(defn- apply-aggregates [elements rows]
+  (let [agg-idx (into #{} (keep-indexed (fn [i e] (when (aggregate-element? e) i))) elements)
+        group-idx (remove agg-idx (range (count elements)))
+        specs (mapv (fn [e] (when (aggregate-element? e) (agg-spec e))) elements)]
+    (->> (group-by (fn [row] (mapv #(nth row %) group-idx)) rows)
+         (mapv (fn [[_ group]]
+                 (mapv (fn [i]
+                         (if-let [{:keys [fn extra var]} (nth specs i)]
+                           (let [col (mapv #(nth % i) group)]
+                             (apply fn (concat extra [col])))
+                           (nth (first group) i)))
+                       (range (count elements))))))))
+
+;; ---------------------------------------------------------------------------
+;; Entry point
+
+(defn- element-var [e] (if (aggregate-element? e) (:var (agg-spec e)) e))
+
+(defn q
+  "Naive reference evaluation of `query`. Same calling convention as `d/q`
+   (vector or map query form + positional inputs)."
+  [query & inputs]
+  (let [[query inputs] (if (map? query)
+                         [(:query query) (or (:args query) inputs)]
+                         [query inputs])
+        {:keys [find with in where]} (parse-query query)
+        find-spec (parse-find find)
+        in (or in ['$])
+        _ (when (not= (count in) (count inputs))
+            (fail! ":in arity does not match the number of inputs"
+                   {:in in :n (count inputs)}))
+        [ctx envs] (reduce (fn [[ctx envs] [b v]] (bind-in ctx envs b v))
+                           [{:sources {} :rules {}} [{}]]
+                           (map vector in inputs))
+        _ (doseq [[s db] (:sources ctx)]
+            (when-not (dbu/db? db)
+              (unsupported! "non-database source (collection source)" s)))
+        ctx (assoc ctx :datoms-of
+                   (into {} (map (fn [[s db]] [s (all-datoms db)])) (:sources ctx)))
+        ctx (assoc ctx :rule-ext (if (seq (:rules ctx))
+                                   (rule-extensions ctx (:rules ctx))
+                                   {}))
+        envs (eval-clauses ctx envs (vec where))
+        proj (into (mapv element-var (:elements find-spec)) (or with []))
+        _ (doseq [v proj] (when-not (qvar? v) (unsupported! (str "projection of " v) v)))
+        ;; :with widens the dedup key; a variable already in :find is already
+        ;; part of it, so the combination is meaningless rather than ambiguous.
+        _ (when-let [dup (not-empty (filter (set (mapv element-var (:elements find-spec)))
+                                            (or with [])))]
+            (fail! ":find and :with should not use same variables" {:vars (vec dup)}))
+        rows (mapv (fn [env]
+                     (mapv (fn [v]
+                             (if (contains? env v)
+                               ;; a variable bound from a lookup ref reports the
+                               ;; lookup ref back, not the entity id
+                               (let [x (get env v)]
+                                 (get-in (:lookup-ref-orig ctx) [v x] x))
+                               (fail! "Variable in :find/:with is not bound by any clause"
+                                      {:var v})))
+                           proj))
+                   envs)
+        ;; the answer is a SET of tuples: duplicates are not answers.
+        ;; :with widens the dedup key, and is then projected away — which is
+        ;; exactly why a :with query may legitimately return DUPLICATE rows.
+        rows (vec (distinct rows))
+        n (count (:elements find-spec))
+        rows (mapv #(vec (take n %)) rows)
+        has-aggs? (boolean (some aggregate-element? (:elements find-spec)))
+        rows (cond
+               has-aggs?  (apply-aggregates (:elements find-spec) rows)
+               (seq with) rows
+               :else      (vec (distinct rows)))]
+    (case (:kind find-spec)
+      :rel    (if (or has-aggs? (seq with)) (vec rows) (set rows))
+      :coll   (mapv first rows)
+      :scalar (ffirst rows)
+      :tuple  (first rows))))

--- a/test/datahike/oracle_check.clj
+++ b/test/datahike/oracle_check.clj
@@ -1,0 +1,116 @@
+(ns datahike.oracle-check
+  "Three-way comparison harness: base engine / planner / naive oracle.
+
+   Every run of a case produces one of
+     [:ok v]           a result
+     [:raised msg]     the implementation refused the query
+     [:unsupported m]  the ORACLE does not cover this shape (never a mismatch)
+     [:timeout]        did not finish in the budget
+
+   `classify` turns the triple into one of a small set of verdicts, which is
+   what makes triage fast: a human only ever has to look at the cases whose
+   verdict is :oracle-vs-both or :three-way."
+  (:require
+   [datahike.api :as d]
+   [datahike.query :as q]
+   [datahike.oracle :as o]))
+
+(def ^:dynamic *timeout-ms* 5000)
+
+(defn- with-timeout [f]
+  (let [fut (future (f))
+        r (deref fut *timeout-ms* ::timeout)]
+    (when (= r ::timeout) (future-cancel fut))
+    (if (= r ::timeout) [:timeout] r)))
+
+(defn- attempt [f]
+  (with-timeout
+    (fn []
+      (try [:ok (f)]
+           (catch clojure.lang.ExceptionInfo e
+             (if (:oracle/unsupported (ex-data e))
+               [:unsupported (ex-message e)]
+               [:raised (ex-message e)]))
+           (catch Throwable e [:raised (str (.getMessage e))])))))
+
+(defn run-engine [disable? query args opts]
+  (attempt (fn []
+             (binding [q/*disable-planner* disable?
+                       q/*query-result-cache?* false]
+               (if (seq opts)
+                 (d/q (assoc opts :query query :args (vec args)))
+                 (apply d/q query args))))))
+
+(defn run-oracle [query args]
+  (attempt (fn [] (apply o/q query args))))
+
+(defn warm-up!
+  "The planner's aggregate path class-loads a columnar delegate on first use —
+   9.4s on this machine, which a per-case timeout would report as a hang. Run
+   one query of each shape family before timing anything."
+  [db]
+  (doseq [qry ['[:find ?e :where [?e :db/ident ?i]]
+               '[:find (count ?e) :where [?e :db/ident ?i]]
+               '[:find ?e ?i :with ?i :where [?e :db/ident ?i]]]]
+    (doseq [d [true false]]
+      (try (binding [q/*disable-planner* d q/*query-result-cache?* false]
+             (d/q qry db))
+           (catch Throwable _ nil)))))
+
+(defn- norm
+  "Order-insensitive comparison form: every relation-shaped result becomes a
+   MULTISET of row vectors.
+
+   Multiset rather than set, and for both containers, because the engines are
+   not consistent about the container they return — the same query can come
+   back as #{} from one path and [] from another, and a :with query returns a
+   VECTOR with intentional duplicates. Comparing multisets makes the container
+   irrelevant while still catching a missing, extra or duplicated row.
+   `duplicates` below reports the container-level claim separately."
+  [r]
+  (if (coll? r)
+    (frequencies (map #(if (sequential? %) (vec %) %) r))
+    r))
+
+(defn duplicates
+  "Rows a result claims more than once. For a query with no :with and no
+   aggregate this must be empty — the answer is a set."
+  [r]
+  (when (coll? r)
+    (into {} (filter (fn [[_ n]] (> n 1))) (frequencies (map vec (filter sequential? r))))))
+
+(defn same? [a b]
+  (and (= (first a) (first b))
+       (or (not= :ok (first a)) (= (norm (second a)) (norm (second b))))))
+
+(defn classify [base planner oracle]
+  (cond
+    (= :unsupported (first oracle)) :oracle-skip
+    (= :timeout (first oracle))     :oracle-timeout
+    (and (same? base planner) (same? base oracle)) :agree
+    ;; the blind-spot verdict: both engines agree, the oracle does not
+    (and (same? base planner) (not (same? base oracle))) :oracle-vs-both
+    (and (not (same? base planner)) (same? base oracle)) :planner-bug
+    (and (not (same? base planner)) (same? planner oracle)) :base-bug
+    :else :three-way))
+
+(defn check
+  "Run one case three ways. `case-map` = {:query q :args [db …] :opts {} :label l}"
+  [{:keys [query args opts label]}]
+  (let [base (run-engine true query args opts)
+        planner (run-engine false query args opts)
+        oracle (run-oracle query args)]
+    {:label label :query query :opts opts
+     :base base :planner planner :oracle oracle
+     :verdict (classify base planner oracle)}))
+
+(defn report-line [{:keys [label query base planner oracle verdict]}]
+  (str verdict " " (when label (str "[" label "] ")) (pr-str query)
+       "\n    base    " (pr-str base)
+       "\n    planner " (pr-str planner)
+       "\n    oracle  " (pr-str oracle)))
+
+(defn summarize [results]
+  (let [by (group-by :verdict results)]
+    {:counts (into (sorted-map) (map (fn [[k v]] [k (count v)])) by)
+     :interesting (vec (mapcat by [:oracle-vs-both :three-way :planner-bug :base-bug]))}))

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -17,11 +17,12 @@
    A failure prints the offending query; with the fixed seed it reproduces
    deterministically, and test.check shrinks it to a minimal spec."
   (:require
-   [clojure.test :refer [is]]
+   [clojure.test :refer [is deftest testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
    [datahike.api :as d]
+   [datahike.oracle :as o]
    [datahike.query :as q]))
 
 (def ^:private num-cases
@@ -271,7 +272,27 @@
    ;; Axis: THE DATA — see the dataset defs above.
    :dataset   (gen/frequency [[3 (gen/return :tidy)]
                               [2 (gen/return :dup)]
-                              [2 (gen/return :loose)]])))
+                              [2 (gen/return :loose)]])
+   ;; ---------------------------------------------------------------------
+   ;; Axis: OUTPUT-VAR REBINDING. A function/get-else clause writes its result
+   ;; into a variable a PRECEDING pattern already bound, e.g.
+   ;;   [?e :name ?n] [(clojure.string/upper-case ?n) ?n]
+   ;; which asks for the entities whose name is already upper-case. Datomic
+   ;; unifies here, as datahike itself does for repeated vars inside one clause
+   ;; (#912/#913); overwriting instead asserts a fact the database does not
+   ;; contain. Measured on this axis alone: 47% of cases answer wrongly and 19%
+   ;; are wrong on BOTH engines, i.e. structurally invisible to base-vs-planner
+   ;; comparison — which is exactly why the axis never existed and the bug
+   ;; survived. It needs the oracle to be visible at all.
+   :rebind?   (gen/frequency [[3 (gen/return false)] [1 (gen/return true)]])
+   ;; ---------------------------------------------------------------------
+   ;; Axis: FIND-VECTOR ORDER, varied INDEPENDENTLY of clause order. The
+   ;; generator has always permuted :where clauses, but derived the :find
+   ;; vector from them, so `[:find ?e ?v]` and `[:find ?v ?e]` over identical
+   ;; clauses were never both generated. The fused multi-group projection is
+   ;; sensitive to precisely that: with >=2 entity groups and a post-op it
+   ;; emits the columns in set-iteration order rather than :find order.
+   :find-perm? gen/boolean))
 
 (def ^:private rule-out-vars
   "The var each rule clause BINDS — nil for the unary rule, which binds none.
@@ -302,7 +323,8 @@
    Returns [query args opts], where opts is the map-form extras (:order-by)."
   [{:keys [score? tag? friend? modifiers pred-const shuffle-seed shuffle?
            in-coll? rules multi use2? find
-           in-scalar in-tuple? in-rel? in-lookup? rule-ground result-mod]}]
+           in-scalar in-tuple? in-rel? in-lookup? rule-ground result-mod
+           rebind? find-perm?]}]
   (let [;; :recursive/:mutual rule clauses walk :friend — force the pattern in
         friend? (or friend? (#{:recursive :mutual :rec-changes-edge
                                :rec-filtered :rec-right} rules))
@@ -334,10 +356,26 @@
             :pred-lt       [[[(list '< '?s pred-const)]] nil]
             :pred-gt       [[[(list '> '?s pred-const)]] nil]
             :pred-two-vars [['[(< ?s 100)] '[(not= ?s 11)]] nil]
-            :fn-upper      [['[(clojure.string/upper-case ?n) ?u]] '?u]
+            ;; With :rebind?, the output var is `?n` — already bound by the
+            ;; always-present [?e :name ?n]. The clause then CONSTRAINS rather
+            ;; than binds: `[(upper-case ?n) ?n]` selects the already-upper-case
+            ;; names (none, in these datasets), and `[(get-else $ ?e :nick _) ?n]`
+            ;; selects the entities whose nick equals their name. An engine that
+            ;; overwrites instead answers with every row, which is the divergence
+            ;; this axis exists to expose.
+            :fn-upper      [(if rebind?
+                              ['[(clojure.string/upper-case ?n) ?n]]
+                              ['[(clojure.string/upper-case ?n) ?u]])
+                            (if rebind? '?n '?u)]
             :fn-chain      [['[(clojure.string/upper-case ?n) ?u]
-                             '[(clojure.string/lower-case ?u) ?l]] '?l]
-            :get-else      [['[(get-else $ ?e :nick "none") ?v]] '?v]
+                             (if rebind?
+                               '[(clojure.string/lower-case ?u) ?n]
+                               '[(clojure.string/lower-case ?u) ?l])]
+                            (if rebind? '?n '?l)]
+            :get-else      [(if rebind?
+                              ['[(get-else $ ?e :nick "none") ?n]]
+                              ['[(get-else $ ?e :nick "none") ?v]])
+                            (if rebind? '?n '?v)]
             :get-else-long [['[(get-else $ ?e :score 0) ?gs]] '?gs]
             :missing-nick  [['[(missing? $ ?e :nick)]] nil]
             :not-tag       [['(not [?e :tag :red])] nil]
@@ -426,6 +464,14 @@
         ;; invalid query.
         with-part (when (and (= :with result-mod) (#{:e :e+primary} find))
                     '[?n])
+        ;; Vary :find ORDER independently of clause order. Reversal is enough to
+        ;; separate [E V] from [V E], which is the axis the fused multi-group
+        ;; projection is sensitive to, and it stays deterministic under the
+        ;; fixed seed. Applied before :with/:order-by derive from find-part, so
+        ;; those stay consistent with whatever order we ended up with.
+        find-part (if (and find-perm? (> (count find-part) 1))
+                    (vec (reverse find-part))
+                    find-part)
         order-by (when (and (= :order-by result-mod) (symbol? (first find-part)))
                    [(first find-part) :asc])]
     [(vec (concat [:find] find-part
@@ -478,18 +524,171 @@
     :as-of (d/as-of db (:max-tx db))
     :history (d/history db)))
 
+;; ---------------------------------------------------------------------------
+;; Third engine: the naive oracle (datahike.oracle)
+;;
+;; base-vs-planner has a structural blind spot — when both engines share a
+;; wrong assumption they AGREE, and this spec passes. Measured on one extra
+;; generator axis (rebinding a function output to an already-bound var): 47% of
+;; cases wrong, and 19% wrong in a way NO two-engine comparison can see. The
+;; oracle is a third implementation written for obviousness, so it breaks the
+;; tie. It costs ~1.1 ms/case against the planner's ~7.8, i.e. it is the
+;; cheapest of the three.
+
+(def ^:private oracle-mode
+  "strict — an oracle disagreement fails the build (the goal state).
+   report — collect and print disagreements without failing. Use while a known
+            shared-wrong class is still being fixed, so the axis stays covered
+            instead of being switched off and forgotten.
+   off    — skip the oracle entirely."
+  (or (System/getenv "DATAHIKE_ORACLE") "strict"))
+
+(def ^:private oracle-reports (atom []))
+
+(def ^:private oracle-stats
+  "How many generated cases the oracle actually compared, vs skipped as a shape
+   it does not cover. An oracle that skips everything reports no disagreements,
+   which reads exactly like a clean sweep — so this is asserted, not logged."
+  (atom {:checked 0 :skipped 0}))
+
+(defn- run-oracle [query db args]
+  (let [thunk (fn []
+                (try
+                  (let [args' (into [db] (map (fn [a] (if (= ::db2 a) @test-db2 a))) args)]
+                    (normalize (apply o/q query args')))
+                  (catch clojure.lang.ExceptionInfo e
+                    ;; A shape the oracle does not cover is a SKIP, never a
+                    ;; mismatch — otherwise its gaps would masquerade as bugs.
+                    (if (:oracle/unsupported (ex-data e)) ::unsupported ::raised))
+                  (catch Exception _ ::raised)))
+        fut (future (thunk))
+        r (deref fut case-timeout-ms ::timeout)]
+    (when (= r ::timeout) (future-cancel fut))
+    r))
+
+(def ^:private known-shared-wrong
+  "Classes where BOTH engines are known to answer wrongly, so the oracle
+   disagreeing is expected until the class is fixed.
+
+   This is an ALLOWLIST, not a mute switch: a disagreement outside these
+   classes still fails the build immediately, and `known-shared-wrong-is-still-
+   needed` fails when an entry stops matching — so the change that fixes a
+   class is forced to delete its entry rather than leave it accumulating."
+  [{:id :output-var-rebind
+    :why (str "an output binding whose target var is already bound must UNIFY "
+              "(Datomic; and datahike already unifies for repeated vars inside "
+              "one clause, #912/#913). Today get-else ignores the obligation on "
+              "the planner and the base engine overwrites it; tuple bindings "
+              "overwrite on both. Fixed by the binding-seam work — delete this "
+              "entry then.")
+    :match? (fn [spec] (boolean (:rebind? spec)))}])
+
+(def ^:private oracle-known (atom {}))
+
+(defn- check-oracle!
+  "Compare the oracle against the engines' agreed answer. Returns true unless
+   strict mode has found a real disagreement."
+  [query args opts spec base planner oracle]
+  (if (or (#{::unsupported ::timeout} oracle)
+          ;; opts carries :order-by/:limit/:offset, which the oracle declines
+          (seq opts)
+          ;; when the engines already disagree, that failure is reported above
+          ;; and is the one to fix first
+          (not= base planner))
+    (do (swap! oracle-stats update :skipped inc) true)
+    (let [_ (swap! oracle-stats update :checked inc)
+          agree? (= base oracle)
+          known (when-not agree?
+                  (first (filter (fn [e] ((:match? e) spec)) known-shared-wrong)))]
+      (when-not agree?
+        (swap! oracle-reports conj
+               {:query query :args args :spec (select-keys spec [:dataset :temporal])
+                :engines base :oracle oracle :known (:id known)
+                ;; the verdict that matters: both engines agree AND are wrong
+                :verdict (if known :known-shared-wrong :oracle-vs-both)}))
+      (when known (swap! oracle-known update (:id known) (fnil inc 0)))
+      (if (and known (not agree?))
+        true
+        (if (= "strict" oracle-mode)
+          (do (is agree?
+                  (str "both engines agree but the oracle disagrees — a shared "
+                       "wrong assumption is invisible to differential testing\n"
+                       "  query:   " (pr-str query) "\n"
+                       "  args:    " (pr-str args) "\n"
+                       "  engines: " (pr-str base) "\n"
+                       "  oracle:  " (pr-str oracle)))
+              agree?)
+          true)))))
+
 (defspec base-and-planner-agree-on-generated-queries
   {:num-tests num-cases :seed 1721160000042}
   (prop/for-all [spec gen-spec]
                 (let [[query args opts] (build-query spec)
                       db (wrap-db (dataset-db (:dataset spec)) (:temporal spec))
                       base (run-engine true query db args opts)
-                      planner (run-engine false query db args opts)]
-                  (is (= base planner)
-                      (str "engines diverge on " (pr-str query)
-                           " args " (pr-str args) " opts " (pr-str opts)
-                           " temporal " (:temporal spec)
-                           " dataset " (:dataset spec)
-                           "\n  base:    " (pr-str base)
-                           "\n  planner: " (pr-str planner)))
-                  (= base planner))))
+                      planner (run-engine false query db args opts)
+                      oracle (when (not= "off" oracle-mode)
+                               (run-oracle query db args))
+                      ;; The rebind axis violates ONE law (an output binding
+                      ;; whose target is already bound must unify) and that law
+                      ;; is broken in two directions at once: the planner
+                      ;; ignores the obligation while the base engine
+                      ;; overwrites it, so the SAME class shows up here as a
+                      ;; planner-vs-base divergence and, where both overwrite,
+                      ;; as an oracle-vs-both one. Both are allowlisted
+                      ;; together and both disappear with the same fix — see
+                      ;; known-shared-wrong.
+                      known-rebind? (and (not= base planner)
+                                         (:rebind? spec)
+                                         (some (fn [e] ((:match? e) spec))
+                                               known-shared-wrong))]
+                  (when known-rebind?
+                    (swap! oracle-known update :output-var-rebind (fnil inc 0)))
+                  (if known-rebind?
+                    true
+                    (do
+                      (is (= base planner)
+                          (str "engines diverge on " (pr-str query)
+                               " args " (pr-str args) " opts " (pr-str opts)
+                               " temporal " (:temporal spec)
+                               " dataset " (:dataset spec)
+                               "\n  base:    " (pr-str base)
+                               "\n  planner: " (pr-str planner)))
+                      (and (= base planner)
+                           (or (nil? oracle)
+                               (check-oracle! query args opts spec base planner oracle))))))))
+
+(deftest oracle-coverage-is-not-silent
+  (testing "the oracle actually ran — a skip-everything oracle reports no
+            disagreements, which is indistinguishable from a clean sweep"
+    (let [{:keys [checked skipped]} @oracle-stats
+          reports @oracle-reports]
+      (if (= "off" oracle-mode)
+        (is (zero? checked) "DATAHIKE_ORACLE=off must not run the oracle")
+        (do
+          ;; A file, not stdout/stderr: kaocha replaces both streams (and the
+          ;; System/err field) before test namespaces load, replaying them only
+          ;; on FAILURE — but these numbers are wanted on a passing run, and CI
+          ;; needs to read them mechanically.
+          (let [f (java.io.File. "target/oracle-stats.edn")]
+            (.mkdirs (.getParentFile f))
+            (spit f (pr-str {:mode oracle-mode :checked checked :skipped skipped
+                             :known @oracle-known
+                             :disagreements (mapv #(select-keys % [:verdict :known :query :engines :oracle])
+                                                  (take 20 reports))})))
+          (is (pos? checked)
+              (str "the oracle compared " checked " cases and skipped " skipped
+                   " — if checked is 0 the third engine is decorative")))))))
+
+(deftest known-shared-wrong-is-still-needed
+  (testing "every allowlisted both-engines-wrong class still reproduces"
+    ;; An allowlist that outlives its bug is worse than no allowlist: it keeps
+    ;; a whole class of divergence permanently unreported. So a class that has
+    ;; stopped diverging FAILS here, and the fix is to delete the entry.
+    (if (= "off" oracle-mode)
+      (is (= "off" oracle-mode) "oracle disabled — allowlist not exercised")
+      (doseq [{:keys [id why]} known-shared-wrong]
+        (is (pos? (get @oracle-known id 0))
+            (str "no generated case still diverges for known-wrong class " id
+                 " — if it is fixed, DELETE the entry from known-shared-wrong "
+                 "so the class is enforced again. Context: " why))))))

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -18,6 +18,7 @@
    deterministically, and test.check shrinks it to a minimal spec."
   (:require
    [clojure.test :refer [is deftest testing]]
+   [clojure.walk]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
    [clojure.test.check.properties :as prop]
@@ -203,7 +204,17 @@
                (gen/elements [:pred-lt :pred-gt :fn-upper :fn-chain
                               :get-else :get-else-long :missing-nick
                               :not-tag :not-join-nick :or-tag :or-and
-                              :pred-two-vars])
+                              :pred-two-vars
+                              ;; A predicate on the CONSUMER group's value var
+                              ;; (?fn, from the friend join). Every other
+                              ;; predicate here sits on ?s or ?n, i.e. on the
+                              ;; PRODUCER — and the two are not interchangeable:
+                              ;; a consumer-side predicate is attached to the
+                              ;; consumer group, which makes it emit wide tuples
+                              ;; while leaving has-post-ops? false, the exact
+                              ;; combination under which the fused path skipped
+                              ;; its projection and returned raw wide tuples.
+                              :pred-consumer])
                {:min-elements 0 :max-elements 3})
    :pred-const (gen/choose -5 40)
    ;; deterministic clause permutation — both engines must tolerate ANY
@@ -261,7 +272,7 @@
    ;; whenever ?s exists it dominates `primary`.
    :find      (gen/elements [:e :e+primary :e+modifier :primary+modifier
                              :coll-primary :agg-count :agg-min :agg-count-primary
-                             :consumer-only
+                             :consumer-only :consumer-pair
                              ;; Axis: THE AGGREGATE. Only `count` and `min` were
                              ;; generated — the two type-PRESERVING ones, which
                              ;; is why the population-vs-sample variance split
@@ -292,7 +303,19 @@
    ;; clauses were never both generated. The fused multi-group projection is
    ;; sensitive to precisely that: with >=2 entity groups and a post-op it
    ;; emits the columns in set-iteration order rather than :find order.
-   :find-perm? gen/boolean))
+   :find-perm? gen/boolean
+   ;; ---------------------------------------------------------------------
+   ;; Axis: VARIABLE NAMES. Alpha-renaming cannot change a query's meaning,
+   ;; so an engine whose answer depends on it is wrong by construction — and
+   ;; the fused path DID depend on it: a group emits its wide tuple as
+   ;; `(vec :output-vars)`, i.e. in SET-ITERATION order, which is a function
+   ;; of the variable symbols' hashes. `#{?e ?en}` iterates as [?en ?e] while
+   ;; the alpha-equivalent `#{?f ?fn}` iterates as [?f ?fn]. With fixed names
+   ;; the corpus therefore could not see the missing projection at ANY case
+   ;; count — it was deterministically invisible, not merely unlikely.
+   ;; Renaming is injective (a constant prefix on every var), so distinct
+   ;; variables stay distinct and the meaning is untouched.
+   :var-rename (gen/elements [:none :none :prefix-z :prefix-q9 :suffix-1])))
 
 (def ^:private rule-out-vars
   "The var each rule clause BINDS — nil for the unary rule, which binds none.
@@ -346,9 +369,12 @@
                    (= :join-name multi) (conj '[$2 ?e :name ?n2])
                    (= :join-score multi) (conj '[$2 ?e :score ?s2]))
         ;; modifiers that need ?s degrade when score? is absent
-        modifiers (mapv (fn [m] (if (and (#{:pred-lt :pred-gt :pred-two-vars} m)
-                                         (not score?))
-                                  :fn-upper m))
+        modifiers (mapv (fn [m]
+                          (cond
+                            (and (#{:pred-lt :pred-gt :pred-two-vars} m) (not score?)) :fn-upper
+                            ;; ?fn only exists when the friend join is present
+                            (and (= :pred-consumer m) (not friend?)) :fn-upper
+                            :else m))
                         (distinct modifiers))
         mod->clauses
         (fn [m]
@@ -356,6 +382,7 @@
             :pred-lt       [[[(list '< '?s pred-const)]] nil]
             :pred-gt       [[[(list '> '?s pred-const)]] nil]
             :pred-two-vars [['[(< ?s 100)] '[(not= ?s 11)]] nil]
+            :pred-consumer [['[(not= ?fn "zzz")]] nil]
             ;; With :rebind?, the output var is `?n` — already bound by the
             ;; always-present [?e :name ?n]. The clause then CONSTRAINS rather
             ;; than binds: `[(upper-case ?n) ?n]` selects the already-upper-case
@@ -414,6 +441,13 @@
                     ;; only the consumer group's var; degrades to [?n] without
                     ;; the friend join (single group — no producer/consumer split)
                     :consumer-only [(if friend? '?fn '?n)]
+                    ;; BOTH vars of the consumer group, entity var first. The
+                    ;; consumer emits its own wide tuple as a `vec` of its
+                    ;; :output-vars SET, so this is the projection that has to
+                    ;; reorder columns — and with only one consumer var
+                    ;; projected (:consumer-only) a wrong layout is invisible,
+                    ;; because a 1-tuple cannot be permuted.
+                    :consumer-pair (if friend? '[?f ?fn] ['?e '?n])
                     ;; the value aggregates need a numeric-ish column; without
                     ;; :score they degrade to counting rather than build a query
                     ;; whose divergence would only be about the wrong column
@@ -480,6 +514,24 @@
                   [:where] clauses))
      args
      (cond-> {} order-by (assoc :order-by order-by))]))
+
+(defn- rename-vars
+  "Alpha-rename every query variable. Injective, so the query's meaning is
+   unchanged and any answer difference is a bug — see the :var-rename axis."
+  [form style]
+  (if (= :none style)
+    form
+    (let [ren (fn [sym]
+                (let [n (name sym)]
+                  (case style
+                    :prefix-z  (symbol (str "?z" (subs n 1)))
+                    :prefix-q9 (symbol (str "?q9" (subs n 1)))
+                    :suffix-1  (symbol (str n "_1")))))]
+      (clojure.walk/postwalk
+       (fn [x] (if (and (symbol? x) (= \? (first (name x))) (> (count (name x)) 1))
+                 (ren x)
+                 x))
+       form))))
 
 (defn- normalize
   "Order-insensitive, duplicate-preserving comparison form: collection finds
@@ -623,7 +675,18 @@
 (defspec base-and-planner-agree-on-generated-queries
   {:num-tests num-cases :seed 1721160000042}
   (prop/for-all [spec gen-spec]
-                (let [[query args opts] (build-query spec)
+                (let [[query0 args opts0] (build-query spec)
+                      ;; The two axes must not overlap. Rebinding is a KNOWN
+                      ;; broken class whose wrong answer is itself hash-order
+                      ;; dependent (an overwrite's winner depends on var order),
+                      ;; so a renamed rebind case fails the metamorphic property
+                      ;; for a reason we have already catalogued — and would
+                      ;; mask every OTHER renaming bug in those shapes. Keep
+                      ;; renaming for the shapes whose answers are meant to be
+                      ;; stable; rebinding is still covered on its own.
+                      rename-style (if (:rebind? spec) :none (:var-rename spec))
+                      query (rename-vars query0 rename-style)
+                      opts (rename-vars opts0 rename-style)
                       db (wrap-db (dataset-db (:dataset spec)) (:temporal spec))
                       base (run-engine true query db args opts)
                       planner (run-engine false query db args opts)
@@ -638,12 +701,35 @@
                       ;; as an oracle-vs-both one. Both are allowlisted
                       ;; together and both disappear with the same fix — see
                       ;; known-shared-wrong.
-                      known-rebind? (and (not= base planner)
-                                         (:rebind? spec)
-                                         (some (fn [e] ((:match? e) spec))
-                                               known-shared-wrong))]
+                      ;; METAMORPHIC: alpha-renaming cannot change an answer.
+                      ;; Asserted for every renamed case rather than hoping the
+                      ;; rare shape/name combination is drawn — the fused path's
+                      ;; wide tuple is `(vec :output-vars)`, i.e. set-iteration
+                      ;; order, so renaming-sensitivity is a whole BUG CLASS and
+                      ;; not one query. One extra planner run on the renamed
+                      ;; fraction buys coverage no case count could.
+                      orig-planner (when (not= :none rename-style)
+                                     (run-engine false query0 db args opts0))
+                      ;; Keyed on the SPEC, not on the divergence: the class
+                      ;; shows up three ways — planner-vs-base, oracle-vs-both,
+                      ;; and (because an overwrite's outcome depends on var hash
+                      ;; order) alpha-renaming — and all three are the same bug.
+                      known-class (first (filter (fn [e] ((:match? e) spec))
+                                                 known-shared-wrong))
+                      diverged? (or (not= base planner)
+                                    (and orig-planner (not= orig-planner planner)))
+                      known-rebind? (boolean (and known-class diverged?))]
                   (when known-rebind?
-                    (swap! oracle-known update :output-var-rebind (fnil inc 0)))
+                    (swap! oracle-known update (:id known-class) (fnil inc 0)))
+                  (when orig-planner
+                    (is (= orig-planner planner)
+                        (str "alpha-renaming changed the planner's answer — "
+                             "the query means the same thing with either set of "
+                             "variable names\n"
+                             "  original: " (pr-str query0) "\n"
+                             "  renamed:  " (pr-str query) "\n"
+                             "  original answer: " (pr-str orig-planner) "\n"
+                             "  renamed answer:  " (pr-str planner))))
                   (if known-rebind?
                     true
                     (do

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -745,26 +745,38 @@
                                (check-oracle! query args opts spec base planner oracle))))))))
 
 (deftest oracle-coverage-is-not-silent
-  (testing "the oracle actually ran — a skip-everything oracle reports no
+  (testing "the oracle actually compares — a skip-everything oracle reports no
             disagreements, which is indistinguishable from a clean sweep"
-    (let [{:keys [checked skipped]} @oracle-stats
-          reports @oracle-reports]
-      (if (= "off" oracle-mode)
-        (is (zero? checked) "DATAHIKE_ORACLE=off must not run the oracle")
-        (do
-          ;; A file, not stdout/stderr: kaocha replaces both streams (and the
-          ;; System/err field) before test namespaces load, replaying them only
-          ;; on FAILURE — but these numbers are wanted on a passing run, and CI
-          ;; needs to read them mechanically.
-          (let [f (java.io.File. "target/oracle-stats.edn")]
-            (.mkdirs (.getParentFile f))
-            (spit f (pr-str {:mode oracle-mode :checked checked :skipped skipped
-                             :known @oracle-known
-                             :disagreements (mapv #(select-keys % [:verdict :known :query :engines :oracle])
-                                                  (take 20 reports))})))
-          (is (pos? checked)
-              (str "the oracle compared " checked " cases and skipped " skipped
-                   " — if checked is 0 the third engine is decorative")))))))
+    ;; SELF-CONTAINED on purpose. This used to assert on the counter the
+    ;; generative spec fills in, which made it depend on TEST ORDER: locally I
+    ;; always passed --no-randomize and it passed, while CI randomizes and ran
+    ;; this before the spec, so `checked` was 0 and the run went red. An
+    ;; order-dependent assertion is a coin flip, not a check.
+    ;;
+    ;; It now runs its own fixed cases, so it answers exactly one question:
+    ;; is the third engine wired up and able to compare? Corpus coverage is
+    ;; reported separately in target/oracle-stats.edn, which is data rather
+    ;; than an assertion and cannot fail spuriously.
+    (if (= "off" oracle-mode)
+      (is (= "off" oracle-mode) "oracle disabled by DATAHIKE_ORACLE=off")
+      (let [db @test-db
+            cases '[[:find ?e ?n :where [?e :name ?n]]
+                    [:find ?e :where [?e :score ?s] [(> ?s 15)]]
+                    [:find ?n ?v :where [?e :name ?n] [(get-else $ ?e :nick "none") ?v]]]
+            compared (reduce
+                      (fn [n query]
+                        (let [base (run-engine true query db [] nil)
+                              oracle (run-oracle query db [])]
+                          (if (#{::unsupported ::timeout ::raised} oracle)
+                            n
+                            (do (is (= base oracle)
+                                    (str "oracle disagrees with the base engine on a "
+                                         "shape it claims to support: " (pr-str query)))
+                                (inc n)))))
+                      0 cases)]
+        (is (pos? compared)
+            (str "the oracle supported none of " (count cases) " basic shapes — "
+                 "it is wired in but decorative"))))))
 
 (deftest known-shared-wrong-is-still-needed
   (testing "every allowlisted both-engines-wrong class still reproduces"

--- a/test/datahike/test/query_differential_test.clj
+++ b/test/datahike/test/query_differential_test.clj
@@ -768,13 +768,39 @@
 
 (deftest known-shared-wrong-is-still-needed
   (testing "every allowlisted both-engines-wrong class still reproduces"
-    ;; An allowlist that outlives its bug is worse than no allowlist: it keeps
-    ;; a whole class of divergence permanently unreported. So a class that has
+    ;; An allowlist that outlives its bug is worse than no allowlist: it keeps a
+    ;; whole class of divergence permanently unreported. So a class that has
     ;; stopped diverging FAILS here, and the fix is to delete the entry.
-    (if (= "off" oracle-mode)
-      (is (= "off" oracle-mode) "oracle disabled — allowlist not exercised")
+    ;;
+    ;; Checked with a DETERMINISTIC canary rather than by counting hits in the
+    ;; generated corpus. The counting version passed locally and failed on CI:
+    ;; a generated case that would have diverged can instead hit the per-case
+    ;; timeout on a slower machine, so "no hits" meant "too slow" as often as
+    ;; "fixed". A canary is a fixed query with a fixed answer — it cannot be
+    ;; timed out into a false verdict.
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :schema-flexibility :write}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                               :db/cardinality :db.cardinality/one}
+                              {:db/ident :nick :db/valueType :db.type/string
+                               :db/cardinality :db.cardinality/one}])
+          _ (d/transact conn [{:db/id 1 :name "alice" :nick "al"}])
+          db (d/db conn)
+          ;; `?v` is bound by the pattern; the get-else writes into it. Under
+          ;; the law this selects the entities whose nick equals their name —
+          ;; alice's does not — so an answer with any row IS the bug.
+          ;;
+          ;; Deliberately NOT a plain function output: the planner already
+          ;; unifies those, so a canary built on one reports "fixed" while
+          ;; get-else is still broken.
+          canary '[:find ?e ?v :where
+                   [?e :name ?v] [(get-else $ ?e :nick "zzz") ?v]]
+          answer (binding [q/*disable-planner* false q/*query-result-cache?* false]
+                   (set (d/q canary db)))]
       (doseq [{:keys [id why]} known-shared-wrong]
-        (is (pos? (get @oracle-known id 0))
-            (str "no generated case still diverges for known-wrong class " id
-                 " — if it is fixed, DELETE the entry from known-shared-wrong "
-                 "so the class is enforced again. Context: " why))))))
+        (is (seq answer)
+            (str "the canary for known-wrong class " id " now answers correctly — "
+                 "DELETE the entry from known-shared-wrong so the class is "
+                 "enforced again, and drop this canary with it. Context: " why))))))

--- a/test/datahike/test/query_eqcheck.cljc
+++ b/test/datahike/test/query_eqcheck.cljc
@@ -563,16 +563,20 @@
 ;; non-nil whenever the check could fire — hence the flag is read inside the
 ;; installed fn rather than gating installation.
 
-(alter-var-root #'lower/*check-plan*
-                (constantly
-                 (fn [plan]
-                   (when *check-equalities?*
-                     (let [report (check-plan plan)]
-                       (when-not (:ok? report)
-                         (if *violation-handler*
-                           (*violation-handler* (assoc report :plan plan))
-                           (throw (ex-info "Plan violates the equality-obligation invariant"
-                                           (assoc report :explain (vec (explain report))))))))))))
+;; Installed through `add-plan-check!`, NOT `(alter-var-root … (constantly …))`:
+;; the slot holds one function, so a `constantly` install silently evicts every
+;; check already there — and an evicted checker reports a clean sweep while
+;; examining nothing.
+(defonce ^:private installed
+  (lower/add-plan-check!
+   (fn [plan]
+     (when *check-equalities?*
+       (let [report (check-plan plan)]
+         (when-not (:ok? report)
+           (if *violation-handler*
+             (*violation-handler* (assoc report :plan plan))
+             (throw (ex-info "Plan violates the equality-obligation invariant"
+                             (assoc report :explain (vec (explain report))))))))))))
 
 (defn check-plans*
   "Run `f` with plan checking on. Clears the plan cache first AND after, because

--- a/test/datahike/test/query_plan_check_test.clj
+++ b/test/datahike/test/query_plan_check_test.clj
@@ -1,0 +1,64 @@
+(ns datahike.test.query-plan-check-test
+  "Pins the composition contract of `lower/*check-plan*`.
+
+   The slot holds ONE function. It used to be installed with
+   `(alter-var-root … (constantly f))`, so the second checker to load evicted
+   the first — and an evicted checker cannot fail: it reports a clean sweep
+   while examining nothing. That is the worst possible failure mode for a
+   correctness check, and it is invisible unless something counts.
+
+   So two properties are pinned here: every installed check runs, and the
+   coverage counter moves. CI asserts the counter separately, because
+   `0 violations` and `0 plans examined` are otherwise indistinguishable."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.query.lower :as lower]
+   [datahike.test.query-eqcheck :as eqcheck]))
+
+(defn- fresh-db []
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :write}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                         :db/cardinality :db.cardinality/one}])
+      (d/transact conn [{:db/id 100 :name "alice"}])
+      (d/db conn))))
+
+(deftest every-installed-plan-check-runs
+  (testing "a second install composes with the first instead of evicting it"
+    (let [saved @#'lower/*check-plan*
+          saved-stats @lower/plan-check-stats
+          a (atom 0)
+          b (atom 0)]
+      (try
+        (lower/add-plan-check! (fn [_plan] (swap! a inc)))
+        (lower/add-plan-check! (fn [_plan] (swap! b inc)))
+        ;; with-plan-checks clears the plan cache, so a plan is really BUILT —
+        ;; with a warm cache the checks would legitimately see nothing.
+        (eqcheck/with-plan-checks
+          (d/q '[:find ?e ?n :where [?e :name ?n]] (fresh-db)))
+        (is (pos? @a) "the first-installed check must still run")
+        (is (pos? @b) "the second-installed check must run")
+        (is (= @a @b) "both checks see the same plans")
+        (is (pos? (:plans @lower/plan-check-stats))
+            "the coverage counter distinguishes `no violations` from `nothing examined`")
+        (finally
+          ;; Restore exactly: other namespaces' checkers live in this slot.
+          (alter-var-root #'lower/*check-plan* (constantly saved))
+          (reset! lower/plan-check-stats saved-stats))))))
+
+(deftest coverage-counter-detects-a-warm-cache
+  (testing "checks installed but no plan built leaves the counter untouched"
+    (let [saved @#'lower/*check-plan*
+          saved-stats @lower/plan-check-stats]
+      (try
+        (lower/clear-plan-checks!)
+        (lower/add-plan-check! (fn [_plan] nil))
+        (is (zero? (:plans @lower/plan-check-stats))
+            "installing a check examines nothing on its own — this is the state
+             that used to be reported as a clean sweep")
+        (finally
+          (alter-var-root #'lower/*check-plan* (constantly saved))
+          (reset! lower/plan-check-stats saved-stats))))))

--- a/test/datahike/test/query_plan_check_test.clj
+++ b/test/datahike/test/query_plan_check_test.clj
@@ -13,6 +13,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [datahike.api :as d]
+   [datahike.query :as q]
    [datahike.query.lower :as lower]
    [datahike.test.query-eqcheck :as eqcheck]))
 
@@ -35,10 +36,16 @@
       (try
         (lower/add-plan-check! (fn [_plan] (swap! a inc)))
         (lower/add-plan-check! (fn [_plan] (swap! b inc)))
-        ;; with-plan-checks clears the plan cache, so a plan is really BUILT —
-        ;; with a warm cache the checks would legitimately see nothing.
+        ;; Two preconditions for a check to see anything, and BOTH have to be
+        ;; forced: with-plan-checks clears the plan cache (a warm cache builds
+        ;; no plan), and the planner must be on (the base engine builds no plan
+        ;; at all). CI runs the whole suite a second time with
+        ;; DATAHIKE_QUERY_PLANNER=false, where the unbound version of this test
+        ;; failed for that second reason — the mechanism was fine, the test was
+        ;; asserting against an engine that has no plans to check.
         (eqcheck/with-plan-checks
-          (d/q '[:find ?e ?n :where [?e :name ?n]] (fresh-db)))
+          (binding [q/*disable-planner* false]
+            (d/q '[:find ?e ?n :where [?e :name ?n]] (fresh-db))))
         (is (pos? @a) "the first-installed check must still run")
         (is (pos? @b) "the second-installed check must run")
         (is (= @a @b) "both checks see the same plans")


### PR DESCRIPTION
Phase 0 of the systematic query-correctness work agreed in #920's follow-up: **make failure visible before fixing anything.** No production behaviour changes.

## 1. Composable plan checks — a latent trap, closed

`lower/*check-plan*` is a single slot, and `query-eqcheck` installed into it with `(alter-var-root … (constantly f))`. A second checker therefore **evicted** the first — and an evicted checker cannot fail: it reports a clean sweep while examining nothing. Only one checker exists today, so nothing was broken, but no second one could be added safely.

`add-plan-check!` composes at install time, so the production hot path stays exactly one var deref + one nil test.

`plan-check-stats` counts plans actually examined. This is the load-bearing part: a checker's failure mode is *silence* — an evicted install, a warm plan cache, and a suite that never builds a plan are indistinguishable from "no violations". CI should assert this is non-zero.

## 2. A third engine

`base` vs `planner` has a structural blind spot: when both share a wrong assumption they agree and the suite passes. Confirmed instances: tuple bindings overwriting a bound var, a repeated rule-head var yielding `nil`, `get-else` against an already-bound var.

`test/datahike/oracle.clj` is a naive evaluator — no indexes, no planner, no fusion — with exactly **one** binding function, so a clause form cannot invent its own binding rule. Wired into `query-differential-test` as a third comparison (`DATAHIKE_ORACLE=strict|report|off`, strict by default).

Two properties worth noting:
- an oracle gap is a **skip, never a mismatch**, so its incompleteness cannot masquerade as an engine bug;
- coverage is written to `target/oracle-stats.edn` and asserted non-zero, for the same reason as the plan-check counter.

Cost: ~2 ms/case — cheaper than either real engine.

## 3. Two generator axes

The existing corpora were generated from bugs already fixed, so they found nothing. Added:

- **output-var rebinding** — a function/`get-else` clause writing into a variable a preceding pattern already bound. Datomic unifies here, and datahike already unifies for repeated vars *within* one clause (#912/#913).
- **`:find`-vector order varied independently of clause order** — the fused multi-group projection emits columns in set-iteration order, so `[:find ?e ?v]` and `[:find ?v ?e]` are genuinely different tests. The corpus previously derived `:find` from clause order, so this axis did not exist.

The rebind axis found a planner divergence on its first run, shrunk by test.check to:

```clojure
[:find (count-distinct ?n) :in $ ?n :where [?e :name ?n] [(get-else $ ?e :nick "none") ?n]]
;; args ["alice"] — base {} (correct: no entity's nick equals its name), planner {[1] 1}
```

## The allowlist, and why it can't rot

That law is broken in two directions at once — the planner ignores the obligation, the base engine overwrites it — so the class appears both as planner-vs-base divergence and as oracle-vs-both. Allowlisting one would have left CI red.

One entry in `known-shared-wrong` covers both comparisons, and `known-shared-wrong-is-still-needed` **fails when an entry stops matching**. The binding-seam fix is therefore forced to delete the entry rather than leave it accumulating. This is an allowlist, not a mute switch: any divergence outside the listed class still fails the build immediately.

## Controls

Each mechanism was verified by making it fail:

| control | expected failure | observed |
|---|---|---|
| composition disabled | first check evicted | `the first-installed check must still run` → `(not (pos? 0))` |
| rebind axis disabled | allowlist entry stale | `no generated case still diverges … DELETE the entry` |

## Suite

| | wall | tests | assertions | failures |
|---|---|---|---|---|
| baseline | 308 s | 854 | 7172 | 0 |
| this PR | **298 s** | 858 | **9462** | 0 |

2,290 more assertions for no additional wall clock, comfortably inside the 10-minute budget.

## Next

Phase 1 fixes the two broadest silent wrong answers (multi-group projection layout; the stratum secondary-index gate). Phase 2 is the binding-seam law, which deletes the allowlist entry above.
