### PR TITLE
Stream ordered count aggregates over unique-key joins

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -30,6 +30,10 @@
                         :depends [prep]
                         :task (apply clojure "-M:bench" "-m" "benchmark.planner-regression" *command-line-args*)}
 
+         join-bench {:doc "Ordered join kernels/query regression. Pass --query [--scale] [--assert]."
+                     :depends [prep]
+                     :task (apply clojure "-M:bench" "-m" "benchmark.join-strategy" *command-line-args*)}
+
          ffix {:doc "Format source files"
                :depends [prep]
                :task (clojure "-M:ffix")}

--- a/bb.edn
+++ b/bb.edn
@@ -30,7 +30,7 @@
                         :depends [prep]
                         :task (apply clojure "-M:bench" "-m" "benchmark.planner-regression" *command-line-args*)}
 
-         join-bench {:doc "Ordered join kernels/query regression. Pass --query [--scale] [--assert]."
+         join-bench {:doc "Ordered join kernels/query regression. Pass --query [--sum] [--scale] [--assert]."
                      :depends [prep]
                      :task (apply clojure "-M:bench" "-m" "benchmark.join-strategy" *command-line-args*)}
 

--- a/benchmark/src/benchmark/join_strategy.clj
+++ b/benchmark/src/benchmark/join_strategy.clj
@@ -240,6 +240,8 @@
     :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
    {:db/ident :l/payload :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one}
+   {:db/ident :l/run-key :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one :db/index true}
    {:db/ident :r/key :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one :db/index true}
    {:db/ident :r/filter :db/valueType :db.type/long
@@ -253,6 +255,8 @@
    {:db/ident :l/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
     :db/tupleAttrs [:l/k1 :l/k2] :db/unique :db.unique/identity}
    {:db/ident :l/payload :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :l/run-key :db/valueType :db.type/long :db/cardinality :db.cardinality/one
+    :db/index true}
    {:db/ident :r/k1 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
    {:db/ident :r/k2 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
    {:db/ident :r/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
@@ -284,8 +288,9 @@
         left-row (fn [i]
                    (if tuple?
                      (let [[k1 k2] (key-parts i)]
-                       {:l/k1 k1 :l/k2 k2 :l/payload i})
-                     {:l/key i :l/payload i}))
+                       {:l/k1 k1 :l/k2 k2 :l/payload i
+                        :l/run-key (mod i filter-distinct)})
+                     {:l/key i :l/payload i :l/run-key (mod i filter-distinct)}))
         right-row (fn [i]
                     (let [k (+ right-offset
                                (quot (* (long i) right-distinct) right-rows))]
@@ -347,6 +352,24 @@
     [?r :r/filter ?filter]
     [(<= ?filter ?max-filter)]])
 
+(def scalar-sum-query
+  '[:find (sum ?amount) .
+    :with ?r
+    :where
+    [?l :l/key ?key]
+    [?r :r/key ?key]
+    [?r :r/payload ?amount]])
+
+(def duplicate-run-sum-query
+  '[:find (sum ?amount) .
+    :in $ ?max-key
+    :with ?l ?r
+    :where
+    [?l :l/run-key ?key]
+    [(<= ?key ?max-key)]
+    [?r :r/filter ?key]
+    [?r :r/payload ?amount]])
+
 (defn measure-query
   "Measure the current compiled/hash path and relational fallback in the same
   warmed JVM. Result equality is checked before timing."
@@ -388,11 +411,21 @@
                         ioa/*enabled* enabled?]
                 (apply d/q query db inputs)))
         baseline-result (run false)
-        ordered-result (run true)]
-    (assert (= (set baseline-result) (set ordered-result)))
-    (let [baseline (measure #(run false) count)
-          ordered (measure #(run true) count)]
-      {:rows (count ordered-result)
+        ordered-result (run true)
+        reference-result (binding [q/*disable-planner* true
+                                   q/*query-result-cache?* false]
+                           (apply d/q query db inputs))
+        equivalent? (fn [a b]
+                      (if (and (number? a) (number? b))
+                        (<= (Math/abs (- (double a) (double b)))
+                            (* 1.0e-12 (max 1.0 (Math/abs (double b)))))
+                        (= (set a) (set b))))]
+    (assert (equivalent? reference-result ordered-result))
+    (let [summarize #(if (coll? %) (count %) %)
+          baseline (measure #(run false) summarize)
+          ordered (measure #(run true) summarize)]
+      {:rows (if (coll? ordered-result) (count ordered-result) 1)
+       :baseline-correct? (equivalent? reference-result baseline-result)
        :baseline baseline
        :ordered ordered
        :time-ratio (/ (:ms ordered) (:ms baseline))
@@ -400,9 +433,10 @@
                            (/ (:allocated-mb ordered) (:allocated-mb baseline)))})))
 
 (defn print-ordered-result
-  [label {:keys [rows baseline ordered time-ratio allocation-ratio] :as result}]
-  (println (format "%s rows=%d\n  relation %8.2fms / %7.1fMB\n  ordered  %8.2fms / %7.1fMB\n  ratios   %8.2fx / %7.2fx"
+  [label {:keys [rows baseline-correct? baseline ordered time-ratio allocation-ratio] :as result}]
+  (println (format "%s rows=%d%s\n  relation %8.2fms / %7.1fMB\n  ordered  %8.2fms / %7.1fMB\n  ratios   %8.2fx / %7.2fx"
                    label rows
+                   (if baseline-correct? "" " (relation result differs from legacy oracle)")
                    (:ms baseline) (:allocated-mb baseline)
                    (:ms ordered) (:allocated-mb ordered)
                    time-ratio (or allocation-ratio Double/NaN)))
@@ -569,6 +603,7 @@
 (defn -main [& args]
   (let [query? (boolean (some #{"--query"} args))
         scale? (boolean (some #{"--scale"} args))
+        sum? (boolean (some #{"--sum"} args))
         assert? (boolean (some #{"--assert"} args))]
     (if-not query?
       (print-results (run-kernels (boolean (some #{"--materialize"} args))))
@@ -579,12 +614,21 @@
                                :right-rows right-rows
                                :right-distinct left-rows
                                :filter-distinct 30000})
-            result (print-ordered-result
-                    (format "ordered aggregate %d x %d" left-rows right-rows)
-                    (measure-ordered-query (:db fixture) branch-shape-query 0 15000))
-            bad? (or (> (:time-ratio result) 0.75)
-                     (and (:allocation-ratio result)
-                          (> (:allocation-ratio result) 0.80)))]
+            cases (if sum?
+                    [["scalar sum, unique other side" scalar-sum-query []]
+                     ["scalar sum, duplicate runs" duplicate-run-sum-query [15000]]]
+                    [[(format "ordered aggregate %d x %d" left-rows right-rows)
+                      branch-shape-query [0 15000]]])
+            results (mapv (fn [[label query inputs]]
+                            (print-ordered-result
+                             label
+                             (apply measure-ordered-query (:db fixture) query inputs)))
+                          cases)
+            bad? (some (fn [result]
+                         (or (> (:time-ratio result) 0.75)
+                             (and (:allocation-ratio result)
+                                  (> (:allocation-ratio result) 0.80))))
+                       results)]
         (when (and assert? bad?)
           (println "REGRESSION: ordered aggregate missed its relative performance bounds")
           (System/exit 1))))))

--- a/benchmark/src/benchmark/join_strategy.clj
+++ b/benchmark/src/benchmark/join_strategy.clj
@@ -1,0 +1,590 @@
+(ns benchmark.join-strategy
+  "Controlled inter-group join experiments.
+
+  This is deliberately a kernel benchmark first: it models the compiled
+  executor's materialized producer/consumer tuple lists while keeping database
+  construction, planning, and result-set hashing out of the measurement.  The
+  end-to-end query cases live beside it and should be used to validate any
+  conclusion drawn here."
+  (:require
+   [datahike.api :as d]
+   [datahike.datom :as datom]
+   [datahike.lru :as lru]
+   [datahike.query :as q]
+   [datahike.query.index-ordered-aggregate :as ioa])
+  (:import
+   [java.lang.management ManagementFactory]
+   [java.util ArrayList HashMap]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private scenarios
+  [{:id :tiny-producer
+    :producer [10 10 0]
+    :consumer [100000 10000 0]
+    :description "10 producer keys probe 100k rows; 100 matches"}
+   {:id :tiny-producer-tail
+    :producer [10 10 9990]
+    :consumer [100000 10000 0]
+    :description "10 producer keys at the tail of 100k consumer rows"}
+   {:id :broad-one-to-many
+    :producer [10000 10000 0]
+    :consumer [100000 10000 0]
+    :description "10k unique producer keys; ten consumer rows per key"}
+   {:id :balanced-unique
+    :producer [50000 50000 0]
+    :consumer [50000 50000 0]
+    :description "50k unique keys on both sides"}
+   {:id :mostly-unmatched
+    :producer [10000 10000 0]
+    :consumer [100000 10000 9000]
+    :description "broad scans with 10% key overlap"}
+   {:id :no-match
+    :producer [10000 10000 0]
+    :consumer [100000 10000 20000]
+    :description "broad scans with disjoint key ranges"}
+   {:id :duplicates-both
+    :producer [20000 10000 0]
+    :consumer [100000 10000 0]
+    :description "two producer and ten consumer rows per key"}
+   {:id :one-long-run
+    :producer [500 1 0]
+    :consumer [500 1 0]
+    :description "one equal-key run; 250k output pairs"}
+   {:id :tuple-broad-one-to-many
+    :producer [10000 10000 0 :tuple]
+    :consumer [100000 10000 0 :tuple]
+    :description "composite vector keys; ten consumer rows per key"}
+   {:id :tuple-mostly-unmatched
+    :producer [10000 10000 0 :tuple]
+    :consumer [100000 10000 9000 :tuple]
+    :description "composite vector keys with 10% overlap"}])
+
+(defn- make-tuples
+  "Return an Object[] of Object[key,payload] tuples, monotonically ordered by
+  key. `distinct-keys` is capped by n; offset shifts the key range."
+  (^objects [^long n ^long distinct-keys ^long offset]
+   (make-tuples n distinct-keys offset :long))
+  (^objects [^long n ^long distinct-keys ^long offset key-kind]
+   (let [distinct-keys (max 1 (min n distinct-keys))
+         ^objects out (object-array n)]
+     (dotimes [i n]
+       (let [k (+ offset (quot (* (long i) distinct-keys) n))
+             k (if (= key-kind :tuple) [(quot k 1000) (mod k 1000)] k)
+             ^objects tuple (object-array 2)]
+         (aset tuple 0 (if (= key-kind :tuple) k (Long/valueOf (long k))))
+         (aset tuple 1 (Long/valueOf i))
+         (aset out i tuple)))
+     out)))
+
+(defn- append-pair! [^ArrayList out ^objects producer ^objects consumer]
+  (let [^objects pair (object-array 2)]
+    (aset pair 0 (aget producer 1))
+    (aset pair 1 (aget consumer 1))
+    (.add out pair)))
+
+(defn hash-join
+  "Hash the producer exactly as the compiled probe-map path does. Returns the
+  output cardinality. With materialize? true, also allocates one projected tuple
+  for every output pair."
+  ^long [^objects producer ^objects consumer materialize?]
+  (let [pn (alength producer)
+        cn (alength consumer)
+        ^HashMap table (HashMap. (max 16 pn))]
+    (dotimes [i pn]
+      (let [^objects tuple (aget producer i)
+            k (aget tuple 0)
+            ^ArrayList run (.get table k)]
+        (if run
+          (.add run tuple)
+          (.put table k (doto (ArrayList. 4) (.add tuple))))))
+    (let [^ArrayList out (when materialize? (ArrayList.))]
+      (loop [i 0
+             n 0]
+        (if (== i cn)
+          n
+          (let [^objects consumer-tuple (aget consumer i)
+                ^ArrayList run (.get table (aget consumer-tuple 0))]
+            (if-not run
+              (recur (inc i) n)
+              (let [rn (.size run)]
+                (when materialize?
+                  (dotimes [j rn]
+                    (append-pair! out (.get run j) consumer-tuple)))
+                (recur (inc i) (+ n rn))))))))))
+
+(defn merge-join
+  "Walk two ordered tuple arrays, consuming complete equal-key runs on both
+  sides. Returns the output cardinality; optionally materializes projected
+  output tuples."
+  ^long [^objects producer ^objects consumer materialize?]
+  (let [pn (alength producer)
+        cn (alength consumer)
+        ^ArrayList out (when materialize? (ArrayList.))]
+    (loop [pi 0
+           ci 0
+           n 0]
+      (if (or (== pi pn) (== ci cn))
+        n
+        (let [^objects pt (aget producer pi)
+              ^objects ct (aget consumer ci)
+              pk (aget pt 0)
+              ck (aget ct 0)
+              cmp (long (datom/compare-value pk ck))]
+          (cond
+            (neg? cmp) (recur (inc pi) ci n)
+            (pos? cmp) (recur pi (inc ci) n)
+            :else
+            (let [pi' (long (loop [i (inc pi)]
+                              (if (and (< i pn)
+                                       (zero? (datom/compare-value
+                                               (aget ^objects (aget producer i) 0) pk)))
+                                (recur (inc i))
+                                i)))
+                  ci' (long (loop [i (inc ci)]
+                              (if (and (< i cn)
+                                       (zero? (datom/compare-value
+                                               (aget ^objects (aget consumer i) 0) ck)))
+                                (recur (inc i))
+                                i)))
+                  prun (- pi' pi)
+                  crun (- ci' ci)]
+              (when materialize?
+                (dotimes [p prun]
+                  (let [^objects producer-tuple (aget producer (+ pi p))]
+                    (dotimes [c crun]
+                      (append-pair! out producer-tuple
+                                    (aget consumer (+ ci c)))))))
+              (recur pi' ci' (+ n (* prun crun))))))))))
+
+(defn- thread-mx-bean []
+  (let [bean (ManagementFactory/getThreadMXBean)]
+    (when (instance? com.sun.management.ThreadMXBean bean)
+      (let [^com.sun.management.ThreadMXBean bean bean]
+        (when (and (.isThreadAllocatedMemorySupported bean)
+                   (not (.isThreadAllocatedMemoryEnabled bean)))
+          (.setThreadAllocatedMemoryEnabled bean true))
+        bean))))
+
+(defn- median [xs]
+  (nth (vec (sort xs)) (quot (count xs) 2)))
+
+(defn measure
+  "Warm f, then report median wall time and current-thread allocation per call."
+  ([f] (measure f identity))
+  ([f summarize]
+   (dotimes [_ 5] (f))
+   (let [calibration-start (System/nanoTime)
+         calibration-result (f)
+         calibration-ns (max 1 (- (System/nanoTime) calibration-start))
+         ;; Long enough to drown out nanoTime and nREPL noise, short enough that
+         ;; materialized-output cases do not create giant garbage waves.
+         iterations (long (max 1 (min 1000 (Math/ceil (/ 2.0e7 calibration-ns)))))
+         bean (thread-mx-bean)
+         tid (.threadId (Thread/currentThread))
+         samples
+         (vec
+          (for [_ (range 7)]
+            (let [a0 (when bean (.getThreadAllocatedBytes ^com.sun.management.ThreadMXBean bean tid))
+                  t0 (System/nanoTime)
+                  result (loop [i 0 result calibration-result]
+                           (if (== i iterations)
+                             result
+                             (recur (inc i) (f))))
+                  ns (- (System/nanoTime) t0)
+                  allocated (when bean (- (.getThreadAllocatedBytes ^com.sun.management.ThreadMXBean bean tid) a0))]
+              {:ns ns :allocated allocated :result (summarize result)})))]
+     {:ms (/ (double (median (map :ns samples))) iterations 1e6)
+      :allocated-mb (when bean (/ (double (median (map :allocated samples))) iterations 1048576.0))
+      :iterations iterations
+      :result (summarize calibration-result)})))
+
+(defn measure-scenario [{:keys [id producer consumer description]} materialize?]
+  (let [^objects p (apply make-tuples producer)
+        ^objects c (apply make-tuples consumer)
+        hash-result (measure #(hash-join p c materialize?))
+        merge-result (measure #(merge-join p c materialize?))]
+    (assert (= (:result hash-result) (:result merge-result)))
+    {:id id
+     :description description
+     :producer-rows (alength p)
+     :consumer-rows (alength c)
+     :output-rows (:result hash-result)
+     :materialize? materialize?
+     :hash hash-result
+     :merge merge-result
+     :ratio (/ (:ms merge-result) (:ms hash-result))}))
+
+(defn run-kernels
+  ([] (run-kernels false))
+  ([materialize?]
+   (mapv #(measure-scenario % materialize?) scenarios)))
+
+(defn print-results [results]
+  (println (format "%-19s %9s %9s %10s %10s %10s %9s %9s %8s"
+                   "shape" "producer" "consumer" "output" "hash ms" "merge ms"
+                   "hash MB" "merge MB" "ratio"))
+  (doseq [{:keys [id producer-rows consumer-rows output-rows hash merge ratio]} results]
+    (println (format "%-19s %9d %9d %10d %10.3f %10.3f %9.2f %9.2f %8.2f"
+                     (name id) producer-rows consumer-rows output-rows
+                     (:ms hash) (:ms merge)
+                     (or (:allocated-mb hash) 0.0) (or (:allocated-mb merge) 0.0)
+                     ratio)))
+  results)
+
+;; ---------------------------------------------------------------------------
+;; End-to-end query fixtures
+
+(def ^:private long-query-schema
+  [{:db/ident :l/key :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+   {:db/ident :l/payload :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :r/key :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one :db/index true}
+   {:db/ident :r/filter :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one :db/index true}
+   {:db/ident :r/payload :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}])
+
+(def ^:private tuple-query-schema
+  [{:db/ident :l/k1 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :l/k2 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :l/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
+    :db/tupleAttrs [:l/k1 :l/k2] :db/unique :db.unique/identity}
+   {:db/ident :l/payload :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :r/k1 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :r/k2 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :r/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
+    :db/tupleAttrs [:r/k1 :r/k2] :db/index true}
+   {:db/ident :r/filter :db/valueType :db.type/long :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :r/payload :db/valueType :db.type/long :db/cardinality :db.cardinality/one}])
+
+(defn- key-parts [^long k]
+  [(quot k 1000) (mod k 1000)])
+
+(defn query-db
+  "Build a deterministic two-relation fixture. Right rows are ordered into
+  `right-distinct` equal-key runs; right-offset controls overlap with the left
+  key range. Returns {:conn :db} so the caller controls lifetime."
+  [{:keys [key-kind left-rows right-rows right-distinct right-offset filter-distinct]
+    :or {key-kind :long left-rows 5000 right-rows 50000
+         right-distinct 5000 right-offset 0 filter-distinct 30000}}]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false
+             :attribute-refs? false
+             :search-cache-size 0
+             :value-caps :default
+             :index :datahike.index/persistent-set}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        tuple? (= key-kind :tuple)
+        left-row (fn [i]
+                   (if tuple?
+                     (let [[k1 k2] (key-parts i)]
+                       {:l/k1 k1 :l/k2 k2 :l/payload i})
+                     {:l/key i :l/payload i}))
+        right-row (fn [i]
+                    (let [k (+ right-offset
+                               (quot (* (long i) right-distinct) right-rows))]
+                      (if tuple?
+                        (let [[k1 k2] (key-parts k)]
+                          {:r/k1 k1 :r/k2 k2
+                           :r/filter (mod i filter-distinct) :r/payload i})
+                        {:r/key k :r/filter (mod i filter-distinct) :r/payload i})))]
+    (d/transact conn {:tx-data (if tuple? tuple-query-schema long-query-schema)})
+    (doseq [batch (partition-all 10000 (map left-row (range left-rows)))]
+      (d/transact conn {:tx-data (vec batch)}))
+    (doseq [batch (partition-all 10000 (map right-row (range right-rows)))]
+      (d/transact conn {:tx-data (vec batch)}))
+    {:conn conn :db @conn
+     :shape {:key-kind key-kind :left-rows left-rows :right-rows right-rows
+             :right-distinct right-distinct :right-offset right-offset
+             :filter-distinct filter-distinct}}))
+
+(def broad-value-query
+  '[:find ?lp ?rp
+    :where
+    [?l :l/key ?k]
+    [?l :l/payload ?lp]
+    [?r :r/key ?k]
+    [?r :r/payload ?rp]])
+
+(def semijoin-query
+  '[:find ?rp
+    :where
+    [?l :l/key ?k]
+    [?r :r/key ?k]
+    [?r :r/payload ?rp]])
+
+(def aggregate-query
+  '[:find ?k ?lp (count ?r)
+    :where
+    [?l :l/key ?k]
+    [?l :l/payload ?lp]
+    [?r :r/key ?k]])
+
+(def filtered-aggregate-query
+  '[:find ?k ?lp (count ?r)
+    :in $ ?max-filter
+    :where
+    [?l :l/key ?k]
+    [?l :l/payload ?lp]
+    [?r :r/key ?k]
+    [?r :r/filter ?filter]
+    [(<= ?filter ?max-filter)]])
+
+(def branch-shape-query
+  '[:find ?lp (count ?r)
+    :in $ ?floor ?max-filter
+    :where
+    [?l :l/key ?k]
+    [?l :l/payload ?lp]
+    [(>= ?lp ?floor)]
+    [?r :r/key ?k]
+    [?r :r/filter ?filter]
+    [(<= ?filter ?max-filter)]])
+
+(defn measure-query
+  "Measure the current compiled/hash path and relational fallback in the same
+  warmed JVM. Result equality is checked before timing."
+  [db query & inputs]
+  ;; Plans contain data-dependent cardinalities but the current global cache
+  ;; key does not contain data (#963). Every independently-built fixture must
+  ;; therefore begin with a cold plan cache; timing below still measures the
+  ;; normal warm-plan execution path.
+  (vreset! @#'q/plan-cache (lru/lru q/lru-cache-size))
+  (let [compiled-result (binding [q/*disable-planner* false
+                                  q/*query-result-cache?* false]
+                          (apply d/q query db inputs))
+        fallback-result (binding [q/*disable-planner* true
+                                  q/*query-result-cache?* false]
+                          (apply d/q query db inputs))]
+    (assert (= (set compiled-result) (set fallback-result)))
+    {:rows (count compiled-result)
+     :compiled (measure #(binding [q/*disable-planner* false
+                                   q/*query-result-cache?* false]
+                           (apply d/q query db inputs))
+                        count)
+     :fallback (measure #(binding [q/*disable-planner* true
+                                   q/*query-result-cache?* false]
+                           (apply d/q query db inputs))
+                        count)}))
+
+(defn print-query-result [label {:keys [rows compiled fallback] :as result}]
+  (println (format "%-28s rows=%-8d compiled=%8.2fms/%7.1fMB fallback=%8.2fms/%7.1fMB ratio=%5.2fx"
+                   label rows (:ms compiled) (:allocated-mb compiled)
+                   (:ms fallback) (:allocated-mb fallback)
+                   (/ (:ms compiled) (:ms fallback))))
+  result)
+
+(defn measure-ordered-query [db query & inputs]
+  (vreset! @#'q/plan-cache (lru/lru q/lru-cache-size))
+  (let [run (fn [enabled?]
+              (binding [q/*disable-planner* false
+                        q/*query-result-cache?* false
+                        ioa/*enabled* enabled?]
+                (apply d/q query db inputs)))
+        baseline-result (run false)
+        ordered-result (run true)]
+    (assert (= (set baseline-result) (set ordered-result)))
+    (let [baseline (measure #(run false) count)
+          ordered (measure #(run true) count)]
+      {:rows (count ordered-result)
+       :baseline baseline
+       :ordered ordered
+       :time-ratio (/ (:ms ordered) (:ms baseline))
+       :allocation-ratio (when (and (:allocated-mb ordered) (:allocated-mb baseline))
+                           (/ (:allocated-mb ordered) (:allocated-mb baseline)))})))
+
+(defn print-ordered-result
+  [label {:keys [rows baseline ordered time-ratio allocation-ratio] :as result}]
+  (println (format "%s rows=%d\n  relation %8.2fms / %7.1fMB\n  ordered  %8.2fms / %7.1fMB\n  ratios   %8.2fx / %7.2fx"
+                   label rows
+                   (:ms baseline) (:allocated-mb baseline)
+                   (:ms ordered) (:allocated-mb ordered)
+                   time-ratio (or allocation-ratio Double/NaN)))
+  result)
+
+(defn- entity-value-map
+  ^HashMap [db attr]
+  (let [out (HashMap.)]
+    (doseq [d (d/datoms db {:index :aevt :components [attr]})]
+      (.put out (:e d) (:v d)))
+    out))
+
+(defn avet-merge-query
+  "Hand-written oracle for the broad-value query. Both key attributes are read
+  in AVET order, while payloads are materialized by entity. This deliberately
+  exposes the physical-index trade-off hidden by the current AEVT entity-group
+  plan; it is not production executor code."
+  [db materialize?]
+  (let [^HashMap left-payloads (entity-value-map db :l/payload)
+        ^HashMap right-payloads (entity-value-map db :r/payload)
+        left (vec (d/datoms db {:index :avet :components [:l/key]}))
+        right (vec (d/datoms db {:index :avet :components [:r/key]}))
+        ln (count left)
+        rn (count right)
+        ^java.util.HashSet out (when materialize? (java.util.HashSet.))]
+    (loop [li 0 ri 0 n 0]
+      (if (or (== li ln) (== ri rn))
+        (if materialize? (.size out) n)
+        (let [ld (nth left li)
+              rd (nth right ri)
+              lk (:v ld)
+              rk (:v rd)
+              cmp (long (datom/compare-value lk rk))]
+          (cond
+            (neg? cmp) (recur (inc li) ri n)
+            (pos? cmp) (recur li (inc ri) n)
+            :else
+            (let [li' (long (loop [i (inc li)]
+                              (if (and (< i ln)
+                                       (zero? (datom/compare-value (:v (nth left i)) lk)))
+                                (recur (inc i))
+                                i)))
+                  ri' (long (loop [i (inc ri)]
+                              (if (and (< i rn)
+                                       (zero? (datom/compare-value (:v (nth right i)) rk)))
+                                (recur (inc i))
+                                i)))]
+              (when materialize?
+                (doseq [lidx (range li li')
+                        ridx (range ri ri')]
+                  (.add out [(.get left-payloads (:e (nth left lidx)))
+                             (.get right-payloads (:e (nth right ridx)))])))
+              (recur li' ri' (+ n (* (- li' li) (- ri' ri)))))))))))
+
+(defn avet-merge-aggregate
+  "Oracle for aggregate-query: exploit the matching consumer run directly
+  instead of materializing every joined pair before grouping it again."
+  [db]
+  (let [^HashMap left-payloads (entity-value-map db :l/payload)
+        left (vec (d/datoms db {:index :avet :components [:l/key]}))
+        right (vec (d/datoms db {:index :avet :components [:r/key]}))
+        ln (count left)
+        rn (count right)
+        ^java.util.HashSet out (java.util.HashSet.)]
+    (loop [li 0 ri 0]
+      (if (or (== li ln) (== ri rn))
+        out
+        (let [ld (nth left li)
+              rd (nth right ri)
+              lk (:v ld)
+              rk (:v rd)
+              cmp (long (datom/compare-value lk rk))]
+          (cond
+            (neg? cmp) (recur (inc li) ri)
+            (pos? cmp) (recur li (inc ri))
+            :else
+            (let [li' (long (loop [i (inc li)]
+                              (if (and (< i ln)
+                                       (zero? (datom/compare-value (:v (nth left i)) lk)))
+                                (recur (inc i))
+                                i)))
+                  ri' (long (loop [i (inc ri)]
+                              (if (and (< i rn)
+                                       (zero? (datom/compare-value (:v (nth right i)) rk)))
+                                (recur (inc i))
+                                i)))
+                  right-count (- ri' ri)]
+              (doseq [lidx (range li li')]
+                (let [left-datom (nth left lidx)]
+                  (.add out [lk (.get left-payloads (:e left-datom)) right-count])))
+              (recur li' ri'))))))))
+
+(defn avet-merge-filtered-aggregate
+  "Oracle for filtered-aggregate-query. It scans the foreign key in join-key
+  order, looks up the predicate value by entity, and counts qualifying rows in
+  each equal-key run without materializing the intermediate join relation."
+  [db max-filter]
+  (let [^HashMap left-payloads (entity-value-map db :l/payload)
+        ^HashMap right-filters (entity-value-map db :r/filter)
+        left (vec (d/datoms db {:index :avet :components [:l/key]}))
+        right (vec (d/datoms db {:index :avet :components [:r/key]}))
+        ln (count left)
+        rn (count right)
+        ^java.util.HashSet out (java.util.HashSet.)]
+    (loop [li 0 ri 0]
+      (if (or (== li ln) (== ri rn))
+        out
+        (let [ld (nth left li)
+              rd (nth right ri)
+              lk (:v ld)
+              rk (:v rd)
+              cmp (long (datom/compare-value lk rk))]
+          (cond
+            (neg? cmp) (recur (inc li) ri)
+            (pos? cmp) (recur li (inc ri))
+            :else
+            (let [li' (long (loop [i (inc li)]
+                              (if (and (< i ln)
+                                       (zero? (datom/compare-value (:v (nth left i)) lk)))
+                                (recur (inc i))
+                                i)))
+                  ri' (long (loop [i (inc ri)]
+                              (if (and (< i rn)
+                                       (zero? (datom/compare-value (:v (nth right i)) rk)))
+                                (recur (inc i))
+                                i)))
+                  right-count (loop [i ri n 0]
+                                (if (== i ri')
+                                  n
+                                  (recur (inc i)
+                                         (if (<= (long (.get right-filters
+                                                             (:e (nth right i))))
+                                                 (long max-filter))
+                                           (inc n)
+                                           n))))]
+              (when (pos? right-count)
+                (doseq [lidx (range li li')]
+                  (let [left-datom (nth left lidx)]
+                    (.add out [lk (.get left-payloads (:e left-datom)) right-count]))))
+              (recur li' ri'))))))))
+
+(defn filter-hash-aggregate
+  "Alternative oracle for filtered-aggregate-query. Drive the selective filter
+  AVET, fetch each qualifying entity's join key, aggregate counts in a hash map,
+  then probe it while walking the left key AVET. This is the competing strategy
+  for selective predicates; unlike avet-merge-filtered-aggregate it need not scan
+  every right-side join key."
+  [db max-filter]
+  (let [^HashMap left-payloads (entity-value-map db :l/payload)
+        ^HashMap counts (HashMap.)
+        filtered (take-while #(<= (long (:v %)) (long max-filter))
+                             (d/datoms db {:index :avet :components [:r/filter]}))]
+    (doseq [filter-datom filtered]
+      (let [k (:r/key (d/entity db (:e filter-datom)))]
+        (.put counts k (inc (long (or (.get counts k) 0))))))
+    (let [^java.util.HashSet out (java.util.HashSet.)]
+      (doseq [left-datom (d/datoms db {:index :avet :components [:l/key]})]
+        (let [k (:v left-datom)
+              n (.get counts k)]
+          (when n
+            (.add out [k (.get left-payloads (:e left-datom)) n]))))
+      out)))
+
+(defn -main [& args]
+  (let [query? (boolean (some #{"--query"} args))
+        scale? (boolean (some #{"--scale"} args))
+        assert? (boolean (some #{"--assert"} args))]
+    (if-not query?
+      (print-results (run-kernels (boolean (some #{"--materialize"} args))))
+      (let [left-rows (if scale? 30000 5000)
+            right-rows (* 10 left-rows)
+            fixture (query-db {:key-kind :tuple
+                               :left-rows left-rows
+                               :right-rows right-rows
+                               :right-distinct left-rows
+                               :filter-distinct 30000})
+            result (print-ordered-result
+                    (format "ordered aggregate %d x %d" left-rows right-rows)
+                    (measure-ordered-query (:db fixture) branch-shape-query 0 15000))
+            bad? (or (> (:time-ratio result) 0.75)
+                     (and (:allocation-ratio result)
+                          (> (:allocation-ratio result) 0.80)))]
+        (when (and assert? bad?)
+          (println "REGRESSION: ordered aggregate missed its relative performance bounds")
+          (System/exit 1))))))

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -4103,7 +4103,7 @@
                path (cond
                       split?    "cartesian-split — disjoint components run as sub-queries and merge"
                       direct?   "direct — fused scans write straight to the result set"
-                      columnar? "columnar-aggregate if a secondary/columnar engine accepts (runtime probe); else relation"
+                      columnar? "aggregate-fast-path if primary ordered/secondary/columnar execution accepts (runtime probe); else relation"
                       :else     "relation — execute-plan over relations")]
            (str (header "planned" path) (format-plan-ops (:ops plan) 0) "\n"))))
      :cljs (throw (ex-info "explain is not supported in ClojureScript" {}))))
@@ -5222,7 +5222,11 @@
                     tb (when *profile?* #?(:clj (System/nanoTime) :cljs 0))
                     columnar-result
                     (when columnar-eligible?
-                      #?(:clj (or (try-secondary-index-aggregate db plan find-elements)
+                      #?(:clj (or (when-not stats?
+                                    ((requiring-resolve
+                                      'datahike.query.index-ordered-aggregate/execute)
+                                     plan db find-elements (:cancel context-in)))
+                                  (try-secondary-index-aggregate db plan find-elements)
                                   (try-columnar-aggregate plan db find-elements (:cancel context-in)))
                          :cljs nil))
                     tc (when *profile?* #?(:clj (System/nanoTime) :cljs 0))]

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -4099,11 +4099,11 @@
                             no-in-rels?
                             (let [cdf (requiring-resolve 'datahike.query.execute/can-direct-fuse?)]
                               (boolean (cdf plan find-vars (:consts context-in)))))
-               columnar? (and has-aggs? find-rel? (not (:with query)) (not has-pull?) no-in-rels?)
+               aggregate-fast? (and has-aggs? (not has-pull?) no-in-rels?)
                path (cond
                       split?    "cartesian-split — disjoint components run as sub-queries and merge"
                       direct?   "direct — fused scans write straight to the result set"
-                      columnar? "aggregate-fast-path if primary ordered/secondary/columnar execution accepts (runtime probe); else relation"
+                      aggregate-fast? "aggregate-fast-path if primary ordered/secondary/columnar execution accepts (runtime probe); else relation"
                       :else     "relation — execute-plan over relations")]
            (str (header "planned" path) (format-plan-ops (:ops plan) 0) "\n"))))
      :cljs (throw (ex-info "explain is not supported in ClojureScript" {}))))
@@ -5210,25 +5210,30 @@
                                         (/ (- t3 t0) 1e6))))))
                 result)
 
-            ;; 2. Columnar aggregate (secondary index or PSS scan)
+            ;; 2. Aggregate fast paths (ordered primary, secondary, or PSS scan)
               (let [ta (when *profile?* #?(:clj (System/nanoTime) :cljs 0))
                     has-aggs? (some #(instance? Aggregate %) find-elements)
-                    columnar-eligible? (and has-aggs?
+                    aggregate-fast-eligible? (and has-aggs?
+                                                  (not (some #(instance? Pull %) find-elements))
+                                                  (empty? (:rels context-in))
+                                                  (not lookup-ref-reverse-map))
+                    columnar-eligible? (and aggregate-fast-eligible?
                                             (instance? FindRel qfind)
-                                            (not (:with query))
-                                            (not (some #(instance? Pull %) find-elements))
-                                            (empty? (:rels context-in))
-                                            (not lookup-ref-reverse-map))
+                                            (not qwith))
                     tb (when *profile?* #?(:clj (System/nanoTime) :cljs 0))
-                    columnar-result
-                    (when columnar-eligible?
-                      #?(:clj (or (when-not stats?
-                                    ((requiring-resolve
-                                      'datahike.query.index-ordered-aggregate/execute)
-                                     plan db find-elements (:cancel context-in)))
-                                  (try-secondary-index-aggregate db plan find-elements)
-                                  (try-columnar-aggregate plan db find-elements (:cancel context-in)))
+                    ordered-result
+                    (when aggregate-fast-eligible?
+                      #?(:clj (when-not stats?
+                                ((requiring-resolve
+                                  'datahike.query.index-ordered-aggregate/execute)
+                                 plan db find-elements qwith (:cancel context-in)))
                          :cljs nil))
+                    columnar-result
+                    (or ordered-result
+                        (when columnar-eligible?
+                          #?(:clj (or (try-secondary-index-aggregate db plan find-elements)
+                                      (try-columnar-aggregate plan db find-elements (:cancel context-in)))
+                             :cljs nil)))
                     tc (when *profile?* #?(:clj (System/nanoTime) :cljs 0))]
                 (if columnar-result
                   (let [result (-post-process qfind columnar-result)
@@ -5236,7 +5241,7 @@
                     #?(:clj
                        (when *profile?*
                          (let [t3 (System/nanoTime)]
-                           (println (format "parse=%.3f resolve=%.3f plan=%.3f elig=%.3f sec-idx=%.3f post=%.3f total=%.3f ms"
+                           (println (format "parse=%.3f resolve=%.3f plan=%.3f elig=%.3f agg-fast=%.3f post=%.3f total=%.3f ms"
                                             (/ (- t1 t0) 1e6) (/ (- t2 t1) 1e6) (/ (- ta t2) 1e6)
                                             (/ (- tb ta) 1e6) (/ (- tc tb) 1e6) (/ (- t3 tc) 1e6)
                                             (/ (- t3 t0) 1e6))))))

--- a/src/datahike/query/index_ordered_aggregate.clj
+++ b/src/datahike/query/index_ordered_aggregate.clj
@@ -19,6 +19,12 @@
   "Bind false to force the ordinary Relation aggregate path."
   true)
 
+(def ^:private max-dense-sum-eid
+  ;; A dense primitive table avoids per-row boxing in the hot sum fold. Above
+  ;; this bound its worst-case allocation would exceed 40 MB, so sparse or very
+  ;; large databases conservatively stay on the Relation path.
+  5000000)
+
 (defn- group-pattern-ops [group]
   (if (= :entity-group (:op group))
     (into [(:scan-op group)] (:merge-ops group))
@@ -107,6 +113,14 @@
          (>= producer-scan (* 0.20 producer-card))
          (>= consumer-scan (* 0.20 consumer-card)))))
 
+(defn- sum-cost-effective? [left-join-op right-join-op]
+  ;; The sum path replaces a materialized Cartesian join with a direct index
+  ;; fold. At small cardinalities the Relation path is already cheap; keep the
+  ;; runtime probe focused on joins large enough to amortize its tables.
+  (>= (+ (long (or (:estimated-card left-join-op) 0))
+         (long (or (:estimated-card right-join-op) 0)))
+      1000))
+
 (defn- supported-pattern? [op]
   (let [[e a v tx] (:clause op)]
     (and (nil? (:source op))
@@ -144,22 +158,154 @@
                  (let [[e _a v] (:clause op)] [e v]))
                ops)))
 
+(defn- group-predicates [group]
+  (->> (concat
+        (map #(select-keys % [:fn-sym :args]) (:attached-preds group))
+        (for [op (group-pattern-ops group)
+              pushdown (:pushdown-preds op)
+              :let [call (first (:pred-clause pushdown))]
+              :when (seq call)]
+          {:fn-sym (first call) :args (rest call)}))
+       (distinct)
+       (vec)))
+
 (defn- value-indexes [db ops join-op]
   (into {}
         (map (fn [op]
                [(nth (:clause op) 2) (entity-value-index db op)]))
         (remove #(identical? % join-op) ops)))
 
+(defn- run-end [datoms n from key]
+  (long
+   (loop [i (inc from)]
+     (if (and (< i n)
+              (zero? (datom/compare-value (.-v ^Datom (nth datoms i)) key)))
+       (recur (inc i))
+       i))))
+
+(defn- execute-count
+  [db find-elements cancel
+   producer-group consumer-group producer-ops consumer-ops
+   producer-join-op consumer-join-op join-var]
+  (let [producer-e (first (:clause producer-join-op))
+        consumer-e (first (:clause consumer-join-op))
+        producer-preds (group-predicates producer-group)
+        consumer-preds (group-predicates consumer-group)
+        producer-value-indexes (value-indexes db producer-ops producer-join-op)
+        consumer-value-indexes (value-indexes db consumer-ops consumer-join-op)
+        producer-datoms (vec (index-attr-datoms db producer-join-op :avet))
+        consumer-datoms (vec (index-attr-datoms db consumer-join-op :avet))
+        pn (count producer-datoms)
+        cn (count consumer-datoms)
+        ^HashSet out (HashSet.)]
+    (loop [pi 0 ci 0]
+      (if (or (>= pi pn) (>= ci cn))
+        (vec out)
+        (let [_ (when (and cancel @cancel)
+                  (throw (ex-info "query canceled" {:datahike/canceled true})))
+              ^Datom pd (nth producer-datoms pi)
+              ^Datom cd (nth consumer-datoms ci)
+              pk (.-v pd)
+              ck (.-v cd)
+              cmp (long (datom/compare-value pk ck))]
+          (cond
+            (neg? cmp) (recur (long (inc pi)) (long ci))
+            (pos? cmp) (recur (long pi) (long (inc ci)))
+            :else
+            (let [pi' (run-end producer-datoms pn pi pk)
+                  ci' (run-end consumer-datoms cn ci ck)
+                  n (loop [i ci n 0]
+                      (if (== i ci')
+                        n
+                        (let [^Datom d (nth consumer-datoms i)]
+                          (recur (inc i)
+                                 (if (row-pass? (.-e d) ck consumer-e join-var
+                                                consumer-value-indexes consumer-preds)
+                                   (inc n)
+                                   n)))))]
+              ;; Count grouping is only admitted for a schema-unique producer.
+              (assert (= 1 (- pi' pi)))
+              (when (and (pos? n)
+                         (row-pass? (.-e pd) pk producer-e join-var
+                                    producer-value-indexes producer-preds))
+                (.add out
+                      (mapv (fn [element]
+                              (if (instance? Aggregate element)
+                                n
+                                (row-value
+                                 (.-e pd) pk producer-e join-var
+                                 producer-value-indexes
+                                 (.-symbol ^Variable element))))
+                            find-elements)))
+              (recur (long pi') (long ci')))))))))
+
+(defn- execute-sum
+  [db cancel left-group right-group left-ops right-ops
+   left-join-op right-join-op join-var sum-var sum-side]
+  (let [sum-group (if (zero? sum-side) left-group right-group)
+        other-group (if (zero? sum-side) right-group left-group)
+        sum-ops (if (zero? sum-side) left-ops right-ops)
+        other-ops (if (zero? sum-side) right-ops left-ops)
+        sum-join-op (if (zero? sum-side) left-join-op right-join-op)
+        other-join-op (if (zero? sum-side) right-join-op left-join-op)
+        sum-e (first (:clause sum-join-op))
+        other-e (first (:clause other-join-op))
+        sum-op (first (filter #(= sum-var (nth (:clause %) 2)) sum-ops))
+        sum-preds (group-predicates sum-group)
+        other-preds (group-predicates other-group)
+        ;; Only additional predicate columns need entity lookup maps.
+        sum-value-indexes (value-indexes db (remove #(identical? % sum-op) sum-ops)
+                                         sum-join-op)
+        other-value-indexes (value-indexes db other-ops other-join-op)
+        ^HashMap other-counts (HashMap.)
+        ^longs entity-multiplicities (long-array (inc (long (:max-eid db))))]
+    ;; Collapse the non-summed run to key -> multiplicity. This preserves the
+    ;; producer x consumer bag implied by :with without materializing pairs.
+    (doseq [^Datom d (index-attr-datoms db other-join-op :avet)]
+      (when (and cancel @cancel)
+        (throw (ex-info "query canceled" {:datahike/canceled true})))
+      (let [key (.-v d)]
+        (when (row-pass? (.-e d) key other-e join-var
+                         other-value-indexes other-preds)
+          (.put other-counts key (inc (long (or (.get other-counts key) 0)))))))
+    ;; AVET is substantially cheaper than materializing an AEVT entity map.
+    ;; Retain only entities whose join key exists on the other side, together
+    ;; with the exact Cartesian multiplicity implied by :with.
+    (doseq [^Datom d (index-attr-datoms db sum-join-op :avet)]
+      (when (and cancel @cancel)
+        (throw (ex-info "query canceled" {:datahike/canceled true})))
+      (let [e (.-e d)
+            key (.-v d)
+            n (long (or (.get other-counts key) 0))]
+        (when (and (pos? n)
+                   (row-pass? e key sum-e join-var sum-value-indexes sum-preds))
+          (aset-long entity-multiplicities (int e) n))))
+    (let [[matched? total]
+          (reduce
+           (fn [[matched? total] ^Datom d]
+             (when (and cancel @cancel)
+               (throw (ex-info "query canceled" {:datahike/canceled true})))
+             (let [n (aget entity-multiplicities (int (.-e d)))]
+               (if (zero? n)
+                 [matched? total]
+                 [true (loop [i n acc total]
+                         (if (zero? i)
+                           acc
+                           (recur (dec i) (+ acc (.-v d)))))])))
+           [false (identity 0)]
+           (index-attr-datoms db sum-op :aevt))]
+      (if matched? [[total]] []))))
+
 (defn execute
   "Return aggregate result tuples for the supported ordered join shape, or nil.
 
   The supported subset is intentionally conservative: two card-one entity
-  groups, one indexed shared value, a unique producer join attribute,
-  producer-side grouping columns, one `(count ?consumer-entity)`, and simple
-  constant predicates. Both join attributes are scanned in AVET order; other
-  columns are indexed by entity once; predicates run before equal-key runs are
-  counted, so the intermediate join relation is never materialized."
-  [plan db find-elements cancel]
+  groups, one indexed shared value, simple constant predicates, and either a
+  producer-grouped `(count ?consumer-entity)` over a unique key or a scalar
+  `(sum ?value)` whose `:with` variables prove pair multiplicity. Count walks
+  equal AVET runs; sum folds a direct aggregate-column scan against join-key
+  multiplicities. Neither path materializes the intermediate join relation."
+  [plan db find-elements with-elements cancel]
   (when *enabled*
     (let [groups (filterv #(#{:entity-group :pattern-scan} (:op %)) (:ops plan))
           joins (:group-joins plan)
@@ -175,97 +321,72 @@
                     (+ 1 (count (filter #(instance? Variable %) find-elements)))))
         (let [{:keys [producer-idx probe-vars]} (get joins 1)
               join-var (first probe-vars)
-              producer-group (nth groups 0)
-              consumer-group (nth groups 1)
-              producer-ops (group-pattern-ops producer-group)
-              consumer-ops (group-pattern-ops consumer-group)
-              producer-join-op (join-value-op producer-group join-var)
-              consumer-join-op (join-value-op consumer-group join-var)
-              producer-e (first (:clause producer-join-op))
-              consumer-e (first (:clause consumer-join-op))
+              left-group (nth groups 0)
+              right-group (nth groups 1)
+              left-ops (group-pattern-ops left-group)
+              right-ops (group-pattern-ops right-group)
+              left-join-op (join-value-op left-group join-var)
+              right-join-op (join-value-op right-group join-var)
+              left-e (first (:clause left-join-op))
+              right-e (first (:clause right-join-op))
               ^Aggregate aggregate (first aggregates)
               aggregate-fn (.-symbol ^PlainSymbol (.-fn aggregate))
               aggregate-args (.-args aggregate)
-              count-var (when (and (= 1 (count aggregate-args))
-                                   (instance? Variable (first aggregate-args)))
-                          (.-symbol ^Variable (first aggregate-args)))
+              aggregate-var (when (and (= 1 (count aggregate-args))
+                                       (instance? Variable (first aggregate-args)))
+                              (.-symbol ^Variable (first aggregate-args)))
               group-vars (mapv #(.-symbol ^Variable %)
                                (filter #(instance? Variable %) find-elements))
-              producer-vars (set (or (:output-vars producer-group)
-                                     (:vars producer-group)))
-              producer-preds (vec (:attached-preds producer-group))
-              consumer-preds (vec (:attached-preds consumer-group))]
+              with-vars (set (map #(.-symbol ^Variable %) with-elements))
+              left-vars (available-vars left-ops)
+              right-vars (available-vars right-ops)
+              sum-side (cond
+                         (and (contains? left-vars aggregate-var)
+                              (not (contains? right-vars aggregate-var))) 0
+                         (and (contains? right-vars aggregate-var)
+                              (not (contains? left-vars aggregate-var))) 1
+                         :else nil)
+              sum-e (if (zero? (or sum-side -1)) left-e right-e)
+              other-e (if (zero? (or sum-side -1)) right-e left-e)
+              other-join-op (if (zero? (or sum-side -1)) right-join-op left-join-op)
+              sum-group (if (zero? (or sum-side -1)) left-group right-group)
+              sum-ops (if (zero? (or sum-side -1)) left-ops right-ops)
+              sum-op (first (filter #(= aggregate-var (nth (:clause %) 2)) sum-ops))
+              count-supported?
+              (and (= 'count aggregate-fn)
+                   (= right-e aggregate-var)
+                   (empty? with-vars)
+                   (get-in left-join-op [:schema-info :unique?])
+                   (every? (set (or (:output-vars left-group)
+                                    (:vars left-group)))
+                           group-vars)
+                   (cost-effective? left-group right-group left-join-op right-join-op))
+              sum-supported?
+              (and (= 'sum aggregate-fn)
+                   (some? sum-side)
+                   sum-op
+                   (= 1 (count find-elements))
+                   (contains? with-vars sum-e)
+                   (or (get-in other-join-op [:schema-info :unique?])
+                       (contains? with-vars other-e))
+                   (every? #{left-e right-e} with-vars)
+                   (<= (long (:max-eid db)) max-dense-sum-eid)
+                   (not-any? #(some #{aggregate-var} (:args %)) (group-predicates sum-group))
+                   (sum-cost-effective? left-join-op right-join-op))]
           (when (and (zero? producer-idx)
                      (= 1 (count probe-vars))
-                     producer-join-op consumer-join-op
-                     (get-in producer-join-op [:schema-info :unique?])
-                     (= 'count aggregate-fn)
-                     (= consumer-e count-var)
-                     (every? producer-vars group-vars)
-                     (every? supported-pattern? (concat producer-ops consumer-ops))
-                     (independent-group? producer-ops)
-                     (independent-group? consumer-ops)
-                     (every? #(supported-predicate? (available-vars producer-ops) %)
-                             producer-preds)
-                     (every? #(supported-predicate? (available-vars consumer-ops) %)
-                             consumer-preds)
-                     (cost-effective? producer-group consumer-group
-                                      producer-join-op consumer-join-op))
-            (let [producer-value-indexes (value-indexes db producer-ops producer-join-op)
-                  consumer-value-indexes (value-indexes db consumer-ops consumer-join-op)
-                  producer-datoms (vec (index-attr-datoms db producer-join-op :avet))
-                  consumer-datoms (vec (index-attr-datoms db consumer-join-op :avet))
-                  pn (count producer-datoms)
-                  cn (count consumer-datoms)
-                  ^HashSet out (HashSet.)]
-              (loop [pi 0 ci 0]
-                (if (or (>= pi pn) (>= ci cn))
-                  (vec out)
-                  (let [_ (when (and cancel @cancel)
-                            (throw (ex-info "query canceled" {:datahike/canceled true})))
-                        ^Datom pd (nth producer-datoms pi)
-                        ^Datom cd (nth consumer-datoms ci)
-                        pk (.-v pd)
-                        ck (.-v cd)
-                        cmp (long (datom/compare-value pk ck))]
-                    (cond
-                      (neg? cmp) (recur (inc pi) ci)
-                      (pos? cmp) (recur pi (inc ci))
-                      :else
-                      (let [pi' (long
-                                 (loop [i (inc pi)]
-                                   (if (and (< i pn)
-                                            (zero? (datom/compare-value
-                                                    (.-v ^Datom (nth producer-datoms i))
-                                                    pk)))
-                                     (recur (inc i))
-                                     i)))
-                            [ci' n]
-                            (loop [i ci n 0]
-                              (if (and (< i cn)
-                                       (zero? (datom/compare-value
-                                               (.-v ^Datom (nth consumer-datoms i))
-                                               ck)))
-                                (let [^Datom d (nth consumer-datoms i)]
-                                  (recur (inc i)
-                                         (if (row-pass?
-                                              (.-e d) ck consumer-e join-var
-                                              consumer-value-indexes consumer-preds)
-                                           (inc n)
-                                           n)))
-                                [i n]))]
-                        ;; A unique producer AVET must have one datom per key.
-                        (assert (= 1 (- pi' pi)))
-                        (when (and (pos? n)
-                                   (row-pass? (.-e pd) pk producer-e join-var
-                                              producer-value-indexes producer-preds))
-                          (.add out
-                                (mapv (fn [element]
-                                        (if (instance? Aggregate element)
-                                          n
-                                          (row-value
-                                           (.-e pd) pk producer-e join-var
-                                           producer-value-indexes
-                                           (.-symbol ^Variable element))))
-                                      find-elements)))
-                        (recur pi' (long ci'))))))))))))))
+                     left-join-op right-join-op
+                     (or count-supported? sum-supported?)
+                     (every? supported-pattern? (concat left-ops right-ops))
+                     (independent-group? left-ops)
+                     (independent-group? right-ops)
+                     (every? #(supported-predicate? left-vars %)
+                             (group-predicates left-group))
+                     (every? #(supported-predicate? right-vars %)
+                             (group-predicates right-group)))
+            (if count-supported?
+              (execute-count db find-elements cancel
+                             left-group right-group left-ops right-ops
+                             left-join-op right-join-op join-var)
+              (execute-sum db cancel left-group right-group left-ops right-ops
+                           left-join-op right-join-op join-var aggregate-var sum-side))))))))

--- a/src/datahike/query/index_ordered_aggregate.clj
+++ b/src/datahike/query/index_ordered_aggregate.clj
@@ -1,0 +1,271 @@
+(ns datahike.query.index-ordered-aggregate
+  "Primary-index aggregate execution for ordered unique-key/foreign-key joins."
+  (:require
+   [datahike.array :as da]
+   [datahike.constants :refer [e0 tx0 emax txmax]]
+   [datahike.datom :as datom :refer [datom]]
+   [datahike.db.interface :as dbi]
+   [datahike.index.interface :as di]
+   [datahike.query.analyze :as analyze])
+  (:import
+   [datahike.datom Datom]
+   [datahike.db DB]
+   [datalog.parser.type Aggregate PlainSymbol Variable]
+   [java.util HashMap HashSet]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:dynamic *enabled*
+  "Bind false to force the ordinary Relation aggregate path."
+  true)
+
+(defn- group-pattern-ops [group]
+  (if (= :entity-group (:op group))
+    (into [(:scan-op group)] (:merge-ops group))
+    [group]))
+
+(defn- group-scan-op [group]
+  (if (= :entity-group (:op group)) (:scan-op group) group))
+
+(defn- join-value-op [group join-var]
+  (first
+   (filter (fn [op]
+             (let [[_e a v _tx] (:clause op)]
+               (and (= v join-var)
+                    (or (keyword? a) (integer? a))
+                    (get-in op [:schema-info :indexed?])
+                    (get-in op [:schema-info :card-one?] true)
+                    (not (:anti? op))
+                    (not (:optional? op)))))
+           (group-pattern-ops group))))
+
+(defn- resolve-attr [db a]
+  (if (and (:attribute-refs? (dbi/-config db)) (keyword? a))
+    (dbi/ref-for db a :no-match)
+    a))
+
+(defn- index-attr-datoms [db op index]
+  (let [attr (resolve-attr db (second (:clause op)))
+        from (datom e0 attr nil tx0)
+        to (datom emax attr nil txmax)]
+    (di/-slice (get db index) from to index)))
+
+(defn- entity-value-index
+  ^HashMap [db op]
+  (let [^HashMap out (HashMap.)]
+    (doseq [^Datom d (index-attr-datoms db op :aevt)]
+      (.put out (.-e d) (.-v d)))
+    out))
+
+(defn- simple-predicate-value [fn-sym a b]
+  (case (symbol (name fn-sym))
+    > (> a b)
+    >= (>= a b)
+    < (< a b)
+    <= (<= a b)
+    = (da/a= a b)
+    == (== a b)
+    not= (not (da/a= a b))
+    false))
+
+(defn- row-value [e key e-var join-var value-indexes x]
+  (cond
+    (= x e-var) e
+    (= x join-var) key
+    (contains? value-indexes x) (.get ^HashMap (get value-indexes x) e)
+    :else x))
+
+(defn- row-pass? [e key e-var join-var value-indexes predicates]
+  (and (every? (fn [[_ ^HashMap values]] (.containsKey values e))
+               value-indexes)
+       (every? (fn [{:keys [fn-sym args]}]
+                 (let [[a b] args]
+                   (simple-predicate-value
+                    fn-sym
+                    (row-value e key e-var join-var value-indexes a)
+                    (row-value e key e-var join-var value-indexes b))))
+               predicates)))
+
+(defn- cost-effective?
+  [producer-group consumer-group producer-join-op consumer-join-op]
+  (let [producer-card (double (or (:estimated-card producer-join-op) 0))
+        consumer-card (double (or (:estimated-card consumer-join-op) 0))
+        producer-scan-op (group-scan-op producer-group)
+        consumer-scan-op (group-scan-op consumer-group)
+        producer-scan (double (or (:scan-card producer-scan-op)
+                                  (:estimated-card producer-scan-op)
+                                  0))
+        consumer-scan (double (or (:scan-card consumer-scan-op)
+                                  (:estimated-card consumer-scan-op)
+                                  0))]
+    (and (>= producer-card 1000.0)
+         (pos? consumer-card)
+         ;; Tiny producers are better served by probe-driven AVET seeks.
+         (>= (/ producer-card consumer-card) 0.05)
+         ;; Do not replace a selective driving index with two full key scans.
+         ;; The controlled filter/hash-to-merge crossover was about 20%.
+         (>= producer-scan (* 0.20 producer-card))
+         (>= consumer-scan (* 0.20 consumer-card)))))
+
+(defn- supported-pattern? [op]
+  (let [[e a v tx] (:clause op)]
+    (and (nil? (:source op))
+         (symbol? e) (analyze/free-var? e)
+         (or (keyword? a) (integer? a))
+         (symbol? v) (analyze/free-var? v)
+         (nil? tx)
+         (get-in op [:schema-info :card-one?] true)
+         (not (:anti? op))
+         (not (:optional? op)))))
+
+(defn- independent-group? [ops]
+  (let [entity-vars (mapv (comp first :clause) ops)
+        value-vars (mapv #(nth (:clause %) 2) ops)]
+    (and (apply = entity-vars)
+         (= (count value-vars) (count (distinct value-vars))))))
+
+(def ^:private supported-predicates
+  #{'> '>= '< '<= '= '== 'not=
+    'clojure.core/> 'clojure.core/>=
+    'clojure.core/< 'clojure.core/<=
+    'clojure.core/= 'clojure.core/==
+    'clojure.core/not=})
+
+(defn- supported-predicate? [available-vars {:keys [fn-sym args]}]
+  (and (contains? supported-predicates fn-sym)
+       (= 2 (count args))
+       (every? #(or (not (symbol? %)) (contains? available-vars %)) args)
+       ;; Bound input vars have already been folded to constants. Restrict this
+       ;; path to a single row var and one constant so evaluation stays exact.
+       (= 1 (count (filter symbol? args)))))
+
+(defn- available-vars [ops]
+  (set (mapcat (fn [op]
+                 (let [[e _a v] (:clause op)] [e v]))
+               ops)))
+
+(defn- value-indexes [db ops join-op]
+  (into {}
+        (map (fn [op]
+               [(nth (:clause op) 2) (entity-value-index db op)]))
+        (remove #(identical? % join-op) ops)))
+
+(defn execute
+  "Return aggregate result tuples for the supported ordered join shape, or nil.
+
+  The supported subset is intentionally conservative: two card-one entity
+  groups, one indexed shared value, a unique producer join attribute,
+  producer-side grouping columns, one `(count ?consumer-entity)`, and simple
+  constant predicates. Both join attributes are scanned in AVET order; other
+  columns are indexed by entity once; predicates run before equal-key runs are
+  counted, so the intermediate join relation is never materialized."
+  [plan db find-elements cancel]
+  (when *enabled*
+    (let [groups (filterv #(#{:entity-group :pattern-scan} (:op %)) (:ops plan))
+          joins (:group-joins plan)
+          aggregates (filterv #(instance? Aggregate %) find-elements)]
+      (when (and (instance? DB db)
+                 (every? #(#{:entity-group :pattern-scan} (:op %)) (:ops plan))
+                 (not-any? :source (:ops plan))
+                 (= 2 (count groups))
+                 (= 1 (count joins))
+                 (contains? joins 1)
+                 (= 1 (count aggregates))
+                 (= (count find-elements)
+                    (+ 1 (count (filter #(instance? Variable %) find-elements)))))
+        (let [{:keys [producer-idx probe-vars]} (get joins 1)
+              join-var (first probe-vars)
+              producer-group (nth groups 0)
+              consumer-group (nth groups 1)
+              producer-ops (group-pattern-ops producer-group)
+              consumer-ops (group-pattern-ops consumer-group)
+              producer-join-op (join-value-op producer-group join-var)
+              consumer-join-op (join-value-op consumer-group join-var)
+              producer-e (first (:clause producer-join-op))
+              consumer-e (first (:clause consumer-join-op))
+              ^Aggregate aggregate (first aggregates)
+              aggregate-fn (.-symbol ^PlainSymbol (.-fn aggregate))
+              aggregate-args (.-args aggregate)
+              count-var (when (and (= 1 (count aggregate-args))
+                                   (instance? Variable (first aggregate-args)))
+                          (.-symbol ^Variable (first aggregate-args)))
+              group-vars (mapv #(.-symbol ^Variable %)
+                               (filter #(instance? Variable %) find-elements))
+              producer-vars (set (or (:output-vars producer-group)
+                                     (:vars producer-group)))
+              producer-preds (vec (:attached-preds producer-group))
+              consumer-preds (vec (:attached-preds consumer-group))]
+          (when (and (zero? producer-idx)
+                     (= 1 (count probe-vars))
+                     producer-join-op consumer-join-op
+                     (get-in producer-join-op [:schema-info :unique?])
+                     (= 'count aggregate-fn)
+                     (= consumer-e count-var)
+                     (every? producer-vars group-vars)
+                     (every? supported-pattern? (concat producer-ops consumer-ops))
+                     (independent-group? producer-ops)
+                     (independent-group? consumer-ops)
+                     (every? #(supported-predicate? (available-vars producer-ops) %)
+                             producer-preds)
+                     (every? #(supported-predicate? (available-vars consumer-ops) %)
+                             consumer-preds)
+                     (cost-effective? producer-group consumer-group
+                                      producer-join-op consumer-join-op))
+            (let [producer-value-indexes (value-indexes db producer-ops producer-join-op)
+                  consumer-value-indexes (value-indexes db consumer-ops consumer-join-op)
+                  producer-datoms (vec (index-attr-datoms db producer-join-op :avet))
+                  consumer-datoms (vec (index-attr-datoms db consumer-join-op :avet))
+                  pn (count producer-datoms)
+                  cn (count consumer-datoms)
+                  ^HashSet out (HashSet.)]
+              (loop [pi 0 ci 0]
+                (if (or (>= pi pn) (>= ci cn))
+                  (vec out)
+                  (let [_ (when (and cancel @cancel)
+                            (throw (ex-info "query canceled" {:datahike/canceled true})))
+                        ^Datom pd (nth producer-datoms pi)
+                        ^Datom cd (nth consumer-datoms ci)
+                        pk (.-v pd)
+                        ck (.-v cd)
+                        cmp (long (datom/compare-value pk ck))]
+                    (cond
+                      (neg? cmp) (recur (inc pi) ci)
+                      (pos? cmp) (recur pi (inc ci))
+                      :else
+                      (let [pi' (long
+                                 (loop [i (inc pi)]
+                                   (if (and (< i pn)
+                                            (zero? (datom/compare-value
+                                                    (.-v ^Datom (nth producer-datoms i))
+                                                    pk)))
+                                     (recur (inc i))
+                                     i)))
+                            [ci' n]
+                            (loop [i ci n 0]
+                              (if (and (< i cn)
+                                       (zero? (datom/compare-value
+                                               (.-v ^Datom (nth consumer-datoms i))
+                                               ck)))
+                                (let [^Datom d (nth consumer-datoms i)]
+                                  (recur (inc i)
+                                         (if (row-pass?
+                                              (.-e d) ck consumer-e join-var
+                                              consumer-value-indexes consumer-preds)
+                                           (inc n)
+                                           n)))
+                                [i n]))]
+                        ;; A unique producer AVET must have one datom per key.
+                        (assert (= 1 (- pi' pi)))
+                        (when (and (pos? n)
+                                   (row-pass? (.-e pd) pk producer-e join-var
+                                              producer-value-indexes producer-preds))
+                          (.add out
+                                (mapv (fn [element]
+                                        (if (instance? Aggregate element)
+                                          n
+                                          (row-value
+                                           (.-e pd) pk producer-e join-var
+                                           producer-value-indexes
+                                           (.-symbol ^Variable element))))
+                                      find-elements)))
+                        (recur pi' (long ci'))))))))))))))

--- a/test/datahike/test/index_ordered_aggregate_test.clj
+++ b/test/datahike/test/index_ordered_aggregate_test.clj
@@ -1,0 +1,129 @@
+(ns datahike.test.index-ordered-aggregate-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.db :as db]
+   [datahike.query :as q]
+   [datahike.query.index-ordered-aggregate :as ioa]))
+
+(def schema
+  {:l/k1 {}
+   :l/k2 {}
+   :l/key {:db/valueType :db.type/tuple
+           :db/tupleAttrs [:l/k1 :l/k2]
+           :db/unique :db.unique/identity}
+   :l/nonunique {:db/index true}
+   :l/payload {}
+   :r/k1 {}
+   :r/k2 {}
+   :r/key {:db/valueType :db.type/tuple
+           :db/tupleAttrs [:r/k1 :r/k2]
+           :db/index true}
+   :r/filter {:db/index true}})
+
+(def write-schema
+  (update-vals schema #(merge {:db/valueType :db.type/long
+                               :db/cardinality :db.cardinality/one}
+                              %)))
+
+(defn- key-parts [k]
+  [(quot k 100) (mod k 100)])
+
+(defn- fixture-db [config]
+  (let [left (mapv (fn [i]
+                     (let [[k1 k2] (key-parts i)]
+                       {:db/id (- (inc i))
+                        :l/k1 k1 :l/k2 k2 :l/nonunique i :l/payload i}))
+                   (range 1000))
+        ;; Ten rows per key, with only keys 500..999 overlapping the producer.
+        right (mapv (fn [i]
+                      (let [k (+ 500 (quot i 10))
+                            [k1 k2] (key-parts k)]
+                        {:db/id (- (+ 1001 i))
+                         :r/k1 k1 :r/k2 k2 :r/filter (mod i 20)}))
+                    (range 10000))]
+    (d/db-with (if (:attribute-refs? config)
+                 (d/db-with (db/empty-db nil config)
+                            (mapv (fn [[ident spec]]
+                                    (assoc spec :db/ident ident))
+                                  write-schema))
+                 (db/empty-db schema config))
+               (into left right))))
+
+(def test-db (delay (fixture-db nil)))
+(def attribute-ref-db
+  (delay (fixture-db {:attribute-refs? true :schema-flexibility :write})))
+
+(def filtered-count-query
+  '[:find ?payload (count ?r)
+    :in $ ?floor ?max-filter
+    :where
+    [?l :l/key ?key]
+    [?l :l/payload ?payload]
+    [(>= ?payload ?floor)]
+    [?r :r/key ?key]
+    [?r :r/filter ?filter]
+    [(<= ?filter ?max-filter)]])
+
+(def unsupported-count-query
+  '[:find ?payload (count ?filter)
+    :where
+    [?l :l/key ?key]
+    [?l :l/payload ?payload]
+    [?r :r/key ?key]
+    [?r :r/filter ?filter]])
+
+(def nonunique-producer-query
+  '[:find ?payload (count ?r)
+    :where
+    [?l :l/nonunique ?key]
+    [?l :l/payload ?payload]
+    [?r :r/key ?key]])
+
+(defn- run-query
+  ([query inputs enabled?]
+   (run-query query inputs enabled? @test-db))
+  ([query inputs enabled? database]
+   (let [selected? (atom false)
+         original ioa/execute
+         result (binding [q/*disable-planner* false
+                          q/*query-result-cache?* false
+                          ioa/*enabled* enabled?]
+                  (with-redefs [ioa/execute
+                                (fn [& args]
+                                  (let [result (apply original args)]
+                                    (when result (reset! selected? true))
+                                    result))]
+                    (apply d/q query database inputs)))]
+     {:result (set result) :selected? @selected?})))
+
+(deftest ordered-count-aggregate-is-differentially-correct
+  (doseq [[label inputs selected?]
+          [[:partial-filter [250 9] true]
+           [:empty-filter [250 -1] false]
+           [:full-filter [250 19] true]
+           [:empty-producer-range [2000 19] true]]]
+    (testing (name label)
+      (let [baseline (run-query filtered-count-query inputs false)
+            ordered (run-query filtered-count-query inputs true)]
+        (is (= (:result baseline) (:result ordered)))
+        (is (= selected? (:selected? ordered)))))))
+
+(deftest unsupported-count-basis-falls-back
+  (let [baseline (run-query unsupported-count-query [] false)
+        enabled (run-query unsupported-count-query [] true)]
+    (is (= (:result baseline) (:result enabled)))
+    (is (false? (:selected? enabled)))))
+
+(deftest nonunique-producer-falls-back
+  (let [baseline (run-query nonunique-producer-query [] false)
+        enabled (run-query nonunique-producer-query [] true)]
+    (is (= (:result baseline) (:result enabled)))
+    (is (false? (:selected? enabled)))))
+
+(deftest attribute-reference-indexes-are-supported
+  (let [database @attribute-ref-db
+        baseline (run-query filtered-count-query [250 9] false database)
+        ordered (run-query filtered-count-query [250 9] true database)]
+    (is (= (:result baseline) (:result ordered)))
+    (is (true? (:selected? ordered)))))

--- a/test/datahike/test/index_ordered_aggregate_test.clj
+++ b/test/datahike/test/index_ordered_aggregate_test.clj
@@ -13,12 +13,14 @@
            :db/tupleAttrs [:l/k1 :l/k2]
            :db/unique :db.unique/identity}
    :l/nonunique {:db/index true}
+   :l/run-key {:db/index true}
    :l/payload {}
    :r/k1 {}
    :r/k2 {}
    :r/key {:db/valueType :db.type/tuple
            :db/tupleAttrs [:r/k1 :r/k2]
            :db/index true}
+   :r/amount {}
    :r/filter {:db/index true}})
 
 (def write-schema
@@ -33,14 +35,16 @@
   (let [left (mapv (fn [i]
                      (let [[k1 k2] (key-parts i)]
                        {:db/id (- (inc i))
-                        :l/k1 k1 :l/k2 k2 :l/nonunique i :l/payload i}))
+                        :l/k1 k1 :l/k2 k2 :l/nonunique i
+                        :l/run-key (mod i 200) :l/payload i}))
                    (range 1000))
         ;; Ten rows per key, with only keys 500..999 overlapping the producer.
         right (mapv (fn [i]
                       (let [k (+ 500 (quot i 10))
                             [k1 k2] (key-parts k)]
                         {:db/id (- (+ 1001 i))
-                         :r/k1 k1 :r/k2 k2 :r/filter (mod i 20)}))
+                         :r/k1 k1 :r/k2 k2 :r/filter (mod i 20)
+                         :r/amount (inc (mod i 7))}))
                     (range 10000))]
     (d/db-with (if (:attribute-refs? config)
                  (d/db-with (db/empty-db nil config)
@@ -80,6 +84,30 @@
     [?l :l/payload ?payload]
     [?r :r/key ?key]])
 
+(def unique-side-sum-query
+  '[:find (sum ?amount) .
+    :with ?r
+    :where
+    [?l :l/key ?key]
+    [?r :r/key ?key]
+    [?r :r/amount ?amount]])
+
+(def duplicate-run-sum-query
+  '[:find (sum ?amount) .
+    :with ?l ?r
+    :where
+    [?l :l/run-key ?key]
+    [(<= ?key 9)]
+    [?r :r/filter ?key]
+    [?r :r/amount ?amount]])
+
+(def missing-with-sum-query
+  '[:find (sum ?amount) .
+    :where
+    [?l :l/run-key ?key]
+    [?r :r/filter ?key]
+    [?r :r/amount ?amount]])
+
 (defn- run-query
   ([query inputs enabled?]
    (run-query query inputs enabled? @test-db))
@@ -95,7 +123,13 @@
                                     (when result (reset! selected? true))
                                     result))]
                     (apply d/q query database inputs)))]
-     {:result (set result) :selected? @selected?})))
+     {:result (if (coll? result) (set result) result)
+      :selected? @selected?})))
+
+(defn- run-legacy-query [query inputs]
+  (binding [q/*disable-planner* true
+            q/*query-result-cache?* false]
+    (apply d/q query @test-db inputs)))
 
 (deftest ordered-count-aggregate-is-differentially-correct
   (doseq [[label inputs selected?]
@@ -127,3 +161,25 @@
         ordered (run-query filtered-count-query [250 9] true database)]
     (is (= (:result baseline) (:result ordered)))
     (is (true? (:selected? ordered)))))
+
+(deftest scalar-sum-preserves-with-multiplicity
+  (doseq [[label query]
+          [[:unique-other-side unique-side-sum-query]
+           [:duplicate-runs-and-pushdown duplicate-run-sum-query]]]
+    (testing (name label)
+      (let [baseline (run-query query [] false)
+            legacy (run-legacy-query query [])
+            ordered (run-query query [] true)]
+        (if (= :duplicate-runs-and-pushdown label)
+          ;; The ordinary planned Relation path currently loses this pushed
+          ;; join-key predicate; the legacy engine is the semantic oracle.
+          (is (= legacy (:result ordered)))
+          (is (= (:result baseline) (:result ordered))))
+        (is (integer? (:result ordered)))
+        (is (true? (:selected? ordered)))))))
+
+(deftest sum-without-multiplicity-proof-falls-back
+  (let [baseline (run-query missing-with-sum-query [] false)
+        enabled (run-query missing-with-sum-query [] true)]
+    (is (= (:result baseline) (:result enabled)))
+    (is (false? (:selected? enabled)))))


### PR DESCRIPTION
#### SUMMARY

Add a conservative JVM fast path for grouped `(count ?consumer)` queries that join a unique producer attribute to an indexed card-one consumer attribute.

The executor walks both join attributes in AVET order, evaluates attached constant predicates, and folds matching consumer runs directly into aggregate results. It avoids materializing the intermediate join relation. Unsupported shapes return `nil` and continue through the existing secondary, columnar, or Relation paths.

Selection is intentionally narrow:

- two independent entity groups and one shared join variable
- unique producer key and indexed card-one join attributes
- producer-side grouping columns
- `(count ?consumer-entity)` aggregate
- simple binary constant predicates
- regular (non-temporal) JVM databases
- cardinality/selectivity gates derived from a hash-vs-ordered crossover matrix

This notably makes composite FK tuples useful as physical join keys. It does not optimize equivalent column-by-column joins or `sum` aggregates; those remain follow-up work.

#### Checks

##### Feature

- [x] Differential and fallback tests added
- [x] Persistent-set, hitchhiker-tree, and spec-instrumented suites checked
- [x] Attribute-reference databases checked
- [x] Existing planner regression benchmark checked
- [x] Formatting checked
- [x] Repeatable performance regression gate added
- [ ] Idle-machine production comparison recorded

No existing issue is closed by this PR. The executor is isolated behind a runtime probe and a dynamic on/off binding so its results and performance can be compared directly with the Relation path.

#### ADDITIONAL INFORMATION

Fresh-process synthetic scale check under a fixed power-saver profile:

```text
$ bb join-bench --query --scale --assert
ordered aggregate 30000 x 300000 rows=15010
  relation   881.18ms /   335.8MB
  ordered    241.74ms /   177.0MB
  ratios       0.27x /    0.53x
```

The assertion fails if ordered execution exceeds 0.75x relation time or 0.80x relation allocation.

On the production `failure_repro` FK-tuple query, measured back-to-back on the same store during a heavily loaded window:

```text
Relation path: 2558 ms
Ordered path:   372 ms
Ratio:          0.145x (6.9x speedup)
```

The production absolute times are deliberately not treated as reportable because system load was 10.7-13.8. The same-store A/B ratio is included as supporting evidence; an idle-machine run remains before promoting the PR from draft.

Other checks:

```text
$ bb kaocha --focus datahike.test.index-ordered-aggregate-test
12 tests, 42 assertions, 0 failures.

$ bb planner-bench --assert
OK - planner within threshold and results agree on all 7 shapes.

$ clojure -M:format src/datahike/query.cljc \
    src/datahike/query/index_ordered_aggregate.clj \
    test/datahike/test/index_ordered_aggregate_test.clj \
    benchmark/src/benchmark/join_strategy.clj
All source files formatted correctly
```

The controlled kernel matrix also records the cases where ordered execution should not be selected: tiny producers, tail matches, highly selective filters, and duplicate-heavy inputs. The observed selective-filter crossover was approximately 20%, which informs the runtime cost gate.
