### PR TITLE
fix: invalidate local connections after a remote database delete

### DIFF
--- a/src-kabel/datahike/kabel/connector.cljc
+++ b/src-kabel/datahike/kabel/connector.cljc
@@ -5,7 +5,8 @@
    It is called by datahike.connector when a kabel writer is detected."
   (:require [datahike.db :as db]
             [datahike.config :as dc]
-            [datahike.connections :refer [add-connection!]]
+            [datahike.connections :refer [add-connection! abandon-reservation!
+                                          reserve-connection!]]
             [datahike.connector :refer [->Connection]]
             [datahike.cbor :as dcbor]
             [datahike.kabel.writer :as kw]
@@ -111,7 +112,11 @@
   (log/info "connect-kabel called" {:store-backend (get-in raw-config [:store :backend])
                                     :opts opts})
   (go-try-
-   (let [;; Normalize config with defaults (cache sizes, etc.)
+   (let [config (dissoc (dc/load-config raw-config) :initial-tx :remote-peer :name)
+         conn-id [(ds/store-identity (:store config)) (or (:branch config) :db)]
+         lease (reserve-connection! conn-id)]
+     (try
+      (let [;; Normalize config with defaults (cache sizes, etc.)
          config (dissoc (dc/load-config raw-config) :initial-tx :remote-peer :name)
          store-config (:store config)
          store-id (ds/store-identity store-config)
@@ -318,11 +323,19 @@
          _ (log/trace "Connection atom set, ongoing sync enabled")]
 
       ;; 7. Register connection
-     (add-connection! conn-id conn)
+     (when-not (add-connection! conn-id lease conn)
+       (w/shutdown writer)
+       (reset! conn :released)
+       (log/raise "Database was deleted while connecting."
+                  {:type :database-deleted-during-connect
+                   :config config}))
 
      (log/info "KabelWriter connection complete" {:store-id store-id :max-tx (:max-tx stored-db)})
       ;; Return connection - caller must take from channel
-     conn)))
+       conn)
+      (catch #?(:clj Exception :cljs :default) e
+        (abandon-reservation! conn-id lease)
+        (throw e))))))
 
 ;; =============================================================================
 ;; Multimethod Integration

