### PR TITLE
fix: a connection must not walk a foreign tree as its delta base

### DIFF
--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -539,16 +539,35 @@
                     (log/raise "Branch head vanished from the store; the database may have been deleted."
                                {:type   :branch-head-does-not-exist-in-store
                                 :branch branch}))
+                  ;; A store id survives delete/recreate; :datahike/id does not.
+                  ;; Never use a head from another database as this connection's
+                  ;; delta, or silently rebind a writer to that database.
+                  (let [old-lineage    (get-in old [:meta :datahike/id])
+                        stored-lineage (get-in stored [:meta :datahike/id])]
+                    ;; One missing id and one present id is also a definite
+                    ;; transition (for example, legacy database -> modern recreate).
+                    (when (not= old-lineage stored-lineage)
+                      (log/raise "Branch head belongs to a different database; this connection outlived the database it was opened on. Reconnect."
+                                 {:type            :database-lineage-changed
+                                  :branch          branch
+                                  :connection-db   old-lineage
+                                  :stored-db       stored-lineage})))
                   ;; The engine below this boundary is synchronous. Hydrate only
                   ;; the immutable PSS frontier introduced by a foreign head,
                   ;; then publish the new db. The legacy hitchhiker index cannot
                   ;; expose that structural delta and retains the full tier sync.
                   (let [moved? (not= (get-in stored [:meta :datahike/commit-id])
                                      (get-in old [:meta :datahike/commit-id]))
+                        ;; Two id-less legacy heads are ambiguous. A full rebuild
+                        ;; cannot establish logical identity, but it avoids treating
+                        ;; the old tree as a proven delta base.
+                        lineage-known? (boolean (and (get-in old [:meta :datahike/id])
+                                                     (get-in stored [:meta :datahike/id])))
                         materialized
                         (when moved?
-                          (if (= :datahike.index/persistent-set
-                                 (get-in old [:config :index]))
+                          (if (and lineage-known?
+                                   (= :datahike.index/persistent-set
+                                      (get-in old [:config :index])))
                             (<?- (hydrate-moved-head old stored store sync?))
                             (do
                               (<?- (ds/refresh-tiered-frontend store {:sync? sync?}))

--- a/test/datahike/test/writer_alternating_test.clj
+++ b/test/datahike/test/writer_alternating_test.clj
@@ -1238,3 +1238,80 @@
                    "with no competing writer in existence"))
           (is (every? #(= ::ok %) outcomes)))
         (finally (d/release conn))))))
+
+;; ---------------------------------------------------------------------------
+;; Lineage guard: a connection must not outlive its database
+;; ---------------------------------------------------------------------------
+;;
+;; The store id comes from the user's config and survives a delete/recreate
+;; unchanged, so it cannot distinguish "the head advanced" from "a different
+;; database now lives here". `:datahike/id` can. Without the guard the second
+;; case reaches the index as `Node not found in storage.` -- a true statement
+;; about a wrong question -- because the moved-head path walks the old root as a
+;; delta base.
+
+(defn- lineage-cfg [path]
+  {:store  {:backend :file :path path
+            :id (java.util.UUID/nameUUIDFromBytes (.getBytes ^String path))}
+   :schema-flexibility :read
+   :keep-history? false
+   ;; shared ownership re-reads the head on deref, which is the path under test
+   :writer {:backend :self :writer-ownership :shared}})
+
+(deftest a-connection-that-outlived-its-database-raises-rather-than-walking-a-foreign-tree
+  (testing "delete + recreate under the same store id is caught by :datahike/id"
+    (let [path (str (System/getProperty "java.io.tmpdir") "/dh-lineage-guard-" (random-uuid))
+          cfg  (lineage-cfg path)]
+      (try
+        (d/create-database cfg)
+        (let [stale (d/connect cfg)]
+          (try
+            (d/transact stale [{:db/ident :nm :db/valueType :db.type/string
+                                :db/cardinality :db.cardinality/one}])
+            (d/transact stale [{:db/id -1 :nm "before"}])
+            (is (some? @stale)
+                "control: the connection derefs fine before the database is replaced")
+            ;; A SECOND PROCESS deletes and recreates. Binding the registry away is
+            ;; how this namespace already simulates that; it also keeps the local
+            ;; invalidation in `delete-database` from releasing `stale`, which is
+            ;; precisely the cross-process case this guard exists for.
+            (binding [conns/*connections* (atom {})]
+              (d/delete-database cfg)
+              (d/create-database cfg)
+              (let [other (d/connect cfg)]
+                (d/transact other [{:db/ident :nm :db/valueType :db.type/string
+                                    :db/cardinality :db.cardinality/one}])
+                (d/transact other [{:db/id -1 :nm "after"}])
+                (d/release other)))
+            (is (= :database-lineage-changed
+                   (try @stale nil
+                        (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+                "the stale connection names the real problem instead of failing inside the index")
+            (swap! (:wrapped-atom stale) update :meta dissoc :datahike/id)
+            (is (= :database-lineage-changed
+                   (try @stale nil
+                        (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+                "a legacy connection cannot silently rebind to a modern recreate")
+            (finally
+              (d/release stale true))))
+        (finally
+          (binding [conns/*connections* (atom {})]
+            (try (d/delete-database cfg) (catch Exception _ nil))))))))
+
+(deftest an-unmoved-head-is-unaffected-by-the-lineage-guard
+  (testing "same database, same lineage: deref keeps working across commits"
+    (let [path (str (System/getProperty "java.io.tmpdir") "/dh-lineage-same-" (random-uuid))
+          cfg  (lineage-cfg path)]
+      (try
+        (d/create-database cfg)
+        (let [conn (d/connect cfg)]
+          (d/transact conn [{:db/ident :nm :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (let [id-1 (get-in @conn [:meta :datahike/id])]
+            (d/transact conn [{:db/id -1 :nm "a"}])
+            (d/transact conn [{:db/id -1 :nm "b"}])
+            (is (= id-1 (get-in @conn [:meta :datahike/id]))
+                "the lineage id is stable across commits -- the guard depends on this")
+            (is (= 2 (count (d/q (quote [:find ?e :where [?e :nm _]]) @conn)))))
+          (d/release conn))
+        (finally (try (d/delete-database cfg) (catch Exception _ nil)))))))


### PR DESCRIPTION
## Why

#1001 prevents stale connections in the process performing a delete. A connection in another process can still outlive a delete/recreate under the same configured store id.

The moved-head path previously treated any changed commit id as a delta. After recreation that made it walk the old database tree against the new store and fail deep in the index.

## Fix

Compare the stable database lineage field :datahike/id before hydrating a moved head:

- Different IDs, or only one ID present: raise :database-lineage-changed and require reconnecting.
- Both IDs absent on a pre-0.4.1473 database: use the full rebuild path rather than treating the old tree as a proven delta base.
- Matching IDs: retain incremental persistent-set hydration.

Raising is intentional: silently rebinding a live writer could write to a different logical database.

## Tests

The cross-process test deletes and recreates through an isolated connection registry and verifies both modern-to-modern and legacy-to-modern transitions. A same-lineage control verifies normal commits remain unaffected. The stale test connection is explicitly released.

Focused writer-alternating suite: 117 tests, 441 assertions, 0 failures. Formatting and diff checks are clean.