### PR TITLE
chore: bump superv.async to 0.3.51 (npm package no longer hangs Node)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
                                                      :exclusions [org.clojure/clojurescript]}
         org.replikativ/konserve                     {:mvn/version "0.9.385"}
 
-        org.replikativ/superv.async                 {:mvn/version "0.3.50"
+        org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}
         org.replikativ/datalog-parser               {:mvn/version "0.2.42"}
         ;; canonical fressian node+root handlers + MST boundary (0.4.126); diff-buf write-buffering


### PR DESCRIPTION
Picks up [superv.async#27](https://github.com/replikativ/superv.async/pull/27).

## The bug

Requiring the npm package never lets Node exit.

```
node -e 'require("datahike")'                     # hangs indefinitely
node -e 'require("datahike"); process.exit(0)'    # 151ms
```

`process.getActiveResourcesInfo()` after the require shows a stray `Timeout`.
Tracing `setTimeout` at load time finds exactly one, scheduled from
`superv.async.js` with a 10s delay: `S` is a top-level `def`, so loading the
namespace starts `simple-supervisor`, whose stale-exception sweep re-arms itself
forever. A referenced timer keeps Node alive.

This is silent. Nothing errors and no output appears; the script, test runner,
CI job or Lambda simply never returns. It affects every Node consumer of the
package published this week.

## Verification

Built the package from this branch and installed it into a clean project:

| | exit code | time |
|---|---|---|
| `require("datahike")` before | 124 (killed at 30s) | hangs |
| `require("datahike")` after | **0** | immediate |

And a real script — create a database, transact schema, open an overlay, run an
optimistic transaction, close it — exits on its own in **1s**:

```
### optimistic read: [ [ 'still works' ] ]
### status: :committed
### done — process should now exit by itself
exit 0 after 1s
```

Build clean: `:npm-release`, `:browser-release` and `:browser-s3-release` all
completed with 0 warnings.

Worth a release once merged, since the current published version hangs for
every Node user.