### PR TITLE
ci: make the native-image tests run on Windows

### DIFF
--- a/bb/resources/native-image-tests/run-bb-pod-tests.clj
+++ b/bb/resources/native-image-tests/run-bb-pod-tests.clj
@@ -1,10 +1,14 @@
 #!/usr/bin/env bb
 
 (require '[babashka.pods :as pods]
+         '[babashka.fs :as fs]
          '[clojure.test :refer [run-tests deftest testing is]])
 (import '[java.util Date])
 
-(pods/load-pod "./dthk")
+;; native-image appends .exe on Windows; the rest of the tree spells it dthk.
+;; Same lookup as tools.test/cli-binary.
+(pods/load-pod (or (first (filter fs/exists? ["./dthk" "./dthk.exe"]))
+                   (throw (ex-info "No dthk binary; run 'bb ni-cli' first." {}))))
 
 (require '[datahike.pod :as d])
 

--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -7,7 +7,19 @@ set -o pipefail
 DTHK=./dthk
 [ -x "$DTHK" ] || DTHK=./dthk.exe
 
-TMPSTORE=/tmp/dh-test-store
+# Everything this script writes lives under the repo, NOT under /tmp. The store
+# paths travel inside the edn configs and are read by the native binary, which
+# on Windows is an ordinary Windows program: it resolves an absolute POSIX path
+# like /tmp/dh-test-store to \tmp\dh-test-store on the current drive, which does
+# not exist. That is what "Error executing command: \tmp" was. Relative paths
+# resolve the same way on every platform, so this needs no branching.
+TESTDIR=./target/native-image-tests
+mkdir -p "$TESTDIR"
+
+TMPSTORE=$TESTDIR/dh-test-store
+CBOR_STORE=$TESTDIR/dh-cbor-writer-store
+CBOR_OUT_FILE=$TESTDIR/cbor-out
+CBOR_SERVER_LOG=$TESTDIR/cbor-server.log
 CONFIG=bb/resources/native-image-tests/testconfig.edn
 ATTR_REF_CONFIG=bb/resources/native-image-tests/testconfig.attr-refs.edn
 
@@ -82,8 +94,8 @@ fi
 "$DTHK" metrics db:$CONFIG
 
 # test serialization
-"$DTHK" query '[:find ?e . :where [?e :name ?n]]' db:$CONFIG --format cbor >> /tmp/test
-"$DTHK" query '[:find ?i :in $ ?i . :where [?e :name ?n]]' db:$CONFIG cbor:/tmp/test # => 1
+"$DTHK" query '[:find ?e . :where [?e :name ?n]]' db:$CONFIG --format cbor >> "$CBOR_OUT_FILE"
+"$DTHK" query '[:find ?i :in $ ?i . :where [?e :name ?n]]' db:$CONFIG cbor:$CBOR_OUT_FILE # => 1
 
 # CBOR through a POPULATED registry, which the two lines above do not reach:
 # they use the empty interop registry, so no tag-27 record is ever constructed.
@@ -92,11 +104,26 @@ fi
 # It is worth its own step because boring's record fallbacks fail SILENTLY
 # under a closed-world image rather than erroring.
 CBOR_CONFIG=bb/resources/native-image-tests/testconfig.cbor-writer.edn
+
+# This leg needs a JVM server, so it needs the Clojure CLI callable FROM THIS
+# SHELL. On Windows the CLI is a PowerShell module and Git Bash cannot see it,
+# while `bb` (which invoked this script) can. Rather than assume either way,
+# ask: where `clojure` resolves the leg runs, and where it does not the skip is
+# announced instead of quietly shrinking the suite. Both macOS legs run it, so
+# the path stays covered.
+if ! command -v clojure > /dev/null 2>&1
+then
+  echo "SKIPPING CBOR remote-writer test: no 'clojure' on PATH in this shell."
+  echo "  The rest of this script exercises CBOR with the EMPTY interop"
+  echo "  registry; what goes uncovered here is tag-27 record construction"
+  echo "  through a populated one. Covered on the macOS legs."
+else
+
 clojure -M:http-server \
         bb/resources/native-image-tests/cbor-server-config.edn \
-        > /tmp/dh-cbor-server.log 2>&1 &
+        > "$CBOR_SERVER_LOG" 2>&1 &
 CBOR_SERVER_PID=$!
-trap "rm -rf $TMPSTORE /tmp/dh-cbor-writer-store; kill $CBOR_SERVER_PID 2>/dev/null || true" EXIT
+trap "rm -rf $TMPSTORE $CBOR_STORE; kill $CBOR_SERVER_PID 2>/dev/null || true" EXIT
 
 # The server binds asynchronously; poll rather than sleeping a guessed interval.
 # The budget is generous on purpose: measured at 79s locally with a warm ~/.m2,
@@ -109,8 +136,8 @@ for _ in $(seq 1 240); do
 done
 if [ -z "$SERVER_UP" ]
 then
-  echo "Exception: CBOR test server never came up; see /tmp/dh-cbor-server.log"
-  cat /tmp/dh-cbor-server.log
+  echo "Exception: CBOR test server never came up; see $CBOR_SERVER_LOG"
+  cat "$CBOR_SERVER_LOG"
   exit 1
 fi
 
@@ -126,7 +153,9 @@ else
 fi
 "$DTHK" delete-database edn:$CBOR_CONFIG
 kill $CBOR_SERVER_PID 2>/dev/null || true
-trap "rm -rf $TMPSTORE /tmp/dh-cbor-writer-store" EXIT
+trap "rm -rf $TMPSTORE $CBOR_STORE" EXIT
+
+fi
 
 # test arbitrary :in[puts] as positional args
 QUERY_OUT=`"$DTHK" query '[:find (pull ?e [*]) . :in $ ?name :where [?e :name ?name]]' db:$CONFIG '"Judea"'`

--- a/bb/resources/native-image-tests/testconfig.attr-refs.edn
+++ b/bb/resources/native-image-tests/testconfig.attr-refs.edn
@@ -1,5 +1,5 @@
 {:store  {:backend :file
-          :path "/tmp/dh-test-store"
+          :path "target/native-image-tests/dh-test-store"
           :id #uuid "650e8400-e29b-41d4-a716-446655440001"}
  :keep-history? true
  :attribute-refs? true

--- a/bb/resources/native-image-tests/testconfig.cbor-writer.edn
+++ b/bb/resources/native-image-tests/testconfig.cbor-writer.edn
@@ -10,7 +10,7 @@
 ;; SILENTLY under a closed-world image, returning a carrier or an empty
 ;; registry rather than an error.
 {:store  {:backend :file
-          :path "/tmp/dh-cbor-writer-store"
+          :path "target/native-image-tests/dh-cbor-writer-store"
           :id #uuid "550e8400-e29b-41d4-a716-44665544cb02"}
  :keep-history? true
  :schema-flexibility :read

--- a/bb/resources/native-image-tests/testconfig.edn
+++ b/bb/resources/native-image-tests/testconfig.edn
@@ -1,5 +1,5 @@
 {:store  {:backend :file
-          :path "/tmp/dh-test-store"
+          :path "target/native-image-tests/dh-test-store"
           :id #uuid "550e8400-e29b-41d4-a716-446655440000"}
  :keep-history? true
  :schema-flexibility :read}

--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -82,7 +82,10 @@
 
 (defn bb-pod []
   (if (cli-binary)
-    (p/shell "./bb/resources/native-image-tests/run-bb-pod-tests.clj")
+    ;; Through `bb` rather than executed directly, for the same reason
+    ;; `native-image` goes through bash: the script carries a shebang, and
+    ;; Windows does not honour one.
+    (p/shell "bb" "./bb/resources/native-image-tests/run-bb-pod-tests.clj")
     (do (println "Native image cli missing. Please run 'bb ni-cli' and try again.")
         (System/exit 1))))
 


### PR DESCRIPTION
ci: make the native-image tests run on Windows

The Windows native image now BUILDS — `dthk.exe`, 139MB, 7m48s, and both
macOS legs are green too. What fails is the test step, in three places, none
of them to do with the compiler.

**The store paths were absolute POSIX paths.** `testconfig.edn` and its two
siblings carried `:path "/tmp/dh-test-store"`. The native binary on Windows is
an ordinary Windows program, so Java resolves that to `\tmp\dh-test-store` on
the current drive, which does not exist. It surfaced as the near-contentless
`❌ Error executing command: \tmp`, one line, before any test ran.

Everything the script writes now lives under `./target/native-image-tests`,
which is already gitignored. Relative paths resolve the same way on all three
platforms, so no branching is needed — and the same move fixes `cbor:/tmp/test`,
which was an absolute POSIX path handed to a native binary as an ARGUMENT,
exactly the shape MSYS mangles.

**`bb test bb-pod` executed a .clj by shebang.** Windows does not honour one, so
babashka reported `Cannot resolve program:`. Invoked through `bb` now, for the
same reason `native-image` already goes through `bash`.

**The pod test hardcoded `./dthk`.** native-image writes `dthk.exe` there.
`tools.test/cli-binary` already handles this; the pod script now does the same
lookup and fails with an actionable message rather than a pod-loading error.

## The CBOR remote-writer leg

It needs a JVM server, so it needs the Clojure CLI callable FROM THE SHELL the
script runs in. On Windows the CLI is a PowerShell module that Git Bash cannot
see, while `bb` — which invoked the script — can. Rather than assume either
way, the script asks: where `clojure` resolves the leg runs, and where it does
not the skip is ANNOUNCED, naming what goes uncovered. Both macOS legs run it,
so tag-27 record construction through a populated registry stays covered. If
`clojure` does turn out to resolve on the runner, Windows runs it too with no
further change.

## Verified

Run end-to-end on Linux against a real dthk binary: `Test successful.`, the
history/since/asof queries, pull, pull-many, entity, datoms, schema,
reverse-schema, metrics, and the CBOR round-trip all pass with the new relative
paths, and the CBOR server leg starts and is polled as before.

The pod change was checked for equivalence rather than just for running: the
old direct invocation and the new `bb` one produce identical output — 21
assertions, same result — so nothing about the Linux path moved.

The binary to hand was an older build, which is why the tail of each run
disagrees with current expectations (`:writer-ownership :shared`, and a store
written by a newer persistent-sorted-set). Those are artifacts of the stale
binary, identical before and after this change, not of anything here.
