### PR TITLE
fix: exclude X-Ray from the native build instead of deferring it

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -191,13 +191,6 @@
            :native-cli {:main-opts ["-e" "(set! *warn-on-reflection* true)"
                                     "-m" "clj.native-image" "datahike.cli"
                                     "--initialize-at-build-time"
-                                    ;; X-Ray is a hard dependency of konserve-s3 and
-                                    ;; its build-time init fails against modern
-                                    ;; Jackson. Only the tracing interceptor needs
-                                    ;; it, and that is opt-in via :x-ray?, so
-                                    ;; deferring the whole package costs nothing a
-                                    ;; store without tracing would notice.
-                                    "--initialize-at-run-time=com.amazonaws.xray"
                                     "--no-fallback"
                                     ;; The S3 endpoint rules engine resolves an
                                     ;; endpoint through `RuleUrl.parse`, which calls
@@ -223,12 +216,27 @@
                          {clj.native-image/clj.native-image
                          {:git/url "https://github.com/taylorwood/clj.native-image.git"
                           :sha     "4604ae76855e09cdabc0a2ecc5a7de2cc5b775d6"}
-                         ;; S3 in the binary. 0.1.39 or newer is REQUIRED, not
-                         ;; merely preferred: before it every S3 call resolved
-                         ;; reflectively, which a native image cannot do unless
-                         ;; the target was registered at build time. The image
-                         ;; built and then died on the first client construction.
-                         org.replikativ/konserve-s3 {:mvn/version "0.1.39"}
+                         ;; S3 in the binary. 0.1.40 or newer is REQUIRED, for two
+                         ;; separate reasons: before 0.1.39 every S3 call resolved
+                         ;; reflectively, which a native image cannot do unless the
+                         ;; target was registered at build time (the image built and
+                         ;; then died on the first client construction); and 0.1.40
+                         ;; stops importing X-Ray's TracingInterceptor at namespace
+                         ;; level, which is what makes the exclusion below possible.
+                         ;;
+                         ;; X-Ray is EXCLUDED rather than deferred. It is opt-in
+                         ;; (`:x-ray?`), which dthk never sets, and its 2.x recorder
+                         ;; reads a Jackson field this classpath no longer has —
+                         ;; jsonista pulls Jackson to 2.21.x here, konserve-s3 alone
+                         ;; resolves 2.12.x, so the clash exists only in combination.
+                         ;; `--initialize-at-run-time` was tried and is not
+                         ;; dependable: it loses to the reflection registration in
+                         ;; X-Ray's own META-INF/native-image config, and whether it
+                         ;; loses differs by builder — the same source built on
+                         ;; Oracle GraalVM 25.0.1 and failed on GraalVM Community in
+                         ;; CI. Excluding the jar removes the question.
+                         org.replikativ/konserve-s3 {:mvn/version "0.1.40"
+                                                     :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
                          com.cognitect/transit-clj {:mvn/version "1.1.363"}
                          babashka/pods             {:git/url "https://github.com/babashka/pods"
                                                     :git/sha "ed5e1f3390b9dfca564f66b6e79c739c3cd82d78"}}}


### PR DESCRIPTION
fix: exclude X-Ray from the native build instead of deferring it

Fixes the native builds broken by #1015 — Windows, macOS-intel and both Linux
legs — without giving up S3 in dthk.

    Class initialization of com.amazonaws.xray.AWSXRay failed
    Caused by: NoSuchFieldError: PropertyNamingStrategy does not have member
      field CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES

## What was actually wrong

Two things, and I had only found the first when #1015 landed.

**The Jackson clash is real, and only exists in combination.** Reproduced on the
JVM, no native image involved: X-Ray 2.13 + Jackson 2.21.2 throws
NoSuchFieldError; X-Ray 2.18.2 + Jackson 2.21.2 does not. konserve-s3 on its own
resolves Jackson 2.12.7.2, which still has that field — this classpath converges
it to 2.21.x through metosin/jsonista. So konserve-s3's own CI could never have
caught it.

**`--initialize-at-run-time` is not a dependable answer.** It loses to the
reflection registration in X-Ray's own META-INF/native-image config, and whether
it loses depends on the builder: the identical source, flag and Jackson built on
Oracle GraalVM 25.0.1 locally and failed on GraalVM Community in CI. That is the
mistake behind #1015 — I verified the image WORKED, on the one platform no CI
leg covers, and took that as evidence it would BUILD everywhere.

## The fix

konserve-s3 0.1.40 stops importing `TracingInterceptor` at namespace level
(konserve-s3#20), so X-Ray can be excluded outright rather than deferred. It is
opt-in through `:x-ray?`, which dthk never sets. `--initialize-at-run-time` is
dropped: with no X-Ray on the classpath there is nothing to initialize, which is
a structural fix rather than a bet on builder behaviour.

`--enable-url-protocols=http,https` and `-J-Xmx5g` stay. Both are independently
verified and unrelated: the S3 endpoint rules engine resolves through
`RuleUrl.parse` -> `new java.net.URL(..)`, and the AWS SDK pushes the analysis
past 4g, where the builder thrashes and the watchdog aborts rather than
reporting an OOM.

## Verified here

X-Ray is gone from the `:native-cli` classpath (0 jars), konserve-s3 resolves to
0.1.40, and `datahike.cli` still loads with `konserve-s3.core` on it — so `:s3`
is still a live backend and the class that broke the build is absent:

    :CLI-LOADED true  :KONSERVE-S3-LOADED true  :XRAY-ABSENT true

Deliberately NOT claiming a green build from my machine this time. Local success
is what misled me before; the four CI legs are the check that matters, and this
supersedes the revert in #1017.
