### PR TITLE
Make secondary-index backfill linearizable

### DIFF
--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -50,8 +50,10 @@ Scriptum provides Lucene-powered full-text search. Define a secondary index via 
                    :db.secondary/type :scriptum
                    :db.secondary/attrs [:person/name :person/bio]
                    :db.secondary/config {:path "/tmp/my-fulltext-index"}}])
-;; Wait for backfill to complete (async writer operation)
-(Thread/sleep 1000)
+;; Backfill is asynchronous. Poll the schema status until it is :ready;
+;; explicit secondary-index queries reject :building indices.
+(get-in (d/db conn) [:schema :idx/fulltext :db.secondary/status])
+;; => :building, then :ready
 ```
 
 ### Searching
@@ -275,7 +277,7 @@ Secondary indices are managed through schema transactions:
                    :db.secondary/status :disabled}])
 ```
 
-- **`:building`** — Index was just created, backfill in progress. New transactions feed into the index, but it may return incomplete results until backfill completes. Check status before relying on query results.
+- **`:building`** — Index was just created and its snapshot is being scanned in the background. New transactions continue normally and their index changes are journaled for the serialized handoff. Explicit secondary-index queries are rejected; planner optimizations fall back to the primary index.
 - **`:ready`** — Index is fully populated and maintained on every transaction. Safe for queries.
 - **`:disabled`** — Index is no longer maintained. Monotonic — cannot go back to `:ready`. Queries may return stale results.
 
@@ -306,7 +308,54 @@ Each index type uses its native CoW mechanism:
 - **Stratum**: PSS structural sharing via `dataset/fork` (O(1))
 - **Proximum**: Reflink mmap + konserve CoW via `versioning/branch!`
 
-Index state is persisted in commits via the `IVersionedSecondaryIndex` protocol. On reconnect, indices are restored from their durable storage — no AEVT backfill needed for versioned indices.
+Ready index state is persisted in commits via the `IVersionedSecondaryIndex`
+protocol. A building generation is deliberately not flushed, branched, or
+published as an audit/GC root: it may contain an arbitrary prefix. If a process
+stops during backfill, reconnect creates an empty generation and restarts the
+scan from AEVT. A branch made while an index is building likewise starts without
+a secondary key-map and rebuilds independently.
+
+Factories invoked for a backfill receive the ephemeral configuration keys
+`:datahike.index.secondary/index-ident` and
+`:datahike.index.secondary/build-attempt`. An adapter backed by external mutable
+storage must namespace its private files/keys by `build-attempt`; the factory
+must not reopen a partial generation abandoned by an earlier process. The
+attempt identifier is runtime context, not schema, and a successful flush key-map
+becomes the durable identity of the ready generation.
+
+### Backfill scalability
+
+The current beta path keeps the writer available during the snapshot scan. It
+records concurrent changes in an in-memory, per-index delta journal, then
+replays that journal in a short serialized install operation. This closes the
+lost-write race for mutable and immutable adapters, but the journal is not
+bounded. Registering an index while sustained write volume greatly exceeds
+backfill throughput can therefore consume substantial memory.
+
+For that reason this path currently requires the local self writer with
+`:writer-ownership :exclusive`. Shared writers cannot coordinate an in-memory
+journal across processes, and remote writers cannot transfer a native live
+generation between build and install. If pre-existing data requires a backfill,
+Datahike rejects those writer configurations before committing the index schema.
+Empty indices can still become ready immediately because no asynchronous handoff
+is needed.
+
+The intended scalable follow-up is a resumable generation protocol:
+
+1. Capture and durably pin a base commit.
+2. Scan the snapshot in bounded, checkpointed batches.
+3. Catch up through successive `datahike.experimental.diff/tx-range` windows.
+4. Validate the build generation and install it inside one writer operation.
+
+`tx-range` currently requires `:keep-history? true`, persistent-set indices,
+and materializes each requested window, so it cannot yet replace the general
+path. Its base commit also needs a persistent GC root. `datahike.gc-guard`
+protects newly written nodes before their pointer is published; it does **not**
+by itself pin old snapshot nodes for a long-running reader. The current builder
+therefore holds a process-local read lease which makes offline and online GC
+defer until installation. The experimental `feat/gc-roots` work is the relevant
+starting point for a durable/resumable lease and must also be integrated with
+online GC.
 
 ## Purge propagation
 

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -392,27 +392,31 @@
                          conn      (conn-from-db (dsi/stored->db (assoc stored-db :config config) store))]
                      (swap! (:wrapped-atom conn) assoc :writer
                             (w/create-writer (:writer config) conn))
