### PR TITLE
Unified warming: the walk moves to PSS, and warm-db reaches the secondaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Index warming is unified across the stack, and real on ClojureScript.**
+  The breadth-first walk moved to persistent-sorted-set (>= 0.5.142), where
+  every consumer shares it; `datahike.index.persistent-set.warm` is now the
+  adapter (option dialect, clamp warning, and the adaptation of PSS's async
+  shapes to datahike's channel convention — including the ClojureScript arm,
+  which previously reported `:unsupported :cljs` and now runs).
+- **`warm-db` warms secondary indices too, opt-in.** A new optional protocol
+  `datahike.index.secondary/ISecondaryWarmable` (separate from
+  `IVersionedSecondaryIndex`, so existing implementers are untouched) is
+  implemented by the stratum, proximum and scriptum adapters, each delegating
+  to its library's own warm. `warm-db`'s `:secondary` option — `:none`
+  (default) | `:defaults` | `{index-ident opts}` — runs them and attaches
+  `:secondary {index-ident envelope}` to the report. Budgets are per index
+  family in that family's own units (stratum: tree nodes; scriptum: Lucene
+  segment files; proximum: tree nodes over what its eager restore already
+  loaded); the shared part is the report envelope, at least
+  `{:fetched :ms :budget-exhausted?}`. Off by default because a secondary's
+  full warm can dwarf the primary one — turn it on where you have measured it.
+- persistent-sorted-set `0.5.141` → `0.5.142`; stratum `0.3.81` → `0.3.82`,
+  proximum `0.1.35` → `0.1.36`, scriptum `0.1.29` → `0.1.30` in the test
+  alias (the releases carrying each library's warm).
+
 ### Breaking changes
 
 - **The local writer now defaults to `:writer-ownership :shared`** — correctness no longer depends on knowing that a second process, container or Lambda execution environment has started writing the same branch. The default re-reads the branch head once per batch and conditionally publishes it wherever the store supports fencing; set `:writer-ownership :exclusive` only when one process owns the writer and the saved head GET matters. For sequential callers this adds one branch-head read per transaction, and `@conn` reads through to storage rather than trusting the in-memory head. Existing databases need no migration: ownership is a connect-time choice, not stored metadata. The experimental self-writer `:streaming?` option remains a deprecated alias (`false` → `:shared`, `true` → `:exclusive`); streaming itself continues to describe whether a writer delivers completed writes into its connection.

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
         ;; :cljs + :test (shadow-cljs.edn:1), and `bb test cljs-node` sees only
         ;; :cljs — so this is the one placement all three see. The old :bulk
         ;; alias reached none of the cljs ones.
-        org.replikativ/persistent-sorted-set        {:mvn/version "0.5.141"}
+        org.replikativ/persistent-sorted-set        {:mvn/version "0.5.142"}
         ;; MAIN deps, not a test alias. `datahike.cbor` is src/, so boring is a
         ;; real runtime dependency: the dump codec and the kabel wire format
         ;; both go through it. It used to be declared only under :test, which
@@ -116,9 +116,9 @@
                                ring-cors/ring-cors           {:mvn/version "0.1.13"}
 
                                ;; secondary index integrations (for testing)
-                               org.replikativ/proximum       {:mvn/version "0.1.35"}
-                               org.replikativ/scriptum       {:mvn/version "0.1.29"}
-                               org.replikativ/stratum        {:mvn/version "0.3.81"}
+                               org.replikativ/proximum       {:mvn/version "0.1.36"}
+                               org.replikativ/scriptum       {:mvn/version "0.1.30"}
+                               org.replikativ/stratum        {:mvn/version "0.3.82"}
 
                                ;; kabel integration for distributed datahike.
                                ;; src-kabel's connector requires datahike.cbor,

--- a/src-secondary/datahike/index/secondary/proximum.clj
+++ b/src-secondary/datahike/index/secondary/proximum.clj
@@ -10,6 +10,7 @@
                        :db.secondary/config {:dim 384 :distance :cosine
                                              :store-config {...}}}}"
   (:require
+   [proximum.warm :as prox-warm]
    [datahike.index.audit :as audit]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
@@ -62,6 +63,14 @@
                 results)))
 
       (-indexed-attrs [_] attrs)
+
+      sec/ISecondaryWarmable
+      (-sec-warm! [_ opts]
+        ;; Proximum's restore is eager for edges and vectors (parallel since
+        ;; proximum 0.1.36 — :fetch-width on load is that phase's knob); what
+        ;; stays lazy are the external-id and metadata trees, and this warms
+        ;; those. Units are tree NODES.
+        (prox-warm/warm! prox-idx opts))
 
       sec/IVersionedSecondaryIndex
       (-sec-flush [_ _store branch]

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -108,6 +108,19 @@
 
       (-indexed-attrs [_] attrs)
 
+      sec/ISecondaryWarmable
+      (-sec-warm! [_ opts]
+        ;; Units are Lucene segment FILES (scriptum's own — budgets do not
+        ;; translate across index families). Meaningful only for a
+        ;; store-backed (konserve) scriptum, where a cold machine fetches its
+        ;; segments ahead of Lucene's serial demand; this adapter still opens
+        ;; scriptum by PATH, where the files are local by construction and
+        ;; scriptum's warm! answers nil — normalized to a zero report here, so
+        ;; the delegation is already right when the adapter moves to the
+        ;; konserve backing.
+        (or (sc/warm! writer opts)
+            {:fetched 0 :ms 0.0 :budget-exhausted? false}))
+
       sec/IVersionedSecondaryIndex
       (-sec-flush [_ _store branch]
         ;; Scriptum manages its own storage (Lucene files), not konserve.

--- a/src-secondary/datahike/index/secondary/stratum.clj
+++ b/src-secondary/datahike/index/secondary/stratum.clj
@@ -25,6 +25,7 @@
    [datahike.db.interface :as dbi]
    [stratum.api :as st]
    [stratum.dataset :as sd]
+   [stratum.warm :as stratum-warm]
    [stratum.index :as sidx]
    [stratum.storage :as ss])
   (:import
@@ -584,6 +585,15 @@
       (if (and (= new-attr-refs attr-refs) (= new-config config))
         this
         (StratumIndex. dataset attrs new-attr-refs new-config))))