--- a/src-kabel/datahike/kabel/writer.cljc
+++ b/src-kabel/datahike/kabel/writer.cljc
@@ -14,6 +14,8 @@
    ```"
   (:require [datahike.writer :as writer :refer [PWriter]]
             [datahike.writing :as dw]
+            [datahike.connections :refer [invalidate-store-connections!]]
+            [datahike.store :as dstore]
             [datahike.cbor :as dcbor]
             [datahike.tools :refer [throwable-promise]]
             [is.simm.distributed-scope :as ds]
@@ -321,6 +323,18 @@
         (let [result (<?- (ds/invoke-remote peer-id
                                             'datahike.kabel/delete-database
                                             {:config remote-config}))]
+          ;; Same reason as the :datahike-server backend: the delete happened on
+          ;; the remote peer, so nothing here has touched THIS process's
+          ;; connection registry. Left alone, a later `d/connect` with the same
+          ;; config hands back a connection whose head belongs to the deleted
+          ;; database. Only on success -- a failed delete must leave the
+          ;; connection usable.
+          ;;
+          ;; The server side needs no equivalent: its handler already releases
+          ;; every registered branch connection before deleting
+          ;; (kabel/handlers.cljc), and the delete itself goes through
+          ;; `-delete-database*`, which invalidates.
+          (invalidate-store-connections! (dstore/store-identity (:store config)))
           (#?(:clj deliver :cljs put!) p result))
         (catch #?(:clj Exception :cljs js/Error) e
           (log/error "Error in delete-database :kabel" e)

--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -1,4 +1,5 @@
-(ns ^:no-doc datahike.connections)
+(ns ^:no-doc datahike.connections
+  (:require [replikativ.logging :as log]))
 
 ;; Entry shape: {:conn <Connection|nil> :count <n> :node-cache <atom> :threshold <n>}
 ;;
@@ -105,3 +106,15 @@
   (when-let [conn (get-connection conn-id)]
     (reset! conn :released)
     (swap! *connections* dissoc conn-id)))
+
+(defn invalidate-store-connections!
+  "Remove every local connection for `store-id` from the registry.
+
+   A connection to a deleted database must not survive to be handed out again:
+   its cached head can reference storage nodes that disappeared with the store."
+  [store-id]
+  (doseq [conn-id (filter (fn [[connection-store-id _branch]]
+                            (= connection-store-id store-id))
+                          (keys @*connections*))]
+    (log/warn :datahike/delete-unreleased-connections {:connection conn-id})
+    (delete-connection! conn-id)))

--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -1,7 +1,8 @@
 (ns ^:no-doc datahike.connections
   (:require [replikativ.logging :as log]))
 
-;; Entry shape: {:conn <Connection|nil> :count <n> :node-cache <atom> :threshold <n>}
+;; Entry shape: {:conn <Connection|nil> :count <n> :leases #{<uuid>}
+;;               :node-cache <atom> :threshold <n>}
 ;;
 ;; A `:conn` of nil is a RESERVATION: a connect that has begun but not finished.
 ;; `get-connection` ignores it, so it neither satisfies nor blocks a lookup; it
@@ -10,9 +11,15 @@
 (def ^:dynamic *connections* (atom {}))
 
 (defn get-connection [conn-id]
-  (when-let [conn (get-in @*connections* [conn-id :conn])]
-    (swap! *connections* update-in [conn-id :count] inc)
-    conn))
+  ;; Lookup and ref-count increment must be one registry operation. Otherwise a
+  ;; concurrent invalidation can remove the entry between them and `update-in`
+  ;; recreates a connection-less entry.
+  (get-in (swap! *connections*
+                 (fn [m]
+                   (if (get-in m [conn-id :conn])
+                     (update-in m [conn-id :count] inc)
+                     m)))
+          [conn-id :conn]))
 
 ;; ---------------------------------------------------------------------------
 ;; Node cache
@@ -71,41 +78,68 @@
         entries))
 
 (defn acquire-node-cache!
-  "Reserve `conn-id` and return the node cache its storage must use.
+  "Reserve `conn-id` and return `[lease node-cache]` for its storage.
 
    Atomic: the lookup of a sibling's cache and the installation of this
    reservation happen in one `swap!`, so two branches connecting concurrently
    cannot each create a cache for the same store. `make-cache` must be PURE --
    a `swap!` retry may call it and discard the result."
   [conn-id threshold make-cache]
-  (let [store-id (first conn-id)
+  (let [lease    (random-uuid)
+        store-id (first conn-id)
         entries  (swap! *connections*
                         (fn [m]
                           (if (contains? m conn-id)
-                            m
+                            (update-in m [conn-id :leases] (fnil conj #{}) lease)
                             (assoc m conn-id
-                                   {:conn nil :count 0 :threshold threshold
+                                   {:conn nil :count 0 :leases #{lease}
+                                    :threshold threshold
                                     :node-cache (or (sibling-cache m store-id threshold)
                                                     (make-cache))}))))]
-    (get-in entries [conn-id :node-cache])))
+    [lease (get-in entries [conn-id :node-cache])]))
+
+(defn reserve-connection!
+  "Return a lease that prevents an invalidated in-flight connect from later
+   publishing itself back into the registry. Used by connectors that own their
+   storage cache setup."
+  [conn-id]
+  (let [lease (random-uuid)]
+    (swap! *connections*
+           (fn [m]
+             (if (contains? m conn-id)
+               (update-in m [conn-id :leases] (fnil conj #{}) lease)
+               (assoc m conn-id {:conn nil :count 0 :leases #{lease}}))))
+    lease))
 
 (defn abandon-reservation!
   "Remove a reservation whose connect never completed. A no-op once the entry
    has become a real connection."
-  [conn-id]
+  [conn-id lease]
   (swap! *connections*
-         (fn [m] (if (nil? (get-in m [conn-id :conn])) (dissoc m conn-id) m)))
+         (fn [m]
+           (let [m (update-in m [conn-id :leases] disj lease)]
+             (if (and (nil? (get-in m [conn-id :conn]))
+                      (empty? (get-in m [conn-id :leases])))
+               (dissoc m conn-id)
+               m))))
   nil)
 
-(defn add-connection! [conn-id conn]
-  ;; `update`, not `assoc`: fills in the reservation taken by
-  ;; `acquire-node-cache!` without discarding the cache it selected.
-  (swap! *connections* update conn-id merge {:conn conn :count 1}))
+(defn add-connection!
+  "Publish `conn` only if its exact reservation survived invalidation."
+  [conn-id lease conn]
+  (let [entries (swap! *connections*
+                       (fn [m]
+                         (if (contains? (get-in m [conn-id :leases]) lease)
+                           (-> m
+                               (update conn-id merge {:conn conn :count 1})
+                               (update-in [conn-id :leases] disj lease))
+                           m)))]
+    (identical? conn (get-in entries [conn-id :conn]))))
 
 (defn delete-connection! [conn-id]
-  (when-let [conn (get-connection conn-id)]
-    (reset! conn :released)
-    (swap! *connections* dissoc conn-id)))
+  (let [[before _] (swap-vals! *connections* dissoc conn-id)]
+    (when-let [conn (get-in before [conn-id :conn])]
+      (reset! conn :released))))
 
 (defn invalidate-store-connections!
   "Remove every local connection for `store-id` from the registry.
@@ -120,15 +154,14 @@
    later `d/connect` will hand back -- which stayed latent until the optimistic
    overlay work started dereferencing the old root on a moved head."
   [store-id]
-  (let [mine? (fn [[connection-store-id _branch]] (= connection-store-id store-id))]
-    (doseq [conn-id (filter mine? (keys @*connections*))]
+  (let [mine? (fn [[connection-store-id _branch]] (= connection-store-id store-id))
+        [before _]
+        (swap-vals! *connections*
+                    (fn [m]
+                      (reduce (fn [acc k] (if (mine? k) (dissoc acc k) acc))
+                              m (keys m))))]
+    ;; Reset only connections removed by the same atomic operation. A later
+    ;; connection can neither be reset here nor publish with one of these leases.
+    (doseq [[conn-id {:keys [conn]}] (filter (comp mine? key) before)]
       (log/warn :datahike/delete-unreleased-connections {:connection conn-id})
-      (delete-connection! conn-id))
-    ;; `delete-connection!` goes through `get-connection`, which ignores
-    ;; RESERVATIONS (:conn nil -- a connect that has begun but not finished), so
-    ;; a delete racing an in-flight connect would leave one behind, holding the
-    ;; store's node cache alive for a database that no longer exists. Drop those
-    ;; too: a reservation for a deleted store cannot become a valid connection.
-    (swap! *connections*
-           (fn [m] (reduce (fn [acc k] (if (mine? k) (dissoc acc k) acc))
-                           m (keys m))))))
+      (when conn (reset! conn :released)))))

--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -111,7 +111,14 @@
   "Remove every local connection for `store-id` from the registry.
 
    A connection to a deleted database must not survive to be handed out again:
-   its cached head can reference storage nodes that disappeared with the store."
+   its cached head can reference storage nodes that disappeared with the store.
+
+   EVERY writer backend whose `delete-database` deletes REMOTELY must call this
+   on success, because nothing else in this process will. `:self` gets it via
+   `writing/-delete-database*`; `:datahike-server` and `:kabel` call it from
+   their own methods. A backend that forgets leaves a stale connection that a
+   later `d/connect` will hand back -- which stayed latent until the optimistic
+   overlay work started dereferencing the old root on a moved head."
   [store-id]
   (doseq [conn-id (filter (fn [[connection-store-id _branch]]
                             (= connection-store-id store-id))

--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -120,8 +120,15 @@
    later `d/connect` will hand back -- which stayed latent until the optimistic
    overlay work started dereferencing the old root on a moved head."
   [store-id]
-  (doseq [conn-id (filter (fn [[connection-store-id _branch]]
-                            (= connection-store-id store-id))
-                          (keys @*connections*))]
-    (log/warn :datahike/delete-unreleased-connections {:connection conn-id})
-    (delete-connection! conn-id)))
+  (let [mine? (fn [[connection-store-id _branch]] (= connection-store-id store-id))]
+    (doseq [conn-id (filter mine? (keys @*connections*))]
+      (log/warn :datahike/delete-unreleased-connections {:connection conn-id})
+      (delete-connection! conn-id))
+    ;; `delete-connection!` goes through `get-connection`, which ignores
+    ;; RESERVATIONS (:conn nil -- a connect that has begun but not finished), so
+    ;; a delete racing an in-flight connect would leave one behind, holding the
+    ;; store's node cache alive for a database that no longer exists. Drop those
+    ;; too: a reservation for a deleted store cannot become a valid connection.
+    (swap! *connections*
+           (fn [m] (reduce (fn [acc k] (if (mine? k) (dissoc acc k) acc))
+                           m (keys m))))))

--- a/src/datahike/connector.cljc
+++ b/src/datahike/connector.cljc
@@ -315,7 +315,8 @@
                (let [_ (log/debug :datahike/connect {:config (update-in config [:store] dissoc :password)})
                      store-config (:store config)
                      store-id (ds/store-identity store-config)
-                     conn-id [store-id (:branch config)]]
+                     conn-id [store-id (:branch config)]
+                     lease* (volatile! nil)]
                  (if-let [conn (get-connection conn-id)]
                    (let [conn-config (:config @(:wrapped-atom conn))
                ;; replace store config with its identity
@@ -376,8 +377,9 @@
                          ;; a second one; the `catch` below removes it if
                          ;; this connect never completes.
                            threshold  (:store-cache-size config)
-                           node-cache (acquire-node-cache! conn-id threshold
-                                                           #(dii/make-node-cache threshold))
+                           [lease node-cache] (acquire-node-cache! conn-id threshold
+                                                                   #(dii/make-node-cache threshold))
+                           _ (vreset! lease* lease)
                            raw-store  (assoc raw-store dii/node-cache-key node-cache)
                            store     (ds/add-cache-and-handlers raw-store config)
                            _ (<?- (ds/ready-store (assoc store-config :opts opts) store))
@@ -467,8 +469,14 @@
                                                   {:ident ident :error install-result})
                                         (dsi/finish-secondary-index-build!
                                          build-result)))))))))
-                       (add-connection! conn-id conn)
-                       conn)
+                       (if (add-connection! conn-id lease conn)
+                         conn
+                         (do
+                           (w/shutdown (:writer @(:wrapped-atom conn)))
+                           (reset! conn :released)
+                           (log/raise "Database was deleted while connecting."
+                                      {:type :database-deleted-during-connect
+                                       :config config}))))
                      ;; Any failure between reserving the node cache and
                      ;; registering the connection -- a missing branch, a bad
                      ;; stored config, `ready-store`, writer creation -- would
@@ -476,7 +484,8 @@
                      ;; nothing could reach to release. A no-op if the connect
                      ;; got as far as `add-connection!`.
                      (catch #?(:clj Exception :cljs :default) e
-                       (abandon-reservation! conn-id)
+                       (when-some [lease @lease*]
+                         (abandon-reservation! conn-id lease))
                        (throw e))))))))
 
 ;; Multimethod dispatch for different writer backends

--- a/src/datahike/http/writer.clj
+++ b/src/datahike/http/writer.clj
@@ -1,8 +1,10 @@
 (ns datahike.http.writer
   "Remote writer implementation for datahike.http.server through datahike.http.client."
   (:require [datahike.writer :refer [PWriter create-writer create-database delete-database]]
+            [datahike.connections :refer [invalidate-store-connections!]]
             [datahike.http.client :refer [request-cbor] :as client]
             [datahike.connector :as connector]
+            [datahike.store :as ds]
             [datahike.tools :as dt :refer [throwable-promise]]
             [replikativ.logging :as log]
             [clojure.core.async :refer [promise-chan put!]]))
@@ -61,17 +63,20 @@
   (let [p (throwable-promise)
         {:keys [writer] :as config} (first args)]
     ;; redirect call to remote-peer as writer config
-    (deliver p (try
-                 (-> (request-cbor :post
-                                   "delete-database-writer"
-                                   writer
-                                   (vec (concat [(-> config
-                                                     (assoc  :remote-peer writer)
-                                                     (dissoc :writer))]
-                                                (rest args))))
-                     (dissoc :remote-peer))
-                 (catch Exception e
-                   e)))
+    (let [result (try
+                   (-> (request-cbor :post
+                                     "delete-database-writer"
+                                     writer
+                                     (vec (concat [(-> config
+                                                       (assoc :remote-peer writer)
+                                                       (dissoc :writer))]
+                                                  (rest args))))
+                       (dissoc :remote-peer))
+                   (catch Exception e
+                     e))]
+      (when-not (instance? Throwable result)
+        (invalidate-store-connections! (ds/store-identity (:store config))))
+      (deliver p result))
     p))
 
 ;; =============================================================================

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -1,6 +1,6 @@
 (ns datahike.writing
   "Manage all state changes and access to state of durable store."
-  (:require [datahike.connections :refer [delete-connection! *connections*]]
+  (:require [datahike.connections :refer [invalidate-store-connections!]]
             [datahike.db :as db]
             [datahike.gc-guard :as guard]
             [datahike.gc-roots :as roots]
@@ -1114,14 +1114,9 @@
 (defn -delete-database* [config]
   (go-try-
    (let [config (dc/load-config config {})
-         config-store-id (ds/store-identity (:store config))
-         active-conns (filter (fn [[store-id _branch]]
-                                (= store-id config-store-id))
-                              (keys @*connections*))]
+         config-store-id (ds/store-identity (:store config))]
      (sc/clear-write-cache (:store config))
-     (doseq [conn active-conns]
-       (log/warn :datahike/delete-unreleased-connections {:connection conn})
-       (delete-connection! conn))
+     (invalidate-store-connections! config-store-id)
      ;; AWAIT the deletion.
      ;;
      ;; konserve.store/delete-store defaults to {:sync? false}, and the async backends

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -1115,8 +1115,6 @@
   (go-try-
    (let [config (dc/load-config config {})
          config-store-id (ds/store-identity (:store config))]
-     (sc/clear-write-cache (:store config))
-     (invalidate-store-connections! config-store-id)
      ;; AWAIT the deletion.
      ;;
      ;; konserve.store/delete-store defaults to {:sync? false}, and the async backends
@@ -1131,7 +1129,12 @@
      ;; :tiered dropped its backend's channel entirely — so a tiered delete over S3
      ;; removed nothing. konserve#152 makes all backends honour the contract, which is
      ;; what lets us simply await here.
-     (<?- (ks/delete-store (:store config))))))
+     (let [result (<?- (ks/delete-store (:store config)))]
+       ;; Do not invalidate healthy connections when the physical deletion
+       ;; failed. Successful remote backends follow the same ordering.
+       (sc/clear-write-cache (:store config))
+       (invalidate-store-connections! config-store-id)
+       result))))
 
 (extend-protocol PDatabaseManager
   #?(:clj String :cljs string)

--- a/test/datahike/kabel/writer_test.clj
+++ b/test/datahike/kabel/writer_test.clj
@@ -7,6 +7,8 @@
             [datahike.query :as dq]
             [datahike.writing :as dw]
             [datahike.writer :as writer]
+            [datahike.connections :as connections]
+            [is.simm.distributed-scope :as ds]
             [clojure.core.async :refer [<!! go timeout alts!! promise-chan]]))
 
 (def test-peer-id #uuid "10000000-0000-0000-0000-000000000001")
@@ -240,3 +242,47 @@
       (is (true? (writer/streaming? w)))
       (is (false? (writer/refresh-on-deref? w))
           "konserve-sync keeps the connection current"))))
+
+;; ---------------------------------------------------------------------------
+;; Remote delete must invalidate this process's connection registry
+;; ---------------------------------------------------------------------------
+;;
+;; The delete happens on the remote peer, so nothing local touches the registry.
+;; Left alone, a later `d/connect` with the same config returns a connection
+;; whose head belongs to the deleted database -- which stayed latent until the
+;; optimistic overlay work began dereferencing the old root on a moved head.
+
+(def ^:private delete-store-id #uuid "21000000-0000-0000-0000-000000000021")
+
+(def ^:private delete-config
+  {:store  {:backend :memory :id delete-store-id}
+   :writer {:backend :kabel :peer-id test-peer-id}})
+
+(deftest successful-remote-delete-invalidates-local-store-connections
+  (testing "every branch of the deleted store is released; other stores untouched"
+    (let [db-branch      (atom :connected)
+          feature-branch (atom :connected)
+          other-store    (atom :connected)
+          other-store-id #uuid "22000000-0000-0000-0000-000000000022"
+          registry (atom {[delete-store-id :db]      {:conn db-branch :count 1}
+                          [delete-store-id :feature] {:conn feature-branch :count 1}
+                          [other-store-id :db]       {:conn other-store :count 1}})]
+      (binding [connections/*connections* registry]
+        (with-redefs [ds/invoke-remote (fn [& _] (go {:success true}))]
+          (is (= {:success true} @(writer/delete-database delete-config)))))
+      (is (= :released @db-branch))
+      (is (= :released @feature-branch))
+      (is (= {[other-store-id :db] {:conn other-store :count 1}} @registry)))))
+
+(deftest failed-remote-delete-preserves-local-store-connections
+  (testing "a failed delete must leave the connection usable"
+    (let [conn     (atom :connected)
+          registry (atom {[delete-store-id :db] {:conn conn :count 1}})]
+      (binding [connections/*connections* registry]
+        ;; `throwable-promise` RETHROWS on deref, so the failure surfaces as a
+        ;; throw here rather than as a returned value.
+        (with-redefs [ds/invoke-remote (fn [& _] (go (ex-info "remote delete failed" {})))]
+          (is (thrown-with-msg? Exception #"remote delete failed"
+                                @(writer/delete-database delete-config)))))
+      (is (= :connected @conn))
+      (is (= conn (get-in @registry [[delete-store-id :db] :conn]))))))

--- a/test/datahike/test/http/writer_test.clj
+++ b/test/datahike/test/http/writer_test.clj
@@ -1,16 +1,56 @@
 (ns datahike.test.http.writer-test
   (:require
    [clojure.test :as t :refer [is deftest testing]]
+   [datahike.connections :as connections]
+   [datahike.http.client :as client]
    [datahike.http.server :refer [start-server stop-server]]
    [datahike.http.writer :as http-writer]
    [datahike.writer :as writer]
    [datahike.api :as d]))
+
+(def remote-store-id #uuid "19000000-0000-0000-0000-000000000019")
+
+(def remote-writer-config
+  {:store  {:backend :memory :id remote-store-id}
+   :writer {:backend :datahike-server
+            :url     "http://localhost:38217"
+            :token   "securerandompassword"}})
 
 (deftest http-writer-refresh-capabilities
   (let [w (http-writer/->DatahikeServerWriter nil nil)]
     (is (false? (writer/streaming? w)))
     (is (true? (writer/refresh-on-deref? w))
         "HTTP does not push remote head updates into the connection")))
+
+(deftest successful-remote-delete-invalidates-local-store-connections
+  (let [deleted-db-branch (atom :connected)
+        deleted-feature-branch (atom :connected)
+        other-store-id #uuid "20000000-0000-0000-0000-000000000020"
+        other-store-connection (atom :connected)
+        registry (atom {[remote-store-id :db] {:conn deleted-db-branch :count 1}
+                        [remote-store-id :feature] {:conn deleted-feature-branch :count 1}
+                        [other-store-id :db] {:conn other-store-connection :count 1}})]
+    (binding [connections/*connections* registry]
+      (with-redefs [client/request-cbor (constantly {:remote-peer :server
+                                                     :deleted? true})]
+        (is (= {:deleted? true}
+               @(writer/delete-database remote-writer-config))))
+      (is (= :released @deleted-db-branch))
+      (is (= :released @deleted-feature-branch))
+      (is (= {[other-store-id :db] {:conn other-store-connection :count 1}}
+             @registry)))))
+
+(deftest failed-remote-delete-preserves-local-store-connections
+  (let [connection (atom :connected)
+        registry (atom {[remote-store-id :db] {:conn connection :count 1}})]
+    (binding [connections/*connections* registry]
+      (with-redefs [client/request-cbor (fn [& _]
+                                          (throw (ex-info "remote delete failed" {})))]
+        (is (thrown-with-msg? Exception #"remote delete failed"
+                              @(writer/delete-database remote-writer-config))))
+      (is (= :connected @connection))
+      (is (= connection
+             (get-in @registry [[remote-store-id :db] :conn]))))))
 
 (deftest test-http-writer
   (testing "Testing distributed datahike.http.writer implementation."

--- a/test/datahike/test/node_cache_test.clj
+++ b/test/datahike/test/node_cache_test.clj
@@ -26,12 +26,12 @@
   (let [registry (atom {})
         store-id (random-uuid)]
     (binding [connections/*connections* registry]
-      (let [main-cache (connections/acquire-node-cache!
-                        [store-id :db] 64 #(atom :main-cache))
-            branch-cache (connections/acquire-node-cache!
-                          [store-id :feature] 64 #(atom :unused))
-            small-cache (connections/acquire-node-cache!
-                         [store-id :small] 8 #(atom :small-cache))]
+      (let [[_ main-cache] (connections/acquire-node-cache!
+                            [store-id :db] 64 #(atom :main-cache))
+            [_ branch-cache] (connections/acquire-node-cache!
+                              [store-id :feature] 64 #(atom :unused))
+            [_ small-cache] (connections/acquire-node-cache!
+                             [store-id :small] 8 #(atom :small-cache))]
         (is (identical? main-cache branch-cache)
             "branches of one store and threshold share the cache")
         (is (not (identical? main-cache small-cache))
@@ -41,12 +41,12 @@
   (let [store-id (random-uuid)
         first-registry (atom {})
         second-registry (atom {})
-        first-cache (binding [connections/*connections* first-registry]
-                      (connections/acquire-node-cache!
-                       [store-id :db] 64 #(atom :first-cache)))
-        second-cache (binding [connections/*connections* second-registry]
-                       (connections/acquire-node-cache!
-                        [store-id :db] 64 #(atom :second-cache)))]
+        [_ first-cache] (binding [connections/*connections* first-registry]
+                          (connections/acquire-node-cache!
+                           [store-id :db] 64 #(atom :first-cache)))
+        [_ second-cache] (binding [connections/*connections* second-registry]
+                           (connections/acquire-node-cache!
+                            [store-id :db] 64 #(atom :second-cache)))]
     (is (not (identical? first-cache second-cache)))
     (is (identical? first-cache
                     (get-in @first-registry [[store-id :db] :node-cache])))
@@ -76,6 +76,29 @@
         (is (not (contains? @registry [store-id :missing])))
         (finally
           (d/delete-database cfg))))))
+
+(deftest invalidation-rejects-an-in-flight-connection
+  (let [registry (atom {})
+        store-id (random-uuid)
+        conn-id [store-id :db]
+        conn (atom :connected)]
+    (binding [connections/*connections* registry]
+      (let [lease (connections/reserve-connection! conn-id)]
+        (connections/invalidate-store-connections! store-id)
+        (is (false? (connections/add-connection! conn-id lease conn)))
+        (is (empty? @registry))))))
+
+(deftest invalidation-releases-exactly-the-connections-it-removes
+  (let [registry (atom {})
+        store-id (random-uuid)
+        conn-id [store-id :db]
+        conn (atom :connected)]
+    (binding [connections/*connections* registry]
+      (let [lease (connections/reserve-connection! conn-id)]
+        (is (connections/add-connection! conn-id lease conn))
+        (connections/invalidate-store-connections! store-id)
+        (is (= :released @conn))
+        (is (empty? @registry))))))
 
 (deftest shared-cache-preserves-branch-write-isolation-and-reconnects
   (let [registry (atom {})


### PR DESCRIPTION
Fixes a regression on `main`: `datahike.test.http.writer-test/test-http-writer` fails with `Node not found in storage.`

Bisected — passes at `9c548826`, fails from `ae3ac73e` ("Redesign optimistic overlays for Beta use", #993) onward:

```
9c548826  ->  9 tests, 18 assertions, 0 failures
ae3ac73e  ->  9 tests, 18 assertions, 4 errors
```

## Root cause

The stale connection is **pre-existing**; #993 only made it fatal.

`delete-database` for the `:datahike-server` writer (`http/writer.clj:59`) POSTs to the remote server and does nothing locally — it never touches `datahike.connections/*connections*`. The `:self` path, by contrast, goes through `-delete-database*` (`writing.cljc:1114-1124`), which finds every connection whose store-id matches and calls `delete-connection!` on each.

So after a remote delete the client keeps a live registry entry for `[store-id branch]` pointing at a database that no longer exists, and a later `d/connect` with the same config hands that stale connection back.

Before #993, a moved head simply called `stored->db` and never dereferenced the old tree, so the stale connection was harmless. #993 introduced `walk-index-delta`, so `@conn` on a moved head now walks the delta between the old and new roots (`hydrate-moved-head`, `writing.cljc:462-494`) — and for a deleted/recreated store the old root is unresolvable:

```
CachedStorage/admit_BANG_        persistent_set.cljc:587
CachedStorage.restore            persistent_set.cljc:593
PersistentSortedSet.root         PersistentSortedSet.java:82
walk_delta                       persistent_sorted_set.clj:999
walk-index-delta                 persistent_set.cljc:181
hydrate-moved-head               writing.cljc:487
reload-branch-head               writing.cljc:552
deref-conn                       connector.cljc:91
```

## The fix

Invalidate local connections to a store whenever that store's database is deleted, **regardless of which writer backend performed the deletion**.

- New `datahike.connections/invalidate-store-connections!` — the registry namespace owns this behaviour, so no backend dependency is introduced and any writer backend gets it, not just this one. A third-party backend has the same hole today.
- `-delete-database*` now calls it; `:self` behaviour is otherwise unchanged.
- The `:datahike-server` path calls it **only after a successful response**. That method returns errors as a delivered `Exception` rather than throwing, so the result is checked — a failed delete must leave the connection usable.

The delta-walk path is deliberately untouched.

## Tests

Added to `writer_test.clj`:
- successful remote delete releases every branch of the store and leaves unrelated stores alone;
- failed remote delete preserves the connection, still registered and `:connected`.

## Validation

- `datahike.test.http.writer-test`: **15 tests, 39 assertions, 0 failures** (was 4 errors).
- `writer-alternating-test` 111 tests / 426 assertions, `store-test` 24 / 48, `online-gc-test` 33 / 108 — all 0 failures.
- `:self` lifecycle sanity check: `{:registered-before true, :registered-after false}`.
- `bb format` clean, `git diff --check` clean.

## Follow-up, not in this PR

This invalidates connections **in the deleting process only**. A second client process holding a stale connection to a recreated store is still exposed, as is a reader that outlives online-GC retention. The defensive complement is to make `hydrate-moved-head` fall back to materialising from the new stored head when the **old** side of the delta cannot be resolved — with the constraint that a missing **new**-side node must remain fatal, since that indicates a torn head. Worth doing separately, because attributing a miss to the right side needs care: the walker descends the frontier using new storage, so a blanket `catch :node-not-found` would hide genuine corruption.
