### PR TITLE
Add secondary candidate scan contract

### DIFF
--- a/src/datahike/index/secondary.cljc
+++ b/src/datahike/index/secondary.cljc
@@ -64,6 +64,188 @@
      persist alongside their content keys.
      Returns updated index instance (must be persistent/immutable)."))
 
+(defprotocol ISecondaryCandidateScan
+  "Optional, paged candidate API for secondary indexes.
+
+   `ISecondaryIndex` deliberately remains unchanged: existing adapters keep
+   working and query paths may adopt this richer API incrementally.  This
+   protocol is for indexes which can expose enough information for Datahike to
+   decide whether a primary-index recheck is required and whether exhausting
+   the scan is guaranteed to find every match.
+
+   The result of `-candidate-page` is validated by `candidate-page` and has:
+
+     :candidates    vector of candidate maps
+     :precision     :exact or :recheck
+     :recall        :complete or :approximate
+     :ordering      :exact, :approximate, or :none
+     :exhausted?    boolean
+     :continuation  opaque token when more pages remain, nil when exhausted
+
+   A candidate map contains at least `:entity-id` and `:attribute`.  Those two
+   fields identify the primary datoms that core must inspect for an exact
+   recheck.  `:value-hash` may additionally identify one value of a
+   cardinality-many or `:db.secondary/only` attribute.  Adapters may attach
+   result columns such as `:score` or `:distance`.
+
+   Precision and recall are independent.  For example, a text index may return
+   a complete superset (`:recheck` + `:complete`), while ANN typically has
+   approximate recall even if every returned distance is subsequently
+   rechecked.  Ordering describes the advertised result order, relative to the
+   order requested by `query-spec`; it does not describe match precision."
+  (-candidate-page [this query-spec entity-filter page-request]
+    "Return one candidate page. `page-request` contains a positive `:limit`
+     and optionally the opaque `:continuation` returned by the previous page."))
+
+(def ^:private candidate-precisions #{:exact :recheck})
+(def ^:private candidate-recalls #{:complete :approximate})
+(def ^:private candidate-orderings #{:exact :approximate :none})
+
+(defn candidate-scannable?
+  "Whether `index` implements the optional paged candidate contract."
+  [index]
+  (satisfies? ISecondaryCandidateScan index))
+
+(defn candidate-recheck-required?
+  "Whether candidates must be checked against canonical primary datoms."
+  [page]
+  (= :recheck (:precision page)))
+
+(defn candidate-recall-complete?
+  "Whether exhausting the scan is guaranteed to enumerate every match."
+  [page]
+  (= :complete (:recall page)))
+
+(defn candidate-order-exact?
+  "Whether the page's advertised ordering is exact."
+  [page]
+  (= :exact (:ordering page)))
+
+(defn- invalid-candidate-page!
+  [message data]
+  (throw (ex-info message (assoc data :type :invalid-secondary-candidate-page))))
+
+(defn validate-candidate-page
+  "Validate and normalize a page returned by `ISecondaryCandidateScan`.
+
+   Returns the page with `:candidates` realized as a vector.  Throws a typed
+   `ExceptionInfo` for malformed adapter output, so a bad index cannot silently
+   turn into incomplete query results."
+  [page]
+  (when-not (map? page)
+    (invalid-candidate-page! "A secondary candidate page must be a map."
+                             {:page page}))
+  (let [{:keys [candidates precision recall ordering exhausted? continuation]}
+        page]
+    (when-not (sequential? candidates)
+      (invalid-candidate-page! "Secondary candidate :candidates must be sequential."
+                               {:page page}))
+    (when-not (contains? candidate-precisions precision)
+      (invalid-candidate-page! "Secondary candidate :precision must be :exact or :recheck."
+                               {:page page :precision precision}))
+    (when-not (contains? candidate-recalls recall)
+      (invalid-candidate-page! "Secondary candidate :recall must be :complete or :approximate."
+                               {:page page :recall recall}))
+    (when-not (contains? candidate-orderings ordering)
+      (invalid-candidate-page! "Secondary candidate :ordering must be :exact, :approximate, or :none."
+                               {:page page :ordering ordering}))
+    (when-not (boolean? exhausted?)
+      (invalid-candidate-page! "Secondary candidate :exhausted? must be boolean."
+                               {:page page :exhausted? exhausted?}))
+    (when (and exhausted? (some? continuation))
+      (invalid-candidate-page! "An exhausted candidate page cannot have a continuation."
+                               {:page page}))
+    (when (and (not exhausted?) (nil? continuation))
+      (invalid-candidate-page! "A non-exhausted candidate page must have a continuation."
+                               {:page page}))
+    (doseq [candidate candidates]
+      (when-not (and (map? candidate)
+                     (integer? (:entity-id candidate))
+                     (keyword? (:attribute candidate)))
+        (invalid-candidate-page!
+         "Each secondary candidate must identify an integer :entity-id and keyword :attribute."
+         {:page page :candidate candidate})))
+    (assoc page :candidates (vec candidates))))
+
+(defn- candidate-identity
+  [candidate]
+  (cond-> [(:entity-id candidate) (:attribute candidate)]
+    (contains? candidate :value-hash) (conj (:value-hash candidate))))
+
+(defn- invalid-candidate-scan!
+  [message data]
+  (throw (ex-info message (assoc data :type :invalid-secondary-candidate-scan))))
+
+(defn validate-candidate-scan
+  "Validate pages collected from one candidate scan and return them normalized.
+
+   This is also the reusable adapter conformance assertion: Scriptum, Proximum,
+   and third-party indexes can collect a small fixture scan by feeding each
+   page's `:continuation` into the next request, then pass the pages here.
+
+   A scan has stable precision, recall, and ordering declarations; every page
+   except the last has a distinct continuation; the last is exhausted; and a
+   candidate identity does not repeat across pages.  Identity is
+   `[entity-id attribute]`, extended by `value-hash` when supplied."
+  [pages]
+  (when-not (seq pages)
+    (invalid-candidate-scan! "A secondary candidate scan must contain at least one page."
+                             {:pages pages}))
+  (let [pages (mapv validate-candidate-page pages)
+        declaration (select-keys (first pages) [:precision :recall :ordering])
+        declarations (mapv #(select-keys % [:precision :recall :ordering]) pages)
+        preceding (pop pages)
+        final-page (peek pages)
+        continuations (mapv :continuation preceding)
+        identities (mapv candidate-identity (mapcat :candidates pages))]
+    (when-not (every? #(= declaration %) declarations)
+      (invalid-candidate-scan!
+       "Secondary candidate precision, recall, and ordering must remain stable across pages."
+       {:pages pages :declarations declarations}))
+    (when (some :exhausted? preceding)
+      (invalid-candidate-scan! "Only the final secondary candidate page may be exhausted."
+                               {:pages pages}))
+    (when-not (:exhausted? final-page)
+      (invalid-candidate-scan! "The final secondary candidate page must be exhausted."
+                               {:pages pages}))
+    (when-not (= (count continuations) (count (distinct continuations)))
+      (invalid-candidate-scan! "Secondary candidate continuations must not repeat."
+                               {:pages pages :continuations continuations}))
+    (when-not (= (count identities) (count (distinct identities)))
+      (invalid-candidate-scan! "Secondary candidate identities must not repeat within a scan."
+                               {:pages pages :candidate-identities identities}))
+    pages))
+
+(declare require-query-eligible!)
+
+(defn candidate-page
+  "Read and validate one candidate page from `index`.
+
+   The database and index ident are mandatory so every core caller goes through
+   the same lifecycle-readiness gate as existing external-engine queries.
+   Direct calls to the adapter protocol are intentionally low-level."
+  [db idx-ident index query-spec entity-filter page-request]
+  (require-query-eligible! db idx-ident)
+  (when-not (candidate-scannable? index)
+    (throw (ex-info (str "Secondary index " (pr-str idx-ident)
+                         " does not support candidate scans.")
+                    {:type :secondary-candidate-scan-unsupported
+                     :index-ident idx-ident})))
+  (when-not (and (map? page-request)
+                 (integer? (:limit page-request))
+                 (pos? (:limit page-request)))
+    (throw (ex-info "A secondary candidate page request requires a positive integer :limit."
+                    {:type :invalid-secondary-candidate-request
+                     :index-ident idx-ident
+                     :request page-request})))
+  (let [page (validate-candidate-page
+              (-candidate-page index query-spec entity-filter page-request))]
+    (when (> (count (:candidates page)) (:limit page-request))
+      (invalid-candidate-page!
+       "A secondary candidate page cannot exceed the requested :limit."
+       {:page page :request page-request}))
+    page))
+
 (defprotocol ISecondaryScannable
   "Optional: enumerate what this index holds, so a BACKUP can carry it.
 

--- a/test/datahike/test/secondary_candidate_test.clj
+++ b/test/datahike/test/secondary_candidate_test.clj
@@ -1,0 +1,197 @@
+(ns datahike.test.secondary-candidate-test
+  "Focused tests for the optional paged secondary candidate contract."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.db :as db]
+   [datahike.index.secondary :as sec]))
+
+(defn- candidate-index
+  [calls result]
+  (reify
+    sec/ISecondaryIndex
+    (-search [_ _ _] nil)
+    (-estimate [_ _] 0)
+    (-can-order? [_ _ _] false)
+    (-slice-ordered [_ _ _ _ _ _] nil)
+    (-indexed-attrs [_] #{:doc/body})
+    (-transact [this _] this)
+
+    sec/ISecondaryCandidateScan
+    (-candidate-page [_ query-spec entity-filter page-request]
+      (swap! calls conj [query-spec entity-filter page-request])
+      result)))
+
+(defn- legacy-index
+  []
+  (reify sec/ISecondaryIndex
+    (-search [_ _ _] nil)
+    (-estimate [_ _] 0)
+    (-can-order? [_ _ _] false)
+    (-slice-ordered [_ _ _ _ _ _] nil)
+    (-indexed-attrs [_] #{:doc/body})
+    (-transact [this _] this)))
+
+(defn- error-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
+(deftest candidate-contract-is-additive
+  (testing "an existing ISecondaryIndex does not have to implement candidate scans"
+    (let [idx (legacy-index)]
+      (is (satisfies? sec/ISecondaryIndex idx))
+      (is (false? (sec/candidate-scannable? idx)))
+      (is (= :secondary-candidate-scan-unsupported
+             (:type (error-data
+                     #(sec/candidate-page
+                       (db/empty-db {}) :idx/legacy idx {} nil {:limit 10}))))))))
+
+(deftest candidate-page-preserves-independent-correctness-axes
+  (doseq [[precision recall ordering]
+          [[:exact :complete :exact]
+           [:recheck :complete :none]
+           [:exact :approximate :approximate]
+           [:recheck :approximate :exact]]]
+    (testing (str precision "/" recall "/" ordering)
+      (let [calls (atom [])
+            page {:candidates (list {:entity-id 7
+                                     :attribute :doc/body
+                                     :value-hash "value-7"
+                                     :score 0.75})
+                  :precision precision
+                  :recall recall
+                  :ordering ordering
+                  :exhausted? false
+                  :continuation {:after 7}}
+            idx (candidate-index calls page)
+            result (sec/candidate-page
+                    (db/empty-db {}) :idx/search idx {:query "needle"}
+                    :entity-filter {:limit 25})]
+        (is (= page (assoc result :candidates (seq (:candidates result)))))
+        (is (vector? (:candidates result)) "candidate sequences are normalized")
+        (is (= (= precision :recheck)
+               (sec/candidate-recheck-required? result)))
+        (is (= (= recall :complete)
+               (sec/candidate-recall-complete? result)))
+        (is (= (= ordering :exact)
+               (sec/candidate-order-exact? result)))
+        (is (= [[{:query "needle"} :entity-filter {:limit 25}]] @calls))))))
+
+(deftest candidate-page-validates-adapter-output
+  (let [valid {:candidates [{:entity-id 1 :attribute :doc/body}]
+               :precision :exact
+               :recall :complete
+               :ordering :none
+               :exhausted? true
+               :continuation nil}
+        invalid-pages [(assoc valid :precision :lossy)
+                       (assoc valid :recall :unknown)
+                       (assoc valid :ordering :ranked)
+                       (assoc valid :exhausted? :yes)
+                       (assoc valid :continuation :after)
+                       (assoc valid :exhausted? false :continuation nil)
+                       (assoc valid :candidates [{:entity-id 1}])
+                       (assoc valid :candidates [{:attribute :doc/body}])]]
+    (is (= valid (sec/validate-candidate-page valid)))
+    (doseq [page invalid-pages]
+      (is (= :invalid-secondary-candidate-page
+             (:type (error-data #(sec/validate-candidate-page page))))
+          (pr-str page)))))
+
+(deftest adapter-scan-conformance-helper
+  (let [first-page {:candidates [{:entity-id 1 :attribute :doc/body}
+                                 {:entity-id 2
+                                  :attribute :doc/body
+                                  :value-hash "two-a"}]
+                    :precision :recheck
+                    :recall :complete
+                    :ordering :exact
+                    :exhausted? false
+                    :continuation {:after 2}}
+        final-page {:candidates [{:entity-id 2
+                                  :attribute :doc/body
+                                  :value-hash "two-b"}
+                                 {:entity-id 3 :attribute :doc/body}]
+                    :precision :recheck
+                    :recall :complete
+                    :ordering :exact
+                    :exhausted? true
+                    :continuation nil}]
+    (is (= [first-page final-page]
+           (sec/validate-candidate-scan [first-page final-page])))
+
+    (doseq [pages [[first-page (assoc final-page :recall :approximate)]
+                   [first-page (assoc final-page
+                                      :candidates
+                                      [{:entity-id 1 :attribute :doc/body}])]
+                   [(assoc first-page :continuation :same)
+                    (assoc first-page :continuation :same)
+                    final-page]
+                   [first-page (assoc final-page
+                                      :exhausted? false
+                                      :continuation :more)]]]
+      (is (= :invalid-secondary-candidate-scan
+             (:type (error-data #(sec/validate-candidate-scan pages))))
+          (pr-str pages)))))
+
+(deftest candidate-page-validates-request-before-dispatch
+  (let [calls (atom [])
+        idx (candidate-index calls {:candidates []
+                                    :precision :exact
+                                    :recall :complete
+                                    :ordering :none
+                                    :exhausted? true
+                                    :continuation nil})]
+    (doseq [request [nil {} {:limit 0} {:limit -1} {:limit 1.5}]]
+      (is (= :invalid-secondary-candidate-request
+             (:type (error-data
+                     #(sec/candidate-page
+                       (db/empty-db {}) :idx/search idx {} nil request))))))
+    (is (empty? @calls))))
+
+(deftest candidate-page-enforces-requested-bound
+  (let [idx (candidate-index
+             (atom [])
+             {:candidates [{:entity-id 1 :attribute :doc/body}
+                           {:entity-id 2 :attribute :doc/body}]
+              :precision :exact
+              :recall :complete
+              :ordering :none
+              :exhausted? true
+              :continuation nil})]
+    (is (= :invalid-secondary-candidate-page
+           (:type (error-data
+                   #(sec/candidate-page
+                     (db/empty-db {}) :idx/search idx {} nil {:limit 1})))))))
+
+(deftest candidate-page-honours-query-readiness
+  (let [calls (atom [])
+        result {:candidates []
+                :precision :recheck
+                :recall :complete
+                :ordering :none
+                :exhausted? true
+                :continuation nil}
+        idx (candidate-index calls result)
+        base (db/empty-db {:idx/search {:db.secondary/status :ready}})]
+    (doseq [status [:building :disabled :failed]]
+      (let [unavailable (assoc-in base [:schema :idx/search :db.secondary/status]
+                                  status)]
+        (is (= {:type :secondary-index-unavailable
+                :index-ident :idx/search
+                :status status}
+               (error-data
+                #(sec/candidate-page
+                  unavailable :idx/search idx {} nil {:limit 10}))))))
+    (is (empty? @calls) "unavailable indexes are rejected before adapter dispatch")
+
+    (is (= result
+           (sec/candidate-page base :idx/search idx {} nil {:limit 10})))
+    (is (= result
+           (sec/candidate-page
+            (update-in base [:schema :idx/search] dissoc :db.secondary/status)
+            :idx/search idx {} nil {:limit 10})))
+    (is (= 2 (count @calls)) ":ready and legacy nil states dispatch")))


### PR DESCRIPTION
Adds an optional, additive paged candidate protocol for secondary indexes. The contract separates precision, recall, and ordering; requires stable continuation/exhaustion semantics and primary-datom identity; gates reads on lifecycle readiness; and includes a reusable whole-scan conformance validator.

Existing ISecondaryIndex adapters and query execution are unchanged.

Verification: focused Kaocha 21 tests / 165 assertions green; formatting and diff checks green; changed-file lint has zero errors.