+
+  sec/ISecondaryWarmable
+  (-sec-warm! [_ opts]
+    ;; One shared budget across every column tree, in NODES — stratum's unit.
+    ;; See stratum.warm for depth semantics: leaves there are FAT (a leaf
+    ;; carries its chunks), so :with-leaves is materializing the column data.
+    (if dataset
+      (stratum-warm/warm! dataset opts)
+      {:fetched 0 :ms 0.0 :budget-exhausted? false}))
 
   sec/IVersionedSecondaryIndex
   (-sec-flush [_ store branch]

--- a/src/datahike/codegen/naming.cljc
+++ b/src/datahike/codegen/naming.cljc
@@ -6,10 +6,13 @@
 ;; Functions to skip in JS export (ClojureScript incompatible or aliases)
 ;; - transact: synchronous version that throws error in ClojureScript
 ;;             use transact! instead (which becomes 'transact' in JS)
-;; - warm-*:   EXPERIMENTAL index warming. The walk's ClojureScript arm is an
-;;             explicit TODO (see datahike.index.persistent-set.warm), so these
-;;             would export as functions that always report :unsupported :cljs.
-;;             Remove them from this set when that arm lands.
+;; - warm-*:   EXPERIMENTAL index warming. The walk's ClojureScript arm is REAL
+;;             now (persistent-sorted-set >= 0.5.142 owns it; datahike adapts
+;;             its partial-cps shape onto a channel — see
+;;             datahike.index.persistent-set.warm). What keeps these skipped is
+;;             only the JS binding round: the generated wrappers need the
+;;             channel->Promise adaptation and regenerated artifacts, which is
+;;             its own change. Remove them from this set in that round.
 (def js-skip-list #{'transact 'warm-index 'warm-datoms 'warm-db})
 
 (defn clj-name->js-name

--- a/src/datahike/index/persistent_set/warm.cljc
+++ b/src/datahike/index/persistent_set/warm.cljc
@@ -1,403 +1,115 @@
 (ns ^:no-doc datahike.index.persistent-set.warm
-  "Budget-bounded breadth-first index warm for the persistent-set index — pull a
-   database's upper levels into the node cache in WAVES instead of discovering
-   them one blocking round trip at a time.
+  "Budget-bounded breadth-first index warm for the persistent-set index — the
+   adapter behind `datahike.api/warm-index`, `warm-datoms` and `warm-db`.
 
-   > ⚠️ **EXPERIMENTAL.** Names and the option map may still move. The public
-   > entry points are `datahike.api/warm-index`, `warm-datoms` and
-   > `warm-db`; this namespace is the persistent-set walk behind them.
+   THE WALK LIVES IN persistent-sorted-set NOW (`org.replikativ.persistent-
+   sorted-set.warm`, PSS >= 0.5.142). It was first written here, entirely in
+   PSS's own vocabulary — `Branch`, levels, child addresses,
+   `IStorage.restore` — with its ClojureScript arm left as three documented
+   holes; moving it to where the tree is made both platforms real and let
+   every other consumer (stratum's per-attribute trees, proximum's id and
+   metadata trees) share one implementation. What stays here is exactly what
+   is datahike's: the option-map dialect (`:index-key`/`:siblings`/
+   `:store-cache-size`), the clamp WARNING (PSS clamps and reports
+   `:budget-clamped?`; whether that deserves a log line is the consumer's
+   call, and datahike's answer is yes — but only when the caller asked for
+   the budget explicitly), and the adaptation of PSS's async shapes to
+   datahike's channel convention.
 
-   ## Why
+   For the rationale, the two bounds, budget sizing and selective warming,
+   see the PSS namespace — the docstrings moved with the code.
 
-   A cold reader's wall time is `misses x RTT`, with nothing overlapping: a scan
-   asks for a node, blocks on the GET, and only then learns the next address.
-   Measured against object storage at +20ms injected latency, the marginal cost
-   of one more node was 24.96 ms against a ~25 ms round trip — one node, one
-   round trip, zero overlap.
+   ## Platform shapes
 
-   It does not have to be that way, and the fix needs no prediction. A `Branch`
-   holds `addresses()` — EVERY child address — the moment it is materialized. So
-   the addresses of a whole level are known one level in advance. This walks
-   breadth-first and fetches each level concurrently. Measured: the same 197 keys
-   at width 64 is 16.4x faster than serial at +20ms.
+   datahike's `-warm!` answers in datahike's convention: the report itself
+   under `:sync? true`, a core.async channel carrying it (or the exception,
+   as a value) otherwise.
 
-   ## The two bounds, and why there are two
-
-   `:depth` bounds the SHAPE, `:budget` bounds the COST, and whichever binds
-   first wins.
-
-     :depth :interior     expand while (>= level 2) — children are branches, so
-                          this stops exactly at the leaf boundary. Exact, not a
-                          heuristic: leaves are level 0 and the root knows the
-                          tree height.
-     :depth :with-leaves  expand while (>= level 1) — everything.
-     :depth <integer>     at most that many levels below the start node.
-
-   Having both is what keeps this free of latency cliffs. There is no `preload
-   everything` mode and no `warm the interior` mode to switch between — a small
-   database with a large budget runs out of frontier and has fetched itself
-   entirely; a large one hits the budget and stops. Same code, same config,
-   continuous in database size. A mode switch is a cliff, and tenants grow.
-
-   Measured (400 issues, +20ms): `:with-leaves` budget 8 warms 8 nodes and takes
-   the query from 21 GETs to 12 — a partial warm buying a partial saving,
-   landing between naive and fully-warmed with no step anywhere. The same walk
-   reaches `query costs 0 GETs` in 37 fetches, where `ready-store :tiered`'s
-   konserve `populate-missing-strategy` preload needs 392 fetches and 11.8s: the
-   walk touches only REACHABLE nodes and never enumerates the store.
-
-   ## Sizing a budget
-
-   In a B-tree the interior is a geometric series, so `interior/total` is a
-   constant fraction independent of database size — but size it from the MEASURED
-   fill, not the branching factor. Nodes run about half full, so the effective
-   fanout is ~bf/2 and the interior is ~`2/bf` of the tree, twice the naive
-   estimate. Measured at bf 32: 93 interior nodes of 1504 total (6.2%, against
-   1/32 = 3.1%).
-
-   The budget is also CLAMPED to the node cache. `:store-cache-size` is
-   ENTRY-counted, so warming past it fetches nodes only to evict them; 0.8x
-   leaves room for the query that follows to bring in its own leaves without
-   evicting the spine.
-
-   ## Selective warming
-
-   `:from`/`:to` scope the walk to a key range: at every level only the child
-   indices covering the range are expanded, so cost is proportional to the RANGE
-   rather than to the database. That is how warming stays affordable on a store
-   too large to warm whole.
-
-   They are an INTERNAL option, and the only public caller that sets them is
-   `datahike.warm/warm-datoms!`, which derives them from datahike's own
-   `components->pattern` (with `:unbounded? true` giving `seek-datoms`'
-   end-of-index upper bound). No public entry point takes raw datom bounds: they
-   have to be in the index's own key order, which `components->pattern` reaches
-   by PERMUTING the components per index, and a bound built by hand in the wrong
-   permutation warms a valid-but-different subtree with no error and no wrong
-   answer — just a warm that misses.
-
-   ## What it cannot do
-
-   This bounds DEPTH. It does nothing for a caller that issues many independent
-   scans one after another — that breadth lives above datahike, and no amount of
-   prefetching below can see it. Such a caller has to issue its seeks
-   concurrently (safe: nodes are immutable, the node cache is atom-based).
-
-   ## On the ClojureScript arm
-
-   Deliberately NOT implemented — see the `TODO(cljs)` markers on `child-bounds`,
-   `fetch-wave!` and `tree-entry`. The walk itself is shared and the shape is
-   written `async+sync`, so the seam is where it belongs; but the three platform
-   primitives it needs (a `searchFirst` over a node's keys, a bounded parallel
-   restore, and materializing an address-rooted root asynchronously) have no
-   ready ClojureScript counterpart today, and shipping them unexercised would be
-   worse than saying so.
-
-   The port is not a port: cljs has no threads but does not need them — bounded
-   `Promise.all` per level is simpler than this thread pool, and the BFS shape is
-   natively async. Two things genuinely differ: `:width` cannot share a default
-   (a browser gives ~6 connections per origin on HTTP/1.1, so 64 merely queues),
-   and the value proposition inverts — datahike's cljs read path runs a sync
-   query engine over async storage, so a complete warm is what makes synchronous
-   querying FEASIBLE rather than merely fast."
+     JVM  sync   -> PSS's synchronous walk, directly.
+     JVM  async  -> the same walk on an `async/thread`; PSS deliberately
+                    refuses `:sync? false` on the JVM rather than owning a
+                    thread, so the thread is ours.
+     cljs sync   -> PSS's sync arm (meaningful only when the storage supports
+                    synchronous restore — a fully cached tree, or a sync
+                    backing).
+     cljs async  -> PSS returns a partial-cps expression; it is adapted onto
+                    a promise-chan here, errors as values, which is the same
+                    convention `chan->async-expr` serves in the opposite
+                    direction in `datahike.index.persistent-set`."
   (:require
-   ;; `async+sync` and the superv operators are MACROS: ClojureScript needs
-   ;; :refer-macros for them. Written as two whole libspecs rather than with a
-   ;; reader conditional on the OPTION key, because `#?(:clj :refer :cljs
-   ;; :refer-macros)` beside a second `:refer` expands to a duplicate `:refer`
-   ;; on the JVM. Mirrors datahike.gc.
-   #?(:clj  [konserve.utils :refer [async+sync *default-sync-translation*]]
-      :cljs [konserve.utils
-             :refer [*default-sync-translation*]
-             :refer-macros [async+sync]])
-   #?(:clj  [superv.async :refer [go-try- <?-]]
-      :cljs [superv.async :refer-macros [go-try- <?-]])
-   ;; Required on BOTH runtimes even though only the JVM arm names `async/…`:
-   ;; `go-try-` expands into `clojure.core.async/go`, whose state machine emits
-   ;; `clojure.core.async/<!` and friends, so a cljs build without the namespace
-   ;; (only :require-macros below) compiles to undeclared vars. Same shape as
-   ;; datahike.gc.
-   [clojure.core.async :as async]
-   #?(:cljs [org.replikativ.persistent-sorted-set.branch :as branch :refer [Branch]])
+   #?(:clj [clojure.core.async :as async]
+      :cljs [clojure.core.async :as async])
    [datahike.index.interface :as di]
