### PR TITLE
A dump records an attribute's identity, not the name it happens to have now

### DIFF
--- a/src-datomic/datahike/migrate/datomic.clj
+++ b/src-datomic/datahike/migrate/datomic.clj
@@ -113,6 +113,7 @@
        recovered by any reader."
   (:require [datomic.api :as dt]
             [datahike.migrate :as m]
+            [datahike.migrate.cbor :as mcbor]
             [datahike.constants :as const]
             [replikativ.logging :as log])
   (:import [datomic Datom]))
@@ -193,6 +194,40 @@
 (defn- ident-map [db]
   (into {} (dt/q '[:find ?e ?i :where [?e :db/ident ?i]] db)))
 
+(defn ident-timeline
+  "attribute-entity -> [[dh-t ident] ...] ascending, for the attributes whose
+   ident actually CHANGED. `{}` when none did, which is the usual case.
+
+   `ident-map` is a SNAPSHOT of the current database, so resolving a historical
+   datom through it names that datom with the attribute's FINAL ident. For an
+   attribute that was never renamed those are the same string and nothing is
+   lost. For one that was, a datom written before the rename comes out carrying a
+   name that did not exist yet — while the `:db/ident` records still replay the
+   rename in causal order, so replaying meets the datom before its name is
+   installed.
+
+   Datomic keeps the ident assertions in its own history, so this is one query
+   over a handful of datoms rather than a pass over the log. `t` is converted to
+   datahike's frame with `datomic-t->dh-t`, the same conversion the records get,
+   so the timeline and the records agree about when the rename happened.
+
+   Assertions only: a retraction is implied by the assertion that supersedes it."
+  [db]
+  (let [rows (dt/q (quote [:find ?e ?i ?tx
+                           :where [?e :db/ident ?i ?tx true]])
+                   (dt/history db))]
+    (into (sorted-map)
+          (keep (fn [[e entries]]
+                  (let [sorted (vec (sort-by first
+                                             (map (fn [[_ i tx]]
+                                                    [(datomic-t->dh-t (dt/tx->t tx)) i])
+                                                  entries)))]
+                    ;; only what MOVED — a single-entry timeline says nothing the
+                    ;; snapshot does not already say
+                    (when (> (count (distinct (map second sorted))) 1)
+                      [e sorted]))))
+          (group-by first rows))))
+
 (defn- ref-attr-idents [db]
   (into #{} (map first)
         (dt/q '[:find ?i :where [?a :db/valueType :db.type/ref] [?a :db/ident ?i]] db)))
@@ -223,7 +258,7 @@
    The tx entity's own eid is rewritten to the mapped `t` so that the
    `:db/txInstant` datom names its own transaction, which is the shape datahike
    expects and `export-db` writes."
-  [{:keys [t data]} idents refs dropped {:keys [provenance? extra]}]
+  [{:keys [t data]} idents refs dropped {:keys [provenance? extra renamed-attrs]}]
   (let [dh-t   (datomic-t->dh-t t)
         tx-eid (dt/t->tx t)
         ;; tx-META: `e` equal to `t` makes these datoms ABOUT the transaction.
@@ -250,7 +285,18 @@
                                (instance? java.net.URI v) (str v)
                                :else v)
                            e (.e dm)]
-                       [(if (= e tx-eid) dh-t e) a v dh-t (.added dm)])))))
+                       ;; A RENAMED attribute goes on the wire by ENTITY, so no
+                       ;; naming decision is baked into the record and the READER
+                       ;; picks what its target needs — period-correct for an
+                       ;; attribute-refs target, flattened for a keyword one. See
+                       ;; `ident-timeline` on why the snapshot cannot name these.
+                       ;; Every other attribute keeps its ident, so a source with
+                       ;; no rename emits exactly what it emitted before.
+                       [(if (= e tx-eid) dh-t e)
+                        (if (contains? renamed-attrs (.a dm))
+                          (mcbor/->AttrRef (.a dm))
+                          a)
+                        v dh-t (.added dm)])))))
          ;; `extra` is the provenance SCHEMA, emitted once with the first
          ;; transaction — a source owes its own schema before the data using it.
          (concat prov (map (fn [r] (assoc r 3 dh-t)) extra))
@@ -352,17 +398,28 @@
    (let [db      (dt/db conn)
          idents  (ident-map db)
          refs    (ref-attr-idents db)
+         ;; The attributes the SNAPSHOT above cannot name correctly. Read once,
+         ;; like the snapshot, and exposed on the chunk-src so `import-source`
+         ;; can be handed it as `:source-meta`.
+         timeline (ident-timeline db)
+         renamed  (not-empty (set (keys timeline)))
          dropped (volatile! #{})
          [from to] (or (log-t-range conn) [0 0])
          schema  (when provenance? (provenance-schema))
          chunks  (vec (for [start (range from to window)]
                         {:from start :to (min to (+ start window))}))]
      {:chunks chunks
+      ;; NOT part of the `chunk-src` contract `import-source` reads — that is
+      ;; `:chunks` and `:read`. Carried alongside so `import-from-datomic!` can
+      ;; pass it as `:source-meta`, which is where a source's format-level facts
+      ;; belong; a caller driving `source` directly can do the same.
+      :ident-timeline timeline
       :read   (fn [{f :from t :to} _opts]
                 (let [rs (into []
                                (mapcat (fn [{:keys [t] :as tx}]
                                          (tx->records tx idents refs dropped
                                                       {:provenance? provenance?
+                                                       :renamed-attrs renamed
                                                        ;; only with the log's FIRST
                                                        ;; transaction, whichever chunk
                                                        ;; that turns out to be in
@@ -419,7 +476,10 @@
                              ;; transactions. The `:datomic/t` provenance datoms
                              ;; carry the real correspondence.
                              {:source-meta (cond-> {:history? true}
-                                             n (assoc :expected-count n))})))))
+                                             n (assoc :expected-count n)
+                                             (seq (:ident-timeline src))
+                                             (assoc :ident-timeline
+                                                    (:ident-timeline src)))})))))
 
 ;; ---------------------------------------------------------------------------
 ;; records -> Datomic

--- a/src/datahike/migrate.cljc
+++ b/src/datahike/migrate.cljc
@@ -2815,10 +2815,18 @@
    Everything `import-db` takes (`:batch-size` `:xform` `:eids` `:merge?`
    `:build-indexes?` `:on-error` `:sync?` …) plus:
 
-     :source-meta  {:history? :expected-count :max-tx}, all three OPTIONAL.
-                   Absent `:expected-count` only means the count check has
-                   nothing to compare against; absent `:max-tx` only means no
+     :source-meta  {:history? :expected-count :max-tx :ident-timeline}, all
+                   OPTIONAL. Absent `:expected-count` only means the count check
+                   has nothing to compare against; absent `:max-tx` only means no
                    drift warning. A source that knows none of them passes none.
