### PR TITLE
Fix Object.equals/hashCode contract on DB and the DB views

### DIFF
--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -27,7 +27,7 @@
                    [java.io Writer]
                    [java.util Date])))
 
-(declare equiv-db empty-db)
+(declare equiv-db empty-db db-view-hash)
 #?(:cljs (declare pr-db pr-hist-db))
 
 ;; ----------------------------------------------------------------------------
@@ -318,7 +318,16 @@
        (-persistent! [db] (db-persistent! db))]
 
       :clj
+      ;; `equals` must be given explicitly, not inherited. defrecord's
+      ;; generated one delegates to APersistentMap/mapEquals, which walks
+      ;; `(.seq this)` casting each element to Map.Entry — but `seq` here
+      ;; yields Datoms, so it raised a ClassCastException from inside JDK
+      ;; code instead of answering false. That breaks the Object.equals
+      ;; contract and takes down any java.util collection holding a DB
+      ;; (HashMap, HashSet, Objects.equals, List.contains). Delegating to
+      ;; equiv-db also keeps `.equals` and `=` in agreement.
       [Object (hashCode [db] hash)
+       (equals [db other] (equiv-db db other))
        clojure.lang.IHashEq (hasheq [db] hash)
        Seqable (seq [db] (di/-seq eavt))
        IPersistentCollection
@@ -401,7 +410,21 @@
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on FilteredDB")))]
 
       :clj
-      [IPersistentCollection
+      ;; Same reasoning as DB above, and here `hashCode`/`hasheq` are
+      ;; needed too: this view overrides `seq` to yield Datoms but
+      ;; declared no Object impls at all, so the INHERITED mapHash /
+      ;; mapHasheq / mapEquals all walked that seq casting to Map.Entry
+      ;; and threw. A view could not be hashed or put in a HashSet, and
+      ;; `(= view db)` threw while `(= db view)` answered true —
+      ;; asymmetric, which `equals` may never be.
+      [Object
+       (hashCode [db] (db-view-hash db))
+       (equals [db other] (equiv-db db other))
+
+       clojure.lang.IHashEq
+       (hasheq [db] (db-view-hash db))
+
+       IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on FilteredDB")))
@@ -476,7 +499,21 @@
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on HistoricalDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on HistoricalDB")))]
       :clj
-      [IPersistentCollection
+      ;; Same reasoning as DB above, and here `hashCode`/`hasheq` are
+      ;; needed too: this view overrides `seq` to yield Datoms but
+      ;; declared no Object impls at all, so the INHERITED mapHash /
+      ;; mapHasheq / mapEquals all walked that seq casting to Map.Entry
+      ;; and threw. A view could not be hashed or put in a HashSet, and
+      ;; `(= view db)` threw while `(= db view)` answered true —
+      ;; asymmetric, which `equals` may never be.
+      [Object
+       (hashCode [db] (db-view-hash db))
+       (equals [db other] (equiv-db db other))
+
+       clojure.lang.IHashEq
+       (hasheq [db] (db-view-hash db))
+
+       IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on HistoricalDB")))
@@ -541,7 +578,21 @@
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on AsOfDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on AsOfDB")))]
       :clj
-      [IPersistentCollection
+      ;; Same reasoning as DB above, and here `hashCode`/`hasheq` are
+      ;; needed too: this view overrides `seq` to yield Datoms but
+      ;; declared no Object impls at all, so the INHERITED mapHash /
+      ;; mapHasheq / mapEquals all walked that seq casting to Map.Entry
+      ;; and threw. A view could not be hashed or put in a HashSet, and
+      ;; `(= view db)` threw while `(= db view)` answered true —
+      ;; asymmetric, which `equals` may never be.
+      [Object
+       (hashCode [db] (db-view-hash db))
+       (equals [db other] (equiv-db db other))
+
+       clojure.lang.IHashEq
+       (hasheq [db] (db-view-hash db))
+
+       IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on AsOfDB")))
@@ -607,7 +658,21 @@
        (-contains-key? [_ _] (throw (js/Error. "-contains-key? is not supported on SinceDB")))
        (-assoc [_ _ _] (throw (js/Error. "-assoc is not supported on SinceDB")))]
       :clj
-      [IPersistentCollection
+      ;; Same reasoning as DB above, and here `hashCode`/`hasheq` are
+      ;; needed too: this view overrides `seq` to yield Datoms but
+      ;; declared no Object impls at all, so the INHERITED mapHash /
+      ;; mapHasheq / mapEquals all walked that seq casting to Map.Entry
+      ;; and threw. A view could not be hashed or put in a HashSet, and
+      ;; `(= view db)` threw while `(= db view)` answered true —
+      ;; asymmetric, which `equals` may never be.
+      [Object
+       (hashCode [db] (db-view-hash db))
+       (equals [db other] (equiv-db db other))
+
+       clojure.lang.IHashEq
+       (hasheq [db] (db-view-hash db))
+
+       IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
        (equiv [db o] (equiv-db db o))
        (cons [db [k v]] (throw (UnsupportedOperationException. "cons is not supported on SinceDB")))
@@ -671,10 +736,27 @@
       :else false)))
 
 (defn- equiv-db [db other]
-  (and (or (instance? DB other) (instance? FilteredDB other))
-       (or (not (instance? DB other)) (= (hash db) (hash other)))
-       (= (dbi/-schema db) (dbi/-schema other))
-       (equiv-db-index (dbi/datoms db :eavt []) (dbi/datoms other :eavt []))))
+  ;; The identity case has to come first. Only DB and FilteredDB are
+  ;; comparable by content below, so without it a HistoricalDB / AsOfDB /
+  ;; SinceDB was not even equal to itself — and `equals` is required to
+  ;; be reflexive.
+  (or (identical? db other)
+      (and (or (instance? DB other) (instance? FilteredDB other))
+           (or (not (instance? DB other)) (= (hash db) (hash other)))
+           (= (dbi/-schema db) (dbi/-schema other))
+           (equiv-db-index (dbi/datoms db :eavt []) (dbi/datoms other :eavt [])))))
+
+(defn- db-view-hash
+  "Content hash for the DB views (FilteredDB / HistoricalDB / AsOfDB /
+   SinceDB), which carry no precomputed `:hash` field of their own.
+
+   Deliberately the SAME additive datom-sum DB maintains incrementally
+   (see `:hash` in `new-db`), so a view and a DB holding the same datoms
+   hash alike — `equiv-db` reports those equal, so their hashes must
+   agree. O(n) per call: there is no running sum to read off, the same
+   reason `count` on a view is O(n)."
+  [db]
+  (reduce #(+ %1 (hash %2)) 0 (dbi/datoms db :eavt [])))
 
 #?(:cljs
    (do

--- a/test/datahike/test/db_test.cljc
+++ b/test/datahike/test/db_test.cljc
@@ -52,3 +52,69 @@
                                    :db/cardinality :db.cardinality/one
                                    :db/valueType :db.type/string}]
                                  {:schema-flexibility :write}))))))