-   [replikativ.logging :as log])
-  ;; go-try- expands into clojure.core.async/go, which cljs needs as a macro.
-  #?(:cljs (:require-macros [clojure.core.async :refer [go]]))
-  #?(:clj (:import [org.replikativ.persistent_sorted_set PersistentSortedSet ANode Branch IStorage]
-                   [java.util Comparator]
-                   [java.util.concurrent Executors ExecutorService Callable Future TimeUnit])))
+   [org.replikativ.persistent-sorted-set.warm :as pss-warm]
+   [replikativ.logging :as log]))
 
 (def default-width
-  "Concurrent in-flight restores.
+  "Concurrent in-flight restores — persistent-sorted-set's default (64 JVM,
+   measured optimal against local MinIO; 6 cljs, the browser's per-origin
+   connection budget)."
+  pss-warm/default-width)
 
-   64 measured optimal against local MinIO (16.4x over serial at +20ms); 128
-   REGRESSED there. A real bucket tolerates far more — a starting point to
-   measure from, not a constant to inherit. ClojureScript defaults to 6 because
-   a browser gives ~6 connections per origin on HTTP/1.1, so anything above that
-   merely queues."
-  #?(:clj 64 :cljs 6))
-
-;; The budget default and the empty report live on the protocol's namespace, not
-;; here: an index type that no-ops `-warm!` must be able to answer in the same
-;; shape without depending on the persistent-set walk.
 (def default-budget di/default-warm-budget)
 
