### PR TITLE
Scope Kabel client handshakes to the active branch

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -129,7 +129,7 @@
                                ;; tested and shipped versions came apart.
                                org.replikativ/kabel          {:mvn/version "0.3.108"}
                                is.simm/distributed-scope     {:mvn/version "0.1.9"}
-                               org.replikativ/konserve-sync  {:mvn/version "0.1.39"}
+                               org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
 
                                ;; S3-compatible store integration test (migrate-s3-test, needs docker; runs Garage)
                                org.replikativ/konserve-s3    {:mvn/version "0.1.37"}

--- a/src-kabel/datahike/kabel/connector.cljc
+++ b/src-kabel/datahike/kabel/connector.cljc
@@ -28,6 +28,12 @@
 ;; TieredStore Support
 ;; =============================================================================
 
+(defn- branch-walk-fn
+  "Create a konserve-sync walk function scoped to one Datahike branch."
+  [branch]
+  (fn [store opts]
+    (dh-walker/datahike-walk-fn store (assoc opts :branches branch))))
+
 (defn- make-branch-walk-fn
   "Create a walk function for perform-walk-sync that walks a specific branch.
 
@@ -36,11 +42,7 @@
    node addresses from its indices."
   [branch]
   (fn [backend-store _root-values opts]
-    ;; datahike-walk-fn now walks EVERY branch in the store (reads `:branches`),
-    ;; so `branch`'s head + reachable blocks are always included. Walking all
-    ;; branches is a (small) superset for a single-branch client; a future
-    ;; optimization could restrict the walk to just `branch`.
-    (dh-walker/datahike-walk-fn backend-store opts)))
+    ((branch-walk-fn branch) backend-store opts)))
 
 (defn- populate-tiered-from-cache!
   "For tiered stores, populate memory frontend from backend (IndexedDB) cache.
@@ -207,7 +209,12 @@
          _ (log/trace "Calling subscribe-store!")
          sub-result (<?- (kp/subscribe-store!
                           local-peer store-topic sync-store
-                          {:on-key-update
+                          {;; Inventory only this branch's reachable local keys.
+                           ;; A durable browser cache may contain many abandoned
+                           ;; fork nodes; enumerating all of IndexedDB here blocks
+                           ;; the handshake before the server sees the request.
+                           :walk-fn (branch-walk-fn branch)
+                           :on-key-update
                            (fn [key value _op]
                              (when (= key branch)
                                ;; Replace server config with client config in synced stored-db


### PR DESCRIPTION
#### SUMMARY

Kabel-backed Datahike clients now pass an active-branch walk to konserve-sync for both the local timestamp inventory and tiered-cache restoration.

A persistent browser cache can contain abandoned forks and unrelated branches. Enumerating all of those keys before the initial handshake delays room loading and defeats lightweight-client behavior. Scoping the walk to the subscribed branch includes its head and reachable blocks while excluding unrelated cache history.

Depends on replikativ/konserve-sync#14.

#### Checks

##### Bugfix

- [ ] Related issues linked using fixes #number
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature

- [ ] Implements an existing discussion or RFC
- [x] Integration tests added
- [ ] Architecture Decision Record added
- [ ] Formatting checked

#### TEST PLAN

clojure -Sdeps with konserve-sync PR 14 as a local override, then:
clojure -M:test -m kaocha.runner --focus datahike.kabel.integration-test

7 tests, 46 assertions, 0 failures.