### PR TITLE
ci: a failed native test withholds one artifact, and says why

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -17,6 +17,9 @@ jobs:
   native:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
+      # One platform's failure must not cancel the others, and must not
+      # withhold their artifacts. Matters as soon as this matrix grows.
+      fail-fast: false
       matrix:
         include:
           - os: macos-15-intel
@@ -61,20 +64,44 @@ jobs:
       - name: Build libdatahike
         run: bb ni-compile
 
+      # Tests gate this platform's upload and nothing else. `continue-on-error`
+      # records the outcome without ending the job, so a red test here cannot
+      # withhold another platform's binaries.
       - name: Test native image
+        id: test-native-image
+        continue-on-error: true
         run: bb test native-image
 
       - name: Test babashka pod
-        run:  bb test bb-pod
+        id: test-bb-pod
+        continue-on-error: true
+        run: bb test bb-pod
 
       - name: Test libdatahike
+        id: test-libdatahike
+        continue-on-error: true
         run: bb test libdatahike
 
       - name: Release native-image
+        if: steps.test-native-image.outcome == 'success' && steps.test-bb-pod.outcome == 'success'
         run: bb release native-image
 
       - name: Release libdatahike
+        if: steps.test-libdatahike.outcome == 'success'
         run: bb release libdatahike
+
+      # The job still fails if anything above did, so the red X is not lost —
+      # it just no longer pre-empts the uploads that did pass.
+      - name: Fail the job if any test failed
+        if: |
+          steps.test-native-image.outcome != 'success' ||
+          steps.test-bb-pod.outcome != 'success' ||
+          steps.test-libdatahike.outcome != 'success'
+        run: |
+          echo "native-image: ${{ steps.test-native-image.outcome }}"
+          echo "bb-pod:       ${{ steps.test-bb-pod.outcome }}"
+          echo "libdatahike:  ${{ steps.test-libdatahike.outcome }}"
+          exit 1
 
       - name: Save cache
         uses: actions/cache/save@v4

--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -32,13 +32,34 @@ for i in {1..100}; do
   ./dthk transact conn:$CONFIG "[[:db/add -$i :name \"User-$i\"]]"
 done
 ./dthk transact conn:$CONFIG '[[:db/add -1 :name "Judea"]]'
-QUERY_OUT=`./dthk query '[:find (count ?e) . :where [?e :name _]]' db:$CONFIG`
+# Capture stdout and stderr separately. Command substitution swallows stdout,
+# and under `set -o errexit` a non-zero exit here kills the script before
+# anything is printed -- which is how a silent failure in CI left no evidence
+# at all beyond "exit 1". Report both streams and the status before exiting.
+set +o errexit
+QUERY_ERR=$(mktemp)
+QUERY_OUT=$(./dthk query '[:find (count ?e) . :where [?e :name _]]' db:$CONFIG 2>"$QUERY_ERR")
+QUERY_STATUS=$?
+set -o errexit
 
-if [ $QUERY_OUT -eq 101 ]
+if [ $QUERY_STATUS -ne 0 ]; then
+  echo "Exception: dthk query exited $QUERY_STATUS"
+  echo "--- stdout ---"; echo "$QUERY_OUT"
+  echo "--- stderr ---"; cat "$QUERY_ERR"
+  rm -f "$QUERY_ERR"
+  exit 1
+fi
+
+if [ "$QUERY_OUT" = "101" ]
 then
   echo "Test successful."
+  rm -f "$QUERY_ERR"
 else
   echo "Exception: Query did not return correct value."
+  echo "  expected: 101"
+  echo "  actual:   '$QUERY_OUT'"
+  echo "--- stderr ---"; cat "$QUERY_ERR"
+  rm -f "$QUERY_ERR"
   exit 1
 fi
 


### PR DESCRIPTION
The last four releases (0.8.1809 through 0.8.1812) shipped the jar alone. No
`dthk`, no `libdatahike`, on any platform. Two separate problems.

## The upload was collateral damage

In `native-image.yml` the two release steps run *after* the test steps **in the
same job**, so one red test skips both. There is no per-artifact granularity and
no way for a passing build to publish.

This splits them: tests record their outcome with `continue-on-error`, each
release step is gated on the tests that cover it, and a final step re-fails the
job so the red X is not lost. `fail-fast: false` is inert against today's
single-entry matrix and is what stops one platform cancelling the others the
moment a second is added.

**CircleCI needs no change.** Its generated pipeline already gates
`release-linux-amd64` on `build-linux-amd64` alone, and the aarch64 pair
likewise, so those platforms are independent already.

## The failure was silent

`run-native-image-tests` captures the count query with command substitution, so
stdout is swallowed, and under `errexit` a non-zero exit ends the script before
anything prints. The log for the current failure is 101 transaction reports
followed by nothing at all: no message, no exit status, no output from `dthk`.
That is not enough to debug from, and it is why the underlying bug is still
open.

Now it captures stdout and stderr separately, reports the exit status, and
prints both streams on either failure path. The count is compared as a string,
so an empty result reports itself instead of becoming a malformed `[ -eq ]`.

## The underlying bug, for context

Bisecting by each run's `headSha` rather than by timestamp:

| commit | native build |
|---|---|
| `6c28a95a` bump superv.async | success |
| **`9858a1dd` Stream ordered count aggregates over unique-key joins (#999)** | **first failure** |
| `d2b9e525` #998 | failure |
| `48a461da` #1001 | failure |

The script dies on exactly `./dthk query '[:find (count ?e) . :where [?e :name _]]'`,
immediately after the last successful transact. A count aggregate, against the
commit that rewrote count aggregates.

It is not a logic error: on the JVM at current `main` the same flow returns
`COUNT: 101`, and forcing both paths via
`datahike.query.index-ordered-aggregate/*enabled*` gives identical results and
types. `dthk` exits **1, not 139**, so not a segfault.

This PR does not fix that bug. It makes the next run report what actually
happened, and stops one platform's failure from withholding every platform's
binaries in the meantime.