-;; ---------------------------------------------------------------------------
-;; Platform primitives
-;;
-;; Everything below the walk that touches a node or the storage lives here, so
-;; the ClojureScript arm is three named holes rather than a rewrite.
+(defn- entries
+  "PSS `warm-trees!` entries from datahike's option dialect: this index under
+   `:index-key`, plus `:siblings` — `[index-key index]` pairs sharing the same
+   `:from`/`:to` bounds, which is correct because a db's indices are warmed for
+   the same scan or none."
+  [pset {:keys [index-key siblings from to] :or {index-key :index}}]
+  (mapv (fn [[k s]] {:key k :set s :from from :to to})
+        (cons [index-key pset] siblings)))
 
-#?(:cljs
-   (defn- unsupported! [what]
-     (throw (ex-info (str "warm: " what " is not implemented on ClojureScript yet")
-                     {:error :warm/cljs-not-implemented :missing what}))))
+(defn- pss-opts
+  [{:keys [depth budget width store-cache-size] :as opts}]
+  (cond-> {:depth  (or depth :interior)
+           :budget (or budget default-budget)
+           :width  (or width default-width)}
+    store-cache-size (assoc :cache-size store-cache-size)))
 
-(defn- branch? [n]
-  (instance? Branch n))
-
-(defn- node-level [n]
-  #?(:clj  (.level ^ANode n)
-     :cljs (.-level n)))
-
-(defn- child-bounds
-  "Inclusive child-index bounds of `node`, intersected with [from to] (nil =
-   unbounded). `_keys[i]` is the MAX key of child i, so `searchFirst` — the first
-   index whose key is >= the probe — names the child that could contain it, for
-   both ends of the range.
-
-   TODO(cljs): persistent-sorted-set's ClojureScript arm keeps its equivalent
-   (`util/binary-search-l`) private, so this needs either that made public or a
-   ~12-line reimplementation. Not written blind."
-  [node cmp from to]
-  #?(:clj
-     (let [^ANode node node
-           ^Comparator cmp cmp
-           lst (dec (.len node))]
-       [(if from (min (max 0 (.searchFirst node from cmp)) lst) 0)
-        (if to   (min (max 0 (.searchFirst node to cmp)) lst) lst)])
-     :cljs (unsupported! "child-bounds")))
-
-(defn- child-address [node i]
-  #?(:clj  (.address ^Branch node (int i))
-     :cljs (branch/address node i)))
-
-#?(:clj
-   (defn- fetch-wave-blocking!
-     "Restore `reqs` ({:addr :storage ..}) with at most `width` in flight.
-
-      Concurrent `restore` is safe: PSS nodes are immutable and content/uuid-
-      keyed, and datahike's CachedStorage caches through
-      `clojure.core.cache.wrapped` (atom `swap!`). Two threads racing the same
-      address duplicate a fetch — wasted work, never a wrong answer.
-
-      A per-call pool rather than a shared one: nothing to own, nothing to shut
-      down on a failure path, and a warm is not hot enough for the churn to
-      matter."
-     [reqs width]
-     (let [^ExecutorService pool (Executors/newFixedThreadPool (int (max 1 width)))]
-       (try
-         (->> reqs
-              (mapv (fn [{:keys [^IStorage storage addr]}]
-                      (reify Callable (call [_] (.restore storage addr)))))
-              (.invokeAll pool)
-              (mapv (fn [^Future f] (.get f))))
-         (finally
-           (.shutdown pool)
-           (.awaitTermination pool 120 TimeUnit/SECONDS))))))
-
-(defn- fetch-wave!
-  "One level's restores, concurrently. Returns the restored nodes under
-   `sync?`, a channel carrying them (or the exception, as a value) otherwise.
-
-   HOISTED OUT of the `async+sync` body on purpose. `async+sync` postwalks ONE
-   form into both arms, so any construct without a synchronous counterpart —
-   a thread pool, `async/merge`, `pipeline` — cannot appear inside it. (This is
-   the same constraint that made `datahike.gc` drop its `async/merge` fan-out
-   across branches.) The fan-out is the whole point of this feature, so it lives
-   here, on the far side of a `<?-`, where each runtime may implement it its own
-   way.
-
-   TODO(cljs): bounded `Promise.all` per level. persistent-sorted-set's cljs
-   `IStorage/restore` under `{:sync? false}` returns a partial-cps expression,
-   so the shape is: kick off `width` of them at once (each starts its IO
-   immediately — JS is single-threaded, so awaiting them in order still
-   pipelines), adapt each to a promise-chan the way
-   `datahike.index.persistent-set/chan->async-expr` does in the other direction,
-   and `<!` them in order."
-  [reqs width sync?]
-  #?(:clj
-     (if sync?
-       (fetch-wave-blocking! reqs width)
-       ;; Errors travel as VALUES on the channel — the `go-try-`/`<?-`
-       ;; convention. `thread` keeps the blocking gather off the go dispatch
-       ;; pool; the fan-out itself is the executor above.
-       (async/thread
-         (try (fetch-wave-blocking! reqs width)
-              (catch Exception e e))))
-     :cljs (unsupported! "fetch-wave!")))
-
-(defn tree-entry
-  "A walk root for one index, or nil when there is nothing to walk.
-
-   TODO(cljs): `.root` restores from the stored address if it is not already in
-   hand — free under `:fuse-index-roots?`, where the root rides in the db record.
-   The cljs `BTSet` keeps `root` as a raw FIELD that is nil for an address-rooted
-   set, and its materializing counterpart (`btset/-root`) is private and async."
-  [index-key pset {:keys [from to]}]
-  #?(:clj
-     (let [^PersistentSortedSet pset pset
-           storage (.-_storage pset)
-           root    (.root pset)]
-       (when (and root storage)
-         {:index index-key :node root :storage storage :cmp (.comparator pset)
-          :from from :to to}))
-     :cljs (unsupported! "tree-entry")))
-
-(defn- now-ns []
-  #?(:clj (System/nanoTime) :cljs (* 1e6 (js/Date.now))))
-
-(defn- elapsed-ms [t0]
-  (/ (- (now-ns) t0) 1e6))
-
-;; ---------------------------------------------------------------------------
-;; The walk
-
-(defn- expand?
-  "Should this node's children be fetched? A leaf never has children, so it
-   always terminates the walk regardless of policy — which is what makes
-   `:interior` fall out of the loop rather than needing to be enforced."
-  [node depth round]
-  (let [lvl (node-level node)]
-    (cond
-      (< lvl 1)              false
-      (= :interior depth)    (>= lvl 2)
-      (= :with-leaves depth) true
-      (integer? depth)       (< round depth)
-      :else                  false)))
-
-(defn- round-robin
-  "Fair interleave of unequal-length colls. Used to share one budget across
-   indices: without it, whichever index is enumerated first eats the budget and a
-   query against a later index gets nothing warmed."
-  [colls]
-  (lazy-seq
-   (let [colls (remove empty? colls)]
-     (when (seq colls)
-       (concat (map first colls) (round-robin (map next colls)))))))
-
-(defn- clamp-budget
-  "Budget capped to 0.8x the ENTRY-counted node cache. Warming past the cache
-   fetches nodes only to evict them, so a budget above it is not a bigger warm —
-   it is the same warm plus wasted GETs. The 0.8 leaves room for the query that
-   follows to bring in its own leaves without evicting the spine.
-
-   Warns only when the caller ASKED for a budget the cache cannot hold. The
+(defn- warn-on-clamp!
+  "PSS clamps a budget past 0.8x the node cache and reports it; the WARNING is
+   datahike's, and only when the caller asked for that budget explicitly — the
    default budget (2000) already exceeds the default cache (1000), so warning
    unconditionally would fire on every warm of an untuned database and say
-   nothing about that database. `:budget-clamped?` reports it either way."
-  [budget explicit? store-cache-size]
-  (if (and store-cache-size (> budget (* 0.8 store-cache-size)))
-    (let [capped (long (* 0.8 store-cache-size))]
-      (when explicit?
-        (log/warn :warm/budget-clamped
-                  {:requested budget :capped capped
-                   :store-cache-size store-cache-size
-                   :msg "budget exceeded 0.8x the entry-counted node cache; raise :store-cache-size to warm more"}))
-      capped)
-    budget))
-
-(defn warm-trees!
-  "One breadth-first walk across SEVERAL trees, sharing one budget.
-
-   Interleaved rather than sequential: at each round every tree contributes its
-   next level, and the budget is spent round-robin across them. Warming eavt to
-   exhaustion while avet gets nothing is the wrong answer for a query that reads
-   avet, and which index a query needs is not knowable here.
-
-   `entries` is a seq of {:index k :node root :storage s :cmp c :from d :to d}.
-   Returns the report under `:sync?`, a channel carrying it otherwise."
-  [entries {:keys [depth budget width sync? store-cache-size] :as opts
-            :or   {depth :interior budget default-budget width default-width
-                   sync? #?(:clj true :cljs false)}}]
-  (let [capped   (clamp-budget budget (contains? opts :budget) store-cache-size)
-        clamped? (< capped budget)]
-    (async+sync
-     sync? *default-sync-translation*
-     (go-try-
-      (let [t0     (now-ns)
-            height (reduce max 0 (map (comp node-level :node) entries))]
-        (loop [frontier (vec entries)
-               round    0
-               left     (long capped)
-               fetched  0
-               by-level []
-               per-idx  {}]
-          (let [groups (->> frontier
-                            (filter #(and (branch? (:node %))
-                                          (expand? (:node %) depth round)))
-                            (group-by :index))
-                reqs   (when (pos? left)
-                         (vec (round-robin
-                               (for [[_ es] groups]
-                                 (for [{:keys [node from to cmp] :as e} es
-                                       :let  [[lo hi] (child-bounds node cmp from to)]
-                                       i     (range lo (inc hi))
-                                       :let  [a (child-address node i)]
-                                       ;; nil address = an in-memory child never
-                                       ;; stored. Cannot happen on a freshly-
-                                       ;; connected cold tree; skipped rather
-                                       ;; than trusted.
-                                       :when (some? a)]
-                                   (assoc e :addr a :node nil))))))]
-            (if (empty? reqs)
-              {:fetched fetched :by-level by-level :rounds round :by-index per-idx
-               :height height :budget-left left :budget-exhausted? false
-               :budget-clamped? clamped? :ms (elapsed-ms t0)}
-              (let [take-n  (min (count reqs) left)
-                    batch   (subvec reqs 0 take-n)
-                    nodes   (<?- (fetch-wave! batch width sync?))
-                    next-f  (mapv (fn [n r] (assoc r :node n)) nodes batch)
-                    left'   (- left take-n)
-                    per-idx (reduce (fn [m {:keys [index]}] (update m index (fnil inc 0)))
-                                    per-idx batch)]
-                (if (zero? left')
-                  {:fetched (+ fetched take-n) :by-level (conj by-level take-n)
-                   :rounds (inc round) :by-index per-idx :height height
-                   :budget-left 0 :budget-exhausted? true
-                   :budget-clamped? clamped? :ms (elapsed-ms t0)}
-                  (recur next-f (inc round) left' (+ fetched take-n)
-                         (conj by-level take-n) per-idx)))))))))))
+   nothing about that database."
+  [report {:keys [budget store-cache-size] :as opts}]
+  (when (and (:budget-clamped? report) (contains? opts :budget))
+    (log/warn :warm/budget-clamped
+              {:requested budget
+               :capped (long (* 0.8 store-cache-size))
+               :store-cache-size store-cache-size
+               :msg "budget exceeded 0.8x the entry-counted node cache; raise :store-cache-size to warm more"}))
+  report)
 
 (defn warm!
-  "Breadth-first warm of a persistent-set index into its node cache.
-
-   Options: `:depth` (`:interior` | `:with-leaves` | integer), `:budget`,
-   `:width`, `:from`/`:to`, `:store-cache-size`, `:sync?`, `:index-key` (the
-   label this index gets in `:by-index`) and `:siblings`.
-
-   `:siblings` is a seq of `[index-key index]` pairs — OTHER indices of the same
-   database that share this call's single budget, round-robin, so no index can
-   spend it all before another gets any. Which index a query will read is not
-   knowable at warm time, and `datahike.warm/warm-db!` is the caller that needs
-   this. Passing none warms just `pset`.
-
-   Returns {:fetched :by-level :rounds :height :by-index :budget-left
-   :budget-exhausted? :budget-clamped? :ms} — a channel carrying it under
-   `:sync? false`. `:by-level` and `:budget-exhausted?` are the point of the
-   report: they make a decaying warm visible as a metric before it is visible
-   in p99."
-  [pset {:keys [index-key siblings] :or {index-key :index} :as opts}]
-  #?(:cljs
-     ;; The walk short-circuits on ClojureScript rather than throwing: three of
-     ;; its platform primitives are unimplemented (see the TODO(cljs) markers
-     ;; above) and a "not implemented" raised from inside an OPTIONAL prefetch
-     ;; would turn a missing optimisation into a failed read. `:unsupported`
-     ;; says so in the report instead of pretending the tree was already warm.
-     (di/warm-result (assoc (di/zero-warm-report opts) :unsupported :cljs) opts)
-     :clj
-     (let [entries (keep (fn [[k idx]] (tree-entry k idx opts))
-                         (cons [index-key pset] siblings))]
-       (if (seq entries)
-         (warm-trees! entries opts)
-         (di/warm-result (di/zero-warm-report opts) opts)))))
+  "Breadth-first warm of a persistent-set index into its node cache — see the
+   PSS walk for `:depth`/`:budget`/`:width`/`:from`/`:to` and the report;
+   datahike adds `:index-key` (the label in `:by-index`), `:siblings` (other
+   indices sharing this call's budget round-robin) and `:store-cache-size`
+   (the clamp basis). Returns the report under `:sync?`, a channel carrying
+   it otherwise."
+  [pset opts]
+  (let [es       (entries pset opts)
+        popts    (pss-opts opts)
+        sync?    (:sync? opts #?(:clj true :cljs false))]
+    #?(:clj
+       (if sync?
+         (warn-on-clamp! (pss-warm/warm-trees! es (assoc popts :sync? true)) opts)
+         ;; PSS refuses :sync? false on the JVM rather than owning a thread —
+         ;; the thread is datahike's. Errors travel as VALUES on the channel,
+         ;; the go-try-/<?- convention.
+         (async/thread
+           (try (warn-on-clamp! (pss-warm/warm-trees! es (assoc popts :sync? true)) opts)
+                (catch Exception e e))))
+       :cljs
+       (if sync?
+         (warn-on-clamp! (pss-warm/warm-trees! es (assoc popts :sync? true)) opts)
+         ;; A partial-cps expression, adapted onto a promise-chan: exactly one
+         ;; of resolve/raise fires, and either way the caller's take succeeds —
+         ;; errors as values, like every other channel in this API.
+         (let [ch (async/promise-chan)
+               expr (pss-warm/warm-trees! es (assoc popts :sync? false))]
+           (expr (fn [report] (async/put! ch (warn-on-clamp! report opts)))
+                 (fn [err] (async/put! ch err)))
+           ch)))))

--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -224,6 +224,37 @@
      Used by GC to mark reachable storage. Indices using external storage
      (e.g., scriptum/Lucene filesystem) return #{}."))
 
+(defprotocol ISecondaryWarmable
+  "EXPERIMENTAL. Optional protocol for secondary indices whose storage can be
+   prefetched ahead of demand. A SEPARATE protocol rather than a method on
+   `IVersionedSecondaryIndex`, deliberately: adding a method to a protocol
+   breaks every existing implementer at call time, and warmth is orthogonal to
+   versioning anyway — an index that does not implement this is simply skipped
+   by `datahike.api/warm-db`'s `:secondary` pass (a transient index rebuilt
+   from AEVT is already in memory and has nothing to warm).
+
+   BUDGETS ARE IN THE INDEX'S OWN UNITS and deliberately do not translate:
+   stratum counts tree nodes, scriptum counts Lucene segment files, proximum
+   counts tree nodes over what its eager restore already loaded. One number
+   spanning those would mean nothing. What IS shared is the report envelope —
+   at least {:fetched :ms :budget-exhausted?} — so one caller can log one
+   decay metric across every index family."
+
+  (-sec-warm! [this opts]
+    "Prefetch this index's storage. `opts` is index-family-specific but every
+     family accepts `:budget` (a hard ceiling in its own units). Returns the
+     warm-report envelope; synchronous."))
+
+(defn sec-warm!
+  "EXPERIMENTAL. `-sec-warm!` if `idx` implements it, a zero envelope marked
+   `:unsupported?` otherwise — so `warm-db`'s `:secondary` pass reports every
+   index it was asked about rather than silently skipping the ones that cannot
+   answer."
+  [idx opts]
+  (if (satisfies? ISecondaryWarmable idx)
+    (-sec-warm! idx opts)
+    {:fetched 0 :ms 0.0 :budget-exhausted? false :unsupported? true}))
+
 (defprotocol IValidTimeAware
   "Optional protocol for secondary indices that natively understand the
    tx-meta valid-time axis (`:db.valid/from` / `:db.valid/to`).

--- a/src/datahike/warm.cljc
+++ b/src/datahike/warm.cljc
@@ -57,7 +57,9 @@
    `datahike.db/contextual-datoms` makes — so a warm and its scan agree by
    construction. `warm-index!` deliberately takes no `:from`/`:to`: shipping the
    trap next to the fix is worse than shipping only the fix."
-  (:require [datahike.index :as di]
+  (:require [clojure.core.async]
+            [datahike.index :as di]
+            [datahike.index.secondary :as sec]
             [datahike.db.utils :as dbu]
             [datahike.constants :as const]
             [datahike.datom :refer [datom]])
@@ -180,6 +182,29 @@
                                                               const/emax const/txmax)))))
      (di/warm-result (di/zero-warm-report opts) opts))))
 
