### PR TITLE
Avoid reopening secondary index writers for legacy heads

### DIFF
--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -36,6 +36,30 @@
     (= (count (select-keys obj keys-to-check))
        (count keys-to-check))))
 
+(def ^:private stored-head-identity-keys
+  "Persisted fields that determine the database materialized by `stored->db`.
+
+   Current branch heads carry a commit-id and never need this.  Legacy heads do
+   not, however, and a shared writer re-reads them before every transaction and
+   deref.  Keeping this identity on the in-memory db lets an unchanged legacy
+   head retain its live secondary-index instances (notably Scriptum's
+   lock-holding Lucene writer) without making the writer blind to a foreign
+   update.
+
+   Fused roots are represented by their content-derived keys; the root values
+   themselves are deliberately excluded because they are materialized index
+   objects rather than branch-head identity."
+  [:eavt-key :aevt-key :avet-key
+   :temporal-eavt-key :temporal-aevt-key :temporal-avet-key
+   :schema-meta-key :secondary-index-keys
+   ;; Pre schema-meta layouts kept these values inline.
+   :schema :rschema :system-entities :ref-ident-map :ident-ref-map
+   :max-tx :max-eid :op-count :hash :meta])
+
+(defn- stored-head-identity [stored]
+  (-> (select-keys stored stored-head-identity-keys)
+      (update :meta dissoc :datahike/commit-id)))
+
 (defn get-and-clear-pending-kvs!
   "Retrieves and clears pending key-value pairs from the store's pending-writes atom.
   Assumes :pending-writes in store's storage holds an atom of a collection of [key value] pairs."
@@ -388,6 +412,12 @@
        {:secondary-index-keys secondary-index-keys})
      (when (seq sec-indices)
        {:secondary-indices sec-indices})
