### PR TITLE
A settable GC sweep floor (:min-age-ms), so a store can be collected from outside the writer process

### DIFF
--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -868,6 +868,7 @@
 
     gc-storage
     {:args [:function
+            [:=> [:cat :datahike/SConnection :datahike/time-point? [:map [:min-age-ms {:optional true} :int]]] :any]
             [:=> [:cat :datahike/SConnection :datahike/time-point?] :any]
             [:=> [:cat :datahike/SConnection] :any]]
      :ret :any
@@ -875,11 +876,13 @@
      :stability :stable
      :supports-remote? true
      :referentially-transparent? false
-     :doc "Invokes garbage collection on connection's store. Removes old snapshots before given time point."
+     :doc "Invokes garbage collection on connection's store. Removes old snapshots before given time point. `:min-age-ms` spares anything written more recently than that, which is what makes collecting from outside the writer process possible — it must exceed the longest values-then-pointer window any writer can have."
      :examples [{:desc "GC all old snapshots"
                  :code "(gc-storage conn)"}
                 {:desc "GC snapshots before date"
-                 :code "(gc-storage conn (java.util.Date.))"}]
+                 :code "(gc-storage conn (java.util.Date.))"}
+                {:desc "Collect from a cron job or offline process: spare anything written in the last 24h"
+                 :code "(gc-storage conn (java.util.Date. 0) {:min-age-ms 86400000})"}]
      :impl datahike.writer/gc-storage!}
 
     ;; =========================================================================

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -189,6 +189,26 @@
               (recur r (conj visited to-check) reachable refs)))
           {:reachable reachable :store-refs refs}))))))
 