-                     ;; Recovery: backfill secondary indices that are :building
-                     ;; and were not restored from durable storage
+                     ;; Recovery: every :building index is reconstructed from
+                     ;; the primary index. Its stored key-map, if any was written
+                     ;; by an older release, is deliberately ignored by
+                     ;; stored->db because it may describe a partial backfill.
                      #?(:clj
                         (let [db @(:wrapped-atom conn)
                               schema (:schema db)
-                              writer (:writer db)
-                              sec-idx-keys (:secondary-index-keys stored-db)]
+                              writer (:writer db)]
                           (doseq [[ident entry] schema
                                   :when (and (map? entry)
                                              (:db.secondary/type entry)
-                                             (= :building (:db.secondary/status entry))
-                                             ;; Only backfill if no stored key-map exists
-                                             (not (get sec-idx-keys ident)))]
+                                             (= :building (:db.secondary/status entry)))]
                             (log/trace :datahike/secondary-index-backfill {:ident ident})
                             (go
                               (let [build-result (<! (w/dispatch! writer
                                                                   {:op 'build-secondary-index!
                                                                    :args [ident]}))]
                                 (when (map? build-result)
-                                  (w/dispatch! writer {:op 'install-secondary-index!
-                                                       :args [build-result]})))))))
+                                  (let [install-result
+                                        (<! (w/dispatch! writer
+                                                         {:op 'install-secondary-index!
+                                                          :args [build-result]}))]
+                                    (when-not (map? install-result)
+                                      (dsi/finish-secondary-index-build!
+                                       build-result)))))))))
                      (add-connection! conn-id conn)
                      conn))))))
 

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -254,12 +254,15 @@
      [db idx-ident idx-schema]
      (let [idx-type (:db.secondary/type idx-schema)
            idx-attrs (set (:db.secondary/attrs idx-schema))
-           idx-config (cond-> (merge (:db.secondary/config idx-schema)
-                                     {:attrs idx-attrs})
-                        (seq (:ident-ref-map db))
-                        (assoc :ident-ref-map (:ident-ref-map db)))
-           idx (sec/create-index idx-type idx-config nil)
            needs-backfill? (attrs-have-datoms? db idx-attrs)
+           idx-config (cond-> (merge (:db.secondary/config idx-schema)
+                                     {:attrs idx-attrs
+                                      ::sec/index-ident idx-ident})
+                        (seq (:ident-ref-map db))
+                        (assoc :ident-ref-map (:ident-ref-map db))
+                        needs-backfill?
+                        (assoc ::sec/build-attempt (random-uuid)))
+           idx (sec/create-index idx-type idx-config nil)
            base (-> db
                     (assoc-in [:secondary-indices idx-ident] idx)
                     (assoc-in [:schema idx-ident :db.secondary/status]
@@ -405,9 +408,19 @@
                          true (assoc :tx-meta (tx-meta-for-secondary db datom)))]
          (reduce (fn [db' idx-ident]
                    (let [status (get-in db' [:schema idx-ident :db.secondary/status])]
-                    ;; Skip disabled indices — they are no longer maintained
-                     (if (= :disabled status)
-                       db'
+                     (cond
+                       ;; Disabled indices are no longer maintained.
+                       (= :disabled status) db'
+
+                       ;; The background worker exclusively owns the building
+                       ;; instance. Journal concurrent changes for the short
+                       ;; serialized install step instead of racing it or
+                       ;; replacing an immutable result with a stale snapshot.
+                       (= :building status)
+                       (update-in db' [:secondary-index-build-deltas idx-ident]
+                                  (fnil conj []) tx-report)
+
+                       :else
                        (if-let [idx (get-in db' [:secondary-indices idx-ident])]
                          (cond
                            (not (idx-pred idx)) db'

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -267,6 +267,10 @@
    (go-try S
            (let [{:keys [config store]} db
                  store-id (:id (:store config))
+                 _ (when (guard/read-in-flight? store-id)
+                     (log/raise "Garbage collection is deferred while a secondary index scans an older database snapshot."
+                                {:type :gc/read-lease-active
+                                 :store-id store-id}))
                  min-age-ms (or min-age-ms DEFAULT_SWEEP_MIN_AGE_MS)
                  ;; Cutoff from konserve's monotonic write clock — the SAME
                  ;; source that stamps :last-write. Strictly increasing, so a

--- a/src/datahike/gc_guard.cljc
+++ b/src/datahike/gc_guard.cljc
@@ -60,6 +60,11 @@
 ;; one must see a sequence in flight on another.
 (defonce ^:private in-flight (atom {}))
 
+;; Long-running readers of an OLD root need a different guarantee from the
+;; values-then-pointer writers above. A sweep safe-point cannot protect nodes
+;; written before the reader began, so GC must defer while such a lease exists.
+(defonce ^:private read-leases (atom {}))
+
 ;; Tokens are counter values, not fresh objects: a token is a MAP KEY, and a bare
 ;; `(js/Object.)` implements neither IHash nor IEquiv in cljs, so it cannot be one.
 (defonce ^:private token-seq (atom 0))
@@ -100,6 +105,30 @@
    compares timestamps cannot tell a held guard from a missing one. This can."
   [store-id]
   (boolean (seq (get @in-flight store-id))))
+
+(defn reading!
+  "Pin old reachable nodes in-process by making GC defer for `store-id`.
+   Returns a token for [[read-done!]]. This is a process-local lease matching
+   Datahike's single-writer/maintenance model, not a cross-process lock."
+  [store-id]
+  (let [token (swap! token-seq inc)]
+    (swap! read-leases assoc-in [store-id token] true)
+    token))
+
+(defn read-done!
+  "Release a token returned by [[reading!]]."
+  [store-id token]
+  (swap! read-leases (fn [m]
+                       (let [m' (update m store-id dissoc token)]
+                         (if (empty? (get m' store-id))
+                           (dissoc m' store-id)
+                           m'))))
+  nil)
+
+(defn read-in-flight?
+  "Whether an old-root reader currently requires GC to defer."
+  [store-id]
+  (boolean (seq (get @read-leases store-id))))
 
 (defn ever-guarded?
   "Has THIS PROCESS ever opened an unreferenced-write sequence on `store-id`?

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -420,7 +420,13 @@
   "Create a secondary index instance from a registered type.
    config is the index-specific configuration map.
    db is the current database (for initial population if needed).
-   Auto-requires the integration namespace if the type is namespace-qualified."
+   Auto-requires the integration namespace if the type is namespace-qualified.
+
+   A factory invoked for an asynchronous backfill also receives the ephemeral
+   keys `::index-ident` and `::build-attempt`. An adapter with external mutable
+   storage must use `::build-attempt` to create a private, empty generation;
+   reopening a path left by an earlier crashed attempt can duplicate replayed
+   datoms. These keys are runtime context and are not stored in schema."
   [type-keyword config db]
   #?(:clj
      (when-not (get @index-types type-keyword)

--- a/src/datahike/online_gc.cljc
+++ b/src/datahike/online_gc.cljc
@@ -21,6 +21,7 @@
      ;; Later: (async/close! stop-ch)"
   (:require [konserve.core :as k]
             [konserve.utils :as ku :refer [multi-key-capable?]]
+            [datahike.gc-guard :as guard]
             #?@(:clj  [[clojure.core.cache.wrapped :as wrapped]]
                 :cljs [[cljs.cache.wrapped :as wrapped]])
             [replikativ.logging :as log]
@@ -182,8 +183,16 @@
       ;; Synchronous mode
       (let [branches (k/get store :branches nil {:sync? true})
             multi-branch? (> (count branches) 1)
-            diff-buf (:datahike/diff-buf-size store 0)]
+            diff-buf (:datahike/diff-buf-size store 0)
+            store-id (or (:datahike/store-id store)
+                         (get-in store [:storage :config :store :id]))]
         (cond
+          (guard/read-in-flight? store-id)
+          (do
+            (log/debug :datahike/ogc-skip-read-lease
+                       {:store-id store-id})
+            0)
+
           ;; Online GC consumes persistent-sorted-set's markFreed stream, which pss documents
           ;; as a HINT and not a reachability claim. Under diff-buf that hint is only sound for
           ;; a LINEAR history: a parent's slot names an anchor PLUS a diff, so two versions can
@@ -224,8 +233,16 @@
       (go-try-
        (let [branches (<?- (k/get store :branches nil {:sync? false}))
              multi-branch? (> (count branches) 1)
-             diff-buf (:datahike/diff-buf-size store 0)]
+             diff-buf (:datahike/diff-buf-size store 0)
+             store-id (or (:datahike/store-id store)
+                          (get-in store [:storage :config :store :id]))]
          (cond
+           (guard/read-in-flight? store-id)
+           (do
+             (log/debug :datahike/ogc-skip-read-lease
+                        {:store-id store-id})
+             0)
+
            ;; See the synchronous arm above for why diff-buf is refused here.
            (pos? diff-buf)
            (do

--- a/src/datahike/versioning.cljc
+++ b/src/datahike/versioning.cljc
@@ -218,27 +218,58 @@
                                            :commit-graph? (get (:config @conn) :commit-graph? true)})))
                   ;; Branch secondary indices via their native CoW support.
                   ;; Prefer live indices from the connection (they hold the write lock).
-                        (let [sec-keys (:secondary-index-keys stored-db)
+                        (let [schema-meta (when-let [schema-meta-key
+                                                     (:schema-meta-key stored-db)]
+                                            (<?- (k/get store schema-meta-key nil opts)))
+                              source-schema (or (:schema schema-meta)
+                                                (:schema stored-db))
+                              building? (fn [ident]
+                                          (= :building
+                                             (get-in source-schema
+                                                     [ident :db.secondary/status])))
+                              sec-keys (into {}
+                                             (remove (fn [[ident _]] (building? ident)))
+                                             (:secondary-index-keys stored-db))
                               live-indices (:secondary-indices @conn)
+                              use-live? (and (keyword? from)
+                                             (= from (get-in @conn [:config :branch]))
+                                             (= (get-in stored-db
+                                                        [:meta :datahike/commit-id])
+                                                (get-in @conn
+                                                        [:meta :datahike/commit-id])))
                               from-branch (or (when (keyword? from) from) :db)
                               branched-sec-keys
                               #?(:clj
                                  (when (or (seq sec-keys) (seq live-indices))
-                                   (reduce-kv
-                                    (fn [acc idx-ident idx]
-                                      (if (satisfies? sec/IVersionedSecondaryIndex idx)
-                                        (let [branched (sec/-sec-branch idx store from-branch new-branch)
-                                              key-map (sec/-sec-flush branched store new-branch)]
-                                          (when (instance? java.io.Closeable branched)
-                                            (.close ^java.io.Closeable branched))
-                                          (assoc acc idx-ident key-map))
-                                        (if-let [key-map (get sec-keys idx-ident)]
-                                          (assoc acc idx-ident
-                                                 (sec/branch-from-key-map key-map store from-branch new-branch))
-                                          acc)))
-                                    {} (or live-indices {})))
+                                   (if use-live?
+                                     (reduce-kv
+                                      (fn [acc idx-ident idx]
+                                        (if (building? idx-ident)
+                                          acc
+                                          (if (satisfies? sec/IVersionedSecondaryIndex idx)
+                                            (let [branched (sec/-sec-branch idx store from-branch new-branch)
+                                                  key-map (sec/-sec-flush branched store new-branch)]
+                                              (when (instance? java.io.Closeable branched)
+                                                (.close ^java.io.Closeable branched))
+                                              (assoc acc idx-ident key-map))
+                                            (if-let [key-map (get sec-keys idx-ident)]
+                                              (assoc acc idx-ident
+                                                     (sec/branch-from-key-map key-map store from-branch new-branch))
+                                              acc))))
+                                      {} (or live-indices {}))
+                                     ;; A historical source must be forked from
+                                     ;; the key-maps stored on THAT commit, never
+                                     ;; from the connection's newer live index.
+                                     (reduce-kv
+                                      (fn [acc idx-ident key-map]
+                                        (assoc acc idx-ident
+                                               (sec/branch-from-key-map
+                                                key-map store from-branch new-branch)))
+                                      {} sec-keys)))
                                  :cljs nil)
-                              updated-db (cond-> (assoc-in stored-db [:config :branch] new-branch)
+                              updated-db (cond-> (-> stored-db
+                                                     (assoc-in [:config :branch] new-branch)
+                                                     (dissoc :secondary-index-keys))
                                            (seq branched-sec-keys) (assoc :secondary-index-keys branched-sec-keys))]
                           ;; A deleted branch leaves its old head behind until GC,
                           ;; so "must be absent" is too strong here. Fence against

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -693,7 +693,18 @@
                                 (log/error :datahike/writer-shutdown {:error e})
                             ;; Re-throw Errors (AssertionError, OutOfMemoryError, etc.) to crash the writer
                                 #?(:clj (when (instance? Error e)
-                                          (throw e)))))))
+                                          (throw e))))))
+                          (finally
+                            ;; A background secondary build holds a GC guard
+                            ;; until the commit that publishes its ready key-map
+                            ;; has either landed or definitively failed.
+                            #?(:clj
+                               (doseq [[tx-report _] txs
+                                       :let [build-guard
+                                             (:secondary-index-build-guard
+                                              tx-report)]
+                                       :when build-guard]
+                                 (w/finish-secondary-index-build! build-guard)))))
                         ;; Signalled AFTER the head flip (or after the failure
                         ;; path closed everything), so the transaction loop's
                         ;; next head read sees this commit.
@@ -747,7 +758,8 @@
                            ;; async operations that run in background — NOT report
                            ;; producers, must not be wrapped (they return channels)
                            'gc-storage!   gc/gc-storage!
-                           ;; secondary index backfill (async, runs in background)
+                           ;; The scan is asynchronous; install/delta replay is
+                           ;; a short serialized report-producing operation.
                            #?@(:clj ['build-secondary-index! w/build-secondary-index!
                                      'install-secondary-index! w/install-secondary-index!])
                            ;; merge with multi-parent commit tracking
@@ -973,12 +985,8 @@
    i.e. they are :building in db-after but were not already :building in
    db-before. Returns a seq of idx-idents that need a one-time backfill.
 
-   Comparing against db-before is essential: any transaction applied while
-   an index is still building would otherwise re-dispatch a full backfill,
-   and a second backfill that runs after the first one's
-   install-secondary-index! has dissoc'd :db.secondary/building-since-tx
-   loses the snapshot guard and re-delivers post-creation datoms that were
-   already applied live — double-counting them in the index."
+   Comparing against db-before is essential: only the schema transaction that
+   creates or re-enables the index owns the initial backfill."
   [tx-report]
   (let [before (get-in tx-report [:db-before :schema])
         after  (get-in tx-report [:db-after :schema])]
@@ -994,24 +1002,34 @@
 (defn transact!
   [connection arg-map]
   (let [p (throwable-promise)
-        writer (:writer @(:wrapped-atom connection))]
+        db @(:wrapped-atom connection)
+        writer (:writer db)
+        local-writer? (= :self (get-in db [:config :writer :backend] :self))]
     (go
       (let [tx-report (<! (dispatch! writer
                                      {:op 'transact!
                                       :args [arg-map]}))]
         (when (map? tx-report) ;; not error
-          ;; Dispatch backfill for any newly created secondary indices
           #?(:clj
              (doseq [idx-ident (detect-new-building-indices tx-report)]
                (log/trace :datahike/dispatch-backfill {:idx-ident idx-ident})
-               ;; build-secondary-index! is async (returns channel).
-               ;; When it completes, dispatch install to swap in the result.
                (go
-                 (let [build-result (<! (dispatch! writer {:op 'build-secondary-index!
-                                                           :args [idx-ident]}))]
+                 (let [build-result (<! (dispatch! writer
+                                                   {:op 'build-secondary-index!
+                                                    :args [idx-ident]}))]
                    (when (map? build-result)
-                     (dispatch! writer {:op 'install-secondary-index!
-                                        :args [build-result]}))))))
+                     ;; Awaiting here does not block the writer. The install is
+                     ;; merely queued behind transactions that may have arrived
+                     ;; during the scan; it replays their journaled deltas.
+                     (let [install-result
+                           (<! (dispatch! writer
+                                          {:op 'install-secondary-index!
+                                           :args [build-result]}))]
+                       ;; If release shut the local queue between scan and
+                       ;; install, no commit report exists to release the guard.
+                       ;; The build ran in this JVM, so clean it up here.
+                       (when (and local-writer? (not (map? install-result)))
+                         (w/finish-secondary-index-build! build-result))))))))
           (doseq [[_ callback] (some-> (:listeners (meta connection)) (deref))]
             (callback tx-report)))
         (#?(:clj deliver :cljs put!) p tx-report)))

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -91,7 +91,14 @@
              (when flush?
                (let [flushed (reduce-kv
                               (fn [acc idx-ident idx]
-                                (if (satisfies? sec/IVersionedSecondaryIndex idx)
+                                ;; A :building index is not a durable snapshot.
+                                ;; Publishing its key-map lets a crash preserve an
+                                ;; arbitrary prefix of the backfill, which cannot
+                                ;; safely be replayed for non-idempotent indices.
+                                (if (and (satisfies? sec/IVersionedSecondaryIndex idx)
+                                         (not= :building
+                                               (get-in db [:schema idx-ident
+                                                           :db.secondary/status])))
                                   (assoc acc idx-ident (sec/-sec-flush idx store (:branch config)))
                                   acc))
                               {} (:secondary-indices db))
@@ -107,7 +114,10 @@
                      ;; instance" is never read as "delete".
                      carried (into {}
                                    (filter (fn [[ident _]]
-                                             (get-in db [:schema ident :db.secondary/type])))
+                                             (and (get-in db [:schema ident :db.secondary/type])
+                                                  (not= :building
+                                                        (get-in db [:schema ident
+                                                                    :db.secondary/status])))))
                                    (:secondary-index-keys db))]
                  (not-empty (merge carried flushed))))
              :cljs nil)
@@ -132,12 +142,17 @@
                              (try (audit/-merkle-root x)
                                   (catch #?(:clj Throwable :cljs js/Error) _ nil))))
           sec-roots      (when (seq (:secondary-indices db))
-                           (reduce-kv
-                            (fn [acc idx-ident idx]
-                              (assoc acc idx-ident
-                                     (or (safe-root idx)
-                                         (:merkle-root (get secondary-index-keys idx-ident)))))
-                            {} (:secondary-indices db)))
+                           (not-empty
+                            (reduce-kv
+                             (fn [acc idx-ident idx]
+                               (if (= :building
+                                      (get-in db [:schema idx-ident :db.secondary/status]))
+                                 acc
+                                 (assoc acc idx-ident
+                                        (or (safe-root idx)
+                                            (:merkle-root
+                                             (get secondary-index-keys idx-ident))))))
+                             {} (:secondary-indices db))))
           merkle-roots
           (cond-> {:eavt-key (safe-root eavt')
                    :aevt-key (safe-root aevt')
@@ -235,11 +250,18 @@
         (if (and (map? entry) (:db.secondary/type entry))
           (let [idx-type (:db.secondary/type entry)
                 idx-attrs (set (:db.secondary/attrs entry))
-                key-map (get secondary-index-keys ident)
+                ;; A key-map written while the schema says :building is, at
+                ;; best, a partial snapshot from an older Datahike. Ignore it
+                ;; and rebuild from the primary index instead.
+                key-map (when-not (= :building (:db.secondary/status entry))
+                          (get secondary-index-keys ident))
                 idx-config (cond-> (merge (:db.secondary/config entry)
-                                          {:attrs idx-attrs})
+                                          {:attrs idx-attrs
+                                           ::sec/index-ident ident})
                              (seq ident-ref-map)
                              (assoc :ident-ref-map ident-ref-map)
+                             (= :building (:db.secondary/status entry))
+                             (assoc ::sec/build-attempt (random-uuid))
                              ;; When a key-map carries a branch, route the
                              ;; skeleton into that branch too — otherwise
                              ;; the factory defaults to "main" and a non-
@@ -306,6 +328,15 @@
                           (sc/cache-miss schema-meta-key schema-meta)
                           schema-meta))
         effective-schema (or (:schema schema-meta) schema)
+        ;; A partial key-map from an older release must not survive merely
+        ;; because stored->db retained it for the carry-forward path.
+        secondary-index-keys
+        (not-empty
+         (into {}
+               (remove (fn [[ident _]]
+                         (= :building
+                            (get-in effective-schema [ident :db.secondary/status]))))
+               secondary-index-keys))
         effective-ident-ref-map (or (:ident-ref-map schema-meta) ident-ref-map)
         sec-indices (restore-secondary-indices effective-schema effective-ident-ref-map
                                                secondary-index-keys store)
@@ -1094,72 +1125,146 @@
    (-database-exists? config)))
 
 #?(:clj
+   (defn- close-secondary-index! [idx]
+     (when (instance? java.io.Closeable idx)
+       (try (.close ^java.io.Closeable idx)
+            (catch Exception e
+              (log/warn :datahike/secondary-index-close-failed
+                        {:error (.getMessage e)}))))))
+
+#?(:clj
    (defn build-secondary-index!
      "Backfill a secondary index by scanning AEVT for all covered attributes.
-      Returns a channel (async op) so the writer continues processing other
-      transactions during backfill. When complete, dispatches a lightweight
-      install-secondary-index! op to atomically swap in the result."
+      Returns a channel so the writer can continue serving transactions. While
+      it runs, those transactions journal changes for this index; the serialized
+      install operation replays that delta before publishing the result."
      [old idx-ident]
      (log/trace :datahike/build-secondary-index {:idx-ident idx-ident})
-     ;; Return a channel — writer runs this in background (lines 89-93 of writer.cljc)
      (let [db old
+           writer-config (get-in db [:config :writer])
+           _ (when-not (and (= :self (get writer-config :backend :self))
+                            (= :exclusive
+                               (get writer-config :writer-ownership :shared)))
+               (log/raise
+                "Asynchronous secondary-index backfill requires local exclusive writer ownership."
+                {:type :secondary-index-backfill-unsupported-writer
+                 :idx-ident idx-ident
+                 :writer writer-config}))
            idx (get-in db [:secondary-indices idx-ident])
            _ (when-not idx
                (log/raise "Secondary index not found" {:idx-ident idx-ident}))
            attrs (sec/-indexed-attrs idx)
            building-since-tx (get-in db [:schema idx-ident :db.secondary/building-since-tx])
+           _ (when-not building-since-tx
+               (log/raise "A building secondary index has no snapshot boundary"
+                          {:type :secondary-index-missing-build-boundary
+                           :idx-ident idx-ident}))
            use-transient? (satisfies? sec/ITransientSecondaryIndex idx)
-           t-idx (if use-transient? (sec/-as-transient idx) idx)]
-       ;; Background go block — doesn't block the writer
+           t-idx (if use-transient? (sec/-as-transient idx) idx)
+           gc-store-id (:id (:store (:config db)))
+           ;; A versioned adapter may write private nodes while it builds. They
+           ;; remain unreachable until install's commit publishes its key-map,
+           ;; so protect the whole scan -> ready-commit window from GC.
+           gc-token (guard/writing! gc-store-id)
+           read-token (guard/reading! gc-store-id)]
        (go-try-
-        (let [populated-idx
-              (reduce
-               (fn [current-idx attr]
-                 (let [datoms (dbi/datoms db :aevt [attr])
-                       n (atom 0)]
-                   (log/debug :datahike/backfilling {:attr attr})
-                   (let [result (reduce
-                                 (fn [idx d]
-                                   (if (and building-since-tx
-                                            (> (.-tx ^datahike.datom.Datom d) building-since-tx))
-                                     idx
-                                     (do (swap! n inc)
-                                         ;; Reconstruct each datom's tx-meta from the
-                                         ;; historical EAVT seek on its tx-id. Without
-                                         ;; this, vt-aware adapters miss the writing-tx
-                                         ;; `:db.valid/from` and degrade to `txInstant`.
-                                         (let [tx-id (.-tx ^datahike.datom.Datom d)
-                                               tx-report {:datom d :added? true
-                                                          :tx-meta (dbtx/meta-for-tx-id db tx-id)}]
-                                           (if use-transient?
-                                             (do (sec/-transact! idx tx-report) idx)
-                                             (sec/-transact idx tx-report))))))
-                                 current-idx datoms)]
-                     (log/debug :datahike/backfilled {:attr attr :count @n})
-                     result)))
-               t-idx attrs)
-              final-idx (if use-transient?
-                          (sec/-persistent! populated-idx)
-                          populated-idx)]
-          (log/trace :datahike/secondary-index-built {:idx-ident idx-ident})
-          ;; Return the populated index — the writer dispatch callback
-          ;; receives this, but we need to install it via a separate writer op.
-          ;; Store it in an atom for install-secondary-index! to pick up.
-          {:idx-ident idx-ident :index final-idx})))))
+        (try
+          (let [populated-idx
+                (reduce
+                 (fn [current-idx attr]
+                   (let [datoms (dbi/datoms db :aevt [attr])
+                         n (atom 0)]
+                     (log/debug :datahike/backfilling {:attr attr})
+                     (let [result (reduce
+                                   (fn [idx d]
+                                     (if (> (.-tx ^datahike.datom.Datom d) building-since-tx)
+                                       idx
+                                       (do (swap! n inc)
+                                           (let [tx-id (.-tx ^datahike.datom.Datom d)
+                                                 tx-report {:datom d :added? true
+                                                            :tx-meta (dbtx/meta-for-tx-id db tx-id)}]
+                                             (if use-transient?
+                                               (do (sec/-transact! idx tx-report) idx)
+                                               (sec/-transact idx tx-report))))))
+                                   current-idx datoms)]
+                       (log/debug :datahike/backfilled {:attr attr :count @n})
+                       result)))
+                 t-idx attrs)
+                final-idx (if use-transient?
+                            (sec/-persistent! populated-idx)
+                            populated-idx)]
+            (log/trace :datahike/secondary-index-built {:idx-ident idx-ident})
+            {:idx-ident idx-ident
+             :index final-idx
+             :building-since-tx building-since-tx
+             ::gc-store-id gc-store-id
+             ::gc-token gc-token
+             ::read-token read-token})
+          (catch Throwable e
+            (close-secondary-index! idx)
+            (guard/done! gc-store-id gc-token)
+            (guard/read-done! gc-store-id read-token)
+            (throw e)))))))
+
+#?(:clj
+   (defn finish-secondary-index-build!
+     "Release the GC guard carried by a completed background build. Call only
+      after install's writer callback, which means its ready commit is durable."
+     [build-result]
+     (when-let [token (::gc-token build-result)]
+       (guard/done! (::gc-store-id build-result) token))
+     (when-let [token (::read-token build-result)]
+       (guard/read-done! (::gc-store-id build-result) token))))
 
 #?(:clj
    (defn install-secondary-index!
-     "Lightweight synchronous writer op that installs a backfilled index.
-      Called after build-secondary-index! completes in the background."
-     [old {:keys [idx-ident index]}]
-     (let [db-after (-> old
-                        (assoc-in [:secondary-indices idx-ident] index)
-                        (assoc-in [:schema idx-ident :db.secondary/status] :ready)
-                        (update-in [:schema idx-ident] dissoc :db.secondary/building-since-tx))]
-       (complete-db-update old {:db-before old
-                                :db-after db-after
-                                :tx-data []
-                                :tx-meta {}}))))
+     "Replay changes accumulated during an asynchronous backfill and publish
+      the resulting index. This operation is serialized by the writer, which
+      closes the handoff gap between the delta journal and normal live updates."
+     [old {:keys [idx-ident index building-since-tx] :as build-result}]
+     (try
+       (let [status (get-in old [:schema idx-ident :db.secondary/status])
+             current-boundary (get-in old [:schema idx-ident
+                                           :db.secondary/building-since-tx])]
+         (when-not (and (= :building status)
+                        (= building-since-tx current-boundary))
+           (log/raise "Discarding a stale secondary-index build"
+                      {:type :secondary-index-stale-build
+                       :idx-ident idx-ident
+                       :expected-building-since-tx current-boundary
+                       :actual-building-since-tx building-since-tx
+                       :status status}))
+         (let [deltas (get-in old [:secondary-index-build-deltas idx-ident] [])
+               use-transient? (satisfies? sec/ITransientSecondaryIndex index)
+               t-idx (if use-transient? (sec/-as-transient index) index)
+               replayed (reduce (fn [idx tx-report]
+                                  (if use-transient?
+                                    (do (sec/-transact! idx tx-report) idx)
+                                    (sec/-transact idx tx-report)))
+                                t-idx deltas)
+               final-idx (if use-transient? (sec/-persistent! replayed) replayed)
+               db-after (-> old
+                            (assoc-in [:secondary-indices idx-ident] final-idx)
+                            (assoc-in [:schema idx-ident :db.secondary/status] :ready)
+                            (update-in [:schema idx-ident] dissoc
+                                       :db.secondary/building-since-tx)
+                            (update :secondary-index-build-deltas dissoc idx-ident)
+                            (cond-> (empty? (dissoc (:secondary-index-build-deltas old)
+                                                    idx-ident))
+                              (dissoc :secondary-index-build-deltas)))]
+           (complete-db-update
+            old {:db-before old
+                 :db-after db-after
+                 :tx-data []
+                 :tx-meta {:db/txInstant (get-in old [:meta :datahike/updated-at])}
+                 :secondary-index-build-guard
+                 {::gc-store-id (::gc-store-id build-result)
+                  ::gc-token (::gc-token build-result)
+                  ::read-token (::read-token build-result)}})))
+       (catch Throwable e
+         (close-secondary-index! index)
+         (finish-secondary-index-build! build-result)
+         (throw e)))))
 
 (defn merge-writer!
   "Writer operation for merge. Applies tx-data and records merge parents
@@ -1173,10 +1278,44 @@
     (update tx-report :db-after
             assoc-in [:meta :datahike/merge-parents] all-parents)))
 
+#?(:clj
+   (defn- validate-secondary-backfill-writer!
+     "Reject a new asynchronous backfill before its schema report reaches the
+      commit queue. This belongs at the writer boundary so pure `db-with` can
+      still model a :building database without owning a writer."
+     [old {:keys [db-after]}]
+     (let [before (:schema old)
+           new-building
+           (into []
+                 (keep (fn [[ident entry]]
+                         (when (and (= :building (:db.secondary/status entry))
+                                    (not= :building
+                                          (get-in before
+                                                  [ident :db.secondary/status])))
+                           ident)))
+                 (:schema db-after))
+           writer-config (get-in old [:config :writer])
+           local-exclusive? (and (= :self (get writer-config :backend :self))
+                                 (= :exclusive
+                                    (get writer-config :writer-ownership :shared)))]
+       (when (and (seq new-building) (not local-exclusive?))
+         ;; Factories already ran in core/with. Close any native private
+         ;; generation before refusing its uncommitted schema report.
+         (doseq [idx-ident new-building]
+           (close-secondary-index! (get-in db-after [:secondary-indices idx-ident])))
+         (log/raise
+          "Asynchronous secondary-index backfill currently requires local exclusive writer ownership. Remote writers cannot transfer a live build generation, and shared writers cannot coordinate its in-memory delta journal across processes."
+          {:type :secondary-index-backfill-unsupported-writer
+           :idx-ident (first new-building)
+           :idx-idents (set new-building)
+           :writer writer-config})))))
+
 (defn transact! [old {:keys [tx-data tx-meta]}]
   (log/debug :datahike/transact {:tx-count (count tx-data)})
   (log/trace :datahike/transact-detail {:tx-data tx-data :tx-meta tx-meta})
-  (complete-db-update old (core/with old tx-data tx-meta)))
+  (let [tx-report (core/with old tx-data tx-meta)]
+    #?(:clj (validate-secondary-backfill-writer! old tx-report))
+    (complete-db-update old tx-report)))
 
 (defn load-entities
   [old entities]

--- a/test/datahike/test/secondary_dynamic_test.clj
+++ b/test/datahike/test/secondary_dynamic_test.clj
@@ -3,7 +3,80 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [datahike.api :as d]
-   [datahike.index.secondary :as sec]))
+   [datahike.gc-guard :as guard]
+   [datahike.index.secondary :as sec]
+   [datahike.writing :as writing]
+   [superv.async :refer [<?? S]]))
+
+(defonce slow-build-control (atom nil))
+
+(defrecord SlowImmutableIndex [attrs events values]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [this {:keys [datom added?] :as tx-report}]
+    (when-let [{:keys [entered release blocked?]} @slow-build-control]
+      (when (compare-and-set! blocked? false true)
+        (deliver entered true)
+        @release))
+    (let [pair [(:e datom) (:v datom)]]
+      (assoc this
+             :events (conj events tx-report)
+             :values ((if added? conj disj) values pair))))
+
+  clojure.lang.IDeref
+  (deref [_] {:events events :values values}))
+
+(defonce _register-slow-immutable
+  (sec/register-index-type!
+   :test/slow-immutable
+   (fn [config _db]
+     (->SlowImmutableIndex (set (:attrs config)) [] #{}))))
+
+(defrecord VersionedRecorder [attrs flushes restores]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [this _] this)
+
+  sec/IVersionedSecondaryIndex
+  (-sec-flush [_ _ _]
+    (swap! flushes inc)
+    {:type :test/versioned-recorder :root :complete})
+  (-sec-restore [this _ _]
+    (swap! restores inc)
+    this)
+  (-sec-branch [this _ _ _] this)
+  (-sec-mark [_] #{}))
+
+(defonce versioned-recorder-control
+  (atom {:flushes (atom 0) :restores (atom 0)}))
+
+(defonce _register-versioned-recorder
+  (sec/register-index-type!
+   :test/versioned-recorder
+   (fn [config _db]
+     (let [{:keys [flushes restores]} @versioned-recorder-control]
+       (->VersionedRecorder (set (:attrs config)) flushes restores)))))
+
+(defn- await-status [conn idx-ident status]
+  (let [deadline (+ (System/currentTimeMillis) 5000)]
+    (loop []
+      (let [actual (get-in (d/db conn) [:schema idx-ident :db.secondary/status])]
+        (cond
+          (= status actual) actual
+          (< (System/currentTimeMillis) deadline)
+          (do (Thread/sleep 10) (recur))
+          :else actual)))))
+
+(defn- throwable-type [error]
+  (some (comp :type ex-data) (take-while some? (iterate ex-cause error))))
 
 ;; Register a test recorder index type for all tests
 (defonce _register-recorder
@@ -35,6 +108,7 @@
   (testing "schema transaction creates secondary index with :building status"
     (let [cfg {:store {:backend :memory
                        :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
           _ (d/create-database cfg)
@@ -138,12 +212,176 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest asynchronous-backfill-replays-concurrent-deltas
+  (testing "the writer remains available and immutable index updates are not lost"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :keep-history? false
+               :schema-flexibility :write}
+          entered (promise)
+          release (promise)
+          control {:entered entered :release release :blocked? (atom false)}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :person/name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:person/name "Alice"} {:person/name "Bob"}])
+          (let [alice (d/q '[:find ?e . :where [?e :person/name "Alice"]]
+                           (d/db conn))]
+            (reset! slow-build-control control)
+            ;; This returns after publishing :building, not after the scan.
+            (d/transact conn [{:db/ident :idx/slow
+                               :db.secondary/type :test/slow-immutable
+                               :db.secondary/attrs [:person/name]}])
+            (is (= true (deref entered 5000 ::timeout))
+                "the background scan reached its deterministic barrier")
+            (is (= :building
+                   (get-in (d/db conn) [:schema :idx/slow :db.secondary/status])))
+            (is (guard/read-in-flight? (get-in cfg [:store :id]))
+                "the primary snapshot is leased against GC during the scan")
+            (let [error (try
+                          (<?? S (d/gc-storage conn (java.util.Date.)))
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+              (is (= :gc/read-lease-active (:type (ex-data error)))
+                  "offline GC refuses to sweep the leased snapshot"))
+
+            ;; Both transactions complete while the backfill is paused. The
+            ;; card-one replacement contributes a retract and an assertion.
+            (d/transact conn [[:db/add alice :person/name "Alicia"]])
+            (d/transact conn [{:person/name "Charlie"}])
+            (is (= 3 (count (get-in (d/db conn)
+                                    [:secondary-index-build-deltas :idx/slow])))
+                "concurrent changes are journaled instead of racing the build")
+
+            (deliver release true)
+            (is (= :ready (await-status conn :idx/slow :ready)))
+            (let [{:keys [values]} @(get-in (d/db conn)
+                                            [:secondary-indices :idx/slow])]
+              (is (= #{"Alicia" "Bob" "Charlie"}
+                     (set (map second values))))
+              (is (nil? (:secondary-index-build-deltas (d/db conn)))
+                  "the install removes its in-memory delta journal")
+              (is (not (guard/in-flight? (get-in cfg [:store :id])))
+                  "the ready commit releases the build's GC guard")
+              (is (not (guard/read-in-flight? (get-in cfg [:store :id])))
+                  "the ready commit releases the primary snapshot lease")))
+          (finally
+            (reset! slow-build-control nil)
+            (deliver release true)
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(deftest building-versioned-index-is-not-published
+  (testing "partial building state is neither flushed nor carried as durable authority"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :keep-history? false
+               :schema-flexibility :write}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          flushes (atom 0)
+          restores (atom 0)]
+      (try
+        (reset! versioned-recorder-control
+                {:flushes flushes :restores restores})
+        (d/transact conn [{:db/ident :person/name
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one}])
+        (let [idx (->VersionedRecorder #{:person/name} flushes restores)
+              building (-> (d/db conn)
+                           (assoc-in [:schema :idx/versioned]
+                                     {:db.secondary/type :test/versioned-recorder
+                                      :db.secondary/attrs [:person/name]
+                                      :db.secondary/status :building
+                                      :db.secondary/building-since-tx 1})
+                           (assoc-in [:secondary-indices :idx/versioned] idx)
+                           (assoc :secondary-index-keys
+                                  {:idx/versioned {:type :test/versioned-recorder
+                                                   :root :partial}}))
+              stored (second (writing/db->stored building true))]
+          (is (zero? @flushes))
+          (is (nil? (:secondary-index-keys stored)))
+          (is (nil? (get-in stored [:merkle-roots :secondary]))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest release-during-backfill-releases-gc-guard
+  (testing "a scan finishing after its local writer shuts down does not strand a guard"
+    (let [store-id (random-uuid)
+          cfg {:store {:backend :memory :id store-id}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :keep-history? false
+               :schema-flexibility :write}
+          entered (promise)
+          release-build (promise)]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :person/name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}
+                            {:person/name "Alice"}])
+          (reset! slow-build-control
+                  {:entered entered
+                   :release release-build
+                   :blocked? (atom false)})
+          (d/transact conn [{:db/ident :idx/released
+                             :db.secondary/type :test/slow-immutable
+                             :db.secondary/attrs [:person/name]}])
+          (is (= true (deref entered 5000 ::timeout)))
+          (d/release conn)
+          (deliver release-build true)
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (guard/in-flight? store-id)
+                         (< (System/currentTimeMillis) deadline))
+                (Thread/sleep 10)
+                (recur))))
+          (is (not (guard/in-flight? store-id)))
+          (is (not (guard/read-in-flight? store-id)))
+          (finally
+            (reset! slow-build-control nil)
+            (deliver release-build true)
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(deftest backfill-refuses-a-shared-writer
+  (testing "another process cannot bypass the in-memory delta journal"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :shared}
+               :keep-history? false
+               :schema-flexibility :write}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)]
+      (try
+        (d/transact conn [{:db/ident :person/name
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one}
+                          {:person/name "Alice"}])
+        (let [error (try
+                      (d/transact conn [{:db/ident :idx/shared
+                                         :db.secondary/type :test/slow-immutable
+                                         :db.secondary/attrs [:person/name]}])
+                      (catch clojure.lang.ExceptionInfo e e))
+              error-type (throwable-type error)]
+          (is (= :secondary-index-backfill-unsupported-writer
+                 error-type))
+          (is (nil? (get-in (d/db conn) [:schema :idx/shared]))
+              "the unsupported schema transaction is not committed"))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-secondary-index-recovery-on-reconnect
   (testing "secondary index in :building state is recovered after reconnect"
     (let [path (str "/tmp/datahike-sec-recovery-" (random-uuid))
           cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path path}
+               :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
           _ (d/create-database cfg)

--- a/test/datahike/test/secondary_versioning_test.clj
+++ b/test/datahike/test/secondary_versioning_test.clj
@@ -6,14 +6,87 @@
    [datahike.versioning :as dv]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
-   [datahike.index.secondary.scriptum]))
+   [datahike.index.secondary.scriptum]
+   [konserve.core :as k]))
+
+(defrecord HistoricalBranchRecorder [attrs values]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [this {:keys [datom added?]}]
+    (let [value [(:e datom) (:v datom)]]
+      (assoc this :values ((if added? conj disj) values value))))
+
+  sec/IVersionedSecondaryIndex
+  (-sec-flush [_ _ _]
+    {:type :test/historical-branch-recorder
+     :values values})
+  (-sec-restore [this _ key-map]
+    (assoc this :values (:values key-map)))
+  (-sec-branch [this _ _ _] this)
+  (-sec-mark [_] #{}))
+
+(defonce _register-historical-branch-recorder
+  (sec/register-index-type!
+   :test/historical-branch-recorder
+   (fn [config _db]
+     (->HistoricalBranchRecorder (set (:attrs config)) #{}))))
+
+(defn- await-ready [conn idx-ident]
+  (let [deadline (+ (System/currentTimeMillis) 5000)]
+    (loop []
+      (let [status (get-in (d/db conn) [:schema idx-ident :db.secondary/status])]
+        (cond
+          (= :ready status) status
+          (< (System/currentTimeMillis) deadline) (do (Thread/sleep 10) (recur))
+          :else status)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Scriptum + branching + merge (end-to-end)
 
+(deftest test-branch-from-historical-secondary-state
+  (testing "branching a commit forks that commit's index, not the connection head"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :keep-history? false
+               :schema-flexibility :write}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)]
+      (try
+        (d/transact conn [{:db/ident :person/name
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one}
+                          {:person/name "Alice"}
+                          {:person/name "Bob"}])
+        (d/transact conn [{:db/ident :idx/historical
+                           :db.secondary/type :test/historical-branch-recorder
+                           :db.secondary/attrs [:person/name]}])
+        (is (= :ready (await-ready conn :idx/historical)))
+        (let [store (:store @conn)
+              historical-cid (dv/commit-id @conn)
+              historical-key-map (get-in (k/get store historical-cid nil {:sync? true})
+                                         [:secondary-index-keys :idx/historical])]
+          (d/transact conn [{:person/name "Charlie"}])
+          (let [head-key-map (get-in (k/get store :db nil {:sync? true})
+                                     [:secondary-index-keys :idx/historical])]
+            (is (not= historical-key-map head-key-map)
+                "the test must distinguish the historical index from the live head")
+            (dv/branch! conn historical-cid :historical)
+            (is (= historical-key-map
+                   (get-in (k/get store :historical nil {:sync? true})
+                           [:secondary-index-keys :idx/historical]))
+                "historical branch uses the key-map stored on its source commit")))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-scriptum-branch-and-merge
   (testing "secondary index survives branch, diverge, and merge"
     (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
           scriptum-path (str "/tmp/scriptum-ver-test-" (random-uuid))
@@ -91,6 +164,7 @@
 (deftest test-merge-through-writer
   (testing "merge! routes through writer and creates multi-parent commit"
     (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
           _ (d/create-database cfg)
@@ -133,6 +207,7 @@
     (let [cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path (str "/tmp/datahike-ver-test-" (random-uuid))}
+               :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
           scriptum-path (str "/tmp/scriptum-persist-" (random-uuid))


### PR DESCRIPTION
## Summary

- keep schema publication fast while replaying concurrent writes through a serialized install step
- never persist, restore, branch, or expose a partial `:building` generation
- protect the scanned primary snapshot and unpublished secondary nodes from GC
- reject backfill on remote/non-streaming writers until the journal is durable
- branch historical commits from their stored secondary key maps, not the live connection head
- document the unbounded in-memory journal and the tx-range/checkpoint/GC-root follow-up

## Tests

- focused lifecycle/versioning: 12 tests, 42 assertions
- secondary lifecycle, protocol, versioning, writer, Scriptum/Proximum: 65 tests, 340 assertions
- `bb format`
- `git diff --check`