### PR TITLE
Recognize implicit tuple schema attributes

### DIFF
--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -1325,34 +1325,44 @@
         ;; type-invalid heterogeneous tuple was accepted. Resolving first is also
         ;; why `attr-schema` must be a MAP; anything else means the lookup missed.
         a-ident (dbu/attr-ident db a)
-        attr-schema (let [s (-> db dbi/-schema (get a-ident))]
-                      (when (map? s) s))]
-    (cond (:db/tupleType attr-schema)
-          (cond (> (count v) 8)
-                (log/raise "Cannot store more than 8 values for homogeneous tuple: " op-vec
-                           {:error :transact/syntax, :tx-data op-vec})
+        attr-schema (dbu/attr-schema db a)]
+    (when-not (vector? v)
+      (log/raise "Tuple values must be vectors: " op-vec
+                 {:error :transact/syntax, :tx-data op-vec}))
+    ;; Validate assertions, but leave retractions available to clean up values
+    ;; written by an older or more permissive version. Datomic likewise accepts
+    ;; no-op retractions of malformed vector-shaped tuple metadata.
+    (when (= :db/add op)
+      (when (and (contains? #{:db/tupleAttrs :db/tupleTypes} a-ident)
+                 (< (count v) 2))
+        (log/raise "Tuple schema definitions require at least 2 values: " op-vec
+                   {:error :transact/syntax, :tx-data op-vec}))
+      (cond (:db/tupleType attr-schema)
+            (cond (> (count v) 8)
+                  (log/raise "Cannot store more than 8 values for homogeneous tuple: " op-vec
+                             {:error :transact/syntax, :tx-data op-vec})
 
-                (not (apply = (map type v)))
-                (log/raise "Cannot store homogeneous tuple with values of different type: " op-vec
-                           {:error :transact/syntax, :tx-data op-vec})
+                  (not (apply = (map type v)))
+                  (log/raise "Cannot store homogeneous tuple with values of different type: " op-vec
+                             {:error :transact/syntax, :tx-data op-vec})
 
-                ;; `attr-schema` already IS this lookup; the re-fetch used the raw
-                ;; `a` AS A FUNCTION, which throws outright on a numeric ref.
-                (not (s/valid? (:db/tupleType attr-schema) (first v)))
-                (log/raise "Cannot store homogeneous tuple. Values are of wrong type: " op-vec
-                           {:error :transact/syntax, :tx-data op-vec}))
-          (:db/tupleTypes attr-schema)
-          (cond (not (= (count v) (count (:db/tupleTypes attr-schema))))
-                (log/raise (str "Cannot store heterogeneous tuple: expecting " (count (:db/tupleTypes attr-schema)) " values, got " (count v))
-                           {:error :transact/syntax, :tx-data op-vec})
+                  ;; `attr-schema` already IS this lookup; the re-fetch used the raw
+                  ;; `a` AS A FUNCTION, which throws outright on a numeric ref.
+                  (not (s/valid? (:db/tupleType attr-schema) (first v)))
+                  (log/raise "Cannot store homogeneous tuple. Values are of wrong type: " op-vec
+                             {:error :transact/syntax, :tx-data op-vec}))
+            (:db/tupleTypes attr-schema)
+            (cond (not (= (count v) (count (:db/tupleTypes attr-schema))))
+                  (log/raise (str "Cannot store heterogeneous tuple: expecting " (count (:db/tupleTypes attr-schema)) " values, got " (count v))
+                             {:error :transact/syntax, :tx-data op-vec})
 
-                (not (apply = (map s/valid? (:db/tupleTypes attr-schema) v)))
-                (log/raise (str "Cannot store heterogeneous tuple: there is a mismatch between values " v " and their types " (:db/tupleTypes attr-schema))
-                           {:error :transact/syntax, :tx-data op-vec}))
-          (and (:db/tupleAttrs attr-schema)
+                  (not (apply = (map s/valid? (:db/tupleTypes attr-schema) v)))
+                  (log/raise (str "Cannot store heterogeneous tuple: there is a mismatch between values " v " and their types " (:db/tupleTypes attr-schema))
+                             {:error :transact/syntax, :tx-data op-vec}))))
+    (when (and (:db/tupleAttrs attr-schema)
                (not (::internal (meta op-vec))))
-          (log/raise "Can’t modify tuple attrs directly: " op-vec
-                     {:error :transact/syntax, :tx-data op-vec}))
+      (log/raise "Can’t modify tuple attrs directly: " op-vec
+                 {:error :transact/syntax, :tx-data op-vec}))
     ;; String-slot length cap (Datomic parity, default 256). Assert-only
     ;; (`:db/add` — never blocks retracting a pre-cap value) and `:write`-only,
     ;; mirroring the scalar string default. Structural checks above run first.

--- a/src/datahike/db/utils.cljc
+++ b/src/datahike/db/utils.cljc
@@ -39,6 +39,26 @@
   [db attr property]
   (get (dbi/-attrs-by db property) (attr-ident db attr)))
 