+(def ^:const DEFAULT_SWEEP_MIN_AGE_MS
+  "No floor by default: OFF, so in-process collection behaves exactly as it always
+   has.
+
+   Not a hedge — where the writer lives, `safe-point` is EXACT, so a wall-clock
+   floor on top of it can only retain garbage the collector was right about. The
+   floor is not a safety margin for that case, it is a SUBSTITUTE for information
+   that a different process does not have.
+
+   And the substitute cannot have a useful default: the value has to exceed the
+   longest values-then-pointer window a deployment's writers can have, which is a
+   property of the deployment and not of datahike. A default large enough to be
+   meaningful would be wrong for most stores and would silently slow reclamation
+   for everyone; a default small enough to be harmless would not protect anyone
+   while looking as though it did.
+
+   So it is opt-in, and collecting from outside the writer process without it is
+   warned about by name. See [[gc-storage!]]."
+  0)
+
 (defn gc-storage!
   "Invokes garbage collection on the database by whitelisting currently known branches.
   All db snapshots on these branches before remove-before date will also be
@@ -214,21 +234,40 @@
   makes GC collect MORE. The safe point is a SWEEP-side bound (how recently written
   an object may be and still be judged) and makes it collect LESS.
 
-  RUN IT WHERE THE WRITERS ARE. This follows from datahike's writer model, not from
-  anything specific to GC: ALL WRITERS FOR A DATABASE RUN IN ONE JVM — they coordinate
-  in memory, not through the store — and writer-side maintenance runs with them.
-  `d/gc-storage` is a writer op, so it is already in the right place; the note is here
-  because \"collect from a cron sidecar\" is a tempting shape and it is outside the
-  model. Such a collector cannot observe the writer's in-flight sequences, and datahike
-  cannot warn you: a second process gets a `:self` writer by default and looks like a
-  writer too. (Cross-process writers are outside the model for a more basic reason as
-  well — there is no head fencing yet, so they can lose each other's commits regardless
-  of GC. See issue #878.) Readers are unconstrained."
-  ([db] (gc-storage! db (#?(:clj Date. :cljs js/Date.) 0)))
-  ([db remove-before]
+  PREFER TO RUN IT WHERE THE WRITERS ARE. This follows from datahike's writer model,
+  not from anything specific to GC: ALL WRITERS FOR A DATABASE RUN IN ONE JVM — they
+  coordinate in memory, not through the store — and writer-side maintenance runs with
+  them. `d/gc-storage` is a writer op, so it is already in the right place.
+
+  COLLECTING FROM ANOTHER PROCESS — a cron sidecar, an offline job against the bucket
+  — is possible, but ONLY because of `:min-age-ms`, and only if you choose that number
+  deliberately. Such a collector cannot observe the writer's in-flight sequences: its
+  `safe-point` reports `now` because ITS heap is idle, not because the store is quiet.
+  `:min-age-ms` replaces that missing information with a wall-clock bound — spare
+  anything written within the last N — so it must EXCEED THE LONGEST VALUES-THEN-POINTER
+  WINDOW any writer can have.
+
+  Sizing it: a writer that AWAITS ITS TRANSACTS has no such window open once the call
+  returns, so the bound is one request — 15 minutes on AWS Lambda, which makes hours
+  orders of magnitude conservative. A writer that dispatches a transaction and returns
+  WITHOUT awaiting it breaks that reasoning, and so does a suspended process (see
+  issue #960: a frozen Lambda resumes mid-sequence arbitrarily later). The price of a
+  generous value is only delayed reclamation.
+
+  A duration and not an instant, deliberately: the cutoff is compared against konserve's
+  `:last-write` stamps, which come from its monotonic write clock, and a wall-clock
+  `Date` from the caller is not comparable to those in a way anything would detect.
+
+  (Cross-process writers are outside the model for a more basic reason as well — there
+  is no head fencing yet, so they can lose each other's commits regardless of GC. See
+  issue #878.) Readers are unconstrained."
+  ([db] (gc-storage! db (#?(:clj Date. :cljs js/Date.) 0) nil))
+  ([db remove-before] (gc-storage! db remove-before nil))
+  ([db remove-before {:keys [min-age-ms]}]
    (go-try S
            (let [{:keys [config store]} db
                  store-id (:id (:store config))
+                 min-age-ms (or min-age-ms DEFAULT_SWEEP_MIN_AGE_MS)
                  ;; Cutoff from konserve's monotonic write clock — the SAME
                  ;; source that stamps :last-write. Strictly increasing, so a
                  ;; cutoff acquired after a write is strictly greater than the
@@ -239,13 +278,37 @@
                  ;; and closed between the two reads has landed its pointer, and the
                  ;; mark (which runs after) sees it. Reading the guard first would
                  ;; miss a sequence that opens in between.
-                 cutoff (let [sp (guard/safe-point store-id)]
-                          (if (< (get-time sp) (get-time now)) sp now))
-                 _ (log/debug :datahike/gc-start {:time now :cutoff cutoff})
-                 _ (when-not (= :self (:backend (:writer config)))
-                     (log/warn :datahike/gc-without-local-writer
-                               {:writer (:backend (:writer config))
-                                :note "collecting a store this process does not write: in-flight commits elsewhere are invisible and may be swept"}))
+                 ;; The FLOOR: spare anything written within `min-age-ms`
+                 ;; regardless of what the guard says. `min` is the safe
+                 ;; direction — an earlier cutoff sweeps LESS — so this can only
+                 ;; ever retain garbage, never delete a live object. In this
+                 ;; process the safe point is the tighter bound and wins; outside
+                 ;; it, where the safe point degenerates to `now` because this
+                 ;; heap has no in-flight sequences to report, the wall clock is
+                 ;; the only bound there is.
+                 floor (#?(:clj Date. :cljs js/Date.) (- (get-time now) min-age-ms))
+                 cutoff (->> [(guard/safe-point store-id) now floor]
+                             (sort-by get-time)
+                             first)
+                 _ (log/debug :datahike/gc-start {:time now :cutoff cutoff :min-age-ms min-age-ms})
+                 ;; The condition that matters is not which writer backend this
+                 ;; config names — a second process connecting to the same store
+                 ;; gets a `:self` writer by default and looks like the writer —
+                 ;; it is whether anything in THIS process has ever written here.
+                 ;; If not, `safe-point` is `now` because this heap is idle, not
+                 ;; because the store is quiet, and only `min-age-ms` is holding
+                 ;; the line.
+                 _ (when-not (guard/ever-guarded? store-id)
+                     (if (pos? min-age-ms)
+                       (log/info :datahike/gc-outside-writer-process
+                                 {:min-age-ms min-age-ms
+                                  :note "collecting a store this process has never written: the sweep is bounded by :min-age-ms alone"})
+                       (log/warn :datahike/gc-outside-writer-process
+                                 {:min-age-ms min-age-ms
+                                  :note (str "collecting a store this process has never written, and with no sweep floor. "
+                                             "Another process's in-flight commit is invisible here — its objects are on disk, "
+                                             "reachable from nothing yet, and this sweep can delete them. "
+                                             "Set :min-age-ms above the longest values-then-pointer window your writers can have.")})))
                  _ (sc/clear-write-cache (:store config)) ; Clear the schema write cache for this store
                  branches (<? S (k/get store :branches))
                  _ (log/trace :datahike/gc-retain-branches {:branches branches})

--- a/src/datahike/gc_guard.cljc
+++ b/src/datahike/gc_guard.cljc
@@ -64,11 +64,20 @@
 ;; `(js/Object.)` implements neither IHash nor IEquiv in cljs, so it cannot be one.
 (defonce ^:private token-seq (atom 0))
 
+;; `in-flight` only knows about sequences that are open RIGHT NOW — `done!`
+;; removes the entry. So it cannot answer "has this process ever written to this
+;; store", which is what distinguishes a collector running beside its writer from
+;; one running outside it. That distinction has no other reliable signal: a second
+;; process connecting to the same store gets a `:self` writer by default and looks
+;; exactly like the writer.
+(defonce ^:private ever (atom #{}))
+
 (defn writing!
   "Open an unreferenced-write sequence on `store-id`. Returns a token to close it
    with. Call BEFORE the first value is written."
   [store-id]
   (let [token (swap! token-seq inc)]
+    (swap! ever conj store-id)
     (swap! in-flight assoc-in [store-id token] (now))
     token))
 
@@ -91,6 +100,17 @@
    compares timestamps cannot tell a held guard from a missing one. This can."
   [store-id]
   (boolean (seq (get @in-flight store-id))))
+
+(defn ever-guarded?
+  "Has THIS PROCESS ever opened an unreferenced-write sequence on `store-id`?
+
+   False means nothing here has ever written to that store, so a collector
+   running here cannot see any writer's in-flight window and its safe point is
+   meaningless — it is `now` only because this heap is idle. Unlike
+   [[in-flight?]] this stays true after the sequence closes, which is what makes
+   it usable as a \"is this the writer process\" test at collection time."
+  [store-id]
+  (contains? @ever store-id))
 
 (defn safe-point
   "The instant before which every object written to `store-id` is either

--- a/test/datahike/test/gc_test.cljc
+++ b/test/datahike/test/gc_test.cljc
@@ -9,6 +9,7 @@
    [datahike.versioning :refer [branch! delete-branch! merge!
                                 branch-history]]
    [konserve.core :as k]
+   [datahike.gc]
    [datahike.test.core-test])
   (:import [java.util Date]))
 
@@ -157,3 +158,64 @@
         (is (= 7 (count history-after-gc)))))
     (d/release conn)
     (d/release conn-branch1)))
+
+;; ---------------------------------------------------------------------------
+;; The sweep FLOOR (:min-age-ms). The exact bound — the in-process safe point —
+;; is only available where the writing happens; a collector anywhere else gets
+;; `now` from it, because ITS heap is idle rather than because the store is
+;; quiet. The floor is what stands in for the missing information.
+
+(defn- churned-conn
+  "A connection with collectable garbage: history is on, and every snapshot
+   before `remove-before` is erasable, so the superseded roots are unreachable.
+   `(Date. 0)` as remove-before would keep ALL history and leave nothing to
+   collect, which makes any \"the floor spared it\" assertion pass vacuously."
+  [path]
+  (let [cfg (assoc-in cfg [:store :path] path)]
+    (d/delete-database cfg)
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (d/transact conn schema)
+      (d/transact conn txs)
+      conn)))
+
+(deftest min-age-spares-recent-garbage
+  (testing "an object young enough is spared even though the mark called it
+            garbage — the property an offline collector rests on"
+    (let [conn (churned-conn "/tmp/dh-gc-min-age")]
+      (try
+        (let [before (count-store @conn)
+              swept  (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))]
+          (is (empty? swept)
+              "nothing written in the last day may be deleted, reachable or not")
+          (is (= before (count-store @conn))
+              "and the store is untouched"))
+        ;; The control, and it is the assertion that matters: the same store,
+        ;; the same remove-before, no floor. If this collects nothing then the
+        ;; scenario had no garbage and the assertion above proved nothing.
+        (let [swept (<?? S (d/gc-storage conn (Date.) {:min-age-ms 0}))]
+          (is (seq swept)
+              "with no floor the same store does have collectable garbage"))
+        (finally (d/release conn))))))
+
+(deftest min-age-is-off-by-default
+  (testing "the floor is opt-in: where the writer lives the safe point is exact,
+            so a wall-clock floor there would only retain garbage the collector
+            was right about. Passing nothing must collect exactly as before."
+    (is (zero? datahike.gc/DEFAULT_SWEEP_MIN_AGE_MS))
+    (let [conn (churned-conn "/tmp/dh-gc-min-age-default")]
+      (try
+        (is (seq (<?? S (d/gc-storage conn (Date.))))
+            "the default collects the garbage it always did")
+        (finally (d/release conn))))))
+
+(deftest min-age-is-a-floor-not-a-replacement
+  (testing "cutoff is the MINIMUM of the guard and the floor, so the floor can
+            only ever collect LESS — never more than the safe point allows"
+    (let [conn (churned-conn "/tmp/dh-gc-min-age-floor")]
+      (try
+        (let [with-floor (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))
+              no-floor   (<?? S (d/gc-storage conn (Date.) {:min-age-ms 0}))]
+          (is (empty? (clojure.set/difference (set with-floor) (set no-floor)))
+              "a floored sweep deletes nothing an unfloored one would keep"))
+        (finally (d/release conn))))))


### PR DESCRIPTION
Closes #961. Makes the workaround in #960 expressible.

## The problem

`gc-storage!` takes `remove-before`, but that is a **mark-side** policy — how far back the commit graph stays reachable — and its own docstring says it makes GC collect *more*. The **sweep-side** bound was not settable:

```clojure
cutoff (let [sp (guard/safe-point store-id)]
         (if (< (get-time sp) (get-time now)) sp now))
```

`safe-point` is in-process state. In a process that is not the writer, nothing is ever in flight in *its* heap, so the safe point is always `now` and the cutoff collapses to `now`. That collector sweeps every unreachable object regardless of how recently it was written — including the values of a commit whose head flip has not landed yet. The head then points at deleted objects.

So "collect offline with a large cutoff" — the natural shape for a deployment that cannot collect in the writer process, and the only workaround for #960 — was **not expressible**. Passing a large `remove-before` looks like it should do this and does not.

## `:min-age-ms`

Spare anything written more recently than that, applied as a **floor**:

```clojure
cutoff = min(safe-point, now, now - min-age)
```

`min` is the safe direction — an earlier cutoff sweeps *less* — so the option can only ever retain garbage, never delete a live object. Where the writer lives, the safe point remains the tighter bound and this changes nothing.

```clojure
;; in the writer process, as before
(d/gc-storage conn)

;; from a cron job or an offline process against the bucket
(d/gc-storage conn (java.util.Date. 0) {:min-age-ms 86400000})
```

A **duration, not an instant**: the cutoff is compared against konserve's `:last-write` stamps, which come from its monotonic write clock. A wall-clock `Date` from the caller is not comparable to those, and nothing would detect the mistake.

## Off by default, deliberately

The floor is not a safety margin for in-process collection — there `safe-point` is *exact*, so a floor on top of it could only retain garbage the collector was right about. It is a **substitute** for information a different process does not have, and the substitute has no useful default: it has to exceed the longest values-then-pointer window a deployment's writers can have, which is a property of the deployment, not of datahike.

I tried the other way first. Defaulting it to 60s broke 15 existing GC tests, all of them asserting objects *were* reclaimed — a test writes and collects milliseconds apart, so everything is inside the floor. That is not a test artifact; it is the supported path showing that a default floor costs real reclamation and buys nothing where the exact answer is already available. A default large enough to be meaningful would be wrong for most stores; one small enough to be harmless would protect nobody while looking as though it did.

## The warning was checking the wrong thing

```clojure
(when-not (= :self (:backend (:writer config))) …)
```

A second process connecting to the same store gets a `:self` writer **by default** and looks exactly like the writer — so the shape that is actually unsafe was the silent one. `gc-storage!`'s own docstring admitted it: *"datahike cannot warn you"*.

`gc-guard/ever-guarded?` answers the question that matters — has **this process** ever written to this store? The guard could not answer it before: `done!` removes the entry, so it only tracked *live* sequences. `writing!` now also records the store-id permanently.

It **subsumes** the old check: a client of a remote writer has never taken the guard either, so that case still warns, and now the `:self`-looking cron sidecar does too.

Known false positive: a process that connects, never writes, and collects will warn even when it is the only writer. Benign in the single-writer model, and worth saying out loud anyway. (`create-database`, `branch!` and `force-branch!` all take the guard, so a process that created the database does not trip it.)

## Sizing, which is the part that has to be got right

The scheme is sound exactly when `min-age-ms` exceeds the longest values-then-pointer window any writer can have. A writer that **awaits its transacts** has no such window open once the call returns, so the bound is one request — 15 minutes on AWS Lambda — making hours orders of magnitude conservative. What breaks the reasoning is a writer that dispatches a transaction and returns *without* awaiting it, or a suspended process (#960). The price of a generous value is only delayed reclamation. All of this is in the docstring, where someone setting the option will read it.

## Testing

`bb test clj-pss`: **967 tests, 11476 assertions, 0 failures**. `bb lint` identical to main (238 errors / 1918 warnings), cljfmt clean.

Three tests, each paired with a control, because the first version of the first one passed **vacuously** — it used `remove-before (Date. 0)`, which keeps all history, so there was no garbage and "the floor spared it" proved nothing. The `:min-age-ms 0` control is what caught that, and it is why the controls are there:

- `min-age-spares-recent-garbage` — a generous floor collects nothing; the same store with no floor *does* collect, so the scenario genuinely has garbage.
- `min-age-is-off-by-default` — passing nothing collects exactly as before.
- `min-age-is-a-floor-not-a-replacement` — a floored sweep deletes nothing an unfloored one would keep.
