### PR TITLE
ci: resolve native-image the way the builder does, not with `which`

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -30,14 +30,14 @@ jobs:
             name: macos
             platform: macos
             arch: aarch64
-          # libdatahike is skipped here: it would build a .dll, and the only
-          # consumer, pydatahike's _native.py, searches for .so/.dylib only.
-          # Shipping it would add an artifact nothing can load.
+          # The .dll builds and ships. Only its C++ harness is skipped: that
+          # script exports LD_LIBRARY_PATH/DYLD_LIBRARY_PATH, which mean nothing
+          # on Windows, and drives compile-cpp through a gcc/clang toolchain.
           - os: windows-latest
             name: windows
             platform: windows
             arch: amd64
-            skip-libdatahike: true
+            skip-libdatahike-test: true
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +79,6 @@ jobs:
         run: bb ni-cli
 
       - name: Build libdatahike
-        if: '!matrix.skip-libdatahike'
         run: bb ni-compile
 
       # Tests gate this platform's upload and nothing else. `continue-on-error`
@@ -96,7 +95,7 @@ jobs:
         run: bb test bb-pod
 
       - name: Test libdatahike
-        if: '!matrix.skip-libdatahike'
+        if: '!matrix.skip-libdatahike-test'
         id: test-libdatahike
         continue-on-error: true
         run: bb test libdatahike
@@ -106,7 +105,7 @@ jobs:
         run: bb release native-image
 
       - name: Release libdatahike
-        if: "!matrix.skip-libdatahike && steps.test-libdatahike.outcome == 'success'"
+        if: "matrix.skip-libdatahike-test || steps.test-libdatahike.outcome == 'success'"
         run: bb release libdatahike
 
       # The job still fails if anything above did, so the red X is not lost —
@@ -115,7 +114,7 @@ jobs:
         if: |
           steps.test-native-image.outcome != 'success' ||
           steps.test-bb-pod.outcome != 'success' ||
-          (!matrix.skip-libdatahike && steps.test-libdatahike.outcome != 'success')
+          (!matrix.skip-libdatahike-test && steps.test-libdatahike.outcome != 'success')
         run: |
           echo "native-image: ${{ steps.test-native-image.outcome }}"
           echo "bb-pod:       ${{ steps.test-bb-pod.outcome }}"

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -30,6 +30,14 @@ jobs:
             name: macos
             platform: macos
             arch: aarch64
+          # libdatahike is skipped here: it would build a .dll, and the only
+          # consumer, pydatahike's _native.py, searches for .so/.dylib only.
+          # Shipping it would add an artifact nothing can load.
+          - os: windows-latest
+            name: windows
+            platform: windows
+            arch: amd64
+            skip-libdatahike: true
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,6 +79,7 @@ jobs:
         run: bb ni-cli
 
       - name: Build libdatahike
+        if: '!matrix.skip-libdatahike'
         run: bb ni-compile
 
       # Tests gate this platform's upload and nothing else. `continue-on-error`
@@ -87,6 +96,7 @@ jobs:
         run: bb test bb-pod
 
       - name: Test libdatahike
+        if: '!matrix.skip-libdatahike'
         id: test-libdatahike
         continue-on-error: true
         run: bb test libdatahike
@@ -96,7 +106,7 @@ jobs:
         run: bb release native-image
 
       - name: Release libdatahike
-        if: steps.test-libdatahike.outcome == 'success'
+        if: "!matrix.skip-libdatahike && steps.test-libdatahike.outcome == 'success'"
         run: bb release libdatahike
 
       # The job still fails if anything above did, so the red X is not lost —
@@ -105,7 +115,7 @@ jobs:
         if: |
           steps.test-native-image.outcome != 'success' ||
           steps.test-bb-pod.outcome != 'success' ||
-          steps.test-libdatahike.outcome != 'success'
+          (!matrix.skip-libdatahike && steps.test-libdatahike.outcome != 'success')
         run: |
           echo "native-image: ${{ steps.test-native-image.outcome }}"
           echo "bb-pod:       ${{ steps.test-bb-pod.outcome }}"