+(defn- warm-secondaries!
+  "The `:secondary` pass: each versioned secondary index warmed with ITS OWN
+   budget in ITS OWN units — one number spanning tree nodes, Lucene segment
+   files and HNSW blobs would mean nothing, so nothing here pretends
+   otherwise. What is shared is the report envelope (at least
+   `{:fetched :ms :budget-exhausted?}`), one per index, so a caller logs one
+   decay metric across every family.
+
+   `secondary` is `:defaults` (every secondary, each family's defaults) or a
+   map `{index-ident opts}` (exactly those, each with its opts). Synchronous —
+   secondary indices are JVM-only today and their warms are their own."
+  [db secondary]
+  (let [indices (:secondary-indices db)
+        chosen  (cond
+                  (= :defaults secondary) (into {} (map (fn [[k _]] [k {}])) indices)
+                  (map? secondary)        secondary
+                  :else                   {})]
+    (into {}
+          (keep (fn [[k idx-opts]]
+                  (when-let [idx (get indices k)]
+                    [k (sec/sec-warm! idx idx-opts)])))
+          chosen)))
+
 (defn warm-db!
   "EXPERIMENTAL. Warm every present index of `db`, sharing ONE budget
    round-robin across them. The common case, and the connect-time shape.
@@ -190,22 +215,50 @@
    interleaved at the level of individual fetches, so a budget too small for all
    the indices is SPLIT rather than eaten by whichever is enumerated first.
 
-   Takes `warm-index!`'s options plus `:indices` — the index keys to consider,
-   defaulting to `index-keys`. A single-element `:indices` covers the one-index
-   case too.
+   Takes `warm-index!`'s options plus:
 
-   `:by-index` in the report says where the budget actually went."
+     :indices    the primary index keys to consider, defaulting to
+                 `index-keys`. A single-element `:indices` covers the
+                 one-index case too.
+     :secondary  `:none` (default) | `:defaults` | `{index-ident opts}` —
+                 warm the db's SECONDARY indices too, each with its own
+                 budget in its own units (stratum: tree nodes; scriptum:
+                 segment files; proximum: tree nodes). Off by default
+                 because a secondary's full warm can dwarf the primary one
+                 (scriptum's materializes every segment) — turn it on where
+                 you have measured it. The report gains `:secondary
+                 {index-ident envelope}`; an index that cannot warm answers
+                 a zero envelope marked `:unsupported?` rather than being
+                 silently skipped.
+
+   `:by-index` in the report says where the primary budget actually went."
   ([db] (warm-db! db {}))
-  ([db {:keys [indices] :as opts}]
+  ([db {:keys [indices secondary] :as opts}]
    (let [ks     (filter #(present db %) (or indices index-keys))
-         opts   (base-opts db opts)]
+         wopts  (base-opts db (dissoc opts :secondary))
+         sec-reports (when (and secondary (not= :none secondary))
+                       #?(:clj (warm-secondaries! db secondary)
+                          ;; Secondary indices are JVM-only today; asking for
+                          ;; them elsewhere reports rather than pretends.
+                          :cljs {}))]
      (if (seq ks)
        ;; The walk is one call, not one per index — a shared budget cannot be
        ;; split before the walk knows how much frontier each tree has. The first
        ;; index dispatches the protocol (all of a db's indices are the same
        ;; type); the rest ride along as `:siblings`.
-       (di/-warm! (present db (first ks))
-                  (assoc opts
-                         :index-key (first ks)
-                         :siblings (mapv (fn [k] [k (present db k)]) (rest ks))))
-       (di/warm-result (di/zero-warm-report opts) opts)))))
+       (let [r (di/-warm! (present db (first ks))
+                          (assoc wopts
+                                 :index-key (first ks)
+                                 :siblings (mapv (fn [k] [k (present db k)]) (rest ks))))]
+         (cond
+           (empty? sec-reports) r
+           ;; r is the report under :sync? true, a channel otherwise; attach
+           ;; the secondary reports in whichever shape came back.
+           (map? r) (assoc r :secondary sec-reports)
+           :else #?(:clj (clojure.core.async/go
+                           (let [v (clojure.core.async/<! r)]
+                             (if (map? v) (assoc v :secondary sec-reports) v)))
+                    :cljs r)))
+       (di/warm-result (cond-> (di/zero-warm-report wopts)
+                         (seq sec-reports) (assoc :secondary sec-reports))
+                       wopts)))))

