### PR TITLE
feat: compile S3 into dthk

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -191,16 +191,44 @@
            :native-cli {:main-opts ["-e" "(set! *warn-on-reflection* true)"
                                     "-m" "clj.native-image" "datahike.cli"
                                     "--initialize-at-build-time"
+                                    ;; X-Ray is a hard dependency of konserve-s3 and
+                                    ;; its build-time init fails against modern
+                                    ;; Jackson. Only the tracing interceptor needs
+                                    ;; it, and that is opt-in via :x-ray?, so
+                                    ;; deferring the whole package costs nothing a
+                                    ;; store without tracing would notice.
+                                    "--initialize-at-run-time=com.amazonaws.xray"
                                     "--no-fallback"
+                                    ;; The S3 endpoint rules engine resolves an
+                                    ;; endpoint through `RuleUrl.parse`, which calls
+                                    ;; `new java.net.URL(..)`. A native image
+                                    ;; registers no URL protocol handlers by default,
+                                    ;; so that throws MalformedURLException and the
+                                    ;; SDK reports it as "Custom endpoint <uri> was
+                                    ;; not a valid URI" -- which reads like a bad
+                                    ;; config rather than a missing handler.
+                                    "--enable-url-protocols=http,https"
                                     "-H:IncludeResources=DATAHIKE_VERSION"
                                     ; "--future-defaults=all"
-                                    "-J-Xmx4g"
+                                    ;; 5g, not 4g: pulling in konserve-s3 brings the
+                                    ;; AWS SDK with it, and the analysis then needs
+                                    ;; more than 4g. It does not fail cleanly at that
+                                    ;; budget -- the builder thrashes and the deadlock
+                                    ;; watchdog aborts it, which reads like a hang
+                                    ;; rather than OOM.
+                                    "-J-Xmx5g"
                                     "-o dthk"]
                         :jvm-opts  ["-Dclojure.compiler.direct-linking=true"]
                         :extra-deps
                          {clj.native-image/clj.native-image
                          {:git/url "https://github.com/taylorwood/clj.native-image.git"
                           :sha     "4604ae76855e09cdabc0a2ecc5a7de2cc5b775d6"}
+                         ;; S3 in the binary. 0.1.39 or newer is REQUIRED, not
+                         ;; merely preferred: before it every S3 call resolved
+                         ;; reflectively, which a native image cannot do unless
+                         ;; the target was registered at build time. The image
+                         ;; built and then died on the first client construction.
+                         org.replikativ/konserve-s3 {:mvn/version "0.1.39"}
                          com.cognitect/transit-clj {:mvn/version "1.1.363"}
                          babashka/pods             {:git/url "https://github.com/babashka/pods"
                                                     :git/sha "ed5e1f3390b9dfca564f66b6e79c739c3cd82d78"}}}

--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -6,6 +6,10 @@
             [clojure.tools.cli :refer [parse-opts]]
             [datahike.api :as d]
             [datahike.query.execute]
+            ;; Backends register with defmethod, so the namespace has to be
+            ;; loaded for :s3 to exist as a dispatch value at all. Nothing
+            ;; else here references it, which is why it needs naming.
+            [konserve-s3.core]
             [datahike.pod :refer [run-pod]]
             [datahike.codegen.cli :as cli-gen]
             [clojure.edn :as edn]


### PR DESCRIPTION
feat: compile S3 into dthk

`dthk` could open :memory, :file and :tiered stores. This adds :s3, so the
binary can drive a serverless database with nothing but a bucket behind it.

konserve-s3 goes in the `:native-cli` deps, and `datahike.cli` names
`konserve-s3.core` — backends register with `defmethod`, so nothing makes `:s3`
a dispatch value unless the namespace is loaded, and nothing else in the CLI
references it.

## Three things it needed beyond the dependency

**konserve-s3 0.1.39 or newer, and that is a hard requirement.** An earlier
attempt at this stalled here: the image built and then died on the first client
construction, because every S3 call in that backend resolved reflectively, and
a native image can only make a reflective call if the target was registered at
build time. konserve-s3#19 fixed those 45 call sites; without it this change
does not work at all.

**`--enable-url-protocols=http,https`.** The S3 endpoint rules engine resolves
an endpoint through `DefaultS3EndpointProvider` -> `RuleUrl.parse`, which calls
`new java.net.URL(..)`. A native image registers no URL protocol handlers by
default, so that throws MalformedURLException, and the SDK reports it as

    Custom endpoint `http://localhost:9000` was not a valid URI

which reads like a bad config rather than a missing handler. The same config
works on the JVM, which is what narrowed it down.

**`-J-Xmx5g`, up from 4g.** The AWS SDK pushes the analysis past 4g, and it
does not fail cleanly there: the builder thrashes and the deadlock watchdog
aborts it, so it looks like a hang rather than an OOM. 5g is the budget
`ni-compile` already uses for libdatahike, so CI is known to have the headroom.

X-Ray stays deferred to run time (`--initialize-at-run-time=com.amazonaws.xray`):
it is a hard dependency of konserve-s3 whose build-time init fails against
modern Jackson, and only the tracing interceptor touches it, which is opt-in
via `:x-ray?`.

## Cost

180.6MB, against 134.8MB for a pre-S3 build of the same CLI on this machine.
Roughly +46MB for a binary that can talk to any S3-compatible bucket.

## Verified against a real MinIO, not just built

The build succeeding proves nothing here — the previous attempt built too. So
the binary was driven end to end against MinIO on :9000 (the container from
konserve-s3's docker-compose.yml):

    create-database   -> refuses, store already exists (a real round trip)
    database-exists   -> true
    transact          -> 3 entities, tx-report with datoms and a commit id
    query count       -> 3
    query + pull      -> {:db/id 2, :name "Grace"}
    history query     -> 3
    metrics           -> per-attr and per-entity counts

and the objects were confirmed present in the bucket afterwards: 13 `.ksv`
objects under the store id, timestamped from both the JVM and the native runs.

`bb test native-image` also passes in full with this binary, exit 0 — including
the CBOR remote-writer leg — so the non-S3 paths are unaffected.
