### PR TITLE
fix(native): ordered-aggregate namespace must be statically required

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -34,6 +34,11 @@
    #?(:cljs [datahike.query.lower :as lower])
    #?(:clj [datahike.index.entity-set :as es])
    #?(:clj [datahike.index.secondary :as sec])
+   ;; Static, not `requiring-resolve`: this namespace has no cycle with
+   ;; datahike.query and is not an optional dependency, so a dynamic load only
+   ;; hid it from native-image's reachability analysis. See the aggregate call
+   ;; site below.
+   #?(:clj [datahike.query.index-ordered-aggregate :as ioa])
    ;; NOTE: datahike.index.secondary.stratum is loaded lazily via requiring-resolve
    ;; to keep stratum as an optional dependency
    [org.replikativ.persistent-sorted-set.arrays :as da]
@@ -5224,8 +5229,7 @@
                     ordered-result
                     (when aggregate-fast-eligible?
                       #?(:clj (when-not stats?
-                                ((requiring-resolve
-                                  'datahike.query.index-ordered-aggregate/execute)
+                                (ioa/execute
                                  plan db find-elements qwith (:cancel context-in)))
                          :cljs nil))
                     columnar-result


### PR DESCRIPTION
Fixes the failure behind the last four jar-only releases.

## Reproduced

Built `dthk` locally with GraalVM 25.0.1 and ran the native test script:

```
$ ./dthk query '[:find (count ?e) . :where [?e :name _]]' db:$CONFIG
exit: 1
❌ Error executing command: Could not locate
   datahike/query/index_ordered_aggregate__init.class,
   datahike/query/index_ordered_aggregate.clj or
   datahike/query/index_ordered_aggregate.cljc on classpath.
```

Not macOS-specific: it fails identically on Linux. The GitHub matrix only has a
macOS entry, which is why that is where we saw it, but CircleCI's
`build-native-image` runs the same test, which is why the Linux binaries were
withheld too.

Note the message goes to **stdout, not stderr** — worth knowing for
[#1003](https://github.com/replikativ/datahike/pull/1003).

## Cause

[#999](https://github.com/replikativ/datahike/pull/999) reached the new
namespace through `requiring-resolve`. native-image only includes what static
analysis can reach, so it was never compiled into the binary. On the JVM the
same call resolves fine — which is why every non-native path stayed green and
both aggregate code paths return identical results there.

## Why a static require is right here

`requiring-resolve` is load-bearing twice in this file, and neither reason
applies:

| site | why dynamic | reachable in native? |
|---|---|---|
| `datahike.query.execute/*` (7 vars) | real cycle, stated in `execute.cljc:2870` | yes — `cli.clj:8` requires it explicitly |
| `datahike.query/*` from execute (3 vars) | other half of the same cycle | yes |
| `index.secondary.stratum` | genuinely optional dependency | n/a — resolver catches and returns nil |
| `norm.clj` tx-fn, `attr-preds` pred | user-supplied symbols | inherently dynamic |
| **`index-ordered-aggregate/execute`** | **no reason** | **no — this bug** |

It requires `array`, `constants`, `datom`, `db.interface`, `index.interface`
and `query.analyze`, none of which lead back to `datahike.query`, and it ships
in this repo on the same source path. So it becomes an ordinary require, which
reachability analysis finds without a build-list entry to forget next time.

I audited every other `requiring-resolve` in `src/` and `src-kabel/`; the table
above is the complete list and nothing else is exposed.

## Verification

Locally built native image, full `run-native-image-tests`:

- **before**: reproduced the failure
- **after**: suite exits **0**

JVM behaviour unchanged: both aggregate paths still return `101`
(`java.lang.Integer`) and agree.