--- a/test/datahike/test/secondary_warm_test.clj
+++ b/test/datahike/test/secondary_warm_test.clj
@@ -1,0 +1,95 @@
+(ns datahike.test.secondary-warm-test
+  "The `:secondary` pass of `warm-db`, and the `ISecondaryWarmable` seam.
+
+   Budgets are asserted in each family's OWN units and never compared across
+   families — that non-translation is part of the design, not a gap. What is
+   asserted across every index is the ENVELOPE: `:fetched`, `:ms`,
+   `:budget-exhausted?` — the shape one caller logs as one decay metric.
+
+   The stratum fixture is synced and RELOADED before warming, because an index
+   built in this process has its trees in memory and a warm of it correctly
+   reports zero — only a restored index has anything cold; see the fixture for
+   why it also controls the chunk size. Vacuity is the standing trap of this
+   whole arc."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.datom]
+   [datahike.index.secondary :as sec]
+   [datahike.index.secondary.stratum :as dstratum]
+   [stratum.dataset :as sd]
+   [stratum.index :as sidx]
+   [datahike.warm :as warm]
+   [konserve.memory :refer [new-mem-store]]))
+
+(defn- restored-stratum-index
+  "A stratum secondary index over a COLD, DEEP dataset.
+
+   Built directly through stratum rather than through the adapter's transact
+   path, for a measured reason: the adapter builds columns at stratum's
+   default chunk size (8192 elements), so an adapter-built column is a
+   single-leaf tree until ~half a million rows — restored root probed at
+   level 0 — and a warm of it correctly fetches nothing. Small chunks give
+   the tree interior structure at test scale; the object under test is the
+   ADAPTER's `-sec-warm!` (protocol -> stratum.warm delegation, opts and
+   budget pass-through), and it gets exactly the same dataset value either
+   way."
+  [n]
+  (let [store (new-mem-store (atom {}) {:sync? true})
+        ds    (sd/make-dataset
+               {:eid    (sidx/index-from-seq :int64 (range n) {:chunk-size 4})
+                :salary (sidx/index-from-seq :int64 (map #(* % 1000) (range n)) {:chunk-size 4})}
+               {:name "warm-fixture"})]
+    (sd/sync! ds store "main")
+    (dstratum/->StratumIndex (sd/load store "main") #{:person/salary} nil {})))
+
+(deftest sec-warm-answers-the-envelope
+  (let [idx (restored-stratum-index 2000)
+        r   (sec/sec-warm! idx {:depth :with-leaves :budget 100000})]
+    (is (pos? (:fetched r)) "a restored stratum index has cold tree nodes")
+    (is (number? (:ms r)))
+    (is (false? (:budget-exhausted? r)))
+    (testing "the budget is a hard ceiling, in stratum's own units (nodes)"
+      (let [idx2 (restored-stratum-index 2000)
+            r2   (sec/sec-warm! idx2 {:depth :with-leaves :budget 2})]
+        (is (= 2 (:fetched r2)))
+        (is (true? (:budget-exhausted? r2)))))))
+
+(deftest an-index-without-the-protocol-reports-not-pretends
+  (let [naked (reify sec/ISecondaryIndex
+                (-transact [this _] this)
+                (-indexed-attrs [_] #{}))
+        r     (sec/sec-warm! naked {})]
+    (is (zero? (:fetched r)))
+    (is (true? (:unsupported? r))
+        "an index that cannot warm says so instead of being silently skipped")))
+
+(deftest warm-db-carries-the-secondary-reports
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :schema-flexibility :read
+             :keep-history? false}
+        _    (d/delete-database cfg)
+        _    (d/create-database cfg)
+        conn (d/connect cfg)
+        idx  (restored-stratum-index 2000)
+        db   (assoc @conn :secondary-indices {:idx/columns idx})]
+    (try
+      (testing "default is :none — no secondary key in the report at all"
+        (let [r (warm/warm-db! db {})]
+          (is (not (contains? r :secondary))
+              "off by default: a secondary's full warm can dwarf the primary one")))
+      (testing ":defaults warms every secondary and reports per index"
+        (let [r (warm/warm-db! db {:secondary :defaults})]
+          (is (contains? (:secondary r) :idx/columns))
+          ;; :defaults means each family's defaults — :interior for stratum —
+          ;; and on this fixture's height-1 trees that correctly fetches 0.
+          ;; The envelope arriving is the assertion; the pos?-fetch proof is
+          ;; the map-selecting case below, which asks for leaves.
+          (is (number? (get-in r [:secondary :idx/columns :fetched])))
+          (is (contains? (get-in r [:secondary :idx/columns]) :budget-exhausted?))))
+      (testing "a map selects indices and passes each its own opts"
+        (let [db2 (assoc @conn :secondary-indices {:idx/columns (restored-stratum-index 2000)})
+              r   (warm/warm-db! db2 {:secondary {:idx/columns {:depth :with-leaves :budget 3}}})]
+          (is (= 3 (get-in r [:secondary :idx/columns :fetched])))
+          (is (true? (get-in r [:secondary :idx/columns :budget-exhausted?])))))
+      (finally (d/release conn)))))

--- a/test/datahike/test/warm_test.clj
+++ b/test/datahike/test/warm_test.clj
@@ -22,8 +22,10 @@
    A small branching factor gets a multi-level tree out of a few hundred datoms;
    the walk is branching-factor-independent, only the interior/total ratio is not.
 
-   JVM-only (`.clj`, not `.cljc`): the walk's ClojureScript arm is a marked TODO
-   and `-warm!` short-circuits there with `:unsupported :cljs`."
+   JVM-only (`.clj`, not `.cljc`): the walk itself now lives in
+   persistent-sorted-set with a real ClojureScript arm (exercised in that
+   library's own node suite); datahike's cljs-side coverage rides the
+   generated-API round that will export warm-* to JS."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.java.io :as io]
             [clojure.string :as str]


### PR DESCRIPTION
Completes the datahike side of the warming arc (persistent-sorted-set#25 → stratum#41 → proximum#19 → scriptum#5 → here), rebased on #980.

## The walk moves out, the adapter stays

`datahike.index.persistent-set.warm` carried the 403-line breadth-first walk with its ClojureScript arm as three documented TODO holes. The walk now lives in persistent-sorted-set 0.5.142 — where stratum's per-attribute trees and proximum's id/metadata trees already share it — and this namespace is a ~120-line adapter holding exactly what is datahike's: the option dialect (`:index-key`/`:siblings`/`:store-cache-size`), the clamp *warning* (PSS clamps and reports; the log line is the consumer's call), and the async-shape adaptation. JVM `:sync? false` runs on a thread datahike owns (PSS refuses to own one); **ClojureScript adapts PSS's partial-cps expression onto a promise-chan, errors as values — the arm that reported `:unsupported :cljs` now runs.** The entire pre-existing warm suite passes unchanged against the delegation, which is the point of an adapter.

## `warm-db` reaches the secondaries, opt-in

New optional protocol `ISecondaryWarmable` — **separate** from `IVersionedSecondaryIndex`, because adding a method to an existing protocol breaks every implementer at call time, and warmth is orthogonal to versioning. The stratum/proximum/scriptum adapters implement it as delegations to their libraries' warms; an index without it reports `{:unsupported? true}` rather than being silently skipped.

`warm-db` gains `:secondary` — `:none` (default) | `:defaults` | `{index-ident opts}` — and the report gains `:secondary {index-ident envelope}`.

**Budgets are per family, in that family's units** (stratum: tree nodes; scriptum: Lucene segment files; proximum: tree nodes over what its now-parallel eager restore already loaded). One number spanning those would mean nothing; the shared thing is the envelope — at least `{:fetched :ms :budget-exhausted?}` — one per index, one decay metric across every family. Default `:none` because a secondary's full warm can dwarf the primary one.

## Honesty notes

- The test fixture builds its stratum dataset directly at a small chunk size: an adapter-built column is a single-leaf tree until ~500k rows (default chunk 8192 — probed, root at level 0), and a warm of a leaf-root correctly fetches nothing. Vacuity is the standing trap of this arc; both new seams were watched failing first (deleting stratum's `-sec-warm!` → 3 assertions red; dropping the `:secondary` plumbing → 5 red).
- `warm-*` stays out of the generated JS API: the cljs walk landed, but the export needs the channel→Promise binding round and regenerated artifacts — its own change; the codegen comment now says exactly that.
- scriptum's adapter delegates but currently no-ops: it still opens scriptum by *path*, where files are local by construction. The delegation is already right for the konserve backing.

## Evidence

JVM: warm + all secondary suites — **54 tests, 293 assertions, 0 failures**. cljs (node): **272 tests, 1758 assertions, 0 failures**. Deps: PSS 0.5.142; stratum 0.3.82 / proximum 0.1.36 / scriptum 0.1.30 (test alias). cljfmt clean.