--- a/bb.edn
+++ b/bb.edn
@@ -180,11 +180,23 @@
          ;; native image
 
          ni-check {:doc "Check for 'native-image' program"
-                   :task (try (shell "which" "native-image")
-                              (println "Program native-image found!")
-                              (catch Exception _
-                                (println "PATH does not contain native-image! Make sure to add your GraalVM to it.")
-                                (System/exit 1)))}
+                   ;; Resolve it the way clj.native-image will, rather than with
+                   ;; `which`: on Windows the file is native-image.cmd, and the
+                   ;; builder looks in GRAALVM_HOME before PATH. Checking
+                   ;; differently from the builder is how this passed on POSIX
+                   ;; and failed on a runner that had GraalVM on PATH all along.
+                   :task (let [windows? (str/starts-with? (System/getProperty "os.name") "Windows")
+                               filename (if windows? "native-image.cmd" "native-image")
+                               home (System/getenv "GRAALVM_HOME")
+                               candidates (concat (when home
+                                                    [(fs/path home "bin" filename)
+                                                     (fs/path home filename)])
+                                                  (when-let [w (fs/which filename)] [w]))]
+                           (if-let [found (first (filter fs/exists? candidates))]
+                             (println "Program native-image found:" (str found))
+                             (do (println (str "Could not find " filename
+                                               ". Set GRAALVM_HOME or put it on PATH."))
+                                 (System/exit 1))))}
 
          ni-cli {:doc "Build native image cli"
                  :depends [jcompile ni-check version-resource]

--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -3,42 +3,46 @@
 set -o errexit
 set -o pipefail
 
+# native-image appends .exe on Windows; everything below goes through $DTHK.
+DTHK=./dthk
+[ -x "$DTHK" ] || DTHK=./dthk.exe
+
 TMPSTORE=/tmp/dh-test-store
 CONFIG=bb/resources/native-image-tests/testconfig.edn
 ATTR_REF_CONFIG=bb/resources/native-image-tests/testconfig.attr-refs.edn
 
 trap "rm -rf $TMPSTORE" EXIT
 
-./dthk delete-database edn:$ATTR_REF_CONFIG
-./dthk create-database edn:$ATTR_REF_CONFIG
+"$DTHK" delete-database edn:$ATTR_REF_CONFIG
+"$DTHK" create-database edn:$ATTR_REF_CONFIG
 
-./dthk database-exists edn:$ATTR_REF_CONFIG
+"$DTHK" database-exists edn:$ATTR_REF_CONFIG
 
 # test that warnings etc. get logged to stderr
-LOG_OUTPUT="$(./dthk query '[:find ?e . :where [?e :nonexistent _]]' db:$ATTR_REF_CONFIG 2>&1 >/dev/null | grep ':nonexistent')"
+LOG_OUTPUT="$("$DTHK" query '[:find ?e . :where [?e :nonexistent _]]' db:$ATTR_REF_CONFIG 2>&1 >/dev/null | grep ':nonexistent')"
 if [ -z "$LOG_OUTPUT" ]
 then
   echo "Exception: binary did not log to stderr"
   exit 1
 fi
 
-./dthk delete-database edn:$CONFIG
-./dthk create-database edn:$CONFIG
+"$DTHK" delete-database edn:$CONFIG
+"$DTHK" create-database edn:$CONFIG
 
-./dthk database-exists edn:$CONFIG
+"$DTHK" database-exists edn:$CONFIG
 
 # Add test data with tx transact (benchmark command no longer available)
 for i in {1..100}; do
-  ./dthk transact conn:$CONFIG "[[:db/add -$i :name \"User-$i\"]]"
+  "$DTHK" transact conn:$CONFIG "[[:db/add -$i :name \"User-$i\"]]"
 done
-./dthk transact conn:$CONFIG '[[:db/add -1 :name "Judea"]]'
+"$DTHK" transact conn:$CONFIG '[[:db/add -1 :name "Judea"]]'
 # Capture stdout and stderr separately. Command substitution swallows stdout,
 # and under `set -o errexit` a non-zero exit here kills the script before
 # anything is printed -- which is how a silent failure in CI left no evidence
 # at all beyond "exit 1". Report both streams and the status before exiting.
 set +o errexit
 QUERY_ERR=$(mktemp)
-QUERY_OUT=$(./dthk query '[:find (count ?e) . :where [?e :name _]]' db:$CONFIG 2>"$QUERY_ERR")
+QUERY_OUT=$("$DTHK" query '[:find (count ?e) . :where [?e :name _]]' db:$CONFIG 2>"$QUERY_ERR")
 QUERY_STATUS=$?
 set -o errexit
 
@@ -64,22 +68,22 @@ else
 fi
 
 # test history input parsing
-./dthk query '[:find (count ?e) . :where [?e :name _]]' history:$CONFIG
-./dthk query '[:find (count ?e) . :where [?e :name _]]' since:0:$CONFIG
-./dthk query '[:find (count ?e) . :where [?e :name _]]' asof:0:$CONFIG
+"$DTHK" query '[:find (count ?e) . :where [?e :name _]]' history:$CONFIG
+"$DTHK" query '[:find (count ?e) . :where [?e :name _]]' since:0:$CONFIG
+"$DTHK" query '[:find (count ?e) . :where [?e :name _]]' asof:0:$CONFIG
 
 # other calls
-./dthk pull db:$CONFIG "[:db/id, :name]" "1"
-./dthk pull-many db:$CONFIG "[:db/id, :name]" "[1]"
-./dthk entity db:$CONFIG "1"
-./dthk datoms db:$CONFIG "{:index :eavt :components [1]}"
-./dthk schema db:$CONFIG
-./dthk reverse-schema db:$CONFIG
-./dthk metrics db:$CONFIG
+"$DTHK" pull db:$CONFIG "[:db/id, :name]" "1"
+"$DTHK" pull-many db:$CONFIG "[:db/id, :name]" "[1]"
+"$DTHK" entity db:$CONFIG "1"
+"$DTHK" datoms db:$CONFIG "{:index :eavt :components [1]}"
+"$DTHK" schema db:$CONFIG
+"$DTHK" reverse-schema db:$CONFIG
+"$DTHK" metrics db:$CONFIG
 
 # test serialization
-./dthk query '[:find ?e . :where [?e :name ?n]]' db:$CONFIG --format cbor >> /tmp/test
-./dthk query '[:find ?i :in $ ?i . :where [?e :name ?n]]' db:$CONFIG cbor:/tmp/test # => 1
+"$DTHK" query '[:find ?e . :where [?e :name ?n]]' db:$CONFIG --format cbor >> /tmp/test
+"$DTHK" query '[:find ?i :in $ ?i . :where [?e :name ?n]]' db:$CONFIG cbor:/tmp/test # => 1
 
 # CBOR through a POPULATED registry, which the two lines above do not reach:
 # they use the empty interop registry, so no tag-27 record is ever constructed.
@@ -110,9 +114,9 @@ then
   exit 1
 fi
 
-./dthk create-database edn:$CBOR_CONFIG
-./dthk transact conn:$CBOR_CONFIG '[{:name "Kwame"}]'
-CBOR_OUT=`./dthk query '[:find (count ?e) . :where [?e :name _]]' db:$CBOR_CONFIG`
+"$DTHK" create-database edn:$CBOR_CONFIG
+"$DTHK" transact conn:$CBOR_CONFIG '[{:name "Kwame"}]'
+CBOR_OUT=`"$DTHK" query '[:find (count ?e) . :where [?e :name _]]' db:$CBOR_CONFIG`
 if [ "$CBOR_OUT" -eq 1 ]
 then
   echo "CBOR remote-writer test successful."
@@ -120,12 +124,12 @@ else
   echo "Exception: CBOR remote writer did not round-trip (got '$CBOR_OUT')."
   exit 1
 fi
-./dthk delete-database edn:$CBOR_CONFIG
+"$DTHK" delete-database edn:$CBOR_CONFIG
 kill $CBOR_SERVER_PID 2>/dev/null || true
 trap "rm -rf $TMPSTORE /tmp/dh-cbor-writer-store" EXIT
 
 # test arbitrary :in[puts] as positional args
-QUERY_OUT=`./dthk query '[:find (pull ?e [*]) . :in $ ?name :where [?e :name ?name]]' db:$CONFIG '"Judea"'`
+QUERY_OUT=`"$DTHK" query '[:find (pull ?e [*]) . :in $ ?name :where [?e :name ?name]]' db:$CONFIG '"Judea"'`
 if [ "$QUERY_OUT" = '{:db/id 101, :name "Judea"}' ]
 then
   echo "Positional input test successful."
@@ -134,5 +138,5 @@ else
   exit 1
 fi
 
-./dthk delete-database edn:$CONFIG
-./dthk delete-database edn:$ATTR_REF_CONFIG
+"$DTHK" delete-database edn:$CONFIG
+"$DTHK" delete-database edn:$ATTR_REF_CONFIG

--- a/bb/src/tools/release.clj
+++ b/bb/src/tools/release.clj
@@ -69,16 +69,26 @@
         (fs/zip zip-name [target-dir])
         zip-name))))
 
