### PR TITLE
An undeclared attribute matches nothing, not everything

### DIFF
--- a/src/datahike/db/interface.cljc
+++ b/src/datahike/db/interface.cljc
@@ -125,3 +125,50 @@
         :error-on-missing (throw (ex-info "Attribute ref not found"
                                           {:ref a-ref}))
         :allow-missing nil)))
+
+(defn ref-for
+  "`a-ident` as this database stores it in a datom's attribute slot, with the
+   caller stating what an UNKNOWN ident means to them.
+
+   The mirror of `ident-for`, and it exists for the same reason: `-ref-for`
+   answers `nil` for an ident this database has not installed, and `nil` is not a
+   free value here. In a SEARCH PATTERN `nil` in the attribute slot means
+   UNCONSTRAINED — match every attribute. So an unresolvable ident handed
+   straight to a search does not match nothing, it matches EVERYTHING, and the
+   caller cannot tell the two apart because they are the same value.
+
+   That is not hypothetical. Under `:attribute-refs? true` it made
+   `[?e :typo/attr ?v]` return the whole database and inverted `not-join` into
+   excluding every result. Databases without `:attribute-refs?` were immune only
+   by accident: there `-ref-for` is the identity and never produces a `nil`, so
+   an unresolved keyword stays a keyword and matches nothing on its own.
+
+   The strategies say what the CALLER means, which is the whole point — the bug
+   was that nobody had to say:
+
+     `:error-on-missing`  the attribute must exist; raise if it does not. What
+                          the write paths want, and what 19 of the 23
+                          `ident-for` call sites already ask for.
+     `:no-match`          the attribute may not exist, and if it does not then
+                          nothing can match it. What a QUERY wants: a clause over
+                          an undeclared attribute yields no rows, which is what
+                          this database has always done without `:attribute-refs?`
+                          and is therefore what the two configs must agree on.
+     `:allow-missing`     `nil`, the raw protocol answer, for a caller that has
+                          its own handling. Named so that choosing it is visible.
+
+   `:no-match` returns the IDENT itself. Under `:attribute-refs?` a stored
+   attribute is an entity id, so a keyword is equal to none of them and orders
+   against none of them — verified to match nothing across all six pattern shapes
+   and both the current and temporal index families. Without `:attribute-refs?`
+   the ident IS the attribute, so returning it is not a special case at all: the
+   pattern is exactly what the caller wrote, and it matches nothing because no
+   datom carries that attribute. One rule, both configs, no branch."
+  [db a-ident missing-strategy]
+  (or (-ref-for db a-ident)
+      (case missing-strategy
+        :error-on-missing (throw (ex-info "Attribute not found"
+                                          {:error :db/unknown-attribute
+                                           :attribute a-ident}))
+        :no-match a-ident
+        :allow-missing nil)))

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -852,7 +852,7 @@
 
 (defn- translate-for [db a]
   (if (and (-> db dbi/-config :attribute-refs?) (keyword? a))
-    (dbi/-ref-for db a)
+    (dbi/ref-for db a :no-match)
     a))
 
 (defn- -differ? [& xs]
@@ -1927,7 +1927,7 @@
      (dt/with-destructured-vector pattern
        e (resolve-pattern-lookup-entity-id source e error-code)
        a (if (and (:attribute-refs? (dbi/-config source)) (keyword? a))
-           (dbi/-ref-for source a)
+           (dbi/ref-for source a :no-match)
            a)
        v (if (and v (attr? a) (dbu/ref? source a) (or (lookup-ref? v) (attr? v)))
            (dbu/entid-strict source v error-code)
@@ -2186,7 +2186,7 @@
     (case (int pattern-index)
       0 (resolve-pattern-lookup-entity-id source pattern-value error-code)
       1 (if (and (:attribute-refs? (dbi/-config source)) (keyword? pattern-value))
-          (dbi/-ref-for source pattern-value)
+          (dbi/ref-for source pattern-value :no-match)
           pattern-value)
       2 (if (and pattern-value
                  (attr? a)

--- a/src/datahike/query/estimate.cljc
+++ b/src/datahike/query/estimate.cljc
@@ -83,12 +83,24 @@
         e-ground? (ground? e)
         a-ground? (ground? a)
         v-ground? (ground? v)
+        ;; `:allow-missing`, not `:no-match`, and the difference matters HERE
+        ;; rather than in the search: this namespace compares the attribute with
+        ;; `cmp-attr-only` -> `datom/cmp-attr-quick`, which is `.compareTo` and
+        ;; casts. An unresolved KEYWORD against stored Long attributes throws
+        ;; ClassCastException there, where a search would simply have found
+        ;; nothing. So the estimator answers the question directly: an attribute
+        ;; this database has never installed has ZERO datoms, and that needs no
+        ;; index access at all.
         resolved-a (when a-ground?
                      (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
-                       (dbi/-ref-for db a)
-                       a))]
+                       (dbi/ref-for db a :allow-missing)
+                       a))
+        unknown-attr? (and a-ground? (nil? resolved-a))]
     (cond
-      ;; [e a ?v] — single datom for card-one, count EA range for card-many
+      ;; nothing carries an attribute that was never installed
+      unknown-attr? 0
+
+;; [e a ?v] — single datom for card-one, count EA range for card-many
       (and e-ground? a-ground? (not v-ground?))
       (if (:card-one? schema-info)
         1
@@ -180,14 +192,19 @@
   (let [{:keys [a]} pattern-info
         ground? (fn [x] (and (some? x) (not (symbol? x))))]
     (when (ground? a)
-      (let [resolved-a (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
-                         (dbi/-ref-for db a)
+      (let [;; see `estimate-pattern-counted` on why this is `:allow-missing`
+            resolved-a (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
+                         (dbi/ref-for db a :allow-missing)
                          a)
-            attr-count (di/-count-slice (:aevt db)
-                                        (datom e0 resolved-a nil tx0)
-                                        (datom emax resolved-a nil txmax)
-                                        cmp-attr-only)]
+            attr-count (when (some? resolved-a)
+                         (di/-count-slice (:aevt db)
+                                          (datom e0 resolved-a nil tx0)
+                                          (datom emax resolved-a nil txmax)
+                                          cmp-attr-only))]
         (cond
+          ;; an attribute that was never installed selects nothing; 1 is this
+          ;; function's own floor for an empty slice, so it is the same answer
+          (nil? attr-count) 1
           (zero? attr-count) 1
           (:unique? schema-info) attr-count
           :else
@@ -336,7 +353,10 @@
           resolved-a (if (and a-val (not (symbol? a-val)))
                        (if (:attribute-refs? (dbi/-config db))
                          (if (keyword? a-val)
-                           (dbi/-ref-for db a-val)
+                           ;; see `estimate-pattern-counted`; nil flows on as
+                           ;; "no attribute to sample", which the callers below
+                           ;; already handle as an absent estimate
+                           (dbi/ref-for db a-val :allow-missing)
                            a-val) ;; already numeric, don't re-resolve
                          a-val)
                        nil)

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -343,7 +343,8 @@
 
 (defn- resolve-attr [db a]
   (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
-    (dbi/-ref-for db a)
+    ;; :no-match — an undeclared attribute matches nothing, as it always has without :attribute-refs?
+    (dbi/ref-for db a :no-match)
     a))
 
 (defn- val-eq?
@@ -855,7 +856,7 @@
 (defn- resolve-date-to-tx-id*
   [origin-db date]
   (let [txInstant-attr (if (:attribute-refs? (dbi/-config origin-db))
-                         (dbi/-ref-for origin-db :db/txInstant)
+                         (dbi/ref-for origin-db :db/txInstant :error-on-missing)
                          :db/txInstant)
         all-instants (dbi/-datoms origin-db :aevt [txInstant-attr] dbu/temporal-context)
         matching (filter (fn [^Datom d]

--- a/src/datahike/query/logical.cljc
+++ b/src/datahike/query/logical.cljc
@@ -229,7 +229,8 @@
                           raw-attr (nth args 2)
                           attr (if (and (keyword? raw-attr)
                                         (:attribute-refs? (dbi/-config db)))
-                                 (dbi/-ref-for db raw-attr)
+                                 ;; :no-match — an undeclared attribute matches nothing, as it always has without :attribute-refs?
+                                 (dbi/ref-for db raw-attr :no-match)
                                  raw-attr)
                           ;; (quote x) defaults unwrap to their constant here —
                           ;; matching -call-fn's arg resolution on the legacy

--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -406,7 +406,7 @@
                                  (number? (second x)))))
         resolve-attr-in-pattern (fn [pat]
                                   (if (and attr-refs? (keyword? (second pat)))
-                                    (assoc pat 1 (dbi/-ref-for db (second pat)))
+                                    (assoc pat 1 (dbi/ref-for db (second pat) :no-match))
                                     pat))
         resolve-recursive (fn resolve-recursive [form]
                             (cond


### PR DESCRIPTION
Closes #969. Found while verifying #966; **pre-existing** and confirmed on `ca27ebde` and `3b5a8b88`.

## The bug

Under `:attribute-refs? true`, a query for an attribute that was never declared returns **the whole database** instead of nothing:

```
                    keyword attrs   :attribute-refs?
[?e :p/nope ?v]           0 rows          90 rows     (of 90 — the entire db)
not-join over it          1 row            0 rows     (excludes EVERY result)
```

A typo'd attribute name yields every datom; inside a negation it **inverts** and excludes everything, which reads as "no matches" rather than as anything wrong. `doc/config.md` recommends `:attribute-refs? true` for production, so this is the configuration users are steered toward.

## Root cause

`nil` is doing two incompatible jobs at one seam:

- in a SEARCH PATTERN, `nil` in the attribute slot means **unconstrained** — match every attribute
- `dbi/-ref-for` returns `nil` to mean **this ident is not installed**

The query path fed one straight into the other. Measured directly — the resolved pattern and the wildcard are the same call:

```
search [nil <resolved :p/nope> nil]  ->  120 datoms
search [nil nil nil]                 ->  120 datoms   (identical)
```

Databases without `:attribute-refs?` were immune **by accident**, not by design: there `-ref-for` is the identity, never produces a `nil`, and an unresolved keyword matches nothing on its own. The bug is that the two configurations disagreed.

Two things kept it alive:

- **Both query engines were wrong identically** (90 rows each), so the planner-vs-base differential testing this codebase leans on is structurally blind to it.
- **The write paths were already correct.** `d/datoms`, `d/seek-datoms` and `transact` raise *"not defined in current schema"* through `dbu/validate-attr`. The right behaviour existed; the query path did not use it.

## The fix, and why it is a wrapper

`dbi/ident-for` — the INVERSE direction, eid -> ident — has taken a `missing-strategy` for a long time:

| | |
|---|---|
| `ident-for` wrapper (caller states intent) | **23 call sites**, 19 of them `:error-on-missing` |
| `-ident-for` raw | 8 |
| `-ref-for` raw | **33** |
| a `ref-for` wrapper | **did not exist** |

So this is not a new idea — it is the missing half of one the codebase already committed to. When callers are made to say what they mean, they overwhelmingly mean *"this must exist"*.

`dbi/ref-for` mirrors it, with the strategy a QUERY needs:

```
:error-on-missing   the attribute must exist; raise if not  (system attributes)
:no-match           it may not, and then nothing matches it (queries)
:allow-missing      nil, for a caller with its own handling
```

`:no-match` returns the ident itself. Under `:attribute-refs?` a stored attribute is an entity id, so a keyword equals none of them; without it the ident IS the attribute, so returning it is not a special case at all. One rule, both configs, no branch. Verified to match nothing across all six pattern shapes and both the current and temporal index families.

**Ten query-path sites converted; zero raw `-ref-for` left there.** Eight state `:no-match`; `:db/txInstant` in `resolve-date-to-tx-id*` states `:error-on-missing`, because a missing system attribute is a malformed database rather than a caller asking for something absent.

## The estimator is the exception, and it is the interesting part

Three sites in `query/estimate.cljc` take `:allow-missing` and answer **0** instead. That namespace does not search — it COMPARES, through `cmp-attr-only` -> `datom/cmp-attr-quick`, which is `.compareTo` and casts. An unresolved keyword against stored Long attributes throws `ClassCastException` there, where a search would simply have found nothing.

Measured: the first cut of this fix turned the wildcard into a CCE **on the planner path only**, because the planner estimates and the base engine does not. So the estimator answers the question directly — an attribute this database never installed has zero datoms, and that needs no index access.

This is precisely why `:no-match` is a strategy a caller must ASK for rather than a default: it is safe where a value is *matched* and unsafe where one is *compared*, and only the call site knows which.

## Result

```
refs?=false  total=6    q-planner=0  q-base=0  not-join=1  known=#{["Ann"]}
refs?=true   total=120  q-planner=0  q-base=0  not-join=1  known=#{["Ann"]}
```

Both configurations identical, on both engines, with `not-join` no longer inverting.

| tier | result |
|---|---|
| `:clj-pss` | 1007 tests / 12861 assertions, 0 failures |
| `clojure -M:format` | clean |

## Deliberately not in this PR

**Whether a query should RAISE instead of returning `#{}`.** Measured for comparison — Datomic **raises** for an unknown attribute in a query (`:db.error/not-an-entity`) while `dt/datoms` returns 0, so datahike is inverted from Datomic on *both* APIs. This PR makes the two datahike configs agree on `#{}`, which is what keyword mode has always done; changing that is a separate, breaking decision that also implicates `d/datoms`, cannot be universal (`:schema-flexibility :read` cannot distinguish a typo from "no data yet"), and would require adding a schema check to the keyword path that does not exist today. Worth its own issue and a staged rollout.

**`d/pull` diverges the other way** — keyword mode raises, `:attribute-refs?` returns `nil`. A different consumer with its own right answer; untouched here.