+(defn attr-schema
+  "The effective schema entry for `attr`, including Datahike's implicit
+   built-in attributes.
+
+   `dbi/-schema` deliberately contains installed user schema rather than the
+   entire metaschema.  Callers concerned with an attribute's VALUE TYPE must
+   nevertheless see built-ins such as `:db/tupleAttrs`, `:db/tupleTypes`, and
+   `:db.secondary/attrs`.  Datomic models the first two as tuple-valued schema
+   attributes; treating their vectors as lookup refs based on vector length is
+   both ambiguous and wrong."
+  [db attr]
+  (let [ident (attr-ident db attr)
+        installed (get (dbi/-schema db) ident)
+        implicit (get ds/implicit-schema-spec ident)]
+    ;; In :attribute-refs? databases the system entry can also appear in
+    ;; `-schema`, but its valueType is stored as a numeric ref.  The canonical
+    ;; implicit entry is ident-based and cannot be user-overridden, so prefer it.
+    (when (or (map? installed) implicit)
+      (merge (when (map? installed) installed) implicit))))
+
 (defn #?@(:clj [^Boolean multival?]
           :cljs [^boolean multival?]) [db attr]
   (is-attr? db attr :db.cardinality/many))
@@ -80,7 +100,7 @@
   "Returns true if 'attr' is a tuple attribute.
    I.e., if 'attr' value is of type ':db.type/tuple'"
   [db attr]
-  (is-attr? db attr :db.type/tuple))
+  (= :db.type/tuple (:db/valueType (attr-schema db attr))))
 
 (defn #?@(:clj [^Boolean reverse-ref?]
           :cljs [^boolean reverse-ref?])

--- a/src/datahike/schema.cljc
+++ b/src/datahike/schema.cljc
@@ -227,8 +227,10 @@
                                    :db/tupleType {:db/valueType :db.type/value
                                                   :db/cardinality :db.cardinality/one}
                                    :db/tupleTypes {:db/valueType :db.type/tuple
+                                                   :db/tupleType :db.type/keyword
                                                    :db/cardinality :db.cardinality/one}
                                    :db/tupleAttrs {:db/valueType :db.type/tuple
+                                                   :db/tupleType :db.type/keyword
                                                    :db/cardinality :db.cardinality/one}})
 (s/def :db/helpers #{:db.install/attribute :db})
 (s/def :db.part/types #{:db.part/tx :db.part/sys :db.part/user})

--- a/test/datahike/test/attribute_refs/tuples_test.cljc
+++ b/test/datahike/test/attribute_refs/tuples_test.cljc
@@ -15,7 +15,8 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
-   [datahike.api :as d]))
+   [datahike.api :as d]
+   [datahike.db.utils :as dbu]))
 
 #?(:cljs (def Throwable js/Error))
 
