### PR TITLE
Refuse self-writer options on remote writer backends

### DIFF
--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -135,7 +135,25 @@
   [writer]
   (let [writer (or writer self-writer-backend)]
     (if-not (= :self (:backend writer))
-      writer
+      ;; A remote writer transacts in ANOTHER process, so every option below is
+      ;; about a writer this config does not control: ownership, batching, retry
+      ;; policy and — the one with teeth — :require-fencing. None of them can be
+      ;; honoured from here, and each names a safety property, so accepting them
+      ;; silently is a config that LOOKS protected and is not: exactly the
+      ;; silent-inert-option failure the self writer's closed key set exists to
+      ;; prevent, reappearing one backend over. Remote writers keep their own
+      ;; open key set (:kabel has :local-peer and friends), so only the
+      ;; self-only keys are refused, not everything unknown.
+      (if-let [inert (seq (filter (partial contains? writer)
+                                  [:writer-ownership :streaming? :require-fencing
+                                   :max-batch :head-conflict-retries
+                                   :head-conflict-backoff-ms]))]
+        (log/raise (str "These options configure the :self writer and are inert on a remote writer backend. "
+                        "Configure the writer where it runs — the process that owns it — and remove them here.")
+                   {:type    :self-writer-options-on-remote-writer
+                    :backend (:backend writer)
+                    :inert   (vec inert)})
+        writer)
       (let [legacy? (contains? writer :streaming?)
             legacy (:streaming? writer)
             explicit? (contains? writer :writer-ownership)

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -327,9 +327,18 @@
                        ;; `existing` rather than the requested ownership: what
                        ;; matters is whether the writer in hand re-reads the head,
                        ;; and the warning above has already said the request is ignored.
-                       (w/check-fencing! (get-in config [:writer :require-fencing])
-                                         (or existing :shared)
-                                         (:store @(:wrapped-atom conn))))
+                       ;;
+                       ;; SCOPED to the :self backend, matching where the option is
+                       ;; legal at all: `normalize-writer-config` refuses
+                       ;; :require-fencing on a remote writer before any connect
+                       ;; path runs, and checking it here against the LOCAL store
+                       ;; would be judging a remote writer's guarantee by a store
+                       ;; it does not write to — a refusal or a pass, both about
+                       ;; the wrong thing.
+                       (when (= :self (get-in config [:writer :backend] :self))
+                         (w/check-fencing! (get-in config [:writer :require-fencing])
+                                           (or existing :shared)
+                                           (:store @(:wrapped-atom conn)))))
                      conn)
                    (let [raw-store (<?- (ks/connect-store store-config opts))
                          _         (when-not raw-store

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -173,3 +173,49 @@
       (is (thrown-with-msg? Throwable
                             #"Configuration does not match existing connections."
                             (d/connect file-index))))))
+
+(deftest self-only-writer-options-are-refused-on-remote-writers
+  (testing "every self-writer option is refused, not ignored, on a remote backend.
+            A remote writer transacts in another process, so none of these can be
+            honoured from here — and :require-fencing in particular names a
+            safety property, so a config that carries it and connects anyway
+            LOOKS protected while nothing checks anything."
+    (doseq [k [:writer-ownership :streaming? :require-fencing
+               :max-batch :head-conflict-retries :head-conflict-backoff-ms]]
+      (let [e (try (c/normalize-writer-config {:backend :datahike-server k :anything})
+                   ::not-thrown
+                   (catch #?(:clj Exception :cljs js/Error) ex (ex-data ex)))]
+        (is (= :self-writer-options-on-remote-writer (:type e))
+            (str k " must be refused on a remote writer"))
+        (is (= [k] (:inert e))))))
+
+  (testing "a remote writer's own keys pass untouched — the key set stays open
+            (:kabel has :local-peer and friends), only the self-only keys are
+            closed"
+    (is (= {:backend :kabel :local-peer :a-peer}
+           (c/normalize-writer-config {:backend :kabel :local-peer :a-peer}))))
+
+  (testing "the same options on the :self backend keep their meaning"
+    (is (= :exclusive (:writer-ownership
+                       (c/normalize-writer-config
+                        {:backend :self :writer-ownership :exclusive}))))
+    (is (= :global (:require-fencing
+                    (c/normalize-writer-config
+                     {:backend :self :require-fencing :global}))))))
+
+#?(:clj
+   (deftest self-only-writer-options-are-refused-at-connect
+     (testing "the guard fires through the public API, not only when the helper
+               is called directly: connect normalizes every writer map before it
+               touches a store or a writer. (create-database with a remote
+               writer dispatches to the REMOTE endpoint first, so the config is
+               that server's to validate — connect is the local entry point.)"
+       (let [base {:store {:backend :memory :id #uuid "cf917000-0000-4000-8000-000000000001"}
+                   :schema-flexibility :read
+                   :keep-history? false}]
+         (d/delete-database base)
+         (d/create-database base)
+         (is (thrown-with-msg?
+              clojure.lang.ExceptionInfo #"inert on a remote writer"
+              (d/connect (assoc base :writer {:backend :datahike-server
+                                              :require-fencing :global}))))))))


### PR DESCRIPTION
Follow-up to #977, closing the asymmetry flagged in its review: self-writer options on a remote writer backend were silently inert.

A remote writer transacts in another process, so `:writer-ownership`, `:streaming?`, `:max-batch`, the head-conflict retry options and — the one with teeth — `:require-fencing` are all about a writer this config does not control. Accepting them silently produced a config that *looks* protected and is not: the same silent-inert-option failure the self writer's closed key set exists to prevent, one backend over.

**Where the guard lives:** `normalize-writer-config`, which every connect path runs. Remote writers keep their own **open** key sets (`:kabel` has `:local-peer` and friends), so only the self-only keys are closed, not everything unknown.

**The cached-path `check-fencing!` is scoped to `:self`** for the complementary reason: with the guard, a remote writer carrying `:require-fencing` never reaches it — and checking there against the *local* store judged a remote writer's guarantee by a store it does not write to. A refusal or a pass, both about the wrong thing.

**Tests:** one per refused key via the helper, remote writers' own keys pass untouched, self-backend semantics unchanged, and the guard verified through the public API (`d/connect` with a `:datahike-server` writer carrying `:require-fencing` is refused before any store or writer is touched — `create-database` with a remote writer dispatches to the remote endpoint first, so that config is the server's to validate, and the test documents that). Negative control: guard removed → 12 of 15 assertions red.

config + writer-alternating + versioning-fencing namespaces: **53 tests, 204 assertions, 0 failures**. cljfmt clean; clj-kondo counts identical to baseline.