+     ;; New heads use their durable commit-id.  A legacy head needs a stable,
+     ;; in-memory comparison token so a shared writer does not reopen the same
+     ;; lock-holding secondary index on every deref.  This field is intentionally
+     ;; top-level/internal and db->stored does not persist it.
+     (when-not (get-in stored-db [:meta :datahike/commit-id])
+       {::stored-head-identity (stored-head-identity stored-db)})
      schema-meta)))
 
 (defn stored->db-read-only
@@ -418,12 +448,11 @@
   "`old` itself when `stored` is the very commit `old` already is, otherwise a
    fresh in-memory db built from `stored`.
 
-   A record with NO cid is never treated as unmoved, even against an `old` that
-   also has none: neither side knowing its identity is not evidence that the two
-   match, and reading it as a match would make the writer blind to every other
-   process's commits — precisely the failure shared writer ownership exists to
-   prevent. Unreachable for databases this version creates (`create-database`
-   stamps a cid); the guard is for foreign or legacy records.
+   A record with NO cid (a foreign or legacy head) uses the complete persisted
+   head identity cached by `stored->db`.  This keeps an unchanged legacy head's
+   live secondary indices open while still rebuilding when any primary root,
+   schema pointer, secondary-index key-map, transaction boundary, hash, or
+   metadata changes.
 
    Identity is the commit-id: the same cid means the same stored record, hence
    the same primary index roots AND the same secondary-index key-maps, so there
@@ -437,6 +466,10 @@
   ([old stored store] (reload-head old stored store nil))
   ([old stored store head-revision]
    (let [stored-cid (get-in stored [:meta :datahike/commit-id])
+         same-head? (if stored-cid
+                      (= stored-cid (get-in old [:meta :datahike/commit-id]))
+                      (= (stored-head-identity stored)
+                         (::stored-head-identity old)))
          ;; The konserve revision the head blob was AT when we read it, carried on
          ;; the db so a later commit can fence its head write against it. Distinct
          ;; from the commit-id: the cid identifies datahike's state, the revision
@@ -446,7 +479,7 @@
          ;; public database metadata, or the content-derived commit id.
          stamp (fn [db] (cond-> db head-revision
                                 (assoc ::head-revision head-revision)))]
-     (if (and stored-cid (= stored-cid (get-in old [:meta :datahike/commit-id])))
+     (if same-head?
        ;; Unmoved head: the db is unchanged, but the revision may not be — the blob
        ;; can have been rewritten with identical content. Take the fresh one.
        (stamp old)

--- a/test/datahike/test/writer_alternating_test.clj
+++ b/test/datahike/test/writer_alternating_test.clj
@@ -16,7 +16,9 @@
             [datahike.connections :as conns]
             [datahike.connector :as dcon]
             [datahike.db.transaction :as dbtx]
+            [datahike.index.entity-set :as es]
             [datahike.index.secondary :as sec]
+            [datahike.index.secondary.scriptum]
             [datahike.index.secondary.stratum]
             [datahike.writer :as w]
             [datahike.tx-preds :as txp]
@@ -709,6 +711,49 @@
 
 (defn- head-strat-key [db]
   (get-in (head-record db) [:secondary-index-keys :idx/strat]))
+
+(deftest unchanged-legacy-head-keeps-live-scriptum-writer
+  (testing "a cid-less legacy head is identified without reopening the same
+            Scriptum branch and contending with its live Lucene write lock"
+    (let [tag  (str "legacy-scriptum-" (random-uuid))
+          c    (assoc (cfg tag :shared) :schema-flexibility :write)
+          path (str (System/getProperty "java.io.tmpdir") "/" tag)]
+      (fresh-db! c)
+      ;; Write a normal modern head with a durable Scriptum key-map, then strip
+      ;; only its cid to model an upgraded pre-commit-id database.
+      (let [{:keys [conn] :as p} (connect-as-separate-process c)]
+        (try
+          (d/transact conn [{:db/ident :p/name :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:db/ident :idx/scriptum
+                             :db.secondary/type :scriptum
+                             :db.secondary/attrs [:p/name]
+                             :db.secondary/config {:path path}}])
+          (d/transact conn [{:p/name "alice"}])
+          (let [db     @(:wrapped-atom conn)
+                branch (get-in db [:config :branch])
+                stored (k/get (:store db) branch nil {:sync? true})]
+            (is (some? (get-in stored [:secondary-index-keys :idx/scriptum])))
+            (k/assoc (:store db) branch
+                     (update stored :meta dissoc :datahike/commit-id)
+                     {:sync? true}))
+          (finally (release-separate-process p))))
+      (let [{:keys [conn] :as p} (connect-as-separate-process c)]
+        (try
+          (let [opened @(:wrapped-atom conn)]
+            (is (nil? (get-in opened [:meta :datahike/commit-id])))
+            (let [idx       (get-in opened [:secondary-indices :idx/scriptum])
+                  refreshed @conn
+                  refreshed-again @conn]
+              ;; reload-head may stamp a fresh konserve revision onto the db
+              ;; value, but it must preserve the live index object itself.
+              (is (identical? idx
+                              (get-in refreshed [:secondary-indices :idx/scriptum])))
+              (is (identical? idx
+                              (get-in refreshed-again [:secondary-indices :idx/scriptum])))
+              (is (= 1 (es/entity-bitset-cardinality
+                        (sec/-search idx {:query "alice" :field :value} nil))))))
+          (finally (release-separate-process p)))))))
 
 (deftest secondary-index-survives-alternating-processes
   (testing "a secondary index is named by the commit, so the head re-read has to


### PR DESCRIPTION
#### SUMMARY

Shared writers identify modern branch heads by commit id and preserve their live secondary-index instances when the head has not moved. Legacy heads without a commit id were always reconstructed, which tries to reopen Scriptum's Lucene writer and contends with the writer already held by the connection.

This change stores a non-persistent identity derived from all durable head fields when materializing a legacy head. reload-head can then retain the live database for an unchanged head while still rebuilding after any root, schema, secondary-index, transaction boundary, hash, or metadata change.

A regression test creates a Scriptum index, models a legacy cid-less head, reconnects, and verifies repeated shared-writer derefs retain the same live index and can search it.

#### Checks

##### Bugfix

- [ ] Related issues linked using fixes #number
- [x] Integration tests added
- [ ] Architecture Decision Record added if design changes necessary
- [ ] Formatting checked

##### Feature

- [ ] Implements an existing discussion or RFC
- [ ] Integration tests added
- [ ] Architecture Decision Record added
- [ ] Formatting checked

#### TEST PLAN

clojure -M:test -m kaocha.runner --focus datahike.test.writer-alternating-test

111 tests, 432 assertions, 0 failures across the configured focused suites.