### PR TITLE
Fix npm logging defaults and package exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ npm-package/s3/
 npm-package/LICENSE
 npm-package/karma.conf.js
 !npm-package/test.js
+!npm-package/test-log-level-env.js
 !npm-package/test-browser.js
 !npm-package/typescript-test.ts
 !npm-package/test-isomorphic.ts

--- a/bb/src/tools/npm.clj
+++ b/bb/src/tools/npm.clj
@@ -13,7 +13,8 @@
   (let [js-files (fs/glob npm-package-path "*.js")
         js-map-files (fs/glob npm-package-path "*.js.map")
         all-files (concat js-files js-map-files)
-        files-to-keep #{"test.js" "test-final.js" "test-config-keys.js" "test-key-duplication.js"}
+        files-to-keep #{"test.js" "test-log-level-env.js" "test-final.js"
+                        "test-config-keys.js" "test-key-duplication.js"}
         files-to-delete (remove #(contains? files-to-keep (str (fs/file-name %))) all-files)]
     (doseq [file files-to-delete]
       (fs/delete file))
@@ -129,6 +130,10 @@
   "Exercise both public entry points, compile the declaration contract, and
   audit the exact tarball before it can be published."
   [npm-package-path]
+  (run-package-command! npm-package-path "Default npm logging test"
+                        "node" "test-log-level-env.js" "default")
+  (run-package-command! npm-package-path "Environment npm logging test"
+                        "node" "test-log-level-env.js" "trace")
   (run-package-command! npm-package-path "CommonJS API test" "node" "test.js")
   (run-package-command! npm-package-path "ESM wrapper syntax check"
                         "node" "--check" "browser/index.mjs")

--- a/doc/javascript-api.md
+++ b/doc/javascript-api.md
@@ -1,6 +1,6 @@
 # Datahike JavaScript API
 
-**Status: Beta** - API is functional and tested, but may receive breaking changes. Published as `datahike@next` on npm.
+**Status: Beta** - API is functional and tested, but may receive breaking changes.
 
 ## Overview
 
@@ -47,7 +47,7 @@ Output is generated in `npm-package/datahike.js.api.js` with advanced compilatio
 ## Installation
 
 ```bash
-npm install datahike@next
+npm install datahike
 ```
 
 ## Usage
@@ -63,7 +63,8 @@ async function example() {
     store: {
       backend: ':memory',
       id: d.randomUuid()
-    }
+    },
+    'value-caps': ':default'
   };
 
   // Create database
@@ -113,6 +114,18 @@ async function example() {
   await d.deleteDatabase(config);
 }
 ```
+
+### Logging
+
+The npm package logs warnings and errors by default. Use `setLogLevel` when an
+application needs more diagnostic detail or wants to disable library logging:
+
+```javascript
+d.setLogLevel('trace'); // 'off', 'trace', 'debug', 'info', 'warn', or 'error'
+```
+
+Node.js applications can set the initial level before import with
+`DATAHIKE_LOG_LEVEL`, for example `DATAHIKE_LOG_LEVEL=off node app.js`.
 
 ## Data Conversion
 

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -29,7 +29,8 @@ async function example() {
     store: {
       backend: ':memory',
       id: d.randomUuid()
-    }
+    },
+    'value-caps': ':default'
   };
 
   // Create and connect to database
@@ -75,6 +76,16 @@ async function example() {
 
 example();
 ```
+
+Datahike logs warnings and errors by default. Applications can change the
+runtime level, or disable library logging entirely:
+
+```javascript
+d.setLogLevel('debug'); // 'off', 'trace', 'debug', 'info', 'warn', or 'error'
+```
+
+In Node.js, set `DATAHIKE_LOG_LEVEL` before importing the package to choose the
+initial level (for example, `DATAHIKE_LOG_LEVEL=off node app.js`).
 
 ## Documentation
 

--- a/npm-package/package.template.json
+++ b/npm-package/package.template.json
@@ -42,7 +42,10 @@
         "default": "./s3/index.mjs"
       },
       "default": "./s3/index.mjs"
-    }
+    },
+    "./package.json": "./package.json",
+    "./browser/datahike.js": "./browser/datahike.js",
+    "./s3/datahike.js": "./s3/datahike.js"
   },
   "browser" : "./browser/datahike.js"
 }