+
+;; ---------------------------------------------------------------------------
+;; Object.equals / hashCode contract
+;;
+;; DB and the DB views (FilteredDB / HistoricalDB / AsOfDB / SinceDB)
+;; override `seq` to yield Datoms rather than map entries. Any Object
+;; method left to defrecord's generated implementation therefore walked
+;; that seq casting each element to Map.Entry and raised a
+;; ClassCastException from inside APersistentMap — so `.equals` threw
+;; instead of answering false, and the views could not be hashed at all.
+;; Every java.util collection holding a db (HashMap, HashSet,
+;; Objects.equals, List.contains) was affected.
+
+#?(:clj
+   (deftest test-db-equals-contract
+     (let [db1 (d/db-with (db/empty-db) [{:db/id 1 :name "Konrad"}])
+           db2 (d/db-with (db/empty-db) [{:db/id 1 :name "Chrislain"}])]
+       (testing "equals answers false rather than throwing"
+         (is (false? (.equals db1 db2)))
+         (is (true? (.equals db1 db1)))
+         (is (false? (.equals db1 42)))
+         (is (false? (.equals db1 nil)))
+         (is (false? (java.util.Objects/equals db1 db2))))
+
+       (testing "equals agrees with ="
+         (is (= (.equals db1 db2) (= db1 db2)))
+         (is (= (.equals db1 db1) (= db1 db1))))
+
+       (testing "dbs are usable as java.util collection members"
+         (let [s (java.util.HashSet.)]
+           (.add s db1)
+           (.add s db2)
+           (is (= 2 (.size s)))
+           (is (.contains s db1)))))))
+
+#?(:clj
+   (deftest test-db-view-equals-contract
+     ;; history/as-of/since need a temporal db; filter does not, but one
+     ;; db keeps the four views comparable.
+     (let [db  (d/db-with (db/empty-db nil {:keep-history? true})
+                          [{:db/id 1 :name "Konrad"}])
+           f1  (d/filter db (fn [_ _] true))
+           f2  (d/filter db (fn [_ _] true))
+           views {"FilteredDB"   f1
+                  "HistoricalDB" (d/history db)
+                  "AsOfDB"       (d/as-of db (java.util.Date.))
+                  "SinceDB"      (d/since db (java.util.Date. 0))}]
+       (testing "views can be hashed and are reflexive"
+         (doseq [[label v] views]
+           (is (integer? (.hashCode ^Object v)) (str label " .hashCode"))
+           (is (integer? (hash v))              (str label " hash"))
+           (is (true? (.equals ^Object v v))    (str label " reflexive .equals"))
+           (is (= v v)                          (str label " reflexive ="))
+           (let [s (java.util.HashSet.)]
+             (.add s v)
+             (is (.contains s v) (str label " HashSet round trip")))))
+
+       (testing "a pass-through filter equals its db, symmetrically"
+         (is (= db f1))
+         (is (= f1 db))
+         (is (= (.equals f1 db) (.equals ^Object db f1))))
+
+       (testing "equal values hash alike — required by the equals contract"
+         (is (= (hash db) (hash f1)))
+         (is (= f1 f2))
+         (is (= (hash f1) (hash f2)))))))