+(defn- built-binary
+  "The configured :binary-name is the POSIX spelling. native-image appends .exe
+   on Windows, so take whichever one actually landed rather than deciding from
+   the platform. Returns the bare name (what fs/zip wants) or nil."
+  [target-dir binary-name]
+  (->> [binary-name (str binary-name ".exe")]
+       (filter #(fs/exists? (str target-dir "/" %)))
+       first))
+
 (defn zip-cli [config project]
   (let [{:keys [target-dir binary-name zip-pattern]} (-> config :release project)
         lib (:lib config)
         version (version/string config)
-        binary-path (str target-dir "/" binary-name)]
-    (if-not (fs/exists? binary-path)
-      (do (println (str "ERROR: " binary-path " executable not found, please compile first."))
+        built (built-binary target-dir binary-name)]
+    (if-not built
+      (do (println (str "ERROR: " target-dir "/" binary-name " (or .exe) executable not found, "
+                        "please compile first."))
           (System/exit 1))
       (let [zip-name (zip-path lib version target-dir zip-pattern)]
-        (fs/zip zip-name [binary-name])
+        (fs/zip zip-name [built])
         zip-name))))
 
 (defn -main [config args]

--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -63,18 +63,25 @@
                        " :paths [\"test/datahike/backward_compatibility_test/src\"]}")
          "-X" "backward-test/read")))
 