--- a/npm-package/test-log-level-env.js
+++ b/npm-package/test-log-level-env.js
@@ -1,0 +1,49 @@
+// Verify initial logging in a fresh process, before the package can be cached.
+const mode = process.argv[2];
+
+if (mode === 'default') {
+  delete process.env.DATAHIKE_LOG_LEVEL;
+} else if (mode === 'trace') {
+  process.env.DATAHIKE_LOG_LEVEL = 'trace';
+} else {
+  throw new Error(`Expected test mode default or trace, got: ${mode}`);
+}
+
+const originalError = console.error.bind(console);
+const capturedMessages = [];
+const debugMessages = [];
+for (const method of ['debug', 'info', 'warn', 'error']) {
+  console[method] = (...args) => {
+    capturedMessages.push([method, args]);
+    if (method === 'debug') debugMessages.push(args);
+  };
+}
+
+const d = require('./datahike.js.api.js');
+
+async function exerciseDatabase() {
+  const config = {
+    store: { backend: ':memory', id: d.randomUuid() },
+    'value-caps': ':default'
+  };
+  await d.createDatabase(config);
+  const conn = await d.connect(config);
+  d.release(conn);
+  await d.deleteDatabase(config);
+}
+
+exerciseDatabase()
+  .then(() => {
+    if (mode === 'default' && capturedMessages.length !== 0) {
+      throw new Error(`Default quickstart emitted ${capturedMessages.length} log messages`);
+    }
+    if (mode === 'trace' && debugMessages.length === 0) {
+      throw new Error('DATAHIKE_LOG_LEVEL=trace did not enable trace/debug messages');
+    }
+    console.log(`  ✓ ${mode} initial log level (${debugMessages.length} trace/debug messages)`);
+    process.exit(0);
+  })
+  .catch(error => {
+    originalError(error);
+    process.exit(1);
+  });

