### PR TITLE
ci: build native artifacts for macOS on Apple Silicon

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -24,12 +24,21 @@ jobs:
         include:
           - os: macos-15-intel
             name: macos
+            platform: macos
+            arch: amd64
+          - os: macos-15          # Apple Silicon
+            name: macos
+            platform: macos
+            arch: aarch64
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GRAALVM_VERSION: 25.0.0
-      DTHK_PLATFORM: macos
-      DTHK_ARCH: amd64
+      # Per matrix entry, not per job: bb/src/tools/release.clj reads these to
+      # render {{lib}}-{{version}}-{{platform}}-{{arch}}.zip, so hardcoding them
+      # here is what limited this workflow to one architecture.
+      DTHK_PLATFORM: ${{ matrix.platform }}
+      DTHK_ARCH: ${{ matrix.arch }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Releases carry `dthk` and `libdatahike` for `linux-amd64`, `linux-aarch64` and
`macos-amd64`. The architecture most developer laptops run has no binary, so a
Mac user is told to install GraalVM and compile — and `pydatahike`, which loads
`libdatahike`, cannot be picked up there at all.

## Nothing about the build was x86-only

`bb/src/tools/release.clj:52` reads two environment variables and renders the
artifact name:

```clojure
(let [platform (System/getenv "DTHK_PLATFORM")
      arch     (System/getenv "DTHK_ARCH")]
  ... (render zip-pattern {:platform platform :arch arch}) ...)
```

CircleCI already varies them per architecture for its two Linux legs. This
workflow set them **once at job level, hardcoded** to `macos`/`amd64`:

```yaml
    env:
      DTHK_PLATFORM: macos
      DTHK_ARCH: amd64
```

That hardcoding is the entire blocker. This moves both into the matrix and adds
a `macos-15` (Apple Silicon) entry.

`graalvm/setup-graalvm` detects the runner architecture itself and GraalVM
Community publishes `macos-aarch64` for JDK 25, so no other step should need
changing. Uses `aarch64` rather than `arm64` to match what Linux already
publishes.

## Why now rather than on request

GitHub is retiring macOS Intel runners. When `macos-15-intel` goes away this
workflow does not merely fail to gain arm64 — it **loses macOS entirely**. This
is closer to insurance than to an enhancement.

## Caveats, stated plainly

**Untested locally.** This machine is Linux, so CI is the first real run. Worth
merging when someone can watch the first build.

**`bb ni-compile` is the step I would watch.** It builds `libdatahike` as a
shared library and involves a C compilation step; native-image handles the
architecture, but if any flag is hardcoded for x86 that is where it surfaces.
`dthk` alone would still succeed.

Landing after [#1003](https://github.com/replikativ/datahike/pull/1003) means a
failing leg costs one red job rather than every platform's binaries, and
`fail-fast: false` is already in place — this is precisely the scenario it was
added for.