### PR TITLE
Revert "feat: compile S3 into dthk (#1015)"

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -191,44 +191,16 @@
            :native-cli {:main-opts ["-e" "(set! *warn-on-reflection* true)"
                                     "-m" "clj.native-image" "datahike.cli"
                                     "--initialize-at-build-time"
-                                    ;; X-Ray is a hard dependency of konserve-s3 and
-                                    ;; its build-time init fails against modern
-                                    ;; Jackson. Only the tracing interceptor needs
-                                    ;; it, and that is opt-in via :x-ray?, so
-                                    ;; deferring the whole package costs nothing a
-                                    ;; store without tracing would notice.
-                                    "--initialize-at-run-time=com.amazonaws.xray"
                                     "--no-fallback"
-                                    ;; The S3 endpoint rules engine resolves an
-                                    ;; endpoint through `RuleUrl.parse`, which calls
-                                    ;; `new java.net.URL(..)`. A native image
-                                    ;; registers no URL protocol handlers by default,
-                                    ;; so that throws MalformedURLException and the
-                                    ;; SDK reports it as "Custom endpoint <uri> was
-                                    ;; not a valid URI" -- which reads like a bad
-                                    ;; config rather than a missing handler.
-                                    "--enable-url-protocols=http,https"
                                     "-H:IncludeResources=DATAHIKE_VERSION"
                                     ; "--future-defaults=all"
-                                    ;; 5g, not 4g: pulling in konserve-s3 brings the
-                                    ;; AWS SDK with it, and the analysis then needs
-                                    ;; more than 4g. It does not fail cleanly at that
-                                    ;; budget -- the builder thrashes and the deadlock
-                                    ;; watchdog aborts it, which reads like a hang
-                                    ;; rather than OOM.
-                                    "-J-Xmx5g"
+                                    "-J-Xmx4g"
                                     "-o dthk"]
                         :jvm-opts  ["-Dclojure.compiler.direct-linking=true"]
                         :extra-deps
                          {clj.native-image/clj.native-image
                          {:git/url "https://github.com/taylorwood/clj.native-image.git"
                           :sha     "4604ae76855e09cdabc0a2ecc5a7de2cc5b775d6"}
-                         ;; S3 in the binary. 0.1.39 or newer is REQUIRED, not
-                         ;; merely preferred: before it every S3 call resolved
-                         ;; reflectively, which a native image cannot do unless
-                         ;; the target was registered at build time. The image
-                         ;; built and then died on the first client construction.
-                         org.replikativ/konserve-s3 {:mvn/version "0.1.39"}
                          com.cognitect/transit-clj {:mvn/version "1.1.363"}
                          babashka/pods             {:git/url "https://github.com/babashka/pods"
                                                     :git/sha "ed5e1f3390b9dfca564f66b6e79c739c3cd82d78"}}}

--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -6,10 +6,6 @@
             [clojure.tools.cli :refer [parse-opts]]
             [datahike.api :as d]
             [datahike.query.execute]
-            ;; Backends register with defmethod, so the namespace has to be
-            ;; loaded for :s3 to exist as a dispatch value at all. Nothing
-            ;; else here references it, which is why it needs naming.
-            [konserve-s3.core]
             [datahike.pod :refer [run-pod]]
             [datahike.codegen.cli :as cli-gen]
             [clojure.edn :as edn]


### PR DESCRIPTION
Revert "feat: compile S3 into dthk (#1015)"

This reverts #1015. It broke the native builds on Windows and macOS-intel:

    Class initialization of com.amazonaws.xray.AWSXRay failed.
    Caused by: java.lang.NoSuchFieldError: Class
      com.fasterxml.jackson.databind.PropertyNamingStrategy does not have
      member field 'CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES'

X-Ray 2.13 reads a Jackson field that modern Jackson removed, so any X-Ray
class touched at build time dies. `--initialize-at-run-time=com.amazonaws.xray`
was meant to keep it away from build-time init, and it does so on my machine
(GraalVM 25.0.1) — it does not in CI (25.0.2), where reflection registration
pulls `AWSXRay` in and initializes it anyway. So the option I verified against
is not the option CI runs.

That is my mistake and worth naming precisely: I built and ran the S3 image
locally, against real MinIO, and treated a green local build as evidence the
build was portable. It was evidence the image WORKS, not that it BUILDS
everywhere, and the native-image workflow does not run on Linux — so no leg of
CI covered the platform I tested on.

Chasing this class by class is the wrong fix; each X-Ray class reachable at
build time fails the same way, and the list is not ours to enumerate. The right
fix is for konserve-s3 to stop importing `TracingInterceptor` at namespace
level, so X-Ray can be excluded from the native dependency entirely rather than
deferred. That is a change to konserve-s3, a release, and then this again on
top — done in that order rather than held open while main is red and releasing.

Reverted wholesale rather than partially: the `-J-Xmx5g` bump and
`--enable-url-protocols=http,https` are only needed because of S3, and both are
findings worth keeping in the reinstating PR rather than left behind as
unexplained settings.