--- a/npm-package/test.js
+++ b/npm-package/test.js
@@ -4,6 +4,83 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+function testPackageSubpathExports() {
+  console.log('\n=== Package Subpath Exports ===');
+
+  const packageJson = require.resolve('datahike/package.json');
+  const browserBundle = require.resolve('datahike/browser/datahike.js');
+  const s3Bundle = require.resolve('datahike/s3/datahike.js');
+
+  if (path.basename(packageJson) !== 'package.json') {
+    throw new Error(`Unexpected package metadata path: ${packageJson}`);
+  }
+  if (!browserBundle.endsWith(path.join('browser', 'datahike.js'))) {
+    throw new Error(`Unexpected browser bundle path: ${browserBundle}`);
+  }
+  if (!s3Bundle.endsWith(path.join('s3', 'datahike.js'))) {
+    throw new Error(`Unexpected S3 bundle path: ${s3Bundle}`);
+  }
+
+  console.log('  ✓ Package metadata and raw browser bundles are resolvable');
+}
+
+async function testLoggingControls() {
+  console.log('\n=== Logging Controls ===');
+
+  const originalDebug = console.debug;
+  const debugMessages = [];
+  console.debug = (...args) => debugMessages.push(args);
+
+  const exerciseDatabase = async () => {
+    const config = {
+      store: { backend: ':memory', id: d.randomUuid() },
+      'value-caps': ':default'
+    };
+    await d.createDatabase(config);
+    const conn = await d.connect(config);
+    d.release(conn);
+    await d.deleteDatabase(config);
+  };
+
+  try {
+    d.setLogLevel('warn');
+    await exerciseDatabase();
+    if (debugMessages.length !== 0) {
+      throw new Error(`Default logging emitted ${debugMessages.length} debug/trace messages`);
+    }
+
+    if (d.setLogLevel('trace') !== 'trace') {
+      throw new Error('setLogLevel should return the normalized level');
+    }
+    await exerciseDatabase();
+    if (debugMessages.length === 0) {
+      throw new Error('Trace logging did not emit any debug/trace messages');
+    }
+
+    const traceMessageCount = debugMessages.length;
+    d.setLogLevel('off');
+    await exerciseDatabase();
+    if (debugMessages.length !== traceMessageCount) {
+      throw new Error('The off log level still emitted debug/trace messages');
+    }
+
+    let rejectedInvalidLevel = false;
+    try {
+      d.setLogLevel('verbose');
+    } catch (_) {
+      rejectedInvalidLevel = true;
+    }
+    if (!rejectedInvalidLevel) {
+      throw new Error('setLogLevel accepted an unsupported level');
+    }
+  } finally {
+    d.setLogLevel('warn');
+    console.debug = originalDebug;
+  }
+
+  console.log('  ✓ Default, trace, off, and invalid log levels behave as documented');
+}
+
 // Helper to find entity ID by name
 async function findEntityByName(db, name) {
   const datoms = await d.datoms(db, ':eavt');
@@ -633,6 +710,8 @@ async function runAllTests() {
   let failed = 0;
   
   const tests = [
+    testPackageSubpathExports,
+    testLoggingControls,
     testBasicOperations,
     testSchemaAndTransactions,
     testDatomsAPI,

--- a/npm-package/typescript-test.ts
+++ b/npm-package/typescript-test.ts
@@ -3,6 +3,8 @@
 import * as d from './index';
 
 async function typescriptTest() {
+  const configuredLogLevel: d.LogLevel = d.setLogLevel('warn');
+
   // DatabaseConfig type is now properly typed
   const config: d.DatabaseConfig = {
     store: {
@@ -122,7 +124,7 @@ async function typescriptTest() {
 
   console.log(queryResults, pullResult, schema, historyDb, pastDb, s3Config,
               uuidOutput, invalidConfig, temporaryId, branchNames, branchDb,
-              parentIds, mergeReport, reclaimed);
+              parentIds, mergeReport, reclaimed, configuredLogLevel);
 }
 
 void typescriptTest;

--- a/src/datahike/codegen/esm.clj
+++ b/src/datahike/codegen/esm.clj
@@ -18,7 +18,7 @@
 ;; Additional exports defined in datahike.js.api that are not in the
 ;; api-specification (manually exported with ^:export metadata).
 (def ^:private extra-js-exports
-  ["isPromise" "uuid" "randomUuid"
+  ["isPromise" "uuid" "randomUuid" "setLogLevel"
    "openOptimistic" "optimisticDb" "optimisticPending"
    "optimisticTransact" "optimisticPredict" "optimisticAck"
    "optimisticReject" "optimisticAbandon" "optimisticListen"

--- a/src/datahike/codegen/typescript.clj
+++ b/src/datahike/codegen/typescript.clj
@@ -474,6 +474,13 @@ export function closeOptimistic(overlay: OptimisticOverlay): null;
 export function isPromise(value: any): value is Promise<unknown>;
 export function uuid(value: string): DatahikeUuid;
 export function randomUuid(): DatahikeUuid;
+
+export type LogLevel = 'off' | 'trace' | 'debug' | 'info' | 'warn' | 'error';
+/**
+ * Configure logging for the Datahike JavaScript package.
+ * The initial level is `warn`, or `DATAHIKE_LOG_LEVEL` in Node.js.
+ */
+export function setLogLevel(level: LogLevel): LogLevel;
 "]
     (str header types "\n// API Functions\n\n" functions optimistic-functions "\n")))
 

--- a/src/datahike/js/api.cljs
+++ b/src/datahike/js/api.cljs
@@ -11,9 +11,61 @@
             [cljs.core.async :refer [<!]]
             [clojure.string :as str]
             [clojure.walk :as walk]
-            [goog.object :as gobj])
+            [goog.object :as gobj]
+            [taoensso.trove :as trove]
+            [taoensso.trove.console :as trove-console])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [datahike.js.api-macros :refer [emit-js-api]]))
+
+;; The Trove console backend deliberately defaults to logging every level in
+;; ClojureScript. That is useful during development, but makes the installed npm
+;; package print internal trace events during ordinary database operations.
+;; Keep the package quiet unless the application explicitly opts into more
+;; detail through setLogLevel() or DATAHIKE_LOG_LEVEL.
+(def ^:private default-log-level "warn")
+(def ^:private supported-log-levels
+  #{"off" "trace" "debug" "info" "warn" "error"})
+
+(defn- normalize-log-level [level]
+  (when (or (string? level) (keyword? level))
+    (-> (name level)
+        (str/replace #"^:" "")
+        str/lower-case)))
+
+(defn- configure-log-level! [level]
+  (let [normalized (normalize-log-level level)]
+    (when-not (contains? supported-log-levels normalized)
+      (throw (js/Error.
+              (str "Unsupported Datahike log level: " level
+                   ". Expected one of: off, trace, debug, info, warn, error."))))
+    (if (= "off" normalized)
+      (trove/set-log-fn! nil)
+      (trove/set-log-fn!
+       (trove-console/get-log-fn {:min-level (keyword normalized)})))
+    normalized))
+
+(defn- environment-log-level []
+  (let [process-env (when (exists? js/process)
+                      (gobj/get js/process "env"))
+        configured (when process-env
+                     (gobj/get process-env "DATAHIKE_LOG_LEVEL"))
+        normalized (normalize-log-level configured)]
+    ;; An unrelated or malformed environment value should never make importing
+    ;; a database library fail. The explicit setter remains strict.
+    (if (contains? supported-log-levels normalized)
+      normalized
+      default-log-level)))
+
+(configure-log-level! (environment-log-level))
+
+(defn ^:export setLogLevel
+  "Set logging for the JavaScript package.
+
+  Accepted levels are off, trace, debug, info, warn, and error. Returns the
+  normalized level name. Node.js applications may set the initial level with
+  the DATAHIKE_LOG_LEVEL environment variable before importing Datahike."
+  [level]
+  (configure-log-level! level))
 
 ;; Register Node.js file backend - conditional require
 ;; For Node.js: konserve.node-filestore is added to shadow-cljs :entries


### PR DESCRIPTION
## Summary

- default the JavaScript package logger to warn, expose setLogLevel, and honor DATAHIKE_LOG_LEVEL during Node startup
- export package.json and the raw browser bundles (including S3 parity) for downstream tooling
- make the documented quickstart silent with value-caps :default and update the npm/latest installation guidance
- cover default/environment/runtime log levels, subpath resolution, generated ESM exports, and TypeScript declarations

## Verification

- release-mode Node, browser, and S3 bundles compiled with advanced optimizations (zero compiler warnings)
- bb npm-verify under Node 23.11.0 / npm 10.9.2 (14 runtime tests, TypeScript declarations, and 178-file tarball audit)
- default quickstart regression: zero captured debug/info/warn/error messages
- DATAHIKE_LOG_LEVEL=trace regression: 32 captured trace/debug messages
- bb format
- focused clj-kondo lint: zero errors