### PR TITLE
ci: let build-tooling changes trigger a native build

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+    # NOT bb/**: bb/src/tools/build.clj is the native build itself -- it is
+    # what invokes javac and native-image. Ignoring it meant a change to how
+    # we build the image could not trigger a build of the image, which is
+    # exactly backwards. #1010 fixed three Windows bugs in that file and
+    # touched nothing else, so it merged without a single native build running.
     paths-ignore:
       - '**/README.md'
       - 'doc/**'
       - '.circleci/**'
-      - 'bb/**'
       - 'dev/**'
       - 'examples/**'
       - 'test/**'


### PR DESCRIPTION
ci: let build-tooling changes trigger a native build

`bb/**` was in the native-image workflow's `paths-ignore`, but
`bb/src/tools/build.clj` is the native build — it is the code that invokes
javac and native-image. Excluding it means a change to how we build the image
cannot trigger a build of the image.

That is not hypothetical. #1010 fixed three Windows-specific bugs in exactly
that file and touched nothing else, so no native build ran for it and the fix
is sitting on main unverified. There is no workflow run for 73c32787 at all.

Merging this triggers a run (the workflow file itself is not ignored), which
is what will finally exercise those Windows fixes.
