### PR TITLE
ci: make the libdatahike native build work on Windows

### DIFF
--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -92,18 +92,29 @@
            :main main})
   (println "Done."))
 
+(def ^:private windows?
+  (str/starts-with? (System/getProperty "os.name") "Windows"))
+
 (defn native-compile [repo-config {:keys [project-target-dir class-path project-name java-interface] :as project-config}]
   (if-let [graalvm-dir (System/getenv "GRAALVM_HOME")]
     (let [native-jar (jar-path repo-config project-config)
           svm-jar (str graalvm-dir "/lib/svm/builder/svm.jar")
+          ;; ":" is the POSIX classpath separator; Windows uses ";". Getting this
+          ;; wrong makes javac read the whole string as one bogus entry, which
+          ;; surfaces as "package clojure.lang does not exist".
+          cp-sep (java.io.File/pathSeparator)
+          javac (str graalvm-dir "/bin/javac" (when windows? ".exe"))
+          native-image (str graalvm-dir "/bin/native-image" (when windows? ".cmd"))
           java-base-file (str/replace java-interface #"LibDatahike\.java$" "LibDatahikeBase.java")]
       (println "Compiling native bindings Java classes.")
-      (p/shell (str graalvm-dir "/bin/javac")
-               "-cp" (str native-jar ":" svm-jar)
+      (p/shell javac
+               "-cp" (str native-jar cp-sep svm-jar)
                "-d" class-path
                java-base-file java-interface)
       (println "Compiling shared library through native image.")
-      (p/shell (str graalvm-dir "/bin/native-image")
+      (apply p/shell
+             (concat
+              [native-image
                "-jar" native-jar
                "-cp" class-path
                (str "-o " project-name)
@@ -116,9 +127,10 @@
                "--initialize-at-build-time"
                "-H:Log=registerResource:"
                "--verbose"
-               "--no-fallback"
-               "--no-server"
-               "-J-Xmx5g")
+               "--no-fallback"]
+              ;; --no-server is not supported by native-image on Windows.
+              (when-not windows? ["--no-server"])
+              ["-J-Xmx5g"]))
       (fs/delete-tree project-target-dir)
       (fs/create-dir project-target-dir)
       (->> (slurp "build-artifacts.json")


### PR DESCRIPTION
Continues the Windows series. **Both macOS legs now pass** on `main`
(`macos-15` aarch64 and `macos-15-intel` amd64) — only Windows is red.

With the uber jar from [#1009](https://github.com/replikativ/datahike/pull/1009)
in place, the run gets past `ni-cli` and fails in `Build libdatahike`:

```
LibDatahikeBase.java:9:  error: cannot find symbol   import datahike.java.Datahike;
LibDatahikeBase.java:10: error: cannot find symbol   import datahike.java.Util;
LibDatahikeBase.java:12: error: package clojure.lang does not exist
```

## Three POSIX assumptions in `native-compile`

The first explains that message exactly.

**The javac classpath was joined with a literal `":"`.** On Windows the separator
is `;`, so the whole string reads as a single bogus entry and nothing on it
resolves — `clojure.lang` included, which is why even that import fails. Uses
`File/pathSeparator` now.

**`javac` and `native-image` were addressed without a suffix.** Windows needs
`javac.exe` and `native-image.cmd`.

**`--no-server` was passed unconditionally.** native-image does not support it on
Windows; `clj.native-image` has carried that caveat in its source for years.

## Verification

Ran the javac stage on Linux with exactly the command this now constructs, after
`bb codegen-native` and `bb ni-uber`: compiles clean. So the platforms that
already pass are unaffected — the only behavioural change on POSIX is that
`--no-server` is now appended via `concat` rather than inline.

Windows remains CI-verified only. If `Build libdatahike` gets through, the next
thing to watch is the shared-library link step, which is the other place a
toolchain difference could surface.