### PR TITLE
Re-transacting an entity spec no longer rejects a valid transaction

### DIFF
--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -412,16 +412,39 @@
       (log/raise "Attribute " a-ident " is :db.secondary/only but no secondary index covers it — its value would be lost"
                  {:error :transact/secondary-only-uncovered :attribute a-ident :datom datom}))
     (if (datom-added datom)
-      (cond-> db
-        true (update-in [:eavt] #(di/-insert % prim :eavt op-count))
-        true (update-in [:aevt] #(di/-insert % prim :aevt op-count))
-        indexing? (update-in [:avet] #(di/-insert % prim :avet op-count))
-        has-secondary? (update-secondary-indices a-ident datom true)
-        true (advance-max-eid (.-e datom))
-        true (update :hash + (hash prim))
-        schema? (-> (update-schema datom)
-                    update-rschema)
-        true (update :op-count inc))
+      ;; `-insert` is idempotent on [e a v] — asserting a datom the tree already
+      ;; holds returns the receiver untouched. Everything ACCUMULATING alongside
+      ;; it was not, so a redundant assertion moved the derived state while the
+      ;; index stood still. Worst of these is `update-schema`, which `conj`s into
+      ;; the many-valued schema attributes: re-transacting an identical entity
+      ;; spec grew `:db.entity/attrs` from [:name] to [:name :name], and the
+      ;; THIRD such transaction was then refused against the shape the second one
+      ;; wrote — an idempotent schema install failing permanently on boot 3.
+      ;;
+      ;; The count is read BEFORE the insert, not from `(:eavt db)` afterwards:
+      ;; the transaction loop runs over a TRANSIENT index, where `-insert`
+      ;; mutates in place and both reads would see the same object.
+      (let [eavt (:eavt db)
+            n-before (long (di/-count eavt))
+            eavt' (di/-insert eavt prim :eavt op-count)
+            inserted? (> (long (di/-count eavt')) n-before)]
+        (cond-> db
+          true (assoc :eavt eavt')
+          ;; `:aevt`/`:avet` stay UNCONDITIONAL. They are idempotent no-ops in
+          ;; this case, and running them means an index that has somehow skewed
+          ;; from `:eavt` self-heals instead of staying skewed. The gated work
+          ;; below is gated precisely because it is NOT idempotent.
+          true (update-in [:aevt] #(di/-insert % prim :aevt op-count))
+          indexing? (update-in [:avet] #(di/-insert % prim :avet op-count))
+          ;; a secondary index is an external adapter (Lucene, konserve, mmap);
+          ;; a phantom `added?` event is harmless to a set but wrong to anything
+          ;; that counts or appends.
+          (and inserted? has-secondary?) (update-secondary-indices a-ident datom true)
+          true (advance-max-eid (.-e datom))
+          inserted? (update :hash + (hash prim))
+          (and inserted? schema?) (-> (update-schema datom)
+                                      update-rschema)
+          true (update :op-count inc)))
 
       (if-some [removing ^Datom (first (dbi/search db [(.-e prim) (.-a prim) (.-v prim)]))]
         (cond-> db

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -435,7 +435,6 @@
           keep-history? (update-in [:temporal-eavt] #(di/-temporal-insert % prim :eavt (inc op-count)))
           keep-history? (update-in [:temporal-aevt] #(di/-temporal-insert % removing :aevt op-count))
           keep-history? (update-in [:temporal-aevt] #(di/-temporal-insert % prim :aevt (inc op-count)))
-          keep-history? (update :hash + (hash prim))
           (and keep-history? indexing?) (update-in [:temporal-avet] #(di/-temporal-insert % removing :avet op-count))
           (and keep-history? indexing?) (update-in [:temporal-avet] #(di/-temporal-insert % prim :avet (inc op-count)))
           true (update :op-count + (if (or keep-history? indexing?) 2 1)))
@@ -535,6 +534,9 @@
 
       true    (update :op-count inc)
       true    (advance-max-eid (.-e datom))
+      ;; `-upsert` REPLACES `old-datom` rather than adding alongside it, so the
+      ;; running sum has to lose the old term as well as gain the new one.
+      old-datom (update :hash - (hash old-datom))
       true    (update :hash + (hash prim))
       schema? (-> (update-schema datom)
                   update-rschema))))

--- a/test/datahike/test/db_hash_test.cljc
+++ b/test/datahike/test/db_hash_test.cljc
@@ -1,0 +1,294 @@
+(ns datahike.test.db-hash-test
+  "`:hash` must equal the additive datom-sum over `:eavt`.
+
+   That is not an incidental property, it is the field's definition. `init-db`
+   computes `(reduce #(+ %1 (hash %2)) 0 datoms)` directly, and `db-view-hash`
+   computes the same sum for the DB VIEWS, whose docstring says it is
+   \"deliberately the SAME additive datom-sum DB maintains incrementally ...
+   `equiv-db` reports those equal, so their hashes must agree\". `DB` itself
+   returns the stored field from `-hash`, `hashCode` and `hasheq`, and
+   `equiv-db` uses it as a conjunct — so a DB whose running sum has drifted
+   compares UNEQUAL to a DB holding exactly the same datoms.
+
+   The invariant had no test, which is how it drifted for five years:
+
+     2019-06-28  03d45475  introduced the rolling sum, correctly: `+` on assert
+                           and `-` on retract, nothing else.
+     2020-06-23  4a5f062e  added `keep-history? (update :hash + (hash prim))` to
+                           the retract branch, where `prim` is the RETRACTION
+                           datom — which goes to the temporal trees, not `:eavt`.
+     2020-06-24  e9d55972  created `with-datom-upsert` by copying the assert
+                           branch and swapping `-insert` for `-upsert`. `-upsert`
+                           REPLACES rather than adds, so the copied `+` needed a
+                           matching `-`. The commit even carries the old-datom
+                           lookup, commented out, beside a TODO saying the old
+                           datom has to be retracted first.
+
+   Those two are fixed here. A THIRD source is older than both, is not fixed
+   here, and has its own test — see `re-asserting-a-present-datom-double-counts`.
+
+   Note the subtraction in the retract branch uses `removing`, the datom found in
+   the index, and nothing adds the caller's datom back. That matters on the
+   raw-Datom path (`d/transact` with a Datom, `d/load-entities`), which carries
+   the CALLER's value object: `:db.type/bytes` and the array types compare by
+   content but hash by identity, so an added term would not have cancelled the
+   subtracted one. `a-raw-datom-retraction-of-an-identity-hashed-value` pins it.
+
+   The one existing test that touches this (`db-test/test-equiv-db-hash`) asserts
+   that assert-then-`retractEntity` returns to the empty hash — the round trip,
+   which is the case that never broke. `api-test/test-database-hash` passes both
+   before and after: its history arm survives only because every transaction adds
+   a `:db/txInstant` datom to the CURRENT tree, which moves the sum whichever
+   definition is in force. The two consumers that would otherwise have caught the
+   drift are immune: `db-snapshot-key` and `execute`'s cache key both include
+   `:max-tx`, which strictly increases per transaction, so cache identity never
+   depended on `:hash` moving at all.
+
+   Everything here is expressed against the DEFINITION rather than against
+   recorded values, so it stays meaningful if the datom hash ever changes."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.api :as d]
+            [datahike.datom :as dd]
+            [datahike.test.utils :as utils]))
+
+(def ^:private schema
+  [{:db/ident :name :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+   {:db/ident :score :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :tag :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/many}
+   {:db/ident :note :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one :db/noHistory true}])
+
+(defn- sum-over-eavt
+  "The definition: `init-db` and `db-view-hash` both compute exactly this."
+  [db]
+  (reduce #(+ %1 (hash %2)) 0 (d/datoms db :eavt)))
+
+(defn- with-conn
+  "Run `f` on a connection carrying `schema`, then release it."
+  [keep-history? f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :keep-history? keep-history? :schema-flexibility :write}
+        conn (utils/setup-db cfg)]
+    (try
+      (d/transact conn schema)
+      (f conn)
+      (finally (d/release conn)))))
+
+(defn- check-invariant!
+  [label keep-history? txs]
+  (with-conn keep-history?
+    (fn [conn]
+      (doseq [tx txs] (d/transact conn tx))
+      (let [db @conn]
+        (is (= (sum-over-eavt db) (:hash db))
+            (str label " (keep-history? " keep-history? "): :hash must equal the "
+                 "additive datom-sum over :eavt"))))))
+
+;; ---------------------------------------------------------------------------
+
+(deftest hash-equals-the-datom-sum-over-eavt
+  (testing "for every transaction shape, under both history settings"
+    (doseq [keep-history? [false true]]
+      (check-invariant! "plain assertions" keep-history?
+                        [[{:db/id -1 :name "a" :score 1 :tag :x}]])
+
+      ;; regression 2: -upsert replaces, so the running sum must lose the old term
+      (check-invariant! "card-one overwrite" keep-history?
+                        [[{:db/id -1 :name "a" :score 1}]
+                         [{:db/id [:name "a"] :score 2}]])
+
+      (check-invariant! "repeated card-one overwrite" keep-history?
+                        [[{:db/id -1 :name "a" :score 1}]
+                         [{:db/id [:name "a"] :score 2}]
+                         [{:db/id [:name "a"] :score 3}]
+                         [{:db/id [:name "a"] :score 4}]])
+
+      (check-invariant! "overwrite with the SAME value" keep-history?
+                        [[{:db/id -1 :name "a" :score 1}]
+                         [{:db/id [:name "a"] :score 1}]])
+
+      ;; regression 1: the retraction datom goes to temporal, never to :eavt
+      (check-invariant! "explicit retraction" keep-history?
+                        [[{:db/id -1 :name "a" :tag :x}]
+                         [[:db/retract [:name "a"] :tag :x]]])
+
+      (check-invariant! "retract then re-assert" keep-history?
+                        [[{:db/id -1 :name "a" :tag :x}]
+                         [[:db/retract [:name "a"] :tag :x]]
+                         [{:db/id [:name "a"] :tag :x}]])
+
+      (check-invariant! "card-many add and retract" keep-history?
+                        [[{:db/id -1 :name "a" :tag :x}]
+                         [{:db/id [:name "a"] :tag :y}]
+                         [[:db/retract [:name "a"] :tag :x]]])
+
+      (check-invariant! "retractEntity" keep-history?
+                        [[{:db/id -1 :name "a" :score 1 :tag :x}]
+                         [[:db/retractEntity [:name "a"]]]])
+
+      (check-invariant! ":db/noHistory overwrite" keep-history?
+                        [[{:db/id -1 :name "a" :note "first"}]
+                         [{:db/id [:name "a"] :note "second"}]])
+
+      ;; shapes that separate this rule from the plausible alternatives — each
+      ;; one distinguished two candidate definitions during review.
+      ;; NOTE: re-asserting an ALREADY PRESENT card-many datom is deliberately
+      ;; absent here — see `re-asserting-a-present-datom-double-counts`.
+      (check-invariant! "revert to an older value" keep-history?
+                        [[{:db/id -1 :name "a" :score 1}]
+                         [{:db/id [:name "a"] :score 2}]
+                         [{:db/id [:name "a"] :score 1}]])
+
+      (check-invariant! "schema attribute overwritten" keep-history?
+                        [[{:db/id -1 :name "a"}]
+                         [{:db/ident :score :db/doc "first"}]
+                         [{:db/ident :score :db/doc "second"}]])
+
+      (check-invariant! "unique-identity attribute re-upserted" keep-history?
+                        [[{:db/id -1 :name "a" :score 1}]
+                         [{:name "a" :score 2}]])
+
+      (check-invariant! "everything at once" keep-history?
+                        [[{:db/id -1 :name "a" :score 1 :tag :x}
+                          {:db/id -2 :name "b" :score 2 :tag :y}]
+                         [{:db/id [:name "a"] :score 10}]
+                         [[:db/retract [:name "b"] :tag :y]]
+                         [{:db/id [:name "a"] :note "n"}]
+                         [{:db/id [:name "a"] :note "n2"}]
+                         [[:db/retractEntity [:name "b"]]]]))))
+
+(deftest equal-content-implies-equal-hash
+  (testing "two databases holding the same datoms must hash alike, because
+            `equiv-db` uses `(= (hash db) (hash other))` as a conjunct — so a
+            drifted sum makes equal databases compare UNEQUAL.
+
+            The two are reached differently on purpose: one by overwriting a
+            card-one value, one by asserting the final value directly. Before the
+            fix these agreed on datoms and disagreed on hash.
+
+            `:keep-history? false` only, and that is a property of the question
+            rather than a gap in the test. With history on, the tx entities stay
+            in `:eavt`, so the two sequences differ by a `:db/txInstant` datom per
+            extra transaction — and those carry wall-clock values. Two histories
+            of different lengths are then genuinely different databases, and
+            asking them to hash alike would be asking for the wrong answer."
+    (let [final-of (fn [txs]
+                     (with-conn false
+                       (fn [conn]
+                         (doseq [tx txs] (d/transact conn tx))
+                         (let [db @conn]
+                           {:hash (:hash db)
+                            :datoms (set (map (juxt :e :a :v) (d/datoms db :eavt)))}))))
+          overwritten (final-of [[{:db/id -1 :name "a" :score 1}]
+                                 [{:db/id [:name "a"] :score 2}]])
+          direct (final-of [[{:db/id -1 :name "a" :score 2}]])]
+      (is (= (:datoms overwritten) (:datoms direct))
+          "precondition: the same datoms either way")
+      (is (= (:hash overwritten) (:hash direct))
+          "and therefore the same hash"))))
+
+(deftest re-asserting-a-present-datom-double-counts
+  "KNOWN GAP, not fixed here — asserts the CURRENT behaviour so that fixing it
+   trips this test rather than passing silently.
+
+   `with-datom`'s assert branch adds `(hash prim)` unconditionally, including
+   when `di/-insert` changed nothing because the datom was already there.
+   Measured: after asserting the same card-many datom twice, `:eavt` holds ONE
+   entry (with the FIRST transaction's tx, so the insert really was a no-op)
+   while `:hash` has gained the term twice.
+
+   This is a third drift source, independent of the two this commit fixes and
+   older than both — it is in the original 2019 assert branch. It is left alone
+   because the fix belongs on the assert hot path: the cheap form compares the
+   index count before and after the insert, which is O(1) for
+   persistent-sorted-set but not obviously so for every index implementation.
+   That deserves its own change and its own benchmark."
+  (testing "the sum over :eavt and the running :hash disagree by exactly one term"
+    (doseq [keep-history? [false true]]
+      (with-conn keep-history?
+        (fn [conn]
+          (d/transact conn [{:db/id -1 :name "a" :tag :x}])
+          (let [before (:hash @conn)
+                sum-before (sum-over-eavt @conn)]
+            (is (= before sum-before) "consistent before the duplicate assertion")
+            (d/transact conn [{:db/id [:name "a"] :tag :x}])
+            (let [db @conn
+                  entries (filter #(and (= :tag (:a %)) (= :x (:v %)))
+                                  (d/datoms db :eavt))]
+              (is (= 1 (count entries))
+                  "the index holds the datom once — the insert was a no-op")
+              (is (not= (sum-over-eavt db) (:hash db))
+                  "but :hash counted it twice — REMOVE THIS ASSERTION WHEN FIXED"))))))))
+
+(deftest purge-keeps-the-sum-consistent
+  (testing "`with-temporal-datom` subtracts only under `current?`, which is
+            exactly right here: purging removes the datom from the current tree
+            when it is there, and a purge of a temporal-only datom must not move
+            a sum that is taken over the current tree.
+
+            Worth pinning because an earlier proposal added a second subtraction
+            for the temporal-only case. Under a union-based definition that
+            would have been needed — and would still have been wrong, because a
+            superseded triple has TWO temporal entries and the purge visits each."
+    (with-conn true
+      (fn [conn]
+        (d/transact conn [{:db/id -1 :name "a" :score 1 :tag :x}])
+        (d/transact conn [{:db/id [:name "a"] :score 2}])
+        (d/transact conn [[:db/retract [:name "a"] :tag :x]])
+        (let [e (:e (first (d/datoms @conn :avet :name "a")))]
+          (testing "purging a value that is in BOTH trees"
+            (d/transact conn [[:db/purge e :score 2]])
+            (let [db @conn] (is (= (sum-over-eavt db) (:hash db)))))
+          (testing "purging a value that is ONLY in the temporal tree"
+            (d/transact conn [[:db/purge e :score 1]])
+            (let [db @conn] (is (= (sum-over-eavt db) (:hash db)))))
+          (testing "purging a retracted card-many value (temporal only)"
+            (d/transact conn [[:db/purge e :tag :x]])
+            (let [db @conn] (is (= (sum-over-eavt db) (:hash db))))))))))
+
+(deftest a-raw-datom-retraction-of-an-identity-hashed-value
+  (testing "`transact-tx-data` accepts a Datom directly and retracts using the
+            CALLER's value object, not the stored one. `:db.type/bytes` (and the
+            array types) compare by content but hash by identity, so the caller's
+            object and the stored one can hash differently.
+
+            This is safe here only because the sum is maintained by subtracting
+            `removing` — the datom found in the index — and nothing adds the
+            caller's datom. An earlier proposal kept a `+ (hash prim)` term in
+            this branch on the theory that it cancelled the subtraction; on this
+            path it does not, and the sum would drift by the difference."
+    (with-conn true
+      (fn [conn]
+        (d/transact conn [{:db/ident :blob :db/valueType :db.type/bytes
+                           :db/cardinality :db.cardinality/one}])
+        (d/transact conn [{:db/id -1 :name "a" :blob (byte-array [1 2 3])}])
+        (let [db @conn
+              stored (first (filter #(= :blob (:a %)) (d/datoms db :eavt)))]
+          (is (some? stored) "precondition: the blob datom is present")
+          (is (= (sum-over-eavt db) (:hash db)) "consistent before the retraction")
+          ;; a Datom carrying an EQUAL-BUT-NOT-IDENTICAL value
+          (d/transact conn [(dd/datom (:e stored) :blob (byte-array [1 2 3])
+                                      (:tx stored) false)])
+          (let [db' @conn]
+            (is (= (sum-over-eavt db') (:hash db'))
+                "and consistent after retracting through the raw-Datom path")))))))
+
+(deftest a-view-and-a-db-holding-the-same-datoms-hash-alike
+  (testing "`db-view-hash` computes the sum on demand for FilteredDB and friends,
+            and its docstring makes agreement with DB's stored field a
+            requirement. A filter that removes nothing must therefore hash like
+            the database itself."
+    (doseq [keep-history? [false true]]
+      (with-conn keep-history?
+        (fn [conn]
+          (d/transact conn [{:db/id -1 :name "a" :score 1 :tag :x}])
+          (d/transact conn [{:db/id [:name "a"] :score 2}])
+          (d/transact conn [[:db/retract [:name "a"] :tag :x]])
+          (let [db @conn
+                keep-all (d/filter db (fn [_ _] true))]
+            (is (= (hash db) (hash keep-all))
+                (str "a no-op filter must hash like the db (keep-history? "
+                     keep-history? ")"))))))))

--- a/test/datahike/test/db_hash_test.cljc
+++ b/test/datahike/test/db_hash_test.cljc
@@ -190,38 +190,35 @@
       (is (= (:hash overwritten) (:hash direct))
           "and therefore the same hash"))))
 
-(deftest re-asserting-a-present-datom-double-counts
-  "KNOWN GAP, not fixed here — asserts the CURRENT behaviour so that fixing it
-   trips this test rather than passing silently.
+(deftest re-asserting-a-present-datom-counts-it-once
+  (testing "`di/-insert` is idempotent on [e a v], so a redundant card-many
+            assertion must not move the sum either.
 
-   `with-datom`'s assert branch adds `(hash prim)` unconditionally, including
-   when `di/-insert` changed nothing because the datom was already there.
-   Measured: after asserting the same card-many datom twice, `:eavt` holds ONE
-   entry (with the FIRST transaction's tx, so the insert really was a no-op)
-   while `:hash` has gained the term twice.
-
-   This is a third drift source, independent of the two this commit fixes and
-   older than both — it is in the original 2019 assert branch. It is left alone
-   because the fix belongs on the assert hot path: the cheap form compares the
-   index count before and after the insert, which is O(1) for
-   persistent-sorted-set but not obviously so for every index implementation.
-   That deserves its own change and its own benchmark."
-  (testing "the sum over :eavt and the running :hash disagree by exactly one term"
+            This was the third and oldest drift source — the original 2019 assert
+            branch added `(hash prim)` unconditionally, including when the insert
+            changed nothing. It is fixed by reading the index count around the
+            insert; `datahike.test.redundant-assertion-test` covers the rest of
+            what that unconditional chain was doing."
     (doseq [keep-history? [false true]]
       (with-conn keep-history?
         (fn [conn]
           (d/transact conn [{:db/id -1 :name "a" :tag :x}])
-          (let [before (:hash @conn)
-                sum-before (sum-over-eavt @conn)]
-            (is (= before sum-before) "consistent before the duplicate assertion")
+          (let [before (:hash @conn)]
+            (is (= before (sum-over-eavt @conn))
+                "consistent before the duplicate assertion")
             (d/transact conn [{:db/id [:name "a"] :tag :x}])
             (let [db @conn
                   entries (filter #(and (= :tag (:a %)) (= :x (:v %)))
                                   (d/datoms db :eavt))]
               (is (= 1 (count entries))
                   "the index holds the datom once — the insert was a no-op")
-              (is (not= (sum-over-eavt db) (:hash db))
-                  "but :hash counted it twice — REMOVE THIS ASSERTION WHEN FIXED"))))))))
+              (is (= (sum-over-eavt db) (:hash db))
+                  "and the sum counted it once")
+              ;; NOT `(= before (:hash db))`: the transaction is real work and
+              ;; under `:keep-history? true` its tx entity puts a `:db/txInstant`
+              ;; datom into the current tree, which legitimately moves the sum.
+              ;; `redundant-assertion-test` isolates the contribution properly.
+              )))))))
 
 (deftest purge-keeps-the-sum-consistent
   (testing "`with-temporal-datom` subtracts only under `current?`, which is

--- a/test/datahike/test/redundant_assertion_test.cljc
+++ b/test/datahike/test/redundant_assertion_test.cljc
@@ -1,0 +1,160 @@
+(ns datahike.test.redundant-assertion-test
+  "Asserting a datom the database already holds must change nothing.
+
+   `di/-insert` is idempotent on `[e a v]` — it returns the receiver untouched.
+   But `with-datom`'s assert branch ran its whole accumulator chain regardless,
+   so a redundant assertion moved every DERIVED quantity while the index stood
+   still.
+
+   The visible failure is a schema install that is refused on its third run:
+
+     transact #1  ->  :db.entity/attrs [:name]
+     transact #2  ->  :db.entity/attrs [:name :name]     (committed, no error)
+     transact #3  ->  THROWS :transact/schema, :invalid-updates
+                      #:db.entity{:attrs [[:name :name] [:name]]}
+
+   `update-schema` `conj`s into the many-valued schema attributes
+   (`:db.entity/attrs`, `:db.entity/preds`, `:db.attr/preds`), so each redundant
+   assertion appends another copy; the schema-update check then compares what you
+   are declaring against the shape the previous run wrote, and refuses. Applying
+   your schema on every startup — an ordinary, deliberately idempotent pattern —
+   therefore works twice and fails forever after, including across a reconnect,
+   because the mangled value is persisted.
+
+   Nothing else is damaged: the indexes are correct, queries are unaffected, and
+   the mangled spec still enforces (`[:name :name]` demands what `[:name]` does).
+   And re-declaring the shape it now has is accepted but DOUBLES it again, so
+   there is no fixpoint to converge on — recovery means retracting the schema
+   datom, not re-declaring it.
+
+   Only cardinality-MANY assertions are affected. Cardinality-one goes through
+   `with-datom-upsert` (`transact-add`'s `upsert?` is `(not (multival? db a))`),
+   retraction is guarded by its own `if-some`, and purge by `current?`. The
+   damage needs an attribute that is card-many AND a schema attribute — which is
+   exactly what an entity spec is."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.api :as d]
+            [datahike.test.utils :as utils]))
+
+(defn- mem-conn []
+  (utils/setup-db {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+                   :keep-history? false :schema-flexibility :write}))
+
+(def ^:private entity-spec
+  [{:db/ident :name :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :spec :db.entity/attrs [:name]}])
+
+(defn- spec-shape [conn]
+  (:db.entity/attrs (get (:schema @conn) :spec)))
+
+;; ---------------------------------------------------------------------------
+
+(deftest an-idempotent-schema-install-stays-idempotent
+  (testing "transacting the same entity spec repeatedly neither grows the schema
+            nor starts failing — the regression this commit exists for"
+    (let [conn (mem-conn)]
+      (try
+        (dotimes [i 5]
+          (d/transact conn entity-spec)
+          (is (= [:name] (spec-shape conn))
+              (str "after transact #" (inc i) " the spec must still be [:name]")))
+        (finally (d/release conn))))))
+
+(deftest a-redundant-card-many-assertion-contributes-nothing
+  (testing "the index already held the datom, so it must contribute nothing to
+            the derived state.
+
+            Stated over the USER datoms rather than over `:eavt` wholesale: the
+            transaction itself is real work, and under `:keep-history? true` its
+            tx entity puts a `:db/txInstant` datom into the current tree. That
+            datom legitimately moves both the datom set and the sum, so a plain
+            before/after comparison would be asserting something false."
+    (doseq [keep-history? [false true]]
+      (let [conn (utils/setup-db {:store {:backend :memory
+                                          :id (java.util.UUID/randomUUID)}
+                                  :keep-history? keep-history?
+                                  :schema-flexibility :write})
+            user-datoms (fn [db] (remove #(= :db/txInstant (:a %))
+                                         (d/datoms db :eavt)))
+            sum (fn [ds] (reduce (fn [h d] (+ h (hash d))) 0 ds))]
+        (try
+          (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one
+                             :db/unique :db.unique/identity}
+                            {:db/ident :tag :db/valueType :db.type/keyword
+                             :db/cardinality :db.cardinality/many}])
+          (d/transact conn [{:db/id -1 :name "a" :tag :x}])
+          (let [before @conn
+                before-user (vec (user-datoms before))]
+            (d/transact conn [{:db/id [:name "a"] :tag :x}])
+            (let [after @conn]
+              (testing (str "keep-history? " keep-history?)
+                (is (= before-user (vec (user-datoms after)))
+                    "the user datoms are unchanged, down to their tx")
+                (is (= (:max-eid before) (:max-eid after))
+                    ":max-eid is unchanged")
+                (is (= (sum (d/datoms after :eavt)) (:hash after))
+                    ":hash still equals the sum over :eavt")
+                (is (= (- (:hash after) (:hash before))
+                       (- (sum (d/datoms after :eavt)) (sum (d/datoms before :eavt))))
+                    "and it moved by exactly what the tx entity added — nothing
+                     was attributed to the redundant assertion"))))
+          (finally (d/release conn)))))))
+
+(deftest a-genuinely-new-card-many-value-still-lands
+  (testing "the guard must not swallow real assertions — the obvious way to
+            break this fix is to gate too much"
+    (let [conn (mem-conn)]
+      (try
+        (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique :db.unique/identity}
+                          {:db/ident :tag :db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}])
+        (d/transact conn [{:db/id -1 :name "a" :tag :x}])
+        (let [before (:hash @conn)]
+          (d/transact conn [{:db/id [:name "a"] :tag :y}])
+          (let [db @conn
+                tags (set (map :v (filter #(= :tag (:a %)) (d/datoms db :eavt))))]
+            (is (= #{:x :y} tags) "both values are present")
+            (is (not= before (:hash db)) "and the new one moved the sum")
+            (is (= (reduce (fn [h d] (+ h (hash d))) 0 (d/datoms db :eavt))
+                   (:hash db))
+                "which is still exactly the sum over :eavt")))
+        (finally (d/release conn))))))
+
+(deftest duplicate-assertions-within-one-transaction
+  (testing "the same datom twice in a single transaction — the redundant one is
+            the second op of the same tx rather than a later one"
+    (let [conn (mem-conn)]
+      (try
+        (d/transact conn [{:db/ident :name :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique :db.unique/identity}
+                          {:db/ident :tag :db/valueType :db.type/keyword
+                           :db/cardinality :db.cardinality/many}])
+        (d/transact conn [{:db/id -1 :name "a" :tag :x}
+                          {:db/id -1 :name "a" :tag :x}])
+        (let [db @conn]
+          (is (= 1 (count (filter #(= :tag (:a %)) (d/datoms db :eavt))))
+              "the index holds it once")
+          (is (= (reduce (fn [h d] (+ h (hash d))) 0 (d/datoms db :eavt))
+                 (:hash db))
+              "and the sum counted it once"))
+        (finally (d/release conn))))))
+
+(deftest the-spec-still-enforces-after-repeated-installs
+  (testing "whatever the schema shape, the entity spec must keep working — this
+            is what made the old corruption inert and easy to miss"
+    (let [conn (mem-conn)]
+      (try
+        (d/transact conn entity-spec)
+        (d/transact conn entity-spec)
+        (is (= [:name] (spec-shape conn)))
+        (testing "an entity missing the required attribute is refused"
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (d/transact conn [{:db/id -1 :db/ensure :spec}]))))
+        (testing "and a valid one is accepted"
+          (is (some? (d/transact conn [{:db/id -1 :name "ok" :db/ensure :spec}]))))
+        (finally (d/release conn))))))


### PR DESCRIPTION
**Stacked on #940** — review that first; this PR's diff against it is one function and two test files.

Applying your schema on every startup is an ordinary, deliberately idempotent pattern. It works twice and then fails forever:

```
transact #1  ->  :db.entity/attrs [:name]
transact #2  ->  :db.entity/attrs [:name :name]   (committed, no error)
transact #3  ->  THROWS :transact/schema, :invalid-updates
                 #:db.entity{:attrs [[:name :name] [:name]]}
```

## Mechanism

`di/-insert` is idempotent on `[e a v]` — asserting a datom the tree already holds returns the receiver untouched. But `with-datom`'s assert branch ran its whole accumulator chain regardless, so a redundant assertion moved every **derived** quantity while the index stood still.

`update-schema` `conj`s into the many-valued schema attributes (`:db.entity/attrs`, `:db.entity/preds`, `:db.attr/preds`), so each redundant assertion appends another copy. The schema-update check then compares what you are declaring against the shape the previous run wrote, and refuses.

## Severity

The mangled value is **persisted**, so the failure survives a reconnect — run 4 in a fresh connection is rejected too.

Nothing else is damaged. The indexes are correct, queries are unaffected, and the mangled spec still enforces, since `[:name :name]` demands exactly what `[:name]` does:

```
does the spec still ENFORCE? entity missing :name => rejected
does a VALID entity still pass?                   => accepted
```

But re-declaring the shape it now has is accepted and **doubles it again** — `[:name :name]` becomes `[:name :name :name :name]` — so there is no fixpoint to converge on. Recovery meant retracting the schema datom rather than re-declaring it.

## Why card-many only

Card-one goes through `with-datom-upsert` (`transact-add`'s `upsert?` is `(not (multival? db a))`), retraction is guarded by its own `if-some`, and purge by `current?`. The damage needs an attribute that is card-many **and** a schema attribute — which is what an entity spec is. Ordinary card-many user data hit only `:hash` and a phantom `:tx-data` entry, which is why this survived since the 2019 assert branch.

## The fix

Read the index count around the insert and gate only the non-idempotent work. `:aevt`/`:avet` stay unconditional: they are idempotent no-ops here, and running them lets an index that has skewed from `:eavt` self-heal. The count is read **before** the insert because the transaction loop runs over a transient index, where `-insert` mutates in place and both reads would see the same object.

Cost is two `-count` reads — O(1) on persistent-sorted-set — against a ~10 µs/datom pipeline. An A/B over six alternating rounds put the difference inside the harness's own ±3.5% noise floor.

Also closes the third `:hash` drift left open by #940.

## Not addressed here

`:tx-data` still reports a datom that changed nothing. DataScript searches first and routes redundant assertions to a key it drops before returning the report, so callers never see them. Changing that is public-behaviour surgery and wants its own decision.

## Verification

New `redundant-assertion-test`; with `db-hash-test`, 33 tests / 189 assertions, verified non-vacuous — **27 failures and 3 errors without the fix**, the errors being the schema rejection itself. Full suite **2668 tests / 33550 assertions / 0 failures**.