### PR TITLE
Stream scalar sums across indexed joins

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -30,7 +30,7 @@
                         :depends [prep]
                         :task (apply clojure "-M:bench" "-m" "benchmark.planner-regression" *command-line-args*)}
 
-         join-bench {:doc "Ordered join kernels/query regression. Pass --query [--scale] [--assert]."
+         join-bench {:doc "Ordered join kernels/query regression. Pass --query [--sum] [--scale] [--assert]."
                      :depends [prep]
                      :task (apply clojure "-M:bench" "-m" "benchmark.join-strategy" *command-line-args*)}
 

--- a/benchmark/src/benchmark/join_strategy.clj
+++ b/benchmark/src/benchmark/join_strategy.clj
@@ -240,6 +240,8 @@
     :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
    {:db/ident :l/payload :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one}
+   {:db/ident :l/run-key :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one :db/index true}
    {:db/ident :r/key :db/valueType :db.type/long
     :db/cardinality :db.cardinality/one :db/index true}
    {:db/ident :r/filter :db/valueType :db.type/long
@@ -253,6 +255,8 @@
    {:db/ident :l/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
     :db/tupleAttrs [:l/k1 :l/k2] :db/unique :db.unique/identity}
    {:db/ident :l/payload :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+   {:db/ident :l/run-key :db/valueType :db.type/long :db/cardinality :db.cardinality/one
+    :db/index true}
    {:db/ident :r/k1 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
    {:db/ident :r/k2 :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
    {:db/ident :r/key :db/valueType :db.type/tuple :db/cardinality :db.cardinality/one
@@ -284,8 +288,9 @@
         left-row (fn [i]
                    (if tuple?
                      (let [[k1 k2] (key-parts i)]
-                       {:l/k1 k1 :l/k2 k2 :l/payload i})
-                     {:l/key i :l/payload i}))
+                       {:l/k1 k1 :l/k2 k2 :l/payload i
+                        :l/run-key (mod i filter-distinct)})
+                     {:l/key i :l/payload i :l/run-key (mod i filter-distinct)}))
         right-row (fn [i]
                     (let [k (+ right-offset
                                (quot (* (long i) right-distinct) right-rows))]
@@ -347,6 +352,24 @@
     [?r :r/filter ?filter]
     [(<= ?filter ?max-filter)]])
 
+(def scalar-sum-query
+  '[:find (sum ?amount) .
+    :with ?r
+    :where
+    [?l :l/key ?key]
+    [?r :r/key ?key]
+    [?r :r/payload ?amount]])
+
+(def duplicate-run-sum-query
+  '[:find (sum ?amount) .
+    :in $ ?max-key
+    :with ?l ?r
+    :where
+    [?l :l/run-key ?key]
+    [(<= ?key ?max-key)]
+    [?r :r/filter ?key]
+    [?r :r/payload ?amount]])
+
 (defn measure-query
   "Measure the current compiled/hash path and relational fallback in the same
   warmed JVM. Result equality is checked before timing."
@@ -388,11 +411,21 @@
                         ioa/*enabled* enabled?]
                 (apply d/q query db inputs)))
         baseline-result (run false)
-        ordered-result (run true)]
-    (assert (= (set baseline-result) (set ordered-result)))
-    (let [baseline (measure #(run false) count)
-          ordered (measure #(run true) count)]
-      {:rows (count ordered-result)
+        ordered-result (run true)
+        reference-result (binding [q/*disable-planner* true
+                                   q/*query-result-cache?* false]
+                           (apply d/q query db inputs))
+        equivalent? (fn [a b]
+                      (if (and (number? a) (number? b))
+                        (<= (Math/abs (- (double a) (double b)))
+                            (* 1.0e-12 (max 1.0 (Math/abs (double b)))))
+                        (= (set a) (set b))))]
+    (assert (equivalent? reference-result ordered-result))
+    (let [summarize #(if (coll? %) (count %) %)
+          baseline (measure #(run false) summarize)
+          ordered (measure #(run true) summarize)]
+      {:rows (if (coll? ordered-result) (count ordered-result) 1)
+       :baseline-correct? (equivalent? reference-result baseline-result)
        :baseline baseline
        :ordered ordered
        :time-ratio (/ (:ms ordered) (:ms baseline))
@@ -400,9 +433,10 @@
                            (/ (:allocated-mb ordered) (:allocated-mb baseline)))})))
 
 (defn print-ordered-result
-  [label {:keys [rows baseline ordered time-ratio allocation-ratio] :as result}]
-  (println (format "%s rows=%d\n  relation %8.2fms / %7.1fMB\n  ordered  %8.2fms / %7.1fMB\n  ratios   %8.2fx / %7.2fx"
+  [label {:keys [rows baseline-correct? baseline ordered time-ratio allocation-ratio] :as result}]
+  (println (format "%s rows=%d%s\n  relation %8.2fms / %7.1fMB\n  ordered  %8.2fms / %7.1fMB\n  ratios   %8.2fx / %7.2fx"
                    label rows
+                   (if baseline-correct? "" " (relation result differs from legacy oracle)")
                    (:ms baseline) (:allocated-mb baseline)
                    (:ms ordered) (:allocated-mb ordered)
                    time-ratio (or allocation-ratio Double/NaN)))
@@ -569,6 +603,7 @@
 (defn -main [& args]
   (let [query? (boolean (some #{"--query"} args))
         scale? (boolean (some #{"--scale"} args))
+        sum? (boolean (some #{"--sum"} args))
         assert? (boolean (some #{"--assert"} args))]
     (if-not query?
       (print-results (run-kernels (boolean (some #{"--materialize"} args))))
@@ -579,12 +614,21 @@
                                :right-rows right-rows
                                :right-distinct left-rows
                                :filter-distinct 30000})
-            result (print-ordered-result
-                    (format "ordered aggregate %d x %d" left-rows right-rows)
-                    (measure-ordered-query (:db fixture) branch-shape-query 0 15000))
-            bad? (or (> (:time-ratio result) 0.75)
-                     (and (:allocation-ratio result)
-                          (> (:allocation-ratio result) 0.80)))]
+            cases (if sum?
+                    [["scalar sum, unique other side" scalar-sum-query []]
+                     ["scalar sum, duplicate runs" duplicate-run-sum-query [15000]]]
+                    [[(format "ordered aggregate %d x %d" left-rows right-rows)
+                      branch-shape-query [0 15000]]])
+            results (mapv (fn [[label query inputs]]
+                            (print-ordered-result
+                             label
+                             (apply measure-ordered-query (:db fixture) query inputs)))
+                          cases)
+            bad? (some (fn [result]
+                         (or (> (:time-ratio result) 0.75)
+                             (and (:allocation-ratio result)
+                                  (> (:allocation-ratio result) 0.80))))
+                       results)]
         (when (and assert? bad?)
           (println "REGRESSION: ordered aggregate missed its relative performance bounds")
           (System/exit 1))))))

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -4099,11 +4099,11 @@
                             no-in-rels?
                             (let [cdf (requiring-resolve 'datahike.query.execute/can-direct-fuse?)]
                               (boolean (cdf plan find-vars (:consts context-in)))))
-               columnar? (and has-aggs? find-rel? (not (:with query)) (not has-pull?) no-in-rels?)
+               aggregate-fast? (and has-aggs? (not has-pull?) no-in-rels?)
                path (cond
                       split?    "cartesian-split — disjoint components run as sub-queries and merge"
                       direct?   "direct — fused scans write straight to the result set"
-                      columnar? "aggregate-fast-path if primary ordered/secondary/columnar execution accepts (runtime probe); else relation"
+                      aggregate-fast? "aggregate-fast-path if primary ordered/secondary/columnar execution accepts (runtime probe); else relation"
                       :else     "relation — execute-plan over relations")]
            (str (header "planned" path) (format-plan-ops (:ops plan) 0) "\n"))))
      :cljs (throw (ex-info "explain is not supported in ClojureScript" {}))))
@@ -5210,25 +5210,30 @@
                                         (/ (- t3 t0) 1e6))))))
                 result)
 
-            ;; 2. Columnar aggregate (secondary index or PSS scan)
+            ;; 2. Aggregate fast paths (ordered primary, secondary, or PSS scan)
               (let [ta (when *profile?* #?(:clj (System/nanoTime) :cljs 0))
                     has-aggs? (some #(instance? Aggregate %) find-elements)
-                    columnar-eligible? (and has-aggs?
+                    aggregate-fast-eligible? (and has-aggs?
+                                                  (not (some #(instance? Pull %) find-elements))
+                                                  (empty? (:rels context-in))
+                                                  (not lookup-ref-reverse-map))
+                    columnar-eligible? (and aggregate-fast-eligible?
                                             (instance? FindRel qfind)
-                                            (not (:with query))
-                                            (not (some #(instance? Pull %) find-elements))
-                                            (empty? (:rels context-in))
-                                            (not lookup-ref-reverse-map))
+                                            (not qwith))
                     tb (when *profile?* #?(:clj (System/nanoTime) :cljs 0))
-                    columnar-result
-                    (when columnar-eligible?
-                      #?(:clj (or (when-not stats?
-                                    ((requiring-resolve
-                                      'datahike.query.index-ordered-aggregate/execute)
-                                     plan db find-elements (:cancel context-in)))
-                                  (try-secondary-index-aggregate db plan find-elements)
-                                  (try-columnar-aggregate plan db find-elements (:cancel context-in)))
+                    ordered-result
+                    (when aggregate-fast-eligible?
+                      #?(:clj (when-not stats?
+                                ((requiring-resolve
+                                  'datahike.query.index-ordered-aggregate/execute)
+                                 plan db find-elements qwith (:cancel context-in)))
                          :cljs nil))
+                    columnar-result
+                    (or ordered-result
+                        (when columnar-eligible?
+                          #?(:clj (or (try-secondary-index-aggregate db plan find-elements)
+                                      (try-columnar-aggregate plan db find-elements (:cancel context-in)))
+                             :cljs nil)))
                     tc (when *profile?* #?(:clj (System/nanoTime) :cljs 0))]
                 (if columnar-result
                   (let [result (-post-process qfind columnar-result)
@@ -5236,7 +5241,7 @@
                     #?(:clj
                        (when *profile?*
                          (let [t3 (System/nanoTime)]
-                           (println (format "parse=%.3f resolve=%.3f plan=%.3f elig=%.3f sec-idx=%.3f post=%.3f total=%.3f ms"
+                           (println (format "parse=%.3f resolve=%.3f plan=%.3f elig=%.3f agg-fast=%.3f post=%.3f total=%.3f ms"
                                             (/ (- t1 t0) 1e6) (/ (- t2 t1) 1e6) (/ (- ta t2) 1e6)
                                             (/ (- tb ta) 1e6) (/ (- tc tb) 1e6) (/ (- t3 tc) 1e6)
                                             (/ (- t3 t0) 1e6))))))

--- a/src/datahike/query/index_ordered_aggregate.clj
+++ b/src/datahike/query/index_ordered_aggregate.clj
@@ -19,6 +19,12 @@
   "Bind false to force the ordinary Relation aggregate path."
   true)
 
+(def ^:private max-dense-sum-eid
+  ;; A dense primitive table avoids per-row boxing in the hot sum fold. Above
+  ;; this bound its worst-case allocation would exceed 40 MB, so sparse or very
+  ;; large databases conservatively stay on the Relation path.
+  5000000)
+
 (defn- group-pattern-ops [group]
   (if (= :entity-group (:op group))
     (into [(:scan-op group)] (:merge-ops group))
@@ -107,6 +113,14 @@
          (>= producer-scan (* 0.20 producer-card))
          (>= consumer-scan (* 0.20 consumer-card)))))
 
+(defn- sum-cost-effective? [left-join-op right-join-op]
+  ;; The sum path replaces a materialized Cartesian join with a direct index
+  ;; fold. At small cardinalities the Relation path is already cheap; keep the
+  ;; runtime probe focused on joins large enough to amortize its tables.
+  (>= (+ (long (or (:estimated-card left-join-op) 0))
+         (long (or (:estimated-card right-join-op) 0)))
+      1000))
+
 (defn- supported-pattern? [op]
   (let [[e a v tx] (:clause op)]
     (and (nil? (:source op))
@@ -144,22 +158,154 @@
                  (let [[e _a v] (:clause op)] [e v]))
                ops)))
 
+(defn- group-predicates [group]
+  (->> (concat
+        (map #(select-keys % [:fn-sym :args]) (:attached-preds group))
+        (for [op (group-pattern-ops group)
+              pushdown (:pushdown-preds op)
+              :let [call (first (:pred-clause pushdown))]
+              :when (seq call)]
+          {:fn-sym (first call) :args (rest call)}))
+       (distinct)
+       (vec)))
+
 (defn- value-indexes [db ops join-op]
   (into {}
         (map (fn [op]
                [(nth (:clause op) 2) (entity-value-index db op)]))
         (remove #(identical? % join-op) ops)))
 
+(defn- run-end [datoms n from key]
+  (long
+   (loop [i (inc from)]
+     (if (and (< i n)
+              (zero? (datom/compare-value (.-v ^Datom (nth datoms i)) key)))
+       (recur (inc i))
+       i))))
+
+(defn- execute-count
+  [db find-elements cancel
+   producer-group consumer-group producer-ops consumer-ops
+   producer-join-op consumer-join-op join-var]
+  (let [producer-e (first (:clause producer-join-op))
+        consumer-e (first (:clause consumer-join-op))
+        producer-preds (group-predicates producer-group)
+        consumer-preds (group-predicates consumer-group)
+        producer-value-indexes (value-indexes db producer-ops producer-join-op)
+        consumer-value-indexes (value-indexes db consumer-ops consumer-join-op)
+        producer-datoms (vec (index-attr-datoms db producer-join-op :avet))
+        consumer-datoms (vec (index-attr-datoms db consumer-join-op :avet))
+        pn (count producer-datoms)
+        cn (count consumer-datoms)
+        ^HashSet out (HashSet.)]
+    (loop [pi 0 ci 0]
+      (if (or (>= pi pn) (>= ci cn))
+        (vec out)
+        (let [_ (when (and cancel @cancel)
+                  (throw (ex-info "query canceled" {:datahike/canceled true})))
+              ^Datom pd (nth producer-datoms pi)
+              ^Datom cd (nth consumer-datoms ci)
+              pk (.-v pd)
+              ck (.-v cd)
+              cmp (long (datom/compare-value pk ck))]
+          (cond
+            (neg? cmp) (recur (long (inc pi)) (long ci))
+            (pos? cmp) (recur (long pi) (long (inc ci)))
+            :else
+            (let [pi' (run-end producer-datoms pn pi pk)
+                  ci' (run-end consumer-datoms cn ci ck)
+                  n (loop [i ci n 0]
+                      (if (== i ci')
+                        n
+                        (let [^Datom d (nth consumer-datoms i)]
+                          (recur (inc i)
+                                 (if (row-pass? (.-e d) ck consumer-e join-var
+                                                consumer-value-indexes consumer-preds)
+                                   (inc n)
+                                   n)))))]
+              ;; Count grouping is only admitted for a schema-unique producer.
+              (assert (= 1 (- pi' pi)))
+              (when (and (pos? n)
+                         (row-pass? (.-e pd) pk producer-e join-var
+                                    producer-value-indexes producer-preds))
+                (.add out
+                      (mapv (fn [element]
+                              (if (instance? Aggregate element)
+                                n
+                                (row-value
+                                 (.-e pd) pk producer-e join-var
+                                 producer-value-indexes
+                                 (.-symbol ^Variable element))))
+                            find-elements)))
+              (recur (long pi') (long ci')))))))))
+
+(defn- execute-sum
+  [db cancel left-group right-group left-ops right-ops
+   left-join-op right-join-op join-var sum-var sum-side]
+  (let [sum-group (if (zero? sum-side) left-group right-group)
+        other-group (if (zero? sum-side) right-group left-group)
+        sum-ops (if (zero? sum-side) left-ops right-ops)
+        other-ops (if (zero? sum-side) right-ops left-ops)
+        sum-join-op (if (zero? sum-side) left-join-op right-join-op)
+        other-join-op (if (zero? sum-side) right-join-op left-join-op)
+        sum-e (first (:clause sum-join-op))
+        other-e (first (:clause other-join-op))
+        sum-op (first (filter #(= sum-var (nth (:clause %) 2)) sum-ops))
+        sum-preds (group-predicates sum-group)
+        other-preds (group-predicates other-group)
+        ;; Only additional predicate columns need entity lookup maps.
+        sum-value-indexes (value-indexes db (remove #(identical? % sum-op) sum-ops)
+                                         sum-join-op)
+        other-value-indexes (value-indexes db other-ops other-join-op)
+        ^HashMap other-counts (HashMap.)
+        ^longs entity-multiplicities (long-array (inc (long (:max-eid db))))]
+    ;; Collapse the non-summed run to key -> multiplicity. This preserves the
+    ;; producer x consumer bag implied by :with without materializing pairs.
+    (doseq [^Datom d (index-attr-datoms db other-join-op :avet)]
+      (when (and cancel @cancel)
+        (throw (ex-info "query canceled" {:datahike/canceled true})))
+      (let [key (.-v d)]
+        (when (row-pass? (.-e d) key other-e join-var
+                         other-value-indexes other-preds)
+          (.put other-counts key (inc (long (or (.get other-counts key) 0)))))))
+    ;; AVET is substantially cheaper than materializing an AEVT entity map.
+    ;; Retain only entities whose join key exists on the other side, together
+    ;; with the exact Cartesian multiplicity implied by :with.
+    (doseq [^Datom d (index-attr-datoms db sum-join-op :avet)]
+      (when (and cancel @cancel)
+        (throw (ex-info "query canceled" {:datahike/canceled true})))
+      (let [e (.-e d)
+            key (.-v d)
+            n (long (or (.get other-counts key) 0))]
+        (when (and (pos? n)
+                   (row-pass? e key sum-e join-var sum-value-indexes sum-preds))
+          (aset-long entity-multiplicities (int e) n))))
+    (let [[matched? total]
+          (reduce
+           (fn [[matched? total] ^Datom d]
+             (when (and cancel @cancel)
+               (throw (ex-info "query canceled" {:datahike/canceled true})))
+             (let [n (aget entity-multiplicities (int (.-e d)))]
+               (if (zero? n)
+                 [matched? total]
+                 [true (loop [i n acc total]
+                         (if (zero? i)
+                           acc
+                           (recur (dec i) (+ acc (.-v d)))))])))
+           [false (identity 0)]
+           (index-attr-datoms db sum-op :aevt))]
+      (if matched? [[total]] []))))
+
 (defn execute
   "Return aggregate result tuples for the supported ordered join shape, or nil.
 
   The supported subset is intentionally conservative: two card-one entity
-  groups, one indexed shared value, a unique producer join attribute,
-  producer-side grouping columns, one `(count ?consumer-entity)`, and simple
-  constant predicates. Both join attributes are scanned in AVET order; other
-  columns are indexed by entity once; predicates run before equal-key runs are
-  counted, so the intermediate join relation is never materialized."
-  [plan db find-elements cancel]
+  groups, one indexed shared value, simple constant predicates, and either a
+  producer-grouped `(count ?consumer-entity)` over a unique key or a scalar
+  `(sum ?value)` whose `:with` variables prove pair multiplicity. Count walks
+  equal AVET runs; sum folds a direct aggregate-column scan against join-key
+  multiplicities. Neither path materializes the intermediate join relation."
+  [plan db find-elements with-elements cancel]
   (when *enabled*
     (let [groups (filterv #(#{:entity-group :pattern-scan} (:op %)) (:ops plan))
           joins (:group-joins plan)
@@ -175,97 +321,72 @@
                     (+ 1 (count (filter #(instance? Variable %) find-elements)))))
         (let [{:keys [producer-idx probe-vars]} (get joins 1)
               join-var (first probe-vars)
-              producer-group (nth groups 0)
-              consumer-group (nth groups 1)
-              producer-ops (group-pattern-ops producer-group)
-              consumer-ops (group-pattern-ops consumer-group)
-              producer-join-op (join-value-op producer-group join-var)
-              consumer-join-op (join-value-op consumer-group join-var)
-              producer-e (first (:clause producer-join-op))
-              consumer-e (first (:clause consumer-join-op))
+              left-group (nth groups 0)
+              right-group (nth groups 1)
+              left-ops (group-pattern-ops left-group)
+              right-ops (group-pattern-ops right-group)
+              left-join-op (join-value-op left-group join-var)
+              right-join-op (join-value-op right-group join-var)
+              left-e (first (:clause left-join-op))
+              right-e (first (:clause right-join-op))
               ^Aggregate aggregate (first aggregates)
               aggregate-fn (.-symbol ^PlainSymbol (.-fn aggregate))
               aggregate-args (.-args aggregate)
-              count-var (when (and (= 1 (count aggregate-args))
-                                   (instance? Variable (first aggregate-args)))
-                          (.-symbol ^Variable (first aggregate-args)))
+              aggregate-var (when (and (= 1 (count aggregate-args))
+                                       (instance? Variable (first aggregate-args)))
+                              (.-symbol ^Variable (first aggregate-args)))
               group-vars (mapv #(.-symbol ^Variable %)
                                (filter #(instance? Variable %) find-elements))
-              producer-vars (set (or (:output-vars producer-group)
-                                     (:vars producer-group)))
-              producer-preds (vec (:attached-preds producer-group))
-              consumer-preds (vec (:attached-preds consumer-group))]
+              with-vars (set (map #(.-symbol ^Variable %) with-elements))
+              left-vars (available-vars left-ops)
+              right-vars (available-vars right-ops)
+              sum-side (cond
+                         (and (contains? left-vars aggregate-var)
+                              (not (contains? right-vars aggregate-var))) 0
+                         (and (contains? right-vars aggregate-var)
+                              (not (contains? left-vars aggregate-var))) 1
+                         :else nil)
+              sum-e (if (zero? (or sum-side -1)) left-e right-e)
+              other-e (if (zero? (or sum-side -1)) right-e left-e)
+              other-join-op (if (zero? (or sum-side -1)) right-join-op left-join-op)
+              sum-group (if (zero? (or sum-side -1)) left-group right-group)
+              sum-ops (if (zero? (or sum-side -1)) left-ops right-ops)
+              sum-op (first (filter #(= aggregate-var (nth (:clause %) 2)) sum-ops))
+              count-supported?
+              (and (= 'count aggregate-fn)
+                   (= right-e aggregate-var)
+                   (empty? with-vars)
+                   (get-in left-join-op [:schema-info :unique?])
+                   (every? (set (or (:output-vars left-group)
+                                    (:vars left-group)))
+                           group-vars)
+                   (cost-effective? left-group right-group left-join-op right-join-op))
+              sum-supported?
+              (and (= 'sum aggregate-fn)
+                   (some? sum-side)
+                   sum-op
+                   (= 1 (count find-elements))
+                   (contains? with-vars sum-e)
+                   (or (get-in other-join-op [:schema-info :unique?])
+                       (contains? with-vars other-e))
+                   (every? #{left-e right-e} with-vars)
+                   (<= (long (:max-eid db)) max-dense-sum-eid)
+                   (not-any? #(some #{aggregate-var} (:args %)) (group-predicates sum-group))
+                   (sum-cost-effective? left-join-op right-join-op))]
           (when (and (zero? producer-idx)
                      (= 1 (count probe-vars))
-                     producer-join-op consumer-join-op
-                     (get-in producer-join-op [:schema-info :unique?])
-                     (= 'count aggregate-fn)
-                     (= consumer-e count-var)
-                     (every? producer-vars group-vars)
-                     (every? supported-pattern? (concat producer-ops consumer-ops))
-                     (independent-group? producer-ops)
-                     (independent-group? consumer-ops)
-                     (every? #(supported-predicate? (available-vars producer-ops) %)
-                             producer-preds)
-                     (every? #(supported-predicate? (available-vars consumer-ops) %)
-                             consumer-preds)
-                     (cost-effective? producer-group consumer-group
-                                      producer-join-op consumer-join-op))
-            (let [producer-value-indexes (value-indexes db producer-ops producer-join-op)
-                  consumer-value-indexes (value-indexes db consumer-ops consumer-join-op)
-                  producer-datoms (vec (index-attr-datoms db producer-join-op :avet))
-                  consumer-datoms (vec (index-attr-datoms db consumer-join-op :avet))
-                  pn (count producer-datoms)
-                  cn (count consumer-datoms)
-                  ^HashSet out (HashSet.)]
-              (loop [pi 0 ci 0]
-                (if (or (>= pi pn) (>= ci cn))
-                  (vec out)
-                  (let [_ (when (and cancel @cancel)
-                            (throw (ex-info "query canceled" {:datahike/canceled true})))
-                        ^Datom pd (nth producer-datoms pi)
-                        ^Datom cd (nth consumer-datoms ci)
-                        pk (.-v pd)
-                        ck (.-v cd)
-                        cmp (long (datom/compare-value pk ck))]
-                    (cond
-                      (neg? cmp) (recur (inc pi) ci)
-                      (pos? cmp) (recur pi (inc ci))
-                      :else
-                      (let [pi' (long
-                                 (loop [i (inc pi)]
-                                   (if (and (< i pn)
-                                            (zero? (datom/compare-value
-                                                    (.-v ^Datom (nth producer-datoms i))
-                                                    pk)))
-                                     (recur (inc i))
-                                     i)))
-                            [ci' n]
-                            (loop [i ci n 0]
-                              (if (and (< i cn)
-                                       (zero? (datom/compare-value
-                                               (.-v ^Datom (nth consumer-datoms i))
-                                               ck)))
-                                (let [^Datom d (nth consumer-datoms i)]
-                                  (recur (inc i)
-                                         (if (row-pass?
-                                              (.-e d) ck consumer-e join-var
-                                              consumer-value-indexes consumer-preds)
-                                           (inc n)
-                                           n)))
-                                [i n]))]
-                        ;; A unique producer AVET must have one datom per key.
-                        (assert (= 1 (- pi' pi)))
-                        (when (and (pos? n)
-                                   (row-pass? (.-e pd) pk producer-e join-var
-                                              producer-value-indexes producer-preds))
-                          (.add out
-                                (mapv (fn [element]
-                                        (if (instance? Aggregate element)
-                                          n
-                                          (row-value
-                                           (.-e pd) pk producer-e join-var
-                                           producer-value-indexes
-                                           (.-symbol ^Variable element))))
-                                      find-elements)))
-                        (recur pi' (long ci'))))))))))))))
+                     left-join-op right-join-op
+                     (or count-supported? sum-supported?)
+                     (every? supported-pattern? (concat left-ops right-ops))
+                     (independent-group? left-ops)
+                     (independent-group? right-ops)
+                     (every? #(supported-predicate? left-vars %)
+                             (group-predicates left-group))
+                     (every? #(supported-predicate? right-vars %)
+                             (group-predicates right-group)))
+            (if count-supported?
+              (execute-count db find-elements cancel
+                             left-group right-group left-ops right-ops
+                             left-join-op right-join-op join-var)
+              (execute-sum db cancel left-group right-group left-ops right-ops
+                           left-join-op right-join-op join-var aggregate-var sum-side))))))))

--- a/test/datahike/test/index_ordered_aggregate_test.clj
+++ b/test/datahike/test/index_ordered_aggregate_test.clj
@@ -13,12 +13,14 @@
            :db/tupleAttrs [:l/k1 :l/k2]
            :db/unique :db.unique/identity}
    :l/nonunique {:db/index true}
+   :l/run-key {:db/index true}
    :l/payload {}
    :r/k1 {}
    :r/k2 {}
    :r/key {:db/valueType :db.type/tuple
            :db/tupleAttrs [:r/k1 :r/k2]
            :db/index true}
+   :r/amount {}
    :r/filter {:db/index true}})
 
 (def write-schema
@@ -33,14 +35,16 @@
   (let [left (mapv (fn [i]
                      (let [[k1 k2] (key-parts i)]
                        {:db/id (- (inc i))
-                        :l/k1 k1 :l/k2 k2 :l/nonunique i :l/payload i}))
+                        :l/k1 k1 :l/k2 k2 :l/nonunique i
+                        :l/run-key (mod i 200) :l/payload i}))
                    (range 1000))
         ;; Ten rows per key, with only keys 500..999 overlapping the producer.
         right (mapv (fn [i]
                       (let [k (+ 500 (quot i 10))
                             [k1 k2] (key-parts k)]
                         {:db/id (- (+ 1001 i))
-                         :r/k1 k1 :r/k2 k2 :r/filter (mod i 20)}))
+                         :r/k1 k1 :r/k2 k2 :r/filter (mod i 20)
+                         :r/amount (inc (mod i 7))}))
                     (range 10000))]
     (d/db-with (if (:attribute-refs? config)
                  (d/db-with (db/empty-db nil config)
@@ -80,6 +84,30 @@
     [?l :l/payload ?payload]
     [?r :r/key ?key]])
 
+(def unique-side-sum-query
+  '[:find (sum ?amount) .
+    :with ?r
+    :where
+    [?l :l/key ?key]
+    [?r :r/key ?key]
+    [?r :r/amount ?amount]])
+
+(def duplicate-run-sum-query
+  '[:find (sum ?amount) .
+    :with ?l ?r
+    :where
+    [?l :l/run-key ?key]
+    [(<= ?key 9)]
+    [?r :r/filter ?key]
+    [?r :r/amount ?amount]])
+
+(def missing-with-sum-query
+  '[:find (sum ?amount) .
+    :where
+    [?l :l/run-key ?key]
+    [?r :r/filter ?key]
+    [?r :r/amount ?amount]])
+
 (defn- run-query
   ([query inputs enabled?]
    (run-query query inputs enabled? @test-db))
@@ -95,7 +123,13 @@
                                     (when result (reset! selected? true))
                                     result))]
                     (apply d/q query database inputs)))]
-     {:result (set result) :selected? @selected?})))
+     {:result (if (coll? result) (set result) result)
+      :selected? @selected?})))
+
+(defn- run-legacy-query [query inputs]
+  (binding [q/*disable-planner* true
+            q/*query-result-cache?* false]
+    (apply d/q query @test-db inputs)))
 
 (deftest ordered-count-aggregate-is-differentially-correct
   (doseq [[label inputs selected?]
@@ -127,3 +161,25 @@
         ordered (run-query filtered-count-query [250 9] true database)]
     (is (= (:result baseline) (:result ordered)))
     (is (true? (:selected? ordered)))))
+
+(deftest scalar-sum-preserves-with-multiplicity
+  (doseq [[label query]
+          [[:unique-other-side unique-side-sum-query]
+           [:duplicate-runs-and-pushdown duplicate-run-sum-query]]]
+    (testing (name label)
+      (let [baseline (run-query query [] false)
+            legacy (run-legacy-query query [])
+            ordered (run-query query [] true)]
+        (if (= :duplicate-runs-and-pushdown label)
+          ;; The ordinary planned Relation path currently loses this pushed
+          ;; join-key predicate; the legacy engine is the semantic oracle.
+          (is (= legacy (:result ordered)))
+          (is (= (:result baseline) (:result ordered))))
+        (is (integer? (:result ordered)))
+        (is (true? (:selected? ordered)))))))
+
+(deftest sum-without-multiplicity-proof-falls-back
+  (let [baseline (run-query missing-with-sum-query [] false)
+        enabled (run-query missing-with-sum-query [] true)]
+    (is (= (:result baseline) (:result enabled)))
+    (is (false? (:selected? enabled)))))


### PR DESCRIPTION
#### SUMMARY

Stacked on #999. Extend the primary-index aggregate executor to scalar `(sum ?value)` joins whose `:with` variables prove the required row multiplicity.

The executor:

- collapses the non-summed side to join-key multiplicities;
- scans the summed side's join attribute in AVET order;
- records matching entity multiplicities in a bounded primitive table;
- streams the aggregate attribute once and folds directly;
- accepts unique/non-unique runs when `:with` makes every joined pair distinct;
- applies predicates recorded either as attached predicates or scan pushdowns;
- declines grouped sums, missing multiplicity proofs, large/sparse entity spaces, temporal DBs, and unsupported predicates.

This covers the BranchBench `mcts` and `simulation` sum queries without materializing their intermediate joins.

Floating-point sums can differ in the final few bits because index-order reduction changes addition order. The fold uses ordinary Clojure `+`, preserves numeric promotion/type semantics, and the benchmark checks floating results against the legacy semantic oracle at 1e-12 relative tolerance. Integer differential tests remain exact.

#### Checks

##### Feature

- [x] Scalar `:with` sum differential tests added
- [x] Unique and duplicate join runs tested
- [x] Pushdown predicate handling tested against the legacy semantic oracle
- [x] Missing multiplicity proof falls back
- [x] Persistent-set, hitchhiker-tree, and spec-instrumented suites checked
- [x] Existing query planner suite checked
- [x] Planner performance gate checked
- [x] Fresh-process time/allocation regression gate added
- [x] Formatting checked

#### ADDITIONAL INFORMATION

Fresh-process 30k x 300k synthetic checks under a fixed power-saver profile:

```text
$ bb join-bench --query --sum --scale --assert
scalar sum, unique other side rows=1
  relation   858.93ms /   311.8MB
  ordered    231.03ms /   115.5MB
  ratios       0.27x /    0.37x

scalar sum, duplicate runs rows=1
  relation   330.59ms /   126.1MB
  ordered     44.27ms /    39.1MB
  ratios       0.13x /    0.31x
```

On the existing local CH-benCHmark W=1 store during the same loaded-machine investigation:

- `mcts`: about 2333 ms on the current planned path and 221 ms on the selected sum path (10.5x). Subsequent hot-index samples reached 82 ms.
- `simulation` correct sum: about 1118 ms through the legacy semantic oracle and 290 ms through the selected sum path (3.9x).

Absolute production times remain load/cache sensitive; the fresh-process relative gate above is the repeatable regression check.

The investigation also exposed a pre-existing correctness issue in the ordinary planned Relation path for the literal `simulation` predicate. With `[(<= ?i 7500)]` stored only in a standalone scan's `:pushdown-preds`, the current planned path returned the unfiltered total `446634764.25`; the legacy engine and this fast path return approximately `33072019.15`. The new executor normalizes both attached and pushed predicate metadata and its test uses the legacy engine as the semantic oracle. This PR does not alter the ordinary Relation executor when the fast path declines.

Other checks:

```text
$ bb kaocha --focus datahike.test.index-ordered-aggregate-test
18 tests, 66 assertions, 0 failures.

$ bb kaocha --focus datahike.test.query-planner-test
84 tests, 351 assertions, 0 failures.

$ bb planner-bench --assert
OK - planner within threshold and results agree on all 7 shapes.

$ bb join-bench --query --assert
ordered aggregate 5000 x 50000 rows=3002
  relation   128.11ms /    51.7MB
  ordered     60.37ms /    31.3MB
  ratios       0.47x /    0.60x
```
