### PR TITLE
fix(ci): the bb-pod test expects the config normalize-writer-config returns

### DIFF
--- a/bb/resources/native-image-tests/run-bb-pod-tests.clj
+++ b/bb/resources/native-image-tests/run-bb-pod-tests.clj
@@ -32,7 +32,10 @@
             :store {:id #uuid "550e8400-e29b-41d4-a716-446655440763", :backend :memory :scope "test.datahike.io"}
             :store-cache-size 1000
             :attribute-refs? false
-            :writer {:backend :self}
+            ;; `normalize-writer-config` (datahike#977) stamps the ownership a
+            ;; self writer runs with — :shared, the fenced default — into every
+            ;; config it returns, so the pod reports it too.
+            :writer {:backend :self :writer-ownership :shared}
             :crypto-hash? false
             :schema-flexibility :read
             :branch :db}


### PR DESCRIPTION
Every "Building native images" run on main has been red since #977 — and none of the failures were native. The pod's `create-database` returns the **normalized** config, which since the fencing release carries the self writer's ownership (`{:backend :self :writer-ownership :shared}`); the pod test still expected the pre-normalization `{:backend :self}`. The *input* config in the same file stays short-form, correctly: normalization is datahike's job, and the test now checks exactly that it happened.

Diagnosed from the #980 run's failure log (`pod-workflow`, run-bb-pod-tests.clj:22): the only diff between actual and expected is the `:writer-ownership :shared` key. One-literal fix; the macos/linux native builds and image tests themselves were green in those runs.