+
+                   `:ident-timeline` is `{attribute-entity [[t ident] ...]}` and
+                   is needed only by a source that names a RENAMED attribute by
+                   entity — a `#datahike/attr` in the `a` slot — which is how a
+                   source avoids baking a naming decision into its records. See
+                   `manifest/ident-timeline`; `resolve-attr-refs` then picks the
+                   name this target needs, which differs by `:attribute-refs?`.
+                   A source that names attributes by keyword needs none of it.
      :schema       source schema map, index-build path only (ref detection).
 
    ## Verification is DECLINED, not defaulted away

--- a/src/datahike/migrate.cljc
+++ b/src/datahike/migrate.cljc
@@ -1106,6 +1106,53 @@
       (assoc record 2 (dbi/-ref-for db (:ident v)))
       record)))
 
+(defn- resolve-attr-refs
+  "Replace an `AttrRef` in a record's attribute slot with the ident this TARGET
+   needs, using the dump's `:ident-timeline`.
+
+   The dump records a renamed attribute by ENTITY precisely so that this choice
+   is the reader's. There are two right answers and which one is right depends on
+   how the target stores an attribute:
+
+     :attribute-refs? true    PERIOD-CORRECT — the name in force when the datom
+                              was written. The target resolves that ident to its
+                              own attribute entity, and it is installed by then
+                              BY CONSTRUCTION: the name a datom carries is the one
+                              asserted at the latest t0 <= t, and that assertion
+                              is replayed first. Naming it with the FINAL ident is
+                              exactly the bug — the importer meets a datom before
+                              its name exists.
+
+     :attribute-refs? false   FINAL — the target stores the KEYWORD in the datom,
+                              so a period-correct name would split the attribute
+                              across both names, which is the outcome
+                              `validate-ident-renames!` refuses on the live path.
+                              Flattening keeps every datom under one name and the
+                              database queryable; what is lost is the rename as an
+                              EVENT, which a keyword-attribute database cannot
+                              represent at all.
+
+   A dump with no renamed attribute carries no timeline and no `AttrRef`, so this
+   is a `nth` and a type check on that path."
+  [db timeline record]
+  (let [a (nth record 1)]
+    (if-not (mcbor/attr-ref? a)
+      record
+      (let [e (:eid a)
+            entries (get timeline e)
+            ident (if (:attribute-refs? (dbi/-config db))
+                    (mman/ident-at timeline e (nth record 3))
+                    (second (last entries)))]
+        (when (nil? ident)
+          (throw (ex-info (str "The dump names attribute entity " e
+                               " by reference, but its ident timeline does not cover"
+                               " transaction " (nth record 3) ". The dump is inconsistent"
+                               " with its own manifest.")
+                          {:error :import/unresolvable-attr-ref
+                           :attribute-entity e :t (nth record 3)
+                           :timeline entries})))
+        (assoc record 1 ident)))))
+
 (defn- system-eid-seed
   "Identity seed {eid eid} for every target system entity, so refs resolved to a
    system entity are not re-allocated by load-entities (#508)."
@@ -1638,7 +1685,11 @@
   [manifest]
   {:history?       (boolean (:history? manifest))
    :expected-count (:count (:semantic-digest manifest))
-   :max-tx         (:max-tx (:stats manifest))})
+   :max-tx         (:max-tx (:stats manifest))
+   ;; Present only for a dump that renamed an attribute; see
+   ;; `manifest/ident-timeline`. A source that is not a dump has none, and
+   ;; `resolve-attr-refs` is then a type check that never fires.
+   :ident-timeline (:ident-timeline manifest)})
 
 (defn- dangling-refs
   "Ref values in `db` that name an entity holding no datoms.
@@ -1853,7 +1904,10 @@
                                        rs)
                         :else (do (run! mman/validate-record! rs) rs)))
               prepare (fn [records]
-                        (let [rs (mapv #(resolve-sysrefs sref-db %) records)]
+                        (let [tl (:ident-timeline source-meta)
+                              rs (mapv #(->> % (resolve-sysrefs sref-db)
+                                             (resolve-attr-refs sref-db tl))
+                                       records)]
                           (if step
                             (let [out (into [] (mapcat (fn [r]
                                                          (let [o (step [] r)]
@@ -2218,7 +2272,8 @@
                                        "a dump chunk could not be read")]
             (recur (next cs)
                    (reduce (fn [a record]
-                             (let [r (resolve-sysrefs sref-db record)]
+                             (let [r (->> record (resolve-sysrefs sref-db)
+                                          (resolve-attr-refs sref-db (:ident-timeline opts)))]
                                (when counter (vswap! counter inc))
                                (if step
                                  (let [o (step [] r)]
@@ -2348,6 +2403,11 @@
                            :eids :preserve}
                           opts)
         opts       (update opts :eids #(or % :preserve))
+        ;; `reduce-source-records` reads the timeline from `opts`; it arrives in
+        ;; `source-meta`, which is where a dump's format dependencies live.
+        opts       (cond-> opts
+                     (:ident-timeline source-meta)
+                     (assoc :ident-timeline (:ident-timeline source-meta)))
         db0        @conn
         config     (:config db0)
         keep-hist? (boolean (:keep-history? config))

--- a/src/datahike/migrate/cbor.cljc
+++ b/src/datahike/migrate/cbor.cljc
@@ -44,6 +44,7 @@
    A newline-delimited format cannot do this without escaping, which is why the
    EDN codec was line-oriented all the way down into the external sort."
   (:require [boring.core :as boring]
+            [boring.data :as bdata]
             [clojure.walk :as walk]
             [hasch.core :as hasch]))
 
@@ -193,31 +194,31 @@
   (instance? SysRef v))
 
 (def ^:private sysref-name
-  "boring's wire name for the record: `namespace/Name`, the form `pr-str` shows
-   for an unregistered one. Named explicitly rather than derived so a namespace
-   rename is a visible format change rather than a silent one.
+  "boring's wire name for the record, DERIVED rather than written out.
 
-   This read `datahike.migrate.cbor.SysRef` — the CLASS name, dots and all — and
-   that is not what boring writes. The name never matched, so the registry never
-   supplied a constructor and every encoded SysRef came back as a
-   `boring.data.UnknownRecord`. `sysref?` is an `instance?` check, so it answered
-   false, `resolve-sysrefs` never fired, and a ref value pointing at a system
-   entity was imported as that opaque record instead of the target's eid.
-   Measured on origin/main before this change:
+   This was a hand-written `\"datahike.migrate.cbor.SysRef\"` — the CLASS name,
+   dots and all. boring writes `namespace/Name`; its own `record-type-name`
+   docstring is explicit that a slash separates the two because a dot is
+   ambiguous (`a.b.c.D` could split either way). So the name never matched, the
+   registry supplied no constructor, and every encoded SysRef decoded to a
+   `boring.data/UnknownRecord`. `sysref?` is an `instance?` check, so it answered
+   false, `resolve-sysrefs` never fired, and a ref value naming a system entity
+   was imported as that opaque record rather than the target's eid. Nothing
+   raised — an unregistered record decodes and re-encodes to identical bytes by
+   design, which is what made it silent.
 
-     (mcbor/decode-record (mcbor/encode-record [1 :p/x (->SysRef :db/ident) 2 true]))
-     ;; => a is #boring/record [\"datahike.migrate.cbor/SysRef\" {:ident :db/ident}]
-     ;; (sysref? …) => false
+   `boring/register-record`'s own docstring gives `\"my.ns.Point\"` as its
+   example, which is how the wrong form got written; that is a boring
+   documentation bug and is being reported upstream.
 
-   Only reachable from an `:attribute-refs?` dump carrying a user ref whose VALUE
-   is a system entity, which is why it went unnoticed. Correcting the name is
-   strictly a fix: the bytes on disk always carried the slash form, so dumps
-   written before this now decode as they were always meant to."
-  "datahike.migrate.cbor/SysRef")
+   Deriving it removes the class of mistake: `record-type-name` is portable,
+   returns exactly what the writer emits on both platforms, and cannot drift from
+   it when this namespace is renamed."
+  (bdata/record-type-name (map->SysRef {})))
 
 (def ^:private attr-ref-name
-  "As `sysref-name`, and the same form — `namespace/Name`."
-  "datahike.migrate.cbor/AttrRef")
+  "As `sysref-name`, derived for the same reason."
+  (bdata/record-type-name (map->AttrRef {})))
 
 (def registry
   "The dump registry. Only SysRef needs registering: boring emits a defrecord's

--- a/src/datahike/migrate/cbor.cljc
+++ b/src/datahike/migrate/cbor.cljc
@@ -161,6 +161,25 @@
 ;; ---------------------------------------------------------------------------
 ;; system-entity references (#508): translate, never re-insert
 
+(defrecord AttrRef [eid])
+
+(defn attr-ref?
+  "Is `a` a record's attribute given as an attribute-ENTITY reference?
+
+   The `a` slot of a dump record is normally a keyword ident, and for a
+   keyword-attribute source that is the whole truth: there the datom holds the
+   keyword, so nothing is resolved at either end.
+
+   Under `:attribute-refs?` the datom holds the attribute's entity id instead,
+   and a name is a property of that entity which can CHANGE. Naming such a datom
+   in the dump therefore requires choosing a moment, and choosing the export
+   moment is what broke: a datom written before a rename came out carrying a name
+   that did not exist yet, and replaying the dump met it before the name was
+   installed. So the record carries the entity, and the READER picks the name its
+   target needs — see `migrate/resolve-attr-refs`."
+  [a]
+  (instance? AttrRef a))
+
 (defrecord SysRef [ident])
 
 (defn sysref?
@@ -174,10 +193,31 @@
   (instance? SysRef v))
 
 (def ^:private sysref-name
-  "boring's wire name for the record — the class name with / -> . and - -> _.
-   Named explicitly rather than derived so a namespace rename is a visible
-   format change rather than a silent one."
-  "datahike.migrate.cbor.SysRef")
+  "boring's wire name for the record: `namespace/Name`, the form `pr-str` shows
+   for an unregistered one. Named explicitly rather than derived so a namespace
+   rename is a visible format change rather than a silent one.
+
+   This read `datahike.migrate.cbor.SysRef` — the CLASS name, dots and all — and
+   that is not what boring writes. The name never matched, so the registry never
+   supplied a constructor and every encoded SysRef came back as a
+   `boring.data.UnknownRecord`. `sysref?` is an `instance?` check, so it answered
+   false, `resolve-sysrefs` never fired, and a ref value pointing at a system
+   entity was imported as that opaque record instead of the target's eid.
+   Measured on origin/main before this change:
+
+     (mcbor/decode-record (mcbor/encode-record [1 :p/x (->SysRef :db/ident) 2 true]))
+     ;; => a is #boring/record [\"datahike.migrate.cbor/SysRef\" {:ident :db/ident}]
+     ;; (sysref? …) => false
+
+   Only reachable from an `:attribute-refs?` dump carrying a user ref whose VALUE
+   is a system entity, which is why it went unnoticed. Correcting the name is
+   strictly a fix: the bytes on disk always carried the slash form, so dumps
+   written before this now decode as they were always meant to."
+  "datahike.migrate.cbor/SysRef")
+
+(def ^:private attr-ref-name
+  "As `sysref-name`, and the same form — `namespace/Name`."
+  "datahike.migrate.cbor/AttrRef")
 
 (def registry
   "The dump registry. Only SysRef needs registering: boring emits a defrecord's
@@ -189,7 +229,8 @@
    tuples — boring already handles as standard CBOR, which is exactly the
    property that makes the dump readable from another language."
   (-> (boring/tag-registry)
-      (boring/register-record sysref-name map->SysRef)))
+      (boring/register-record sysref-name map->SysRef)
+      (boring/register-record attr-ref-name map->AttrRef)))
 
 (def opts
   "Encode/decode options. `:archival` plus the registry; nothing else is set,

--- a/src/datahike/migrate/manifest.cljc
+++ b/src/datahike/migrate/manifest.cljc
@@ -742,7 +742,8 @@
   [record]
   (letfn [(bad! [why]
             (throw (ex-info (str "Malformed dump record: " why ". Records are "
-                                 "[e a v t op] with e/t integers, a a keyword ident, "
+                                 "[e a v t op] with e/t integers, a a keyword ident "
+                                 "(or an attribute reference), "
                                  "v non-nil and op a boolean.")
                             {:error :import/malformed-record
                              :reason why

--- a/src/datahike/migrate/manifest.cljc
+++ b/src/datahike/migrate/manifest.cljc
@@ -226,9 +226,26 @@
   "Convert a datom to an EDN-encodable record vector [e a v t added]. `a` becomes a
    keyword ident; ref values pointing at a system entity become #datahike/sysref."
   ([db sys-ents sys-idents datom] (datom->record db sys-ents sys-idents nil datom))
-  ([db sys-ents sys-idents sec-read datom]
+  ([db sys-ents sys-idents sec-read datom] (datom->record db sys-ents sys-idents sec-read nil datom))
+  ([db sys-ents sys-idents sec-read renamed-attrs datom]
    (let [e (nth datom 0)
-         a (a-ident db (nth datom 1))
+         raw-a (nth datom 1)
+         ;; A RENAMED attribute is recorded by ENTITY, not by name.
+         ;;
+         ;; `a-ident` resolves against the current database, i.e. the FINAL name,
+         ;; which is right for every attribute whose name never moved — and wrong
+         ;; for one whose did: a datom written before the rename comes out
+         ;; carrying a name that did not exist yet, and replaying the dump meets
+         ;; it before that name is installed. Recording the entity instead defers
+         ;; the choice of name to the reader, which knows what its target needs
+         ;; (see `migrate/resolve-attr-refs`).
+         ;;
+         ;; Only for attributes in `renamed-attrs`, so a dump with no rename —
+         ;; and every keyword-attribute dump, where `ident-timeline` is empty by
+         ;; construction — is byte-identical to one written before this existed.
+         a (if (and renamed-attrs (number? raw-a) (contains? renamed-attrs raw-a))
+             (mcbor/->AttrRef raw-a)
+             (a-ident db raw-a))
         ;; For a `:db.secondary/only` attribute the primary holds a content hash,
         ;; so the real value comes from the secondary index instead — see
         ;; `secondary-only-values`. Falls back to the primary's value, which is
@@ -404,10 +421,11 @@
   (let [src      (if history? (api/history db) db)
         sys-ents (if (attribute-refs? db) (dbi/-system-entities db) #{})
         sidents  (system-idents db)
-        sec-read (secondary-only-reader db)]
+        sec-read (secondary-only-reader db)
+        renamed  (not-empty (set (keys (ident-timeline db))))]
     (->> (api/datoms src :eavt)
          (filter (fn [dm] (> (d/datom-tx dm) c/tx0)))
-         (map (fn [dm] (datom->record db sys-ents sidents sec-read dm))))))
+         (map (fn [dm] (datom->record db sys-ents sidents sec-read renamed dm))))))
 
 (defn export-records-streaming
   "Lazy seq of encoded records for `db` in a load-safe order WITHOUT sorting (so
@@ -431,7 +449,8 @@
                           (let [a (a-ident db (nth dm 1))]
                             (or (ds/schema-attr? a) (ds/meta-attr? a))))
         sec-read (secondary-only-reader db)
-        make     (fn [dm] (datom->record db sys-ents sidents sec-read dm))]
+        renamed  (not-empty (set (keys (ident-timeline db))))
+        make     (fn [dm] (datom->record db sys-ents sidents sec-read renamed dm))]
     (concat
      (->> (api/datoms src :eavt) (filter user?) (filter schema-or-meta?) (map make))
      (->> (api/datoms src :eavt) (filter user?) (remove schema-or-meta?) (map make)))))
@@ -731,7 +750,12 @@
     (when-not (and (vector? record) (= 5 (count record))) (bad! "not a 5-element vector"))
     (let [[e a v t op] record]
       (when-not (integer? e) (bad! (str "e is not an integer: " (pr-str e))))
-      (when-not (keyword? a) (bad! (str "a is not a keyword ident: " (pr-str a))))
+      ;; An attribute is normally a keyword ident. A dump that renamed an
+      ;; attribute records THAT one by entity instead, so the reader can choose
+      ;; the name its target needs — see `ident-timeline`. Both are well-formed;
+      ;; anything else is not.
+      (when-not (or (keyword? a) (mcbor/attr-ref? a))
+        (bad! (str "a is neither a keyword ident nor an attribute reference: " (pr-str a))))
       (when (nil? v) (bad! "v is nil"))
       (when-not (integer? t) (bad! (str "t is not an integer: " (pr-str t))))
       (when (< (long t) (long c/tx0))

--- a/src/datahike/migrate/manifest.cljc
+++ b/src/datahike/migrate/manifest.cljc
@@ -149,6 +149,76 @@
           (dbi/-system-entities db))
     {}))
 
+(defn ident-timeline
+  "Map of attribute-entity -> [[t ident] ...] ascending, for attribute-refs dumps
+   whose history contains a RENAME. `{}` otherwise, which is the overwhelmingly
+   common case and keeps those dumps byte-identical to before.
+
+   ## Why a dump needs this at all
+
+   A datom records its attribute, and how it records it differs by config:
+
+     :attribute-refs? true    the datom holds the attribute ENTITY id
+     :attribute-refs? false   the datom holds the KEYWORD itself
+
+   An entity id is stable; a `:db/ident` is not — it is a property of that entity
+   that can change over time. So under attribute-refs the NAME of a datom`s
+   attribute is not in the datom, and the exporter has to look it up. `a-ident`
+   looks it up in the CURRENT database, i.e. against the FINAL name.
+
+   That is fine until an attribute is renamed. Then a datom written at t2 is
+   exported carrying a name that did not exist until t3, while the `:db/ident`
+   records still replay the rename in causal order. Replaying the dump, the
+   importer meets that datom BEFORE the name it carries has been installed, and
+   the import fails. Measured: a datahike -> datahike round-trip of a renamed
+   attribute under `:attribute-refs?` fails with `:transact/unknown-attribute`.
+
+   With the timeline the exporter can name each datom as of its OWN `t`, which is
+   resolvable by construction: the name a datom carries is the one asserted at the
+   latest t0 <= t, and that assertion is replayed first.
+
+   ## Why it is empty without :attribute-refs?
+
+   Not an optimisation — applying it there would be WRONG. In keyword mode the
+   datom holds the name, so the name IS the ground truth and nothing is resolved
+   at either end; the round trip is the identity and cannot mislabel anything. A
+   keyword database can still carry a two-entry timeline (an import can install
+   one, since the import path bypasses the deferred schema validators), but its
+   datoms record the name they were written with. Resolving those through a
+   timeline would emit a name the datom does not hold — turning a working path
+   into a corrupt one. Measured on such a database: the timeline reads
+   `[[t1 :p/name] [t3 :p/renamed]]` while the datom is `[2 :p/renamed \"Ann\"]`.
+
+   Built from the `:db/ident` datoms the history already holds, so it costs one
+   `:aevt` slice of a single attribute and needs no extra bookkeeping. Assertions
+   only: a retraction is implied by the assertion that supersedes it."
+  [db]
+  (if-not (and (attribute-refs? db) (dbi/-keep-history? db))
+    {}
+    (let [by-e (->> (api/datoms (api/history db) :aevt :db/ident)
+                    (filter (fn [dm] (d/datom-added dm)))
+                    (reduce (fn [m dm]
+                              (update m (nth dm 0) (fnil conj [])
+                                      [(d/datom-tx dm) (nth dm 2)]))
+                            {}))]
+      ;; only the attributes that actually changed name: a single-entry timeline
+      ;; says nothing a reader cannot already see, and emitting one for every
+      ;; attribute would put a table in every attribute-refs dump for nothing.
+      (into (sorted-map)
+            (keep (fn [[e entries]]
+                    (let [sorted (vec (sort-by first entries))]
+                      (when (> (count (distinct (map second sorted))) 1)
+                        [e sorted]))))
+            by-e))))
+
+(defn ident-at
+  "The ident attribute-entity `e` carried at time `t`, or nil when `timeline` does
+   not cover `e` (which means the name never changed — the caller`s current
+   resolution is already right)."
+  [timeline e t]
+  (when-let [entries (get timeline e)]
+    (second (last (take-while (fn [[t0 _]] (<= (long t0) (long t))) entries)))))
+
 ;; ---------------------------------------------------------------------------
 ;; the records a dump contains
 
@@ -403,6 +473,12 @@
          (when (seq (:carried blob-plan)) [:datahike.migrate/store-ref-blobs])
          (when (seq (:external blob-plan)) [:datahike.migrate/external-blobs])
          (when (:attribute-refs? (dbi/-config db)) [:datahike.migrate/attribute-refs])
+         ;; Declared only when the dump actually CONTAINS a rename. A reader
+         ;; without this capability would resolve those datoms against the final
+         ;; name and meet one before it is installed, so refusing by name beats
+         ;; failing mid-import — and a dump with no rename never declares it, so
+         ;; older readers keep reading everything they can read today.
+         (when (seq (ident-timeline db)) [:datahike.migrate/ident-timeline])
          ;; every declared value type in play
          (into #{}
                (keep (fn [[_ attr]] (:db/valueType attr)))
@@ -414,7 +490,8 @@
               :datahike.migrate/history
               :datahike.migrate/store-ref-blobs
               :datahike.migrate/external-blobs
-              :datahike.migrate/attribute-refs)
+              :datahike.migrate/attribute-refs
+              :datahike.migrate/ident-timeline)
         ds/builtin-value-types))
 
 (defn check-capabilities!
@@ -441,10 +518,11 @@
 
 (defn build-manifest [db {:keys [history?] :as opts} digest chunks]
   (let [cfg (dbi/-config db)]
-    (array-map
-     manifest-key                    format-version
-     :history?                       (boolean history?)
-     :serialization                  :cbor-seq
+    (merge
+     (array-map
+      manifest-key                    format-version
+      :history?                       (boolean history?)
+      :serialization                  :cbor-seq
      ;; Provenance in the SAME shape the store carries (`datahike.tools/meta-data`,
      ;; which `connector/version-check` enforces), so a dump and a store can be
      ;; reasoned about with one vocabulary.
@@ -454,16 +532,16 @@
      ;; from a browser or Node carries no provenance — diagnostics, not something
      ;; `check-capabilities!` decides on, which is exactly why the two are
      ;; separate keys.
-     :datahike/meta                  #?(:clj (dt/meta-data) :cljs nil)
+      :datahike/meta                  #?(:clj (dt/meta-data) :cljs nil)
      ;; …and, separately, what is needed to READ this dump. See `dump-requires`:
      ;; provenance is for diagnostics, capabilities are for the accept/reject
      ;; decision, and conflating them is what makes a version stamp too blunt.
-     :requires                       (vec (sort (dump-requires db opts (get opts blob-plan-key))))
-     :source-config                  (into (array-map :store-backend (get-in cfg [:store :backend]))
-                                           (map (fn [k] [k (get cfg k)]))
-                                           (sort source-config-allowlist))
-     :schema                         (ident-schema db)
-     :system-idents                  (system-idents db)
+      :requires                       (vec (sort (dump-requires db opts (get opts blob-plan-key))))
+      :source-config                  (into (array-map :store-backend (get-in cfg [:store :backend]))
+                                            (map (fn [k] [k (get cfg k)]))
+                                            (sort source-config-allowlist))
+      :schema                         (ident-schema db)
+      :system-idents                  (system-idents db)
      ;; :max-eid / :max-tx let an importer estimate the O(entities) id-remap map
      ;; (and thus the heap to give the import) without scanning the dump.
      ;; `:datom-count` is what was WRITTEN; `:source-datom-count` is what the
@@ -481,12 +559,12 @@
      ;; `:source-datom-count` is nil when `:count-source? false` — one extra index
      ;; scan is real cost on a large database, and "unknown" is an honest answer
      ;; where "equal" would be a guess.
-     :stats                          {:datom-count        (:count digest)
-                                      :source-datom-count (:source-datom-count opts)
-                                      :transformed?       (boolean (:xform opts))
-                                      :max-eid            (:max-eid db)
-                                      :max-tx             (:max-tx db)}
-     :semantic-digest                digest
+      :stats                          {:datom-count        (:count digest)
+                                       :source-datom-count (:source-datom-count opts)
+                                       :transformed?       (boolean (:xform opts))
+                                       :max-eid            (:max-eid db)
+                                       :max-tx             (:max-tx db)}
+      :semantic-digest                digest
      ;; Which `:db.type/store-ref` blobs this dump carries, and which it could
      ;; not. A store-ref names an object without saying where the bytes live, so
      ;; a dump is self-contained only for blobs that were IN the source store;
@@ -494,9 +572,16 @@
      ;; and cannot be copied. Recording both halves means an import can refuse a
      ;; dump whose referents it cannot place, instead of restoring datoms that
      ;; name objects which are not there.
-     :store-refs                     (when-let [p (get opts blob-plan-key)]
-                                       (mblobs/manifest-entry p))
-     :chunks                         (vec chunks))))
+      :store-refs                     (when-let [p (get opts blob-plan-key)]
+                                        (mblobs/manifest-entry p))
+      :chunks                         (vec chunks))
+    ;; APPENDED, and only when non-empty. A dump with no renamed attribute is
+    ;; byte-identical to one written before this key existed, which is what keeps
+    ;; the change invisible to the overwhelmingly common case (and to every
+    ;; keyword-attribute dump, where `ident-timeline` is empty by construction —
+    ;; see its docstring on why applying one there would be wrong).
+     (let [tl (ident-timeline db)]
+       (cond-> {} (seq tl) (assoc :ident-timeline tl))))))
 
 ;; ---------------------------------------------------------------------------
 ;; sizes and names

--- a/test-datomic/datahike/datomic/migrate_test.clj
+++ b/test-datomic/datahike/datomic/migrate_test.clj
@@ -689,3 +689,56 @@
                         "and is installed under the new ident"))
                   (finally (d/release conn) (d/delete-database cfg))))))
           (finally (dt/release c) (dt/delete-database uri)))))))
+
+(deftest a-renamed-attribute-imports-under-its-final-name
+  (testing "The Datomic source resolves idents through a SNAPSHOT of the current
+            database, so every historical datom of a renamed attribute came out
+            carrying the FINAL name — one that did not exist when the datom was
+            written. The `:db/ident` records still replay the rename in causal
+            order, so replaying met such a datom before its name was installed.
+
+            `ident-timeline` reads the assertions out of Datomic's own history
+            and `tx->records` names those attributes by ENTITY instead, leaving
+            the choice of name to the reader — period-correct for an
+            attribute-refs target, flattened for a keyword one. Both are checked
+            here, because a Datomic migration goes to either."
+    (let [uri (str "datomic:mem://dh-rn-" (rand-int 1000000))]
+      (dt/create-database uri)
+      (let [c (dt/connect uri)]
+        (try
+          @(dt/transact c [{:db/ident :m/before :db/valueType :db.type/string
+                            :db/cardinality :db.cardinality/one}])
+          @(dt/transact c [{:db/id "e1" :m/before "written-before"}])
+          @(dt/transact c [{:db/id :m/before :db/ident :m/after}])
+          @(dt/transact c [{:db/id "e2" :m/after "written-after"}])
+
+          (testing "the timeline names the attribute that moved"
+            (let [tl (dtm/ident-timeline (dt/db c))
+                  entry (first (filter (fn [[_ es]] (= [:m/before :m/after] (mapv second es))) tl))]
+              (is (some? entry) (str "expected a :m/before -> :m/after entry, got " (pr-str tl)))
+              (is (apply < (map first (second entry))) "ascending by t")
+              (testing "and Datomic's OWN bootstrap renames are in it too —
+                        :db/retractEntity and :db/cas are renamed in every
+                        Datomic database, which is why a timeline is never empty
+                        for one"
+                (is (some (fn [[_ es]] (= [:db/retractEntity :db.fn/retractEntity]
+                                          (mapv second es)))
+                          tl)))))
+
+          (doseq [refs? [true false]]
+            (testing (str ":attribute-refs? " refs?)
+              (let [cfg {:store {:backend :memory :id (random-uuid)}
+                         :keep-history? true :schema-flexibility :write
+                         :attribute-refs? refs?}]
+                (d/create-database cfg)
+                (let [conn (d/connect cfg)]
+                  (try
+                    (dtm/import-from-datomic! conn c)
+                    (is (= #{"written-before" "written-after"}
+                           (into #{} (map first)
+                                 (d/q '[:find ?v :where [?e :m/after ?v]] @conn)))
+                        "BOTH datoms — including the one written before the rename")
+                    (is (empty? (d/q '[:find ?v :where [?e :m/before ?v]] @conn))
+                        "and none left under the retired name")
+                    (finally (d/release conn) (d/delete-database cfg)))))))
+          (finally (dt/release c) (dt/delete-database uri)))))))

--- a/test/datahike/test/migrate_ident_timeline_test.clj
+++ b/test/datahike/test/migrate_ident_timeline_test.clj
@@ -22,6 +22,8 @@
             [datahike.api :as d]
             [datahike.migrate :as m]
             [datahike.migrate.manifest :as mman]
+            [datahike.migrate.cbor :as mcbor]
+            [datahike.constants :as const]
             [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
@@ -109,3 +111,65 @@
             (is (= expect declared?)
                 (str "capability, refs?=" refs? " rename?=" rename?)))
           (finally (teardown conn)))))))
+
+;; ---------------------------------------------------------------------------
+;; the READER names it, and the two targets want different names
+
+(def ^:private attr-e 100)
+
+(defn- renamed-source-records
+  "What a source emits for an attribute renamed at t3: the data datom names the
+   attribute by ENTITY, so no naming decision is baked in.
+
+   Reachable through `import-source` rather than `import-db`, deliberately —
+   `config-must-match` refuses a dump that crosses `:attribute-refs?`, so the
+   keyword arm of `resolve-attr-refs` has no dump path at all. It has a RECORD
+   path, which is what the Datomic adapter will use."
+  []
+  (let [t1 (+ const/tx0 1) t2 (+ const/tx0 2) t3 (+ const/tx0 3)]
+    [[t1 :db/txInstant #inst "2021-01-01" t1 true]
+     [attr-e :db/ident :p/name t1 true]
+     [attr-e :db/valueType :db.type/string t1 true]
+     [attr-e :db/cardinality :db.cardinality/one t1 true]
+     [t2 :db/txInstant #inst "2021-02-01" t2 true]
+     ;; written BEFORE the rename — the datom the old exporter mislabelled
+     [200 (mcbor/->AttrRef attr-e) "Ann" t2 true]
+     [t3 :db/txInstant #inst "2021-03-01" t3 true]
+     [attr-e :db/ident :p/name t3 false]
+     [attr-e :db/ident :p/renamed t3 true]
+     [(+ const/tx0 4) :db/txInstant #inst "2021-04-01" (+ const/tx0 4) true]
+     ;; and one written AFTER it
+     [201 (mcbor/->AttrRef attr-e) "Bob" (+ const/tx0 4) true]]))
+
+(def ^:private timeline
+  {attr-e [[(+ const/tx0 1) :p/name] [(+ const/tx0 3) :p/renamed]]})
+
+(defn- import-records [refs?]
+  (let [conn (d/connect (doto (cfg refs?) d/create-database))]
+    (try
+      (m/import-source conn (m/records->chunk-src (renamed-source-records))
+                       {:sync? true :verify? false :eids :allocate :schema {}
+                        :source-meta {:history? true :ident-timeline timeline}})
+      {:new (into #{} (map first) (d/q '[:find ?v :where [?e :p/renamed ?v]] @conn))
+       :old (into #{} (map first) (d/q '[:find ?v :where [?e :p/name ?v]] @conn))}
+      (finally (teardown conn)))))
+
+(deftest an-attribute-refs-target-gets-every-datom-under-the-new-name
+  (testing "resolved PERIOD-CORRECT, which is what makes it resolvable at all:
+            the datom written before the rename names `:p/name`, installed at
+            that point, and the attribute ENTITY carries the data forward when
+            the ident moves. Naming it `:p/renamed` — what the old exporter did —
+            is the bug: the importer meets it before that name exists."
+    (let [{:keys [new old]} (import-records true)]
+      (is (= #{"Ann" "Bob"} new) "both datoms answer to the attribute's final name")
+      (is (empty? old) "and none to the retired one"))))
+
+(deftest a-keyword-target-gets-them-flattened-to-the-final-name
+  (testing "there the datom stores the KEYWORD, so a period-correct name would
+            split the attribute across both — the outcome
+            `validate-ident-renames!` refuses on the live path. Flattening keeps
+            the database queryable; the rename as an EVENT is what is lost, and a
+            keyword-attribute database cannot represent one anyway."
+    (let [{:keys [new old]} (import-records false)]
+      (is (= #{"Ann" "Bob"} new) "both datoms under one name")
+      (is (empty? old) "not split across the old one"))))

--- a/test/datahike/test/migrate_ident_timeline_test.clj
+++ b/test/datahike/test/migrate_ident_timeline_test.clj
@@ -1,0 +1,111 @@
+(ns datahike.test.migrate-ident-timeline-test
+  "An attribute's ident is a property of its entity that can CHANGE, and a dump
+   has to survive that.
+
+   Under `:attribute-refs?` a datom holds the attribute's ENTITY id, so the NAME
+   is not in the datom and the exporter looks it up. Looking it up in the current
+   database names every historical datom with the FINAL ident — so a datom
+   written before a rename is exported carrying a name that did not exist yet,
+   while the `:db/ident` records still replay the rename in causal order. The
+   importer then meets that datom before the name is installed.
+
+   Without `:attribute-refs?` none of this applies: the datom holds the keyword,
+   so the name IS ground truth and nothing is resolved at either end. A keyword
+   database can still CARRY a timeline (an import can install one — that path
+   bypasses the deferred schema validators) but its datoms record the name they
+   were written with, so resolving them through a timeline would emit a name the
+   datom does not hold. `ident-timeline` is empty there by construction, and
+   `keyword-mode-carries-no-timeline` pins that.
+
+   `migrate-manifest-test` covers `ident-at`, the pure resolution half."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.api :as d]
+            [datahike.migrate :as m]
+            [datahike.migrate.manifest :as mman]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(defn- cfg [refs?]
+  {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+   :keep-history? true :schema-flexibility :write :attribute-refs? refs?})
+
+(defn- teardown [conn]
+  (let [c (:config @conn)] (d/release conn) (d/delete-database c)))
+
+(defn- declared+used [conn]
+  (d/transact conn [{:db/ident :p/name :db/valueType :db.type/string
+                     :db/cardinality :db.cardinality/one}])
+  (d/transact conn [{:db/id 1000 :p/name "Ann"}])
+  conn)
+
+(defn- rename! [conn from to]
+  (let [aid (:db/id (d/entity @conn from))]
+    ;; retract-then-add: the one spelling that retires the old ident (#966)
+    (d/transact conn [[:db/retract aid :db/ident from]
+                      [:db/add aid :db/ident to]])
+    aid))
+
+(deftest a-renamed-attribute-gets-a-timeline
+  (testing "both names, in transaction order, keyed by the attribute ENTITY —
+            which is the thing that did not change"
+    (let [conn (declared+used (d/connect (doto (cfg true) d/create-database)))]
+      (try
+        (let [aid (rename! conn :p/name :p/renamed)
+              tl (mman/ident-timeline @conn)]
+          (is (= [aid] (keys tl)) "only the attribute that moved")
+          (is (= [:p/name :p/renamed] (mapv second (get tl aid))))
+          (is (apply < (map first (get tl aid))) "ascending by t")
+          (testing "and it resolves the name in force at each point"
+            (let [[[t1 _] [t2 _]] (get tl aid)]
+              (is (= :p/name (mman/ident-at tl aid t1)))
+              (is (= :p/renamed (mman/ident-at tl aid t2)))
+              (is (= :p/name (mman/ident-at tl aid (dec (long t2))))
+                  "a datom written the instant before the rename is still :p/name"))))
+        (finally (teardown conn))))))
+
+(deftest an-unrenamed-database-gets-no-timeline
+  (testing "a single-entry history says nothing a reader cannot already see, and
+            emitting one would put a table in every attribute-refs dump for
+            nothing"
+    (let [conn (declared+used (d/connect (doto (cfg true) d/create-database)))]
+      (try (is (= {} (mman/ident-timeline @conn)))
+           (finally (teardown conn))))))
+
+(deftest keyword-mode-carries-no-timeline
+  (testing "empty by construction, and that is a CORRECTNESS requirement rather
+            than an optimisation — in keyword mode the datom holds the name, so
+            resolving through a timeline would emit a name the datom does not
+            hold"
+    (let [conn (declared+used (d/connect (doto (cfg false) d/create-database)))]
+      (try
+        (is (= {} (mman/ident-timeline @conn)))
+        (testing "and the live path refuses the rename that would create one"
+          (is (thrown? Exception (rename! conn :p/name :p/renamed))))
+        (finally (teardown conn))))))
+
+(deftest the-manifest-declares-a-timeline-only-when-it-has-one
+  (testing "a dump with no renamed attribute is byte-identical to one written
+            before this key existed, and an older reader keeps reading it.
+
+            `:datahike.migrate/ident-timeline` is a CAPABILITY rather than a
+            `format-version` bump for the reason `dump-requires` states: a dump
+            declares what it needs and the reader compares against what it has,
+            so a feature nobody used costs nobody anything."
+    (doseq [[refs? rename? expect] [[false false false]
+                                    [true  false false]
+                                    [true  true  true]]]
+      (let [conn (declared+used (d/connect (doto (cfg refs?) d/create-database)))
+            path (str (System/getProperty "java.io.tmpdir")
+                      "/dh-tl-" (java.util.UUID/randomUUID))]
+        (try
+          (when rename? (rename! conn :p/name :p/renamed))
+          (m/export-db @conn path {:history? true})
+          (let [man (edn/read-string {:readers *data-readers*}
+                                     (slurp (io/file path "manifest.edn")))
+                declared? (boolean (some #{:datahike.migrate/ident-timeline}
+                                         (:requires man)))]
+            (is (= expect (contains? man :ident-timeline))
+                (str "manifest key, refs?=" refs? " rename?=" rename?))
+            (is (= expect declared?)
+                (str "capability, refs?=" refs? " rename?=" rename?)))
+          (finally (teardown conn)))))))

--- a/test/datahike/test/migrate_import_hostile_test.clj
+++ b/test/datahike/test/migrate_import_hostile_test.clj
@@ -245,7 +245,11 @@
           (is (re-find #"not a 5-element vector" (str (:threw res)))))
         (let [res (import-into! b strattr-dir {})]
           (is (= :import/malformed-record (:error (:data res))))
-          (is (re-find #"a is not a keyword" (str (:threw res)))))
+          (is (re-find #"a is neither a keyword ident nor an attribute reference"
+                       (str (:threw res)))
+              "a string in the attribute slot is still refused — the message now
+               names BOTH well-formed shapes, because a dump that renamed an
+               attribute records that one by entity (see manifest/ident-timeline)"))
         (finally (release! src a b))))))
 
 ;; ---------------------------------------------------------------------------

--- a/test/datahike/test/migrate_manifest_test.cljc
+++ b/test/datahike/test/migrate_manifest_test.cljc
@@ -236,3 +236,39 @@
                  "/abs/datoms-000001.cbor" "datoms-000001.cbor.gz.gz"]]
       (is (nil? (re-matches mman/chunk-re bad))
           (str bad " must be rejected")))))
+
+;; ---------------------------------------------------------------------------
+;; ident-at — the pure half of the ident timeline (see `ident-timeline` for why
+;; a dump carries one at all). Kept here, on a plain map, because that is what
+;; makes it portable: `ident-timeline` itself needs a database.
+
+(def ^:private tl
+  "One attribute renamed twice, and one that never changed (so it is absent —
+   `ident-timeline` only records attributes whose name actually moved)."
+  {55 [[100 :p/name] [300 :p/renamed] [500 :p/final]]})
+
+(deftest ident-at-resolves-the-name-in-force-at-a-time
+  (testing "the name a datom's attribute carried when the datom was written.
+
+            This is the whole point of the timeline: an exporter resolving
+            against the CURRENT database names every historical datom with the
+            FINAL ident, and a datom written before a rename then carries a name
+            that did not exist yet. Replaying such a dump, the importer meets it
+            before the name is installed."
+    (is (= :p/name (mman/ident-at tl 55 100)) "exactly at the first assertion")
+    (is (= :p/name (mman/ident-at tl 55 299)) "up to the instant before the rename")
+    (is (= :p/renamed (mman/ident-at tl 55 300)) "at the rename")
+    (is (= :p/renamed (mman/ident-at tl 55 499)))
+    (is (= :p/final (mman/ident-at tl 55 500)) "at the second rename")
+    (is (= :p/final (mman/ident-at tl 55 99999)) "and after the last one")))
+
+(deftest ident-at-is-nil-when-it-has-nothing-to-say
+  (testing "nil means `no answer`, not `no attribute` — the caller's own
+            resolution is already right in both of these cases."
+    (is (nil? (mman/ident-at tl 55 99))
+        "before the first assertion: the attribute did not exist yet")
+    (is (nil? (mman/ident-at tl 9999 300))
+        "an attribute the timeline does not cover — i.e. one never renamed, which
+         is every attribute in almost every dump")
+    (is (nil? (mman/ident-at {} 55 300)) "an empty timeline")
+    (is (nil? (mman/ident-at nil 55 300)) "no timeline at all")))


### PR DESCRIPTION
Fixes #967 — and the issue is **mis-scoped**, which is the first thing worth saying. It reads as a Datomic-adapter problem. datahike's own exporter has the identical defect, and that is the more serious half.

Measured on `225d6d23`, a **datahike → datahike** round trip:

```
attribute-refs + history, NO rename     ROUND-TRIP OK
attribute-refs + history, WITH rename   FAILS :transact/unknown-attribute
```

No Datomic involved.

## The defect

A datom records its attribute, and *how* differs by config:

```
:attribute-refs? true     the datom holds the attribute ENTITY id
:attribute-refs? false    the datom holds the KEYWORD itself
```

An entity id is stable. A `:db/ident` is not — it is a property of that entity which can change. So under attribute-refs the **name** of a datom's attribute is not in the datom, and the exporter looks it up. `manifest/a-ident` looks it up in the CURRENT database, i.e. against the FINAL name.

Fine until an attribute is renamed. Then a datom written at `t2` is exported carrying a name that did not exist until `t3`, while the `:db/ident` records still replay the rename in causal order. Replaying, the importer meets that datom **before the name it carries has been installed**.

The dump was performing a lossy projection — `eid → final name` — at export, and trying to invert it at import. It only inverts while the name never changed.

## The fix: record identity, let the reader choose the name

A renamed attribute goes on the wire as `#datahike/attr <eid>`, and the READER picks the name its target needs. There are two right answers:

```
:attribute-refs? true    PERIOD-CORRECT — the name in force at that datom's t.
                         Installed by then BY CONSTRUCTION: the name is the one
                         asserted at the latest t0 <= t, and that assertion is
                         replayed first.

:attribute-refs? false   FINAL — that target stores the KEYWORD in the datom, so
                         a period-correct name would split the attribute across
                         both names, which validate-ident-renames! refuses on the
                         live path. Flattening keeps the database queryable; what
                         is lost is the rename as an EVENT, which a keyword
                         database cannot represent at all.
```

Verified by replaying the stream and asking, at each record, whether the name it carries was installed yet:

```
unresolvable with final idents (today)   [{:t 536870914, :a :p/renamed}]
unresolvable with period-correct         []
```

## Scope: almost nothing changes

- **`{}` without `:attribute-refs?`**, and that is a CORRECTNESS requirement, not an optimisation. There the datom holds the name, so the name is ground truth. A keyword database can still carry a two-entry timeline (an import installs one — that path bypasses the deferred validators), but its datoms record the name they were written with. Resolving those through a timeline would emit a name the datom does not hold. Measured: timeline `[[t1 :p/name] [t3 :p/renamed]]` against a datom of `[2 :p/renamed "Ann"]`.
- **`{}` when nothing was renamed**, so a single-entry history emits nothing.
- Declared as a **capability**, not a `format-version` bump — which is what `dump-requires` exists for: *"a dump declares what it NEEDS and the reader compares against what it HAS."*

```
refs?=false rename?=false   manifest key absent    capability absent
refs?=true  rename?=false   manifest key absent    capability absent
refs?=true  rename?=true    manifest key present   capability present
```

Every existing dump is byte-identical, keyword dumps (the default) never see any of it, and older readers keep reading everything they read today.

**Resolution happens at the same seam as `resolve-sysrefs`** — per record, before `:xform` and before every downstream consumer — so sorting, history collapsing, the id remap and the index build all keep seeing keywords and are untouched.

## A pre-existing silent bug this uncovered

`sysref-name` was `"datahike.migrate.cbor.SysRef"` — the CLASS name. boring writes `namespace/Name`. **The name never matched**, so the registry supplied no constructor, every encoded `SysRef` decoded to a `boring.data/UnknownRecord`, `sysref?` (an `instance?` check) answered false, and **`resolve-sysrefs` never fired**. A ref value naming a system entity was imported as that opaque record instead of the target's eid.

Nothing raised, by design: an unregistered record re-encodes to identical bytes. That is what made it silent, and why it survived — found only because `AttrRef` failed the same way and `SysRef` was the control.

Both names are now DERIVED from `boring.data/record-type-name`, so the mistake cannot recur. Upstream fix in replikativ/boring#27 (merged, `0.1.29`), where the docstring taught the wrong form.

## The Datomic adapter

`ident-timeline` reads the assertions out of Datomic's own history — one query over a handful of datoms, not a log pass — and converts `t` with `datomic-t->dh-t` so timeline and records agree about when the rename happened. Measured against a real `datomic:mem://`:

```
TIMELINE {54 [[… :db/retractEntity] [… :db.fn/retractEntity]]
          55 [[… :db/cas]           [… :db.fn/cas]]
          72 [[… :m/before]         [… :m/after]]}

refs?=true   IMPORT OK   after=#{"written-after" "written-before"}  before=#{}
refs?=false  IMPORT OK   after=#{"written-after" "written-before"}  before=#{}
```

Entities 54 and 55 are Datomic's **own** bootstrap renames, present in every Datomic database — which is why a Datomic timeline is never empty. The import report this work came from noted those two entities and said *"we did not chase why they survive"*; they are simply visible now, and are dropped downstream as Datomic-only vocabulary like any other.

## Tests

The period-correct branch is load-bearing, and here is how I know: mutating it to resolve FINAL for both targets reproduces the original failure exactly —

```
"Attribute :p/renamed is not installed in this :attribute-refs? database"
{:data [200 :p/renamed "Ann" 536870914 true]}
```

— the datom written before the rename, named with an ident that does not exist yet. A test that cannot fail is not evidence.

The keyword arm is driven through `import-source`, not `import-db`, deliberately: `config-must-match` refuses a dump crossing `:attribute-refs?`, so that arm has no dump path at all. It has a RECORD path, which is what the Datomic adapter uses — and a Datomic import into a keyword target is the common case.

| tier | result |
|---|---|
| `:migrate` | 276 tests / 1435 assertions, 0 failures |
| `:clj-pss` | 1007 tests / 12861 assertions, 0 failures |
| `:clj-hht` | 1007 / 12861, 0 failures |
| `:datomic` (real `datomic:mem://`) | 21 / 68, 0 failures |
| `clojure -M:format` | clean |

## Suggested follow-up

**Re-title #967.** It reads as a Datomic-adapter issue; the same defect was in datahike's own exporter, and anyone triaging it from the title will under-rate it.