### PR DESCRIPTION
## What

`DB` and the four DB views (`FilteredDB`, `HistoricalDB`, `AsOfDB`, `SinceDB`) override `seq` to yield `Datom`s rather than map entries. Anything left to `defrecord`'s generated `Object` methods therefore walked that seq casting each element to `Map.Entry`:

```java
Map.Entry e = (Map.Entry) s.first();   // APersistentMap/mapEquals
```

so instead of answering, they raised

```
ClassCastException: class datahike.datom.Datom cannot be cast to class java.util.Map$Entry
```

from inside JDK code, with nothing in the stack pointing at datahike.

`equiv` was always defined and correct, so `=` between two `DB`s was unaffected — this is only about the `Object` methods that `java.util` collections call.

## The three distinct failures

- **`DB` declared `hashCode` but not `equals`**, so `.equals` between any two DBs with equal datom counts threw. In a `HashMap`/`WeakHashMap` that needs a hash-bucket collision first, which makes it an intermittent failure rather than a reproducible one — easy to hit once and never explain.

- **The four views declared no `Object` impls at all**, so the inherited `mapHash`/`mapHasheq` threw as well. A view could not be hashed or put in a `HashSet` under any circumstances.

- **`equiv-db` compares only `DB` and `FilteredDB` by content**, so a `HistoricalDB` / `AsOfDB` / `SinceDB` was not equal to *itself*, and `(= filtered db)` threw while `(= db filtered)` answered `true` — asymmetric, which `equals` may never be.

## The change

- `DB` gets an explicit `equals` delegating to `equiv-db`, keeping `.equals` and `=` in agreement.
- The four views get `hashCode` / `hasheq` / `equals`.
- `equiv-db` gets an identity short-circuit, for reflexivity.

The views hash with the same additive datom-sum `DB` maintains incrementally (`:hash` in `new-db`), so a view and a `DB` holding the same datoms hash alike — required, since `equiv-db` reports them equal. It is O(n) per call because a view has no running sum to read off, the same reason `count` on a view is O(n).

## Before / after

| probe | before | after |
|---|---|---|
| `.equals db1 db2` | `ClassCastException` | `false` |
| `Objects/equals db1 db2` | `ClassCastException` | `false` |
| `.hashCode` on any view | `ClassCastException` | an int |
| view in a `HashSet` | `ClassCastException` | works |
| `(= filtered db)` | throws | `true` |
| `(= db filtered)` | `true` | `true` |
| `(= historical historical)` | `false` | `true` |

## Testing

Two new deftests in `datahike.test.db-test` covering the `equals`/`hashCode` contract for `DB` and for all four views (reflexivity, symmetry, non-throwing on foreign types and `nil`, `HashSet` round trip, and equal-values-hash-alike).

Full suite: **2728 tests, 22261 assertions, 0 failures**.

Found while chasing a comment in a downstream project that was working around this by keying a cache on the schema map instead of the db.