### PR TITLE
ci: fix the Windows native build (native-image.cmd, then the command-line limit)

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -198,9 +198,29 @@
                                                ". Set GRAALVM_HOME or put it on PATH."))
                                  (System/exit 1))))}
 
+         ni-cli-uber {:doc "Build the CLI uber jar (input for the Windows native build)"
+                      :depends [jcompile version-resource]
+                      :task (do (build/compile-clojure (-> config :build :native-cli))
+                                (build/uber config (-> config :build :native-cli)))}
+
          ni-cli {:doc "Build native image cli"
                  :depends [jcompile ni-check version-resource]
-                 :task (clojure "-M:native-cli")}
+                 ;; clj.native-image passes the whole classpath as -cp, which on
+                 ;; Windows exceeds the 8191-character command line and fails with
+                 ;; "The command line is too long." Build an uber jar there and
+                 ;; hand native-image a single -jar instead, which is what
+                 ;; clj-kondo and friends do. POSIX keeps the existing path.
+                 :task (if (str/starts-with? (System/getProperty "os.name") "Windows")
+                         (do (run 'ni-cli-uber)
+                             (let [jar (build/jar-path config (-> config :build :native-cli))
+                                   ni (str (System/getenv "GRAALVM_HOME") "/bin/native-image.cmd")]
+                               (shell ni "-jar" jar
+                                      "--initialize-at-build-time"
+                                      "--no-fallback"
+                                      "-H:IncludeResources=DATAHIKE_VERSION"
+                                      "-J-Xmx4g"
+                                      "-o" "dthk")))
+                         (clojure "-M:native-cli"))}
 
          ni-ccompile {:doc "Compile clojure namespaces for native-image"
                       :depends [jcompile]

--- a/config.edn
+++ b/config.edn
@@ -26,6 +26,18 @@
                            :aliases       [:http-server]
                            :main          datahike.http.server
                            :lib           org.replikativ/datahike-http-server}
+         ;; Used only on Windows, where native-image cannot take the classpath
+         ;; on the command line (8191-char limit). Same shape as :native, but
+         ;; carrying the CLI's own aliases rather than libdatahike's.
+         :native-cli {:src-dirs ["src"]
+                      :java-src-dirs ["java"]
+                      :resource-dir "resources"
+                      :target-dir "target"
+                      :class-dir "target/classes"
+                      :deps-file "deps.edn"
+                      :aliases [:native-cli]
+                      :jar-pattern "{{repo.lib}}-{{version-str}}-cli-standalone.jar"
+                      :main datahike.cli}
          :native {:src-dirs ["src" "libdatahike/src"]
                   :java-src-dirs ["java"]
                   :resource-dir "resources"


### PR DESCRIPTION
Two follow-ups from the Windows runs. Both borrowed from projects that already
solved this, rather than guessed at.

## 1. `which native-image` cannot see `native-image.cmd`

The first run got GraalVM installed and **MSVC configured by `setup-graalvm`**
(Visual Studio 18 paths were in `PATH`), then failed the preflight:

```
/usr/bin/which: no native-image in (...graalvm-community-openjdk-25.0.2+10.1/bin...)
PATH does not contain native-image!
```

GraalVM was on `PATH` the whole time. On Windows the file is `native-image.cmd`.

`clj.native-image` — which performs the build — already handles this:

```clojure
filename (cond-> "native-image" windows? (str ".cmd"))
```

and searches `GRAALVM_HOME/bin` before `PATH`. The preflight was checking for
something different from what the builder resolves, so it could only agree by
accident. It now mirrors that logic and prints the path it found.

## 2. `The command line is too long.`

The second run AOT-compiled everything, then died at the native-image
invocation. `clj.native-image` passes the whole classpath as `-cp`; on Windows
that goes through `native-image.cmd`, so cmd.exe's **8191-character limit**
applies.

The classpath is also longer than it needs to be: `clj.native-image` derives it
from `java.class.path`, which carries **its own** dependencies — `tools.deps`,
`maven-resolver`, `jgit`, `jsch`, `guava` — visible in the run log as downloads,
none of which belong in the image.

[clj-kondo](https://github.com/clj-kondo/clj-kondo/blob/master/script/compile.bat)
solves this by building an uber jar and calling `native-image -jar`, so nothing
but the jar path crosses the command line:

```bat
call %GRAALVM_HOME%\bin\native-image.cmd ^
  "-jar" "target/clj-kondo-%CLJ_KONDO_VERSION%-standalone.jar" ...
```

datahike already has the pieces — `build/uber`, and a `:native` target producing
a `:main datahike.cli` jar for libdatahike. This adds a `:native-cli` build
target beside it, differing only in carrying the CLI's own aliases rather than
libdatahike's, so the pod dependencies the CLI needs are present.

`ni-cli` now branches: **Windows** builds the uber jar and invokes
`native-image.cmd -jar`; **POSIX keeps `clj.native-image` untouched**, so the
platforms that currently work are not disturbed.

## Verification

Both changes are exercised on Linux, since CI is the only Windows oracle:

| check | result |
|---|---|
| `ni-check` with `GRAALVM_HOME` | finds `.../bin/native-image` |
| `ni-check` with `PATH` only | same |
| `ni-check` with neither | exits 1, names both remedies |
| `bb ni-cli-uber` | 74 MB jar, `Main-Class: datahike.cli` |
| `java -jar …` | prints `Datahike 0.8.1819` |
| pod entries in the jar | 163 |

The POSIX `ni-cli` path is unchanged and still runs `clojure -M:native-cli`.