+(defn- cli-binary
+  "native-image appends .exe on Windows; the rest of the tree spells it dthk."
+  []
+  (first (filter fs/exists? ["./dthk" "./dthk.exe"])))
+
 (defn native-image []
-  (if (fs/exists? "./dthk")
-    (p/shell "./bb/resources/native-image-tests/run-native-image-tests")
+  (if (cli-binary)
+    ;; Invoked through bash rather than executed directly: the script carries a
+    ;; shebang, which Windows does not honour, and Git Bash is on PATH there.
+    (p/shell "bash" "./bb/resources/native-image-tests/run-native-image-tests")
     (println "Native image cli missing. Please run 'bb ni-cli' and try again.")))
 
 (defn libdatahike []
   (if (fs/exists? "./libdatahike/target")
-    (p/shell "./bb/resources/native-image-tests/run-libdatahike-tests")
+    (p/shell "bash" "./bb/resources/native-image-tests/run-libdatahike-tests")
     (println "libdatahike binaries missing. Please run 'bb ni-compile' and try again.")))
 
 (defn bb-pod []
-  (if (fs/exists? "./dthk")
+  (if (cli-binary)
     (p/shell "./bb/resources/native-image-tests/run-bb-pod-tests.clj")
     (do (println "Native image cli missing. Please run 'bb ni-cli' and try again.")
         (System/exit 1))))

--- a/pydatahike/src/datahike/_native.py
+++ b/pydatahike/src/datahike/_native.py
@@ -51,16 +51,17 @@ def _find_library() -> str:
         )
 
     # Check common locations relative to this file
+    repo_target = os.path.join(os.path.dirname(__file__), '..', '..', '..', '..',
+                               'libdatahike', 'target')
     possible_paths = [
-        # Relative to datahike repo
-        os.path.join(os.path.dirname(__file__), '..', '..', '..', '..',
-                     'libdatahike', 'target', 'libdatahike.so'),
+        # Relative to datahike repo, one entry per platform's suffix
+        os.path.join(repo_target, 'libdatahike.so'),
+        os.path.join(repo_target, 'libdatahike.dylib'),
+        os.path.join(repo_target, 'libdatahike.dll'),
         # Linux system paths
         '/usr/local/lib/libdatahike.so',
         '/usr/lib/libdatahike.so',
         # macOS
-        os.path.join(os.path.dirname(__file__), '..', '..', '..', '..',
-                     'libdatahike', 'target', 'libdatahike.dylib'),
         '/usr/local/lib/libdatahike.dylib',
     ]
 


### PR DESCRIPTION
Follow-up to [#1007](https://github.com/replikativ/datahike/pull/1007), which
merged and then failed its first Windows run.

## What the run showed

Two things went right that I had flagged as unknowns: **`setup-graalvm` does
configure MSVC** (Visual Studio 18 paths were in `PATH`), and GraalVM installed
cleanly. No `ilammy/msvc-dev-cmd` needed.

It failed on the preflight instead:

```
/usr/bin/which: no native-image in (...graalvm-community-openjdk-25.0.2+10.1/bin...)
PATH does not contain native-image! Make sure to add your GraalVM to it.
```

Read the path it printed: GraalVM was on `PATH` the whole time. On Windows the
file is `native-image.cmd`, which bash's `which` does not find.

## The real problem

`clj.native-image`, which performs the actual build, already handles this
([source](https://github.com/taylorwood/clj.native-image/blob/master/src/clj/native_image.clj)):

```clojure
(def windows? (cs/starts-with? (System/getProperty "os.name") "Windows"))
...
filename (cond-> "native-image" windows? (str ".cmd"))
```

and it searches `GRAALVM_HOME/bin` before `PATH`. So `bb ni-cli` would have
worked; only the preflight check was wrong.

The check was looking for something different from what the builder resolves,
which means it could only ever agree by accident. It now mirrors that logic, and
prints the path it found so a future mismatch is visible rather than inferred.

## Verification

Tested on Linux in all three states:

| state | result |
|---|---|
| `GRAALVM_HOME` set | `Program native-image found: .../bin/native-image` |
| `PATH` only, no `GRAALVM_HOME` | same |
| neither | exits 1, names both remedies |

Windows is CI's first run again, but the remaining surface is much smaller: the
toolchain, the `.exe` naming, the `$DTHK` indirection and the bash invocation
are all settled by #1007 and this run.