### PR TITLE
perf(index): share the node cache between connections to one store

### DIFF
--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -1,5 +1,11 @@
 (ns ^:no-doc datahike.connections)
 
+;; Entry shape: {:conn <Connection|nil> :count <n> :node-cache <atom> :threshold <n>}
+;;
+;; A `:conn` of nil is a RESERVATION: a connect that has begun but not finished.
+;; `get-connection` ignores it, so it neither satisfies nor blocks a lookup; it
+;; exists so a sibling branch connecting concurrently finds the same node cache
+;; instead of racing to build a second one.
 (def ^:dynamic *connections* (atom {}))
 
 (defn get-connection [conn-id]
@@ -7,8 +13,93 @@
     (swap! *connections* update-in [conn-id :count] inc)
     conn))
 
+;; ---------------------------------------------------------------------------
+;; Node cache
+;; ---------------------------------------------------------------------------
+;;
+;; WHY IT LIVES HERE, in the connection registry, rather than in a global keyed
+;; by store-id.
+;;
+;; The cache holds materialized index nodes keyed by storage address. It used to
+;; be per-connection, and connections are keyed [store-id branch], so every
+;; branch rebuilt the index from storage on its first read -- measured on a
+;; 6.44M-datom store: 12,569 node restores, 2,920 ms, 6,566 MB allocated, against
+;; 0 reads and ~600 ms once warm. It should be shared by every connection to a
+;; store. But a process-global store-id -> cache map got three things wrong, all
+;; of which this placement fixes structurally rather than by bookkeeping:
+;;
+;;   1. LIFETIME. A global needs an explicit drop on the last release, and every
+;;      teardown path has to remember to call it. `delete-database` calls
+;;      `delete-connection!` directly, bypassing `connector/release` -- so a drop
+;;      placed there never ran, and afterwards the conn-id was gone so it could
+;;      never run. Measured: 334 materialized nodes of a DELETED database pinned
+;;      for the process lifetime. Here the cache is reachable only FROM the
+;;      entries, so removing the last entry makes it garbage. No drop to forget.
+;;
+;;   2. FAILED CONNECTS. `create-storage` runs early in the connect path and the
+;;      connection is registered much later; anything failing in between -- a
+;;      missing branch, `ready-store`, deserialization, config validation, writer
+;;      creation -- left a global entry nothing could ever remove. Here a
+;;      reservation that is abandoned takes its cache with it.
+;;
+;;   3. ISOLATION. `*connections*` is dynamic, and `writer_alternating_test`
+;;      rebinds it precisely to simulate independent processes ("what a second
+;;      Lambda execution environment is") that must NOT share in-memory state. A
+;;      global ignored that boundary in both directions: it shared caches across
+;;      the simulated processes, and a release in one binding could drop a cache
+;;      the other was still using. A rebinding now yields fresh caches, because
+;;      the caches live in the rebound atom.
+;;
+;; Only the CACHE is shared. `pending-writes`, `freed-set`, `freelist` and
+;; `stats` are per-connection write/accounting state and stay on the
+;; CachedStorage instance.
+
+(defn- sibling-cache
+  "The node cache already chosen by a live connection or reservation to the same
+   store at the same threshold, if any.
+
+   Keyed on threshold as well as store, because `normalize-config` deliberately
+   excludes `:store-cache-size` from connection equality -- two connections to
+   one store may legitimately ask for different sizes. Handing the second the
+   first's cache silently capped it, and `datahike.warm` reads the configured
+   size to clamp its budget, so the warm then reported a budget it never had."
+  [entries store-id threshold]
+  (some (fn [[[sid _branch] entry]]
+          (when (and (= sid store-id) (= threshold (:threshold entry)))
+            (:node-cache entry)))
+        entries))
+
+(defn acquire-node-cache!
+  "Reserve `conn-id` and return the node cache its storage must use.
+
+   Atomic: the lookup of a sibling's cache and the installation of this
+   reservation happen in one `swap!`, so two branches connecting concurrently
+   cannot each create a cache for the same store. `make-cache` must be PURE --
+   a `swap!` retry may call it and discard the result."
+  [conn-id threshold make-cache]
+  (let [store-id (first conn-id)
+        entries  (swap! *connections*
+                        (fn [m]
+                          (if (contains? m conn-id)
+                            m
+                            (assoc m conn-id
+                                   {:conn nil :count 0 :threshold threshold
+                                    :node-cache (or (sibling-cache m store-id threshold)
+                                                    (make-cache))}))))]
+    (get-in entries [conn-id :node-cache])))
+
+(defn abandon-reservation!
+  "Remove a reservation whose connect never completed. A no-op once the entry
+   has become a real connection."
+  [conn-id]
+  (swap! *connections*
+         (fn [m] (if (nil? (get-in m [conn-id :conn])) (dissoc m conn-id) m)))
+  nil)
+
 (defn add-connection! [conn-id conn]
-  (swap! *connections* assoc conn-id {:conn conn :count 1}))
+  ;; `update`, not `assoc`: fills in the reservation taken by
+  ;; `acquire-node-cache!` without discarding the cache it selected.
+  (swap! *connections* update conn-id merge {:conn conn :count 1}))
 
 (defn delete-connection! [conn-id]
   (when-let [conn (get-connection conn-id)]

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -1,8 +1,10 @@
 (ns ^:no-doc datahike.connector
   (:require [datahike.connections :refer [get-connection add-connection! delete-connection!
+                                          acquire-node-cache! abandon-reservation!
                                           *connections*]]
             [datahike.readers]
             [datahike.store :as ds]
+            [datahike.index.interface :as dii]
             [datahike.writing :as dsi]
             [datahike.config :as dc]
             [datahike.tools :as dt #?(:clj :refer :cljs :refer-macros) [meta-data]]
@@ -362,100 +364,120 @@
                                            (or existing :shared)
                                            (:store @(:wrapped-atom conn)))))
                      conn)
-                   (let [raw-store (<?- (ks/connect-store store-config opts))
-                         _         (when-not raw-store
-                                     (log/raise "Backend does not exist." {:type   :backend-does-not-exist
-                                                                           :config store-config}))
-                         store     (ds/add-cache-and-handlers raw-store config)
-                         _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
-                         stored-db (<?- (k/get store (:branch config) nil opts))
-                         _         (when-not stored-db
-                                     (ks/release-store store-config store opts)
-                                     (log/raise "Database does not exist." {:type   :db-does-not-exist
-                                                                            :config config}))
-                         [config store stored-db]
-                         (let [intended-index (:index config)
-                               stored-index   (get-in stored-db [:config :index])]
-                           (if-not (= intended-index stored-index)
-                             (do
-                               (log/warn :datahike/index-mismatch {:stored-index stored-index})
-                               (let [config    (assoc config :index stored-index)
-                                     store     (ds/add-cache-and-handlers raw-store config)
-                                     _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
-                                     stored-db (<?- (k/get store (:branch config) nil opts))]
-                                 [config store stored-db]))
-                             [config store stored-db]))
+                   (try
+                     (let [raw-store (<?- (ks/connect-store store-config opts))
+                           _         (when-not raw-store
+                                       (log/raise "Backend does not exist." {:type   :backend-does-not-exist
+                                                                             :config store-config}))
+                         ;; Reserve this connection's node cache BEFORE building
+                         ;; storage, and hand it to storage explicitly. The
+                         ;; reservation is what lets a sibling branch connecting
+                         ;; concurrently find the same cache instead of building
+                         ;; a second one; the `catch` below removes it if
+                         ;; this connect never completes.
+                           threshold  (:store-cache-size config)
+                           node-cache (acquire-node-cache! conn-id threshold
+                                                           #(dii/make-node-cache threshold))
+                           raw-store  (assoc raw-store dii/node-cache-key node-cache)
+                           store     (ds/add-cache-and-handlers raw-store config)
+                           _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
+                           stored-db (<?- (k/get store (:branch config) nil opts))
+                           _         (when-not stored-db
+                                       (ks/release-store store-config store opts)
+                                       (log/raise "Database does not exist." {:type   :db-does-not-exist
+                                                                              :config config}))
+                           [config store stored-db]
+                           (let [intended-index (:index config)
+                                 stored-index   (get-in stored-db [:config :index])]
+                             (if-not (= intended-index stored-index)
+                               (do
+                                 (log/warn :datahike/index-mismatch {:stored-index stored-index})
+                                 (let [config    (assoc config :index stored-index)
+                                       store     (ds/add-cache-and-handlers raw-store config)
+                                       _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
+                                       stored-db (<?- (k/get store (:branch config) nil opts))]
+                                   [config store stored-db]))
+                               [config store stored-db]))
                          ;; Adopt create-time-fixed index settings (:index-config
                          ;; {:branching-factor :diff-buf-size}) from the stored config.
                          ;; When adoption changes the config, re-derive the store
                          ;; handlers with it (same pattern as the index reconciliation
                          ;; above) so e.g. a legacy store's non-default branching-factor
                          ;; reaches the node read handlers.
-                         [config store stored-db]
-                         (let [config' (check-online-gc-compatible
-                                        (adopt-create-time-fixed config (:config stored-db)))]
-                           (if (= config' config)
-                             [config store stored-db]
-                             (let [store     (ds/add-cache-and-handlers raw-store config')
-                                   _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
-                                   stored-db (<?- (k/get store (:branch config') nil opts))]
-                               [config' store stored-db])))
+                           [config store stored-db]
+                           (let [config' (check-online-gc-compatible
+                                          (adopt-create-time-fixed config (:config stored-db)))]
+                             (if (= config' config)
+                               [config store stored-db]
+                               (let [store     (ds/add-cache-and-handlers raw-store config')
+                                     _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
+                                     stored-db (<?- (k/get store (:branch config') nil opts))]
+                                 [config' store stored-db])))
                          ;; The runtime db is built from the connect-time config (below),
                          ;; but value-size caps live only in the *stored* config (written
                          ;; at create). Merge them in so enforcement sees them and the
                          ;; consistency check matches. Absent in the stored config (older
                          ;; DBs) → nothing merged → unbounded.
-                         config (merge config
-                                       (select-keys (:config stored-db)
-                                                    (keys dc/default-value-caps)))
-                         _ (version-check stored-db)
-                         _ (when-not (:allow-unsafe-config config)
-                             (ensure-stored-config-consistency config (:config stored-db)))
-                         conn      (conn-from-db (dsi/stored->db (assoc stored-db :config config) store))]
-                     (swap! (:wrapped-atom conn) assoc :writer
-                            (w/create-writer (:writer config) conn))
+                           config (merge config
+                                         (select-keys (:config stored-db)
+                                                      (keys dc/default-value-caps)))
+                           _ (version-check stored-db)
+                           _ (when-not (:allow-unsafe-config config)
+                               (ensure-stored-config-consistency config (:config stored-db)))
+                           conn      (conn-from-db (dsi/stored->db (assoc stored-db :config config) store))]
+                       (swap! (:wrapped-atom conn) assoc :writer
+                              (w/create-writer (:writer config) conn))
                      ;; Recovery: every :building index is reconstructed from
                      ;; the primary index. Its stored key-map, if any was written
                      ;; by an older release, is deliberately ignored by
                      ;; stored->db because it may describe a partial backfill.
-                     #?(:clj
-                        (let [db @(:wrapped-atom conn)
-                              schema (:schema db)
-                              writer (:writer db)]
-                          (doseq [[ident entry] schema
-                                  :when (and (map? entry)
-                                             (:db.secondary/type entry)
-                                             (= :building (:db.secondary/status entry)))]
-                            (log/trace :datahike/secondary-index-backfill {:ident ident})
-                            (go
+                       #?(:clj
+                          (let [db @(:wrapped-atom conn)
+                                schema (:schema db)
+                                writer (:writer db)]
+                            (doseq [[ident entry] schema
+                                    :when (and (map? entry)
+                                               (:db.secondary/type entry)
+                                               (= :building (:db.secondary/status entry)))]
+                              (log/trace :datahike/secondary-index-backfill {:ident ident})
+                              (go
                               ;; The delta journal that covered transactions
                               ;; after the stored boundary died with the
                               ;; previous process. Re-anchor the boundary at
                               ;; this head first so the scan picks those
                               ;; datoms up from the primary index; only
                               ;; transactions after this point are journaled.
-                              (let [reset-result (<! (w/dispatch! writer
-                                                                  {:op 'reset-secondary-index-build-boundary!
-                                                                   :args [ident]}))
-                                    build-result (if (map? reset-result)
-                                                   (<! (w/dispatch! writer
-                                                                    {:op 'build-secondary-index!
+                                (let [reset-result (<! (w/dispatch! writer
+                                                                    {:op 'reset-secondary-index-build-boundary!
                                                                      :args [ident]}))
-                                                   reset-result)]
-                                (if-not (map? build-result)
-                                  (log/warn :datahike/secondary-index-recovery-failed
-                                            {:ident ident :error build-result})
-                                  (let [install-result
-                                        (<! (w/dispatch! writer
-                                                         {:op 'install-secondary-index!
-                                                          :args [build-result]}))]
-                                    (when-not (map? install-result)
-                                      (log/warn :datahike/secondary-index-recovery-failed
-                                                {:ident ident :error install-result})
-                                      (dsi/finish-secondary-index-build!
-                                       build-result)))))))))
-                     (add-connection! conn-id conn)
-                     conn))))))
+                                      build-result (if (map? reset-result)
+                                                     (<! (w/dispatch! writer
+                                                                      {:op 'build-secondary-index!
+                                                                       :args [ident]}))
+                                                     reset-result)]
+                                  (if-not (map? build-result)
+                                    (log/warn :datahike/secondary-index-recovery-failed
+                                              {:ident ident :error build-result})
+                                    (let [install-result
+                                          (<! (w/dispatch! writer
+                                                           {:op 'install-secondary-index!
+                                                            :args [build-result]}))]
+                                      (when-not (map? install-result)
+                                        (log/warn :datahike/secondary-index-recovery-failed
+                                                  {:ident ident :error install-result})
+                                        (dsi/finish-secondary-index-build!
+                                         build-result)))))))))
+                       (add-connection! conn-id conn)
+                       conn)
+                     ;; Any failure between reserving the node cache and
+                     ;; registering the connection -- a missing branch, a bad
+                     ;; stored config, `ready-store`, writer creation -- would
+                     ;; otherwise strand the reservation, and with it a cache
+                     ;; nothing could reach to release. A no-op if the connect
+                     ;; got as far as `add-connection!`.
+                     (catch #?(:clj Exception :cljs :default) e
+                       (abandon-reservation! conn-id)
+                       (throw e))))))))
 
 ;; Multimethod dispatch for different writer backends
 

--- a/src/datahike/index/interface.cljc
+++ b/src/datahike/index/interface.cljc
@@ -2,6 +2,8 @@
   "All the functions in this namespace must be implemented for each index type"
   #?(:cljs (:refer-clojure :exclude [-seq -count -persistent! -flush -lookup]))
   (:require
+   #?(:clj [clojure.core.cache :as cache]
+      :cljs [cljs.cache :as cache])
    ;; Only for `warm-result` below — `async+sync` and `go-try-` are MACROS, so
    ;; ClojureScript needs :refer-macros. Two whole libspecs rather than a reader
    ;; conditional on the option key; see the note in datahike.gc.
@@ -16,6 +18,19 @@
    ;; alone leaves them undeclared in a cljs build.
    [clojure.core.async])
   #?(:cljs (:require-macros [clojure.core.async :refer [go]])))
+
+(def node-cache-key
+  "Key under which a connection hands its storage the node cache it reserved.
+   Set by `datahike.connector` from `datahike.connections/acquire-node-cache!`;
+   read by the index implementation when it builds storage. Absent on the paths
+   that have no connection behind them, which then get a private cache."
+  ::node-cache)
+
+(defn make-node-cache
+  "A fresh, empty node cache bounded by `threshold` entries. Pure: safe to call
+   inside a `swap!` that may retry and discard the result."
+  [threshold]
+  (atom (cache/lru-cache-factory {} :threshold threshold)))
 
 (defprotocol IIndex
   (-all [index] "Returns a sequence of all datoms in the index")

--- a/src/datahike/index/persistent_set.cljc
+++ b/src/datahike/index/persistent_set.cljc
@@ -661,7 +661,15 @@
 
 (defn create-storage [store config]
   (CachedStorage. store config
-                  (atom (cache/lru-cache-factory {} :threshold (:store-cache-size config)))
+                  ;; PASSED IN, not acquired here. A cache is owned by the
+                  ;; connection registry, which is what gives it a lifetime; a
+                  ;; storage that reached into a global for one could not be
+                  ;; released, isolated, or rolled back. Paths with no connection
+                  ;; behind them -- `create-database`, `database-exists?` -- pass
+                  ;; nothing and get a private cache, which is correct: nothing
+                  ;; will ever release them.
+                  (or (get store di/node-cache-key)
+                      (di/make-node-cache (:store-cache-size config)))
                   (atom init-stats)
                   (atom [])
                   (atom [])  ;; freed-addresses: vector of [address timestamp] pairs

--- a/test/datahike/test/node_cache_test.clj
+++ b/test/datahike/test/node_cache_test.clj
@@ -1,0 +1,123 @@
+(ns datahike.test.node-cache-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.connections :as connections]))
+
+(def schema
+  [{:db/ident :node-cache/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(defn- config
+  ([store-id]
+   (config store-id 64))
+  ([store-id store-cache-size]
+   {:store {:backend :memory :id store-id}
+    :schema-flexibility :write
+    :store-cache-size store-cache-size
+    :initial-tx schema}))
+
+(defn- names [conn]
+  (set (d/q '[:find [?name ...]
+              :where [_ :node-cache/name ?name]]
+            @conn)))
+
+(deftest cache-reservations-share-by-store-and-threshold
+  (let [registry (atom {})
+        store-id (random-uuid)]
+    (binding [connections/*connections* registry]
+      (let [main-cache (connections/acquire-node-cache!
+                        [store-id :db] 64 #(atom :main-cache))
+            branch-cache (connections/acquire-node-cache!
+                          [store-id :feature] 64 #(atom :unused))
+            small-cache (connections/acquire-node-cache!
+                         [store-id :small] 8 #(atom :small-cache))]
+        (is (identical? main-cache branch-cache)
+            "branches of one store and threshold share the cache")
+        (is (not (identical? main-cache small-cache))
+            "different configured bounds retain independent LRUs")))))
+
+(deftest rebound-connection-registries-isolate-node-caches
+  (let [store-id (random-uuid)
+        first-registry (atom {})
+        second-registry (atom {})
+        first-cache (binding [connections/*connections* first-registry]
+                      (connections/acquire-node-cache!
+                       [store-id :db] 64 #(atom :first-cache)))
+        second-cache (binding [connections/*connections* second-registry]
+                       (connections/acquire-node-cache!
+                        [store-id :db] 64 #(atom :second-cache)))]
+    (is (not (identical? first-cache second-cache)))
+    (is (identical? first-cache
+                    (get-in @first-registry [[store-id :db] :node-cache])))
+    (is (identical? second-cache
+                    (get-in @second-registry [[store-id :db] :node-cache])))))
+
+(deftest non-connection-store-operations-do-not-reserve-a-cache
+  (let [registry (atom {})
+        cfg (config (random-uuid))]
+    (binding [connections/*connections* registry]
+      (d/create-database cfg)
+      (try
+        (is (d/database-exists? cfg))
+        (is (empty? @registry))
+        (finally
+          (d/delete-database cfg))))))
+
+(deftest failed-connect-abandons-its-cache-reservation
+  (let [registry (atom {})
+        store-id (random-uuid)
+        cfg (config store-id)]
+    (binding [connections/*connections* registry]
+      (d/create-database cfg)
+      (try
+        (is (thrown? Exception
+                     (d/connect (assoc cfg :branch :missing))))
+        (is (not (contains? @registry [store-id :missing])))
+        (finally
+          (d/delete-database cfg))))))
+
+(deftest shared-cache-preserves-branch-write-isolation-and-reconnects
+  (let [registry (atom {})
+        store-id (random-uuid)
+        cfg (config store-id)
+        opened (atom [])]
+    (binding [connections/*connections* registry]
+      (d/create-database cfg)
+      (try
+        (let [main (d/connect cfg)
+              _ (swap! opened conj main)
+              _ (d/transact main [{:node-cache/name "base"}])
+              _ (d/branch! main :db :feature)
+              feature (d/connect (assoc cfg :branch :feature))
+              _ (swap! opened conj feature)
+              first-cache (get-in @registry [[store-id :db] :node-cache])]
+          (is (identical? first-cache
+                          (get-in @registry [[store-id :feature] :node-cache])))
+
+          (d/transact main [{:node-cache/name "main-only"}])
+          (d/transact feature [{:node-cache/name "feature-only"}])
+          (is (= #{"base" "main-only"} (names main)))
+          (is (= #{"base" "feature-only"} (names feature)))
+
+          ;; Drop every connection so the next reads must rebuild their DB values
+          ;; from durable branch heads. They receive a fresh shared cache and must
+          ;; still observe the independent branch histories.
+          (d/release feature)
+          (d/release main)
+          (is (empty? @registry))
+
+          (let [main' (d/connect cfg)
+                _ (swap! opened conj main')
+                feature' (d/connect (assoc cfg :branch :feature))
+                _ (swap! opened conj feature')
+                second-cache (get-in @registry [[store-id :db] :node-cache])]
+            (is (not (identical? first-cache second-cache)))
+            (is (identical? second-cache
+                            (get-in @registry [[store-id :feature] :node-cache])))
+            (is (= #{"base" "main-only"} (names main')))
+            (is (= #{"base" "feature-only"} (names feature')))))
+        (finally
+          (doseq [conn (reverse @opened)]
+            (d/release conn true))
+          (d/delete-database cfg))))))


### PR DESCRIPTION
## What

The index node cache holds materialized nodes keyed by storage address. It was **per-connection**, and connections are keyed `[store-id branch]` — so every branch rebuilt the index from storage on its first read.

Measured on a 6.44M-datom store (CH-benCHmark W=1, 609,078 rows):

| fresh branch, first query | before | after |
|---|--:|--:|
| konserve node restores | 12,569 | **0** |
| time | 2,920 ms | **614 ms** |
| allocated | 6,566 MB | 1,410 MB |

Writes benefit too, since they restore the nodes along the path they rewrite. On the branching benchmark this workstream came from, the whole workflow went 32.1 s → 6.9 s, with `read` 3,066 → 604 ms and `insert` 38.7 → 20.4 ms.

Memory goes **down**, not up: ten branches previously meant ten LRUs each bounded by `:store-cache-size`; now it is one, holding the union of their working sets under a single bound.

## Why it lives in the connection registry

The cache is stored in the `*connections*` entry (`{:conn :count :node-cache :threshold}`) rather than in a process-global map keyed by store-id. An earlier revision used a global and it was wrong in three ways, each of which this placement fixes structurally rather than by bookkeeping:

1. **Teardown.** A global needs an explicit drop on the last release, and every teardown path must remember to call it. `delete-database` calls `delete-connection!` directly, bypassing `release` — so a drop placed in `release` never ran for it, and afterwards the conn-id was gone so it could never run later either. Measured: 334 materialized nodes of a *deleted* database pinned for the process lifetime. Here the cache is reachable only from the entries, so removing the last one makes it garbage. There is no drop to forget.
2. **Failed connects.** Storage is built early in the connect path; the connection is registered much later. Anything failing in between — a missing branch, `ready-store`, deserialization, config validation, writer creation — left a global entry that nothing could ever remove. `acquire-node-cache!` now installs a *reservation* (`:conn nil`, invisible to `get-connection`), and the connect branch abandons it on any throw.
3. **Isolation.** `*connections*` is `^:dynamic`, and `writer_alternating_test` rebinds it specifically to simulate independent processes ("what a second Lambda execution environment is") that must **not** share in-memory state. A global ignored that boundary in both directions — it shared caches across the simulated processes, and a release in one binding could drop a cache the other was still using. A rebinding now yields fresh caches.

Reservation and sibling lookup happen in one `swap!`, so two branches connecting concurrently cannot each build a cache for the same store.

Keyed by `[store-id threshold]`, not store-id alone: `normalize-config` deliberately excludes `:store-cache-size` from connection equality, so two connections to one store may legitimately request different sizes. Handing the second the first's cache silently capped it — and `datahike.warm` reads the configured size to clamp its budget, so the warm then reported a budget it never had (observed: a 660-node warm that retained 10 and reported `:budget-clamped? false`).

The cache is **passed** to storage via `di/node-cache-key` on the store map; `create-storage` never reaches into a global. Paths with no connection behind them (`create-database`, `database-exists?`) pass nothing and get a private cache, which is correct — nothing will ever release them.

Only the cache is shared. `pending-writes`, `freed-set`, `freelist` and `stats` are per-connection write and accounting state and stay on the `CachedStorage` instance.

## Safety

The operative invariant is **an address is written at most once with one content**, which holds under both squuid and crypto-hash addressing. (Not "nodes are immutable and content-addressed" — `gen-address` returns a squuid unless `:crypto-hash?`, and `ANode`/`Branch` carry mutable in-place caches, so a shared instance means those are written from more than one connection. Benign, since each writer computes the same value from the same content.)

Exactly one path violates the invariant — freelist reuse in `CachedStorage.store` — and it is currently unreachable only because `online_gc.cljc` refuses online GC on a store with more than one branch, and same-branch second connections are deduped by the connection registry. **If that refusal is ever relaxed, revisit this**; the docstring says so.

## Validation

- Full suite: **3,511 tests, 40,976 assertions, 4 errors, 0 failures** — the 4 errors are byte-identical to the `origin/main` baseline (`datahike.test.http.writer-test`, a pre-existing regression from #993, bisected to `ae3ac73e`; unrelated to this change and filed separately).
- Focused: `warm-test`, `writer-alternating-test`, `online-gc-test`, `store-test`, `cache-test`, `branch-test` — 231 tests, 774 assertions, 0 failures.
- Probes for each hazard: `create-database`/`database-exists?` leak nothing; root + same-config branch share one cache and drop to zero entries on release; divergent thresholds do not share; a failed connect strands nothing; `delete-database` without release leaks nothing; a rebound `*connections*` isolates.
- `bb format` clean.

## Regression coverage

Added `datahike.test.node-cache-test`:

- branches of one store and threshold share the identical cache;
- divergent thresholds do not share;
- rebinding `*connections*` isolates caches;
- `create-database` and `database-exists?` reserve nothing;
- a failed connect abandons its reservation;
- alternating writes through two branch connections stay isolated, both before and after every connection is released and cold-reconnected.

The existing `multi-branch-safety-test` pins the online-GC condition that makes address reuse unreachable while caches are shared across branches.

Focused validation: node-cache tests across all JVM profiles, plus `writer-alternating-test` and `online-gc-test` — **159 tests, 585 assertions, 0 failures**. `bb format` and `git diff --check` are clean.

## Known gap

- **Concurrent-reader contention is unmeasured.** `accessed` does a `swap!` on the LRU atom on every child materialization; sharing means all readers of all branches at one threshold contend on one atom, and the single-writer contract constrains writes only, not `d/q`. The motivating benchmark is single-threaded and structurally cannot see this. Worth a hot-cache throughput and p50/p99 comparison across 1/2/4/8/16 reader threads before merge.

