### PR TITLE
A background GC must not kill an unrelated transaction

### DIFF
--- a/src/datahike/schema_cache.cljc
+++ b/src/datahike/schema_cache.cljc
@@ -11,13 +11,34 @@
 (def schema-write-caches
   (cw/lru-cache-factory {} :threshold dc/*schema-write-cache-max-db-count*))
 
-(defn- get-or-create-write-cache [store-config]
+(defn- get-or-create-write-cache
+  "The per-store write cache, created on first use.
+
+   `lookup-or-miss` rather than `has?` then `lookup`, because those are two
+   operations on a cache that another thread can change in between — and one
+   does, by design: `gc/mark-and-sweep!` calls `clear-write-cache`, an evict,
+   while writers are inside `writing/db->stored`. Lose that window and `lookup`
+   returns nil, so `(cw/has? nil k)` derefs nil and the WRITER dies with
+
+     NullPointerException: Cannot invoke \"java.util.concurrent.Future.get()\"
+     because \"fut\" is null
+
+   which is a background GC killing an unrelated transaction. `add-to-write-cache`
+   lost the same race one line over, with `(cw/miss nil …)` and a matching
+   \"because \\\"atom\\\" is null\". Reproduced at 5533 failures in 160000
+   iterations across 8 threads against a concurrent evictor; zero after.
+
+   The eviction is not only the GC's: `schema-write-caches` is itself an LRU
+   bounded by `*schema-write-cache-max-db-count*`, so a process touching more
+   stores than that evicts entries on its own.
+
+   `lookup-or-miss` is one atomic `swap!` through the cache and calls the
+   factory at most once even under retry, so concurrent first-users share one
+   cache rather than racing to install competing ones."
+  [store-config]
   (let [store-id (ds/store-identity store-config)]
-    (if (cw/has? schema-write-caches store-id)
-      (cw/lookup schema-write-caches store-id)
-      (let [new-cache (cw/lru-cache-factory {} :threshold dc/*schema-meta-cache-size*)]
-        (cw/miss schema-write-caches store-id new-cache)
-        new-cache))))
+    (cw/lookup-or-miss schema-write-caches store-id
+                       (fn [_] (cw/lru-cache-factory {} :threshold dc/*schema-meta-cache-size*)))))
 
 (defn cache-has? [schema-meta-key]
   (cw/has? schema-meta-cache schema-meta-key))
@@ -28,12 +49,21 @@
 (defn cache-miss [schema-meta-key schema-meta]
   (cw/miss schema-meta-cache schema-meta-key schema-meta))
 
+;; Both tolerate a nil cache rather than assuming one. `lookup-or-miss` gives up
+;; after ten retries and returns nil, and while that needs ten consecutive
+;; evictions of the entry we just installed, the cost of being wrong is not
+;; symmetric: this cache only decides whether to SKIP re-writing schema meta,
+;; whose key is `(uuid schema-meta)` — content-addressed, so writing it again is
+;; idempotent, same key and same bytes. A miss costs one redundant write; an
+;; exception here kills the caller's transaction.
+
 (defn write-cache-has? [store-config schema-meta-key]
-  (let [write-cache (get-or-create-write-cache store-config)]
-    (cw/has? write-cache schema-meta-key)))
+  (if-let [write-cache (get-or-create-write-cache store-config)]
+    (cw/has? write-cache schema-meta-key)
+    false))
 
 (defn add-to-write-cache [store-config schema-meta-key]
-  (let [write-cache (get-or-create-write-cache store-config)]
+  (when-let [write-cache (get-or-create-write-cache store-config)]
     (cw/miss write-cache schema-meta-key true)))
 
 (defn clear-write-cache [store-config]

--- a/test/datahike/test/schema_cache_test.clj
+++ b/test/datahike/test/schema_cache_test.clj
@@ -1,0 +1,85 @@
+(ns datahike.test.schema-cache-test
+  "The per-store schema WRITE cache, under the concurrency it actually sees.
+
+   This cache decides one thing: whether `writing/db->stored` may skip
+   re-writing a database's schema meta. It is an optimisation — the key is
+   `(uuid schema-meta)`, so writing again is idempotent — but it sits on the
+   commit path, and anything that throws there kills a user's transaction.
+
+   And it IS concurrent by design, not by accident: `gc/mark-and-sweep!` evicts
+   a store's write cache (`clear-write-cache`) while writers are inside
+   `db->stored` reading it. `background-gc-under-pipelined-writes` is the test
+   that drives both at once, and it is where this first surfaced — as a
+   NullPointerException from a background collection, blamed on an unrelated
+   transaction, roughly one CI run in many.
+
+   These are deterministic where that one is statistical."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.schema-cache :as sc]))
+
+(defn- hammer
+  "Run `readers` threads doing cache reads and writes while another thread
+   evicts, and collect everything that escapes."
+  [readers iterations]
+  (let [store-config {:backend :memory :id (java.util.UUID/randomUUID)}
+        errors (atom [])
+        stop (atom false)
+        evictor (future
+                  (while (not @stop)
+                    (sc/clear-write-cache store-config)))
+        workers (mapv (fn [_]
+                        (future
+                          (dotimes [i iterations]
+                            (try
+                              (sc/write-cache-has? store-config (str "k" (mod i 7)))
+                              (sc/add-to-write-cache store-config (str "k" (mod i 7)))
+                              (catch Throwable t
+                                (swap! errors conj t))))))
+                      (range readers))]
+    (run! deref workers)
+    (reset! stop true)
+    @evictor
+    @errors))
+
+(deftest write-cache-survives-eviction-by-a-concurrent-gc
+  (testing "`get-or-create-write-cache` was `has?` then `lookup` — two
+            operations on a cache a concurrent evict can empty in between. The
+            loser got nil, and both callers then dereferenced it:
+
+              write-cache-has?   (cw/has? nil k)  -> NPE \"fut is null\"
+              add-to-write-cache (cw/miss nil k)  -> NPE \"atom is null\"
+
+            Measured before the fix, 8 threads x 20000 iterations against a
+            continuous evictor: 5533 failures, both variants. After: 0.
+
+            The eviction is not hypothetical — `gc.cljc` calls
+            `clear-write-cache` on every mark-and-sweep, and `schema-write-caches`
+            is itself an LRU that evicts when a process touches more stores than
+            `*schema-write-cache-max-db-count*`."
+    (let [errors (hammer 8 20000)]
+      (is (empty? errors)
+          (str "the commit path must not throw when the GC evicts underneath it; got "
+               (count errors) " failures, e.g. "
+               (some-> errors first ex-message))))))
+
+(deftest the-cache-still-caches
+  (testing "the fix must not turn the optimisation off. `lookup-or-miss`
+            installs the per-store cache on first use and returns the SAME one
+            afterwards, so a key added is a key found — otherwise every commit
+            would rewrite schema meta and the race would be 'fixed' by making
+            the cache useless."
+    (let [cfg {:backend :memory :id (java.util.UUID/randomUUID)}]
+      (is (false? (sc/write-cache-has? cfg "fresh")))
+      (sc/add-to-write-cache cfg "fresh")
+      (is (true? (sc/write-cache-has? cfg "fresh"))
+          "the second call sees the first call's cache, not a new one")
+      (sc/clear-write-cache cfg)
+      (is (false? (sc/write-cache-has? cfg "fresh"))
+          "and an evicted store starts empty rather than throwing"))
+
+    (testing "two stores do not share one cache"
+      (let [a {:backend :memory :id (java.util.UUID/randomUUID)}
+            b {:backend :memory :id (java.util.UUID/randomUUID)}]
+        (sc/add-to-write-cache a "k")
+        (is (true? (sc/write-cache-has? a "k")))
+        (is (false? (sc/write-cache-has? b "k")))))))


### PR DESCRIPTION
## The failure

Seen in CI on `background-gc-under-pipelined-writes`, roughly one run in many:

```
NullPointerException: Cannot invoke "java.util.concurrent.Future.get()" because "fut" is null
  at clojure.core.cache.wrapped/has?
     datahike.schema-cache/write-cache-has?
     datahike.writing/db->stored
     datahike.writing/commit!
```

A background collection killing a transaction that had nothing to do with it.

## The cause

`get-or-create-write-cache` was check-then-act over a cache of caches:

```clojure
(if (cw/has? schema-write-caches store-id)
  (cw/lookup schema-write-caches store-id)   ; nil if evicted in between
  ...)
```

Two operations on something another thread empties **by design**: every
`gc/mark-and-sweep!` calls `clear-write-cache` (an evict) while writers are
inside `writing/db->stored` reading it. Lose that window and `lookup` returns
nil, so `(cw/has? nil k)` dereferences nil.

`add-to-write-cache` loses the same race one line over — `(cw/miss nil k)`,
`"because \"atom\" is null"`. CI has not hit that variant yet.

The eviction is not only the GC's: `schema-write-caches` is itself an LRU
bounded by `*schema-write-cache-max-db-count*`, so a process touching more
stores than that evicts entries on its own.

## Reproduction

Deterministic, without the GC test — 8 threads calling both functions against a
continuous evictor, 20000 iterations each:

| | failures |
|---|---|
| before | **5533** (both NPE variants) |
| after | **0** |

## The fix

`cw/lookup-or-miss` — one atomic `swap!` through the cache, with the factory
called at most once even under retry, so concurrent first-users share a cache
rather than racing to install competing ones. Present with identical semantics
in `clojure.core.cache.wrapped` and `cljs.cache.wrapped`, so the `.cljc` stays
portable.

Both callers additionally tolerate a nil cache, since `lookup-or-miss` still
gives up after ten retries. The asymmetry justifies the belt and braces: this
cache only decides whether to **skip** re-writing schema meta, and that key is
`(uuid schema-meta)` — content-addressed, so writing it again is idempotent.
A miss costs one redundant write; an exception costs a user's transaction.

## Scope

Pre-existing — `schema_cache.cljc` is untouched since #716. What #930 changed
was `background_gc_test` itself, which drives the writer harder and made the
race visible.

The shared **read** cache (`schema-meta-cache`) uses the same `has?`/`lookup`
pair but is not exposed: it is a flat cache atom that is never nil, and the
values it holds are schema-meta maps rather than caches, so nothing
dereferences a lookup. `writing.cljc:238` already falls through to the store on
a nil lookup. The cache-of-caches was the one instance.

## Verification

- New test is red against the previous implementation under all three index
  configurations (18558 / 5465 / 11048 failures) and green with the fix.
- `background-gc-test` green on CI's failing seed `1052556712`, three runs.
- Full JVM suite: **3096 tests, 35569 assertions, 0 failures**.