@@ -30,6 +31,14 @@
 (def hetero-schema
   [{:db/ident :t/ht :db/valueType :db.type/tuple
     :db/tupleTypes [:db.type/keyword :db.type/keyword]
+    :db/cardinality :db.cardinality/one}])
+
+(def triple-composite-schema
+  [{:db/ident :triple/a :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :triple/b :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :triple/c :db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
+   {:db/ident :triple/abc :db/valueType :db.type/tuple
+    :db/tupleAttrs [:triple/a :triple/b :triple/c]
     :db/cardinality :db.cardinality/one}])
 
 (defn- conn-with [schema attribute-refs?]
@@ -66,6 +75,24 @@
   ;; by ident: `:components` accepts either representation, so one call works
   ;; in both modes
   (:v (first (d/datoms db {:index :eavt :components [e :t/ab]}))))
+
+(deftest implicit-tuple-schema-works-in-both-attribute-modes
+  (doseq [refs? [false true]]
+    (testing (str ":attribute-refs? " refs?)
+      (let [conn (conn-with triple-composite-schema refs?)
+            db (d/db conn)
+            tuple-attrs-ref (:db/id (d/entity db :db/tupleAttrs))
+            tuple-eid (:db/id (d/entity db :triple/abc))]
+        (is (dbu/tuple? db :db/tupleAttrs))
+        (when refs?
+          (is (dbu/tuple? db tuple-attrs-ref)))
+        (is (= [[:triple/a :triple/b :triple/c]]
+               (mapv :v (d/datoms db {:index :eavt
+                                      :components [tuple-eid :db/tupleAttrs
+                                                   [:triple/a :triple/b :triple/c]]}))))
+        (is (d/transact conn [[:db/retractEntity tuple-eid]]))
+        (is (nil? (d/q '[:find ?e . :where [?e :db/ident :triple/abc]]
+                       (d/db conn))))))))
 
 ;; ---------------------------------------------------------------------------
 

--- a/test/datahike/test/tuples_test.cljc
+++ b/test/datahike/test/tuples_test.cljc
@@ -4,6 +4,7 @@
       :clj  [clojure.test :as t :refer        [is are deftest testing]])
    [datahike.api :as d]
    [datahike.db :as db]
+   [datahike.db.utils :as dbu]
    [datahike.test.utils :refer [get-time]])
   #?(:clj
      (:import [clojure.lang ExceptionInfo])))
@@ -28,6 +29,99 @@
     (d/delete-database config)
     (d/create-database config)
     (d/connect config)))
