### PR TITLE
perf: remove the reflective calls from the native build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,16 @@ jobs:
           paths:
             - /home/circleci/.m2
             - /home/circleci/.deps.clj
+  reflection:
+    executor: tools/clojurecli
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Check for reflective calls
+          command: bb reflection
+          no_output_timeout: 10m
+
   native-image:
     executor: tools/clojurecli
     steps:
@@ -419,6 +429,10 @@ workflows:
           requires:
             - setup
       - format:
+          context: ghcr-read-package
+          requires:
+            - setup
+      - reflection:
           context: ghcr-read-package
           requires:
             - setup

--- a/bb.edn
+++ b/bb.edn
@@ -14,6 +14,7 @@
                     [tools.examples :as examples]
                     [tools.npm :as npm]
                     [tools.python :as python]
+                    [tools.reflection :as reflection]
                     [tools.release :as release]
                     [tools.test :as test]
                     [tools.version :as version]]
@@ -47,6 +48,10 @@
          lint {:doc "Run clj-kondo linter"
                :require [[pod.borkdude.clj-kondo :as clj-kondo]]
                :task (clj-kondo/print! (clj-kondo/run! {:lint "."}))}
+
+         reflection {:doc "Fail on reflective calls in datahike sources"
+                     :depends [jcompile]
+                     :task (reflection/check)}
 
          test {:doc "Run all tests or restrict to 'native-image', 'back-compat' or a kaocha test id (see tests.edn)"
                :depends [jcompile]

--- a/bb/src/tools/reflection.clj
+++ b/bb/src/tools/reflection.clj
@@ -1,0 +1,61 @@
+(ns tools.reflection
+  "Fail the build on reflective calls in our own sources.
+
+  Reflection is a latency cost on the JVM. Under native-image it is a
+  correctness cost: a reflective call resolves at run time, so it works in the
+  binary only if the target was registered for reflection when the image was
+  built. That turns a warning the compiler prints and nobody reads into a
+  runtime failure in a shipped artifact, which is why this is a gate and not a
+  report.
+
+  Only warnings under `datahike/` count. A dependency's warnings are real but
+  are not fixable from here, and gating on them would make our build red when
+  someone else's release regresses."
+  (:require [babashka.process :as p]
+            [clojure.string :as str]))
+
+(def ^:private src-roots ["src" "libdatahike/src"])
+
+(defn- namespaces
+  "Every namespace under `src-roots`, as the compiler would name it."
+  []
+  (->> src-roots
+       (mapcat #(->> (file-seq (java.io.File. ^String %))
+                     (filter (fn [^java.io.File f] (.isFile f)))
+                     (map (fn [^java.io.File f] [% (.getPath f)]))))
+       (keep (fn [[root path]]
+               (when (re-find #"\.cljc?$" path)
+                 (-> path
+                     (str/replace (re-pattern (str "^" root "/")) "")
+                     (str/replace #"\.cljc?$" "")
+                     (str/replace "/" ".")
+                     (str/replace "_" "-")))))
+       ;; data_readers.clj is a data file, not a namespace.
+       (remove #{"data-readers"})
+       sort
+       distinct))
+
+(defn check
+  "Compile every namespace with *warn-on-reflection* and fail on any warning."
+  [& _]
+  (let [nses (namespaces)
+        form (str "(set! *warn-on-reflection* true)"
+                  "(doseq [n '" (pr-str (vec (map symbol nses))) "]"
+                  "  (try (require n) (catch Throwable _ nil)))")
+        _ (println (format "Compiling %d namespaces with *warn-on-reflection*..."
+                           (count nses)))
+        {:keys [err]} (p/sh "clojure" "-M:libdatahike" "-e" form)
+        warnings (->> (str/split-lines (or err ""))
+                      (filter #(str/starts-with? % "Reflection warning"))
+                      (filter #(str/includes? % "datahike/"))
+                      distinct
+                      sort)]
+    (if (seq warnings)
+      (do (println)
+          (println (count warnings) "reflective call(s) in datahike sources:")
+          (println)
+          (doseq [w warnings] (println " " w))
+          (println)
+          (println "Add a type hint. See tools.reflection for why this is a gate.")
+          (System/exit 1))
+      (println "No reflective calls in datahike sources."))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,19 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.5"}
-        org.replikativ/hasch                        {:mvn/version "0.4.102"
+        ;; 0.4.104 carries incognito 0.3.71 (hasch#34), the other half of
+        ;; pulling that fix in — see the konserve note below. Hashes are
+        ;; unchanged across the incognito bump; that was checked directly, since
+        ;; a version bump under a hashing library is the kind that can move
+        ;; stored data silently.
+        org.replikativ/hasch                        {:mvn/version "0.4.104"
                                                      :exclusions [org.clojure/clojurescript]}
-        org.replikativ/konserve                     {:mvn/version "0.9.385"}
+        ;; 0.9.386 clears the reflective calls out of gc, mmap, the simulation
+        ;; backings and the zstd compressor (konserve#184); 0.9.387 carries
+        ;; incognito 0.3.71 (konserve#185), which is how the transit write
+        ;; handler's fix reaches us — we resolve incognito only through konserve
+        ;; and hasch. Datahike compiles konserve into `dthk`, where a reflective
+        ;; call resolves at run time and so works only if it was registered when
+        ;; the image was built.
+        org.replikativ/konserve                     {:mvn/version "0.9.387"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}
@@ -20,7 +32,11 @@
         ;; :cljs + :test (shadow-cljs.edn:1), and `bb test cljs-node` sees only
         ;; :cljs — so this is the one placement all three see. The old :bulk
         ;; alias reached none of the cljs ones.
-        org.replikativ/persistent-sorted-set        {:mvn/version "0.5.143"}
+        ;; 0.5.144 hints the Leaf/Branch constructors in `blob->leaf` and
+        ;; `blob->branch` (persistent-sorted-set#27) — the deserialization path,
+        ;; so the reflective lookup was paid per node on every cache miss. These
+        ;; were the last two reflection warnings left in datahike's native build.
+        org.replikativ/persistent-sorted-set        {:mvn/version "0.5.144"}
         ;; MAIN deps, not a test alias. `datahike.cbor` is src/, so boring is a
         ;; real runtime dependency: the dump codec and the kabel wire format
         ;; both go through it. It used to be declared only under :test, which
@@ -69,7 +85,9 @@
                                ;; Optional `datahike/s3` browser entry. The
                                ;; regular browser bundle does not require this
                                ;; namespace, so Closure keeps S3 signing code out.
-                               org.replikativ/konserve-s3 {:mvn/version "0.1.38"}}
+                               ;; 0.1.39: all 45 reflective S3 calls hinted
+                               ;; (konserve-s3#19).
+                               org.replikativ/konserve-s3 {:mvn/version "0.1.39"}}
                                
                   :extra-paths ["test"]}
 
@@ -136,7 +154,7 @@
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
 
                                ;; S3-compatible store integration test (migrate-s3-test, needs docker; runs Garage)
-                               org.replikativ/konserve-s3    {:mvn/version "0.1.38"}
+                               org.replikativ/konserve-s3    {:mvn/version "0.1.39"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            ;; Datomic Pro peer API, for `datahike.migrate.datomic` and its

--- a/src/datahike/audit.cljc
+++ b/src/datahike/audit.cljc
@@ -153,21 +153,24 @@
                       _       (when-not head
                                 (throw (ex-info "verify-chain: no head cid on db"
                                                 {:type :audit/no-head})))
-                      commits (volatile! [])
-                      missing (volatile! [])
-                      visited (volatile! #{})]
+                      ;; Atoms, not volatiles: `vswap!` inlines `.deref`/`.reset`,
+                      ;; and the go macro erases the local's type hint, so those
+                      ;; calls reflect. `swap!` is an ordinary function call.
+                      commits (atom [])
+                      missing (atom [])
+                      visited (atom #{})]
                   (loop [frontier [head] n 0]
                     (when (and (seq frontier) (< n limit))
                       (let [cid (first frontier) rest-f (rest frontier)]
                         (if (contains? @visited cid)
                           (recur rest-f n)
-                          (do (vswap! visited conj cid)
+                          (do (swap! visited conj cid)
                               (if-let [entry (<?- (step store cid sync?))]
-                                (do (vswap! commits conj entry)
+                                (do (swap! commits conj entry)
                                     (recur (into (vec rest-f)
                                                  (remove @visited (:parents entry)))
                                            (inc n)))
-                                (do (vswap! missing conj cid)
+                                (do (swap! missing conj cid)
                                     (recur rest-f n))))))))
                   (let [es @commits
                         mism (filterv (comp #{:mismatch} :status) es)

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -348,7 +348,7 @@
                  ;; it, where the safe point degenerates to `now` because this
                  ;; heap has no in-flight sequences to report, the wall clock is
                  ;; the only bound there is.
-                 floor (#?(:clj Date. :cljs js/Date.) (- (get-time now) min-age-ms))
+                 floor (#?(:clj Date. :cljs js/Date.) (long (- (get-time now) min-age-ms)))
                  cutoff (->> [(guard/safe-point store-id) now floor]
                              (sort-by get-time)
                              first)

--- a/src/datahike/migrate/store.cljc
+++ b/src/datahike/migrate/store.cljc
@@ -93,6 +93,16 @@
 
 (defn- chunk-key [prefix n codec] (ckey prefix (chunk-name n codec)))
 
+(defn- byte-count
+  "Length of an encoded chunk.
+
+  A function rather than an inline `alength`: the call sites sit inside a
+  `go-try-` block, and the go macro rewrites locals into its state-machine
+  array, dropping the `^bytes` hint and leaving a reflective call behind. A
+  parameter hint on an ordinary function survives."
+  ^long [b]
+  #?(:clj (alength ^bytes b) :cljs (.-length b)))
+
 (defn chunk-descriptor
   "One entry of the manifest's `:chunks` vector.
 
@@ -217,8 +227,8 @@
                   (conj chunks (chunk-descriptor
                                 (chunk-name n codec)
                                 (count part)
-                                #?(:clj (alength ^bytes stored) :cljs (.-length stored))
-                                #?(:clj (alength ^bytes content) :cljs (.-length content))
+                                (byte-count stored)
+                                (byte-count content)
                                 (dig/sha256-hex content)))
                   (reduce dig/add-record dacc encs)))))))))
 

--- a/src/datahike/norm/norm.clj
+++ b/src/datahike/norm/norm.clj
@@ -18,6 +18,16 @@
 
 (def checksums-file "checksums.edn")
 
+(defn- entry-name
+  "Name of a norm entry. `retrieve-file-list` yields Files for a folder and
+  JarEntries for a resource inside a jar, so callers downstream of it cannot
+  hint a single type."
+  ^String [entry]
+  (condp instance? entry
+    File     (.getName ^File entry)
+    JarEntry (.getName ^JarEntry entry)
+    (log/raise "Can only read a File or a JarEntry" {:entry entry :type (type entry)})))
+
 (defn- attribute-installed? [conn attr]
   (some? (d/entity @conn [:db/ident attr])))
 
@@ -37,7 +47,7 @@
        d/q
        some?))
 
-(defn- get-jar [resource]
+(defn- get-jar ^JarFile [^URL resource]
   (-> (.getPath resource)
       (string/split #"!" 2)
       first
@@ -47,16 +57,16 @@
 (defmulti ^:private retrieve-file-list
   (fn [file-or-resource] (type file-or-resource)))
 
-(defmethod ^:private retrieve-file-list File [file]
+(defmethod ^:private retrieve-file-list File [^File file]
   (if (.exists file)
     (let [migration-files (file-seq file)
           xf (comp
-              (filter #(.isFile %))
-              (filter #(string/ends-with? (.getPath %) ".edn")))]
+              (filter (fn [^File f] (.isFile f)))
+              (filter (fn [^File f] (string/ends-with? (.getPath f) ".edn"))))]
       (into [] xf migration-files))
     (log/raise (format "Norms folder %s does not exist." (str file)) {:folder file})))
 
-(defmethod ^:private retrieve-file-list URL [resource]
+(defmethod ^:private retrieve-file-list URL [^URL resource]
   (if resource
     (let [abs-path (.getPath resource)
           last-path-segment (-> abs-path (string/split #"/") peek)]
@@ -64,11 +74,12 @@
         (->> (get-jar resource)
              .entries
              enumeration-seq
-             (filter #(and (string/starts-with? (.getName %) last-path-segment)
-                           (not (.isDirectory %))
-                           (string/ends-with? % ".edn"))))
+             (filter (fn [^JarEntry e]
+                       (and (string/starts-with? (.getName e) last-path-segment)
+                            (not (.isDirectory e))
+                            (string/ends-with? e ".edn")))))
         (->> (file-seq (io/file abs-path))
-             (filter #(not (.isDirectory %))))))
+             (filter (fn [^File f] (not (.isDirectory f)))))))
     (log/raise "Resource does not exist." {:resource (str resource)})))
 
 (defmethod ^:private retrieve-file-list :default [arg]
@@ -76,7 +87,7 @@
 
 (defn- filter-file-list [file-list]
   (filter #(and (string/ends-with? % ".edn")
-                (not (string/ends-with? (.getName %) checksums-file)))
+                (not (string/ends-with? (entry-name %) checksums-file)))
           file-list))
 
 (defn filename->keyword [filename]
@@ -87,7 +98,7 @@
 (defmulti ^:private read-edn-file
   (fn [file-or-entry _file-or-resource] (type file-or-entry)))
 
-(defmethod ^:private read-edn-file File [f _file]
+(defmethod ^:private read-edn-file File [^File f _file]
   (when (not (.exists f))
     (log/raise "Failed reading file because it does not exist" {:filename (str f)}))
   [(-> (slurp f)
@@ -95,7 +106,7 @@
    {:name (.getName f)
     :norm (filename->keyword (.getName f))}])
 
-(defmethod ^:private read-edn-file JarEntry [entry resource]
+(defmethod ^:private read-edn-file JarEntry [^JarEntry entry resource]
   (when (nil? resource)
     (log/raise "Failed reading resource because it does not exist" {:resource (str resource)}))
   (let [file-name (-> (.getName entry)
@@ -179,7 +190,7 @@
         norm-list (-> (filter-file-list file-list)
                       (read-norm-files resource))
         edn-content (-> (->> file-list
-                             (filter #(-> (.getName %) (string/ends-with? checksums-file)))
+                             (filter #(-> (entry-name %) (string/ends-with? checksums-file)))
                              first)
                         (read-edn-file resource)
                         first)]


### PR DESCRIPTION
perf: remove the reflective calls from the native build

Compiling every namespace under src/ with *warn-on-reflection* reports 27
warnings, 25 of them ours. Reflection is a latency cost on the JVM, but under
native-image it is a correctness cost: a reflective call only works if the
target was registered for reflection at build time, so these are the shape of
failure that shows up as a runtime error in the binary rather than at compile
time.

datahike/norm/norm.clj (16) — the multimethods dispatch on File, URL and
JarEntry but never hint the parameter they just dispatched on, so every
interop call in the bodies reflects. Hinted them, and the anonymous fns in the
filters with them.

filter-file-list and verify-checksums are the exception: retrieve-file-list
yields Files for a folder and JarEntries for a resource inside a jar, so no
single hint is right and .getName there is genuinely polymorphic across two
unrelated classes. Added an entry-name helper that dispatches on instance?.

datahike/audit.cljc (6) and datahike/migrate/store.cljc (2) — both inside
go-try-. The go macro rewrites locals into its state-machine array, which
drops their type hints; store.cljc already carried ^bytes hints at the call
site and still reflected, with the warning pointing at the enclosing loop
rather than the alength. So the hint has to live somewhere the transform
cannot reach: a byte-count function for store.cljc, and atoms in place of
volatiles for audit.cljc, since vswap! inlines .deref/.reset while swap! is an
ordinary call.

datahike/gc.cljc (1) — java.util.Date has no (Object) constructor and the
argument was the result of arithmetic on Objects. Coerced to long.

The remaining 2 are Leaf and Branch constructors in persistent-sorted-set,
fixed upstream separately.

Verified: the same sweep over all 102 namespaces now reports 0 for datahike.
norm (4 tests), migrate (277 tests), audit-verify (16) and the three gc
namespaces (33) all pass, and bb format and bb lint are clean.

The jar branch of norm.clj has no test coverage and this touches it, so it was
also exercised directly: a jar built from the simple-test resources, resolved
through io/resource, gives the same verify-checksums result and migrates the
same two norms before and after the change.
