### PR TITLE
A bound probe's selectivity must survive the clause that binds it

### DIFF
--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -896,20 +896,24 @@
    types return nil — their downstream propagation falls back to the existing
    all-vars-treated-as-free behavior; LEntityJoin / LRuleCall / LUnion arms can
    be added as follow-ups."
-  [node db provenance]
-  (cond
-    (ir/scan? node)
-    (plan/source-cards {:kind :pattern :classified (scan->classified node) :db db})
+  ([node db provenance] (estimate-node-output-cards node db provenance nil))
+  ([node db provenance bound-var-cards]
+   (cond
+     (ir/scan? node)
+     ;; `bound-var-cards` is what is already bound ENTERING this node, so the
+     ;; output estimate reflects the probe rather than the attribute extent.
+     (plan/source-cards {:kind :pattern :classified (scan->classified node) :db db
+                         :bound-var-cards bound-var-cards})
 
-    ;; Function binds whose var advertises :datahike/output-cardinality (e.g.
-    ;; a graph algorithm whose result size is data-dependent). Without this the
-    ;; bind is opaque and downstream patterns over its output var fall back to
-    ;; the full attribute extent. Only the binding's own free vars are bounded.
-    (ir/bind? node)
-    (plan/source-cards {:kind :bind :classified (bind->classified node) :db db
-                        :provenance provenance})
+     ;; Function binds whose var advertises :datahike/output-cardinality (e.g.
+     ;; a graph algorithm whose result size is data-dependent). Without this the
+     ;; bind is opaque and downstream patterns over its output var fall back to
+     ;; the full attribute extent. Only the binding's own free vars are bounded.
+     (ir/bind? node)
+     (plan/source-cards {:kind :bind :classified (bind->classified node) :db db
+                         :provenance provenance})
 
-    :else nil))
+     :else nil)))
 
 (defn- bind-provenance
   "Map each var bound by a scalar function bind to the form that produced it,
@@ -1103,7 +1107,6 @@
         ;; so source-idx is a reasonable proxy for "what's bound entering
         ;; this clause." The execution path itself is reordered later by
         ;; order-plan-ops based on actual cost, independent of this.
-        node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db provenance) nodes))
         ;; Per-node BINDING vars — the free vars a node binds for
         ;; downstream consumption. Distinct from output-cards (which
         ;; carries numeric cardinality estimates and is restricted to
@@ -1163,6 +1166,41 @@
                                    (if (contains? m v) m (assoc m v ::in-scope)))
                                  acc-map
                                  (or vs [])))
+        ;; NOT a pre-pass. Output cards are computed in SOURCE ORDER, each node
+        ;; under the bindings accumulated from the nodes before it, because an
+        ;; unbound pre-pass throws away exactly the information this map exists
+        ;; to carry.
+        ;;
+        ;; A scan cannot output more rows than it matches. `[?c :concept/id
+        ;; ?from-id]` with `?from-id` bound to a one-element `:in` collection
+        ;; matches one row and costed itself at one — but the pre-pass then
+        ;; advertised `?c` at the full 2000-concept extent, so the next clause
+        ;; `[?r :relation/concept-1 ?c]` was priced against 2000 rather than 1
+        ;; and came out at the whole 8000-row relation. The planner duly drove
+        ;; from the relation and hash-joined the probe in.
+        ;;
+        ;; The visible symptom was a plan that did not change at all between a
+        ;; 1-element and a 1000-element probe — constant time in the input,
+        ;; where the base engine scales with it (#973).
+        ;;
+        ;; Order is by `source-idx`, the same proxy the bvc propagation below
+        ;; already uses, and the same caveat applies: correctness never depends
+        ;; on cardinality accuracy (Datalog is set semantics), only plan
+        ;; quality. `merge-cards` takes the MIN, so a bound-aware estimate can
+        ;; only tighten what a later node sees, never loosen it.
+        ordered-nodes (sort-by node->src-idx nodes)
+        node->output-cards
+        (:cards
+         (reduce (fn [{:keys [bvc] :as acc} n]
+                   (let [outs (estimate-node-output-cards n db provenance bvc)]
+                     (-> acc
+                         (assoc-in [:cards n] outs)
+                         (assoc :bvc (cond-> bvc
+                                       (some? outs) (merge-cards outs)
+                                       (seq (node-binding-vars logical-plan n))
+                                       (merge-bindings (node-binding-vars logical-plan n)))))))
+                 {:cards {} :bvc initial-bvc}
+                 ordered-nodes))
         ;; Pre-compute bvc per node from PRECEDING source-idx nodes'
         ;; outputs (cardinality, scan-only) and bindings (every binder
         ;; node).

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -309,10 +309,26 @@
   [{:keys [kind] :as source}]
   (case kind
     :pattern
-    (let [{:keys [classified db]} source
+    (let [{:keys [classified db bound-var-cards]} source
           si (analyze/pattern-schema-info db classified)
-          est (or (estimate/estimate-pattern db classified si)
-                  (di/-count (:eavt db)))
+          base (or (estimate/estimate-pattern db classified si)
+                   (di/-count (:eavt db)))
+          ;; BOUND-AWARE when the caller knows what is bound entering this
+          ;; clause. A scan cannot OUTPUT more rows than it matches, so
+          ;; advertising the unconstrained attribute extent over-states every
+          ;; var it binds — and a downstream consumer inherits that.
+          ;;
+          ;; This is where a selective probe used to evaporate. `[?c :concept/id
+          ;; ?from-id]` with `?from-id` bound to a one-element `:in` collection
+          ;; matched one row and costed itself at one, then advertised `?c` at
+          ;; the full 2000-concept extent — so `[?r :relation/concept-1 ?c]` was
+          ;; priced against 2000 and came out at the whole 8000-row relation.
+          ;; See `lower/node->output-cards` for the other half. (#973)
+          est (if (seq bound-var-cards)
+                (or (estimate/estimate-pattern-with-bindings
+                     db classified si bound-var-cards base)
+                    base)
+                base)
           free-output-vars (filter analyze/free-var? (:vars classified))]
       (when (seq free-output-vars)
         (zipmap free-output-vars (repeat (long est)))))

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -887,9 +887,24 @@
         ;; cardinalities — for now the group-level bound suffices for downstream
         ;; planning decisions (it differentiates a 4k-tuple group from a 150k one).
         group-card-final (max 1 group-card)
+        ;; The same reduction, started from the driving scan's BOUND-AWARE card.
+        ;;
+        ;; `:estimated-card` above is deliberately the unconstrained count — the
+        ;; pass-rate math needs `merge-est / total-entities` to be a ratio of full
+        ;; attribute extents, and feeding it a filtered count would double-count
+        ;; the selectivity. But that left the GROUP with no bound-aware cost at
+        ;; all, so `group-effective-card` (which prefers `:scan-card` for exactly
+        ;; this purpose) fell back to the unbound number for every group and
+        ;; ordered a probe-driven group as though nothing were bound.
+        ;;
+        ;; Only the STARTING card changes; the per-merge pass rates are untouched.
+        ;; The bound-aware bound when there is one: a group cannot OUTPUT more
+        ;; rows than it produces under the bindings entering it, and a consumer
+        ;; downstream inherits whatever this says.
+        output-card-bound (long group-card-final)
         output-var-cards (into {}
                                (comp (filter analyze/free-var?)
-                                     (map (fn [v] [v group-card-final])))
+                                     (map (fn [v] [v output-card-bound])))
                                output-vars)
         ;; Merge-ops' pushdown preds can't be applied (merge uses EAVT lookupGE,
         ;; not AVET scan). Collect them so they can be restored as standalone preds.
@@ -1245,10 +1260,33 @@
                                :cljs (loop [v x c 0]
                                        (if (zero? v) c
                                            (recur (bit-and v (dec v)) (inc c))))))
+                 ;; Largest component wins, and on a TIE the CHEAPEST one — not
+                 ;; whichever happened to come first in `groups`.
+                 ;;
+                 ;; The tie is the common case, not an edge case: two groups
+                 ;; joined only THROUGH a non-group op (an `or`, a rule call, a
+                 ;; function) share no variable, so each is its own singleton
+                 ;; component. Keeping the first meant a 2000-row group could be
+                 ;; chosen as the seed over a 100-row probe scan purely by array
+                 ;; order, and everything after it multiplied against 2000 —
+                 ;; while `sorted-remaining` two lines below already sorts the
+                 ;; REST by cardinality. This makes the seed agree with the tail.
+                 ;;
+                 ;; Ordering the probe first is also what lets the interleaver
+                 ;; place the `or`/rule after it, so the rule runs with its input
+                 ;; var bound and can seek instead of materialising. (#973)
                  best-mask (reduce (fn [best mask]
-                                     (if (aget dp (int mask))
-                                       (if (> (long (popcount mask)) (long (popcount best)))
-                                         mask best)
+                                     (if-let [entry (aget dp (int mask))]
+                                       (let [bp (long (popcount best))
+                                             mp (long (popcount mask))]
+                                         (cond
+                                           (zero? (long best)) mask
+                                           (> mp bp) mask
+                                           (and (= mp bp)
+                                                (< (long (:cost entry))
+                                                   (long (:cost (aget dp (int best))))))
+                                           mask
+                                           :else best))
                                        best))
                                    0
                                    (range 1 (unchecked-inc full)))


### PR DESCRIPTION
Fixes #973. Two independent join-ordering defects; the reported query goes from **9.1x slower than the base engine to 0.7x faster**, and from **17.4x to 0.8x** on a `keep-history?` database.

## The report, and what it actually is

The issue attributes the regression to *"a recursive rule whose body is an `or` of two branches, each opened by a `ground`"*. Reproducing it from the reporter's own script, three of those attributions do not hold:

- **The rule is not recursive.** `jobtech-taxonomy.common.relation/rules` defines `edge` as a plain `or` of two non-recursive branches.
- **It is not about `or`.** A five-clause **conjunctive** query — no rule, no `or`, no `get-else` — reproduces it.
- **It is not `default-in-collection-card`.** Plans are byte-identical with that constant at 100 and at 4.

What is real is the signature the reporter identified exactly: **runtime constant in the probe size**. And the reason is sharper than mis-costing — the plans for `probe=1` and `probe=1000` are **byte-identical**. The planner could not see the probe at all.

Reproduced (2000 concepts / 8000 relations, their query, their rules):

```
probe=1     OFF   6.0 ms   ON  54.6 ms    9.1x
probe=10    OFF   9.9 ms   ON  53.9 ms    5.4x
probe=100   OFF  38.9 ms   ON  52.3 ms    1.3x
probe=ALL   OFF 325.1 ms   ON  73.1 ms    0.2x   <- control, planner wins
```

With `keep-history?` the ratio reaches **17.4x**. Results agree everywhere — purely performance, as reported.

## Root cause

Every part of the machinery was already right:

- `estimate-pattern-with-bindings` returns exactly the bound cardinality — called directly on the real clause: `{?from-id 1} -> 1`, `{?from-id 100} -> 100`
- `plan-pattern-op` already asks it and records the answer as `:scan-card`
- `group-effective-card` already **prefers** `:scan-card` when ordering

The break was one step later. `lower/node->output-cards` computed every node's **output** cardinality in a single **unbound pre-pass**, before any binding propagation:

```clojure
node->output-cards (zipmap nodes (map #(estimate-node-output-cards % db provenance) nodes))
```

So the probe scan costed *itself* correctly at 1 — then advertised its output var at the full attribute extent. Instrumented, before:

```
[?c :concept/id ?from-id]    bvc={?from-id 100}   est=2000  scan=100    <- correct
[?r :relation/concept-1 ?c]  bvc={..., ?c 2000}   est=8000  scan=8000   <- selectivity gone
```

**A bound probe's selectivity survived exactly one clause and then evaporated.** Everything downstream was priced against the whole relation, so the planner drove from the relation and hash-joined the probe in — the same plan whatever the probe size.

## The change

Two halves of one idea: *a scan cannot output more rows than it matches.*

- `plan/source-cards {:kind :pattern}` takes an optional `:bound-var-cards` and estimates through `estimate-pattern-with-bindings` when given one.
- `lower/node->output-cards` is no longer a pre-pass — it folds over nodes in `source-idx` order carrying accumulated bindings, so each node's output estimate reflects what is bound entering it.

Order is by `source-idx`, the same proxy the bvc propagation below it already uses, with the same caveat: correctness never depends on cardinality accuracy (Datalog is set semantics), only plan quality. `merge-cards` takes the MIN, so a bound-aware estimate can only tighten what a later node sees, never loosen it.

After:

```
[?r :relation/concept-1 ?c]  bvc={..., ?c 100}    est=8000  scan=400
```

## Measured

The conjunctive shape — flat becomes scaling, and the planner now wins where it should:

| probe | before (ON) | after (ON) | base (OFF) |
|---|---|---|---|
| 1 | 19.0 ms (7.7x) | **2.7 ms (1.1x)** | 2.6 ms |
| 10 | 13.6 ms | 7.9 ms | 4.3 ms |
| 100 | 13.6 ms | 10.0 ms | 14.3 ms |
| 1000 | 23.1 ms (0.5x) | 29.6 ms (0.5x) | 55.1 ms |

## The second defect: a disconnected component's seed

The first fix above was necessary but not sufficient — the reported query goes through the `edge` **rule**, and rules are ordered differently.

`dp-order-groups` falls back to component-chaining when the join graph is disconnected, and picked its seed by popcount alone:

```clojure
(if (> (popcount mask) (popcount best)) mask best)   ; ties keep `best`
```

On a TIE that keeps whichever group came first in the `groups` vector. **The tie is the common case, not an edge case**: two groups joined only *through* a non-group op — an `or`, a rule call, a function — share no variable, so each is its own singleton component. Instrumented:

```
GROUP-ORDER [0 1]
   group op=:entity-group  eff=2000   vars=#{?deprecated ?related-c ?id}
   group op=:pattern-scan  eff=100    vars=#{?from-id ?c}
   non-groups: [:function :or]
```

A 2000-row group seeded ahead of a 100-row probe purely by array order — while `sorted-remaining`, two lines below, already sorted the REST by cardinality. The seed now agrees with the tail.

That ordering is also what lets the interleaver place the rule AFTER the probe scan, so it runs with its input var bound and seeks instead of materialising.

## The reported query

| probe | before (ON) | after (ON) | base (OFF) | ratio |
|---|---|---|---|---|
| 1 | 54.6 ms | **4.6 ms** | 6.2 ms | **0.7x** |
| 10 | 53.9 ms | 6.9 ms | 9.3 ms | 0.7x |
| 100 | 52.3 ms | 11.9 ms | 32.9 ms | 0.4x |
| ALL | 73.1 ms | 105.3 ms | 343.6 ms | 0.3x |

`keep-history?` probe=1: **17.4x -> 0.8x**. Flat becomes scaling, `agree=true` throughout.

## One change tried and REVERTED

Giving `assemble-entity-group` a bound-aware `:scan-card` looked like the natural companion — `group-effective-card` prefers `:scan-card` and gets `nil` for every group today. It turned out to be unnecessary (the tie-break alone produces the numbers above, byte for byte) **and harmful**: it broke `query-planner-test/array-valued-probe-drives-index-seeks`. The answer stayed correct (6000 rows on both engines) but `@seeks` went to 0 — the SIP probe-driven seek stopped engaging, because that path keys on the scan estimate clearing `probe-driven-threshold` times the probe-set size, and a tighter group card moves that comparison.

Caught by a test written to guard exactly that optimisation. Left out rather than papered over: making entity-group costs bound-aware is worth doing, but it interacts with the SIP threshold and wants its own change with that interaction understood first.

## Verification

| tier | result |
|---|---|
| `:clj-pss` | 1007 tests / 12861 assertions, 0 failures |
| `:clj-hht` | 1007 tests / 12861 assertions, 0 failures |
| `bb planner-bench --assert` | **OK on all shapes**, results agree |
| `clojure -M:format` | clean |

No answer changes anywhere: `agree=true` at every probe size in the reproduction, and both tiers are unchanged.

The regression gate's shapes nearest this one got **faster**:

```
sip-entity-group    compiled  1.6ms   base  3.8ms   0.43x   OK
rule-or             compiled  2.2ms   base  2.5ms   0.85x   OK
recursive-ground    compiled 24.8ms   base 58.9ms   0.42x   OK
```

Worth noting the gate already carries a `rule-or` shape with `:in [?ida ...]` and did **not** catch #973 — its fixture has no low-selectivity clause to mis-order against. A shape with one would be a useful addition, and I can add it here if you'd like.

@mokshasoft — you offered to test a patch, and this one should move the taxonomy `related` query directly. My fixture is 2000 concepts / 8000 relations against your 32k+, and the planner's old constant scaled with relation size, so your 13-120x should collapse further than my 9.1x did. A measurement from the real data would be very welcome, especially the `as-of`/history variant.

Thank you for the reproduction script, the CPU profiles, and the `fast-eligible?` pointer — pulling the real rules and query out of the MR is what made the ablation possible, and the ablation is what showed the `or`-rule was incidental.