+
+(deftest implicit-tuple-schema-attributes
+  (let [conn (connect)]
+    (try
+      (let [db (d/db conn)]
+        (testing "Datomic tuple metaschema attributes are tuple-valued"
+          (is (dbu/tuple? db :db/tupleAttrs))
+          (is (dbu/tuple? db :db/tupleTypes)))
+        (testing "Datahike secondary index attributes are tuple-valued too"
+          (is (dbu/tuple? db :db.secondary/attrs)))
+        (testing "a one-attribute secondary declaration remains valid"
+          (let [{:keys [db-after tempids]}
+                (d/transact conn [[:db/add -1 :db.secondary/attrs [:person/name]]])
+                eid (get tempids -1)]
+            (is (= [[:person/name]]
+                   (mapv :v (d/datoms db-after {:index :eavt
+                                                :components [eid :db.secondary/attrs]})))))))
+      (finally
+        (d/release conn)))))
+
+(deftest retract-tuple-schema-entities
+  (let [conn (connect)
+        attrs [:schema/a :schema/b :schema/c]
+        components (mapv (fn [ident]
+                           {:db/ident ident
+                            :db/valueType :db.type/keyword
+                            :db/cardinality :db.cardinality/one})
+                         attrs)]
+    (try
+      (d/transact conn
+                  (into components
+                        [{:db/ident :schema/composite
+                          :db/valueType :db.type/tuple
+                          :db/tupleAttrs attrs
+                          :db/cardinality :db.cardinality/one}
+                         {:db/ident :schema/heterogeneous
+                          :db/valueType :db.type/tuple
+                          :db/tupleTypes [:db.type/keyword :db.type/long :db.type/string]
+                          :db/cardinality :db.cardinality/one}]))
+      (doseq [[ident schema-attr value]
+              [[:schema/composite :db/tupleAttrs attrs]
+               [:schema/heterogeneous :db/tupleTypes
+                [:db.type/keyword :db.type/long :db.type/string]]]]
+        (let [db (d/db conn)
+              eid (:db/id (d/entity db ident))]
+          (testing (str "exact index search for " schema-attr)
+            (is (= [value]
+                   (mapv :v (d/datoms db {:index :eavt
+                                          :components [eid schema-attr value]})))))
+          (testing (str "retractEntity for " ident)
+            (is (d/transact conn [[:db/retractEntity eid]]))
+            (is (nil? (d/q '[:find ?e . :in $ ?ident
+                             :where [?e :db/ident ?ident]]
+                           (d/db conn) ident))))))
+      (finally
+        (d/release conn)))))
+
+(deftest tuple-schema-metadata-follows-datomic-shape
+  (let [conn (connect)
+        component {:db/ident :shape/a
+                   :db/valueType :db.type/keyword
+                   :db/cardinality :db.cardinality/one}
+        schema (fn [ident attr value]
+                 {:db/ident ident :db/valueType :db.type/tuple
+                  attr value :db/cardinality :db.cardinality/one})]
+    (try
+      (d/transact conn [component])
+      (testing "malformed vector metadata can still be retracted for cleanup"
+        (let [eid (:db/id (d/entity (d/db conn) :shape/a))]
+          (doseq [value [[]
+                         [:shape/a]
+                         [:shape/a "not-an-ident"]
+                         [:shape/a :shape/b :shape/c :shape/d :shape/e
+                          :shape/f :shape/g :shape/h :shape/i]]]
+            (is (d/transact conn [[:db/retract eid :db/tupleAttrs value]])))))
+      (testing "scalar tuple metadata raises a transaction syntax error"
+        (let [error (try
+                      (d/transact conn [(schema :shape/scalar :db/tupleAttrs :shape/a)])
+                      nil
+                      (catch #?(:clj ExceptionInfo :cljs js/Error) e e))]
+          (is (= :transact/syntax (:error (ex-data error))))
+          (is (re-find #"Tuple values must be vectors" (ex-message error)))))
+      (doseq [bad [(schema :shape/attrs-short :db/tupleAttrs [:shape/a])
+                   (schema :shape/attrs-long :db/tupleAttrs
+                           [:shape/a :shape/b :shape/c :shape/d :shape/e
+                            :shape/f :shape/g :shape/h :shape/i])
+                   (schema :shape/attrs-wrong :db/tupleAttrs [:shape/a "not-an-ident"])
+                   (schema :shape/types-short :db/tupleTypes [:db.type/keyword])
+                   (schema :shape/types-wrong :db/tupleTypes
+                           [:db.type/keyword "not-a-type"])]]
+        (is (thrown? ExceptionInfo (d/transact conn [bad]))))
+      (finally
+        (d/release conn)))))
 
 (deftest test-transaction
   (testing "homogeneous tuple"


### PR DESCRIPTION
## Summary

- include implicit built-in schema when determining an attribute's effective value type
- treat `:db/tupleAttrs`, `:db/tupleTypes`, and `:db.secondary/attrs` as tuple values during search, including attribute-ref databases
- match Datomic's homogeneous keyword tuple metadata and 2-8 element bounds for `:db/tupleAttrs` and `:db/tupleTypes`
- retain Datahike's one-attribute `:db.secondary/attrs` extension

This fixes exact searches and `:db/retractEntity` for schema entities containing composite tuples of three or more attributes. Two-element composites previously passed only because the search validator mistook their values for lookup refs.

## Compatibility

Valid tuple schemas are unchanged. New assertions that create malformed built-in tuple metadata (one element, more than eight elements, non-keyword values, or scalar values) are now rejected, matching Datomic's schema contract. Retractions remain available to clean up malformed vector-shaped metadata written by older versions. Stored data is not rewritten. Datahike's physical schema retraction remains an intentional extension over Datomic's discontinued tuple workflow.

## Verification

- `bb test clj-pss`: 1062 tests, 13106 assertions, 0 failures
- focused tuple and attribute-ref tests: 22 tests, 107 assertions, 0 failures
- secondary-index suites: 44 tests, 263 assertions, 0 failures
- `bb node-cljs-test`: passed
- `bb ffix` and `bb format`: clean
- pg-datahike CREATE/INSERT/DROP smoke tests pass for 1-, 2-, 3-, and 4-column primary keys against this worktree
- behavior compared directly with Datomic Peer 1.0.7705 via the repository's `:datomic` profile
