### PR TITLE
fix: give the libdatahike build the S3 backend it now has to compile

### DIFF
--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -125,6 +125,11 @@
                "-J-Dclojure.compiler.direct-linking=true"
                (str "-H:IncludeResources=" (version/string repo-config))
                "--initialize-at-build-time"
+               ;; Same reason as :native-cli in deps.edn: the S3 endpoint rules
+               ;; engine resolves through `RuleUrl.parse`, which calls
+               ;; `new java.net.URL(..)`, and a native image registers no URL
+               ;; protocol handlers by default.
+               "--enable-url-protocols=http,https"
                "-H:Log=registerResource:"
                "--verbose"
                "--no-fallback"]

--- a/deps.edn
+++ b/deps.edn
@@ -185,8 +185,20 @@
                                       org.slf4j/slf4j-simple  {:mvn/version "2.0.18"}}
                          :main-opts ["-m" "datahike.http.server"]}
 
+           ;; konserve-s3 is here for the same reason it is in :native-cli, and it
+           ;; is NOT optional: `datahike.cli` requires `konserve-s3.core`
+           ;; statically (a backend registers by defmethod, so nothing makes :s3
+           ;; a dispatch value unless the namespace loads), and `bb ni-compile`
+           ;; AOT-compiles that namespace. Without it here the libdatahike build
+           ;; fails to compile datahike.cli at all — which is what broke every
+           ;; native leg after #1015, on a path #1015 never exercised.
+           ;;
+           ;; X-Ray excluded, as in :native-cli — see the note there.
            :libdatahike {:main-opts ["-e" "(set! *warn-on-reflection* true)"]
-                         :extra-paths ["libdatahike/src"]}
+                         :extra-paths ["libdatahike/src"]
+                         :extra-deps {org.replikativ/konserve-s3
+                                      {:mvn/version "0.1.40"
+                                       :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}}}
 
            :native-cli {:main-opts ["-e" "(set! *warn-on-reflection* true)"
                                     "-m" "clj.native-image" "datahike.cli"


### PR DESCRIPTION
fix: give the libdatahike build the S3 backend it now has to compile

All three native legs still fail after #1018, at a different step:

    Build libdatahike
    Could not locate konserve_s3/core__init.class, konserve_s3/core.clj or
    konserve_s3/core.cljc on classpath
      at datahike.cli/loading (cli.clj:1)

#1015 added a static `[konserve-s3.core]` require to `datahike.cli` — needed,
because a backend registers by `defmethod` and nothing makes `:s3` a dispatch
value unless that namespace loads, and because `requiring-resolve` would hide it
from native-image reachability. But it put konserve-s3 only on `:native-cli`.
`bb ni-compile` AOT-compiles `datahike.cli` too, under `:libdatahike`, where it
is not on the classpath.

So `bb ni-cli` was green and `bb ni-compile` was red — one alias short. I had
only ever exercised the CLI path, on one platform.

## The fix

konserve-s3 0.1.40 on `:libdatahike` as well, with the same X-Ray exclusion, and
`--enable-url-protocols=http,https` added to the libdatahike native-image
invocation for the reason it is on the CLI one: the S3 endpoint rules engine
resolves through `RuleUrl.parse` -> `new java.net.URL(..)`, and a native image
registers no URL protocol handlers by default. libdatahike gets S3 out of this
too, which is the same value dthk gets — one shared library that can open a
bucket, for the Python and C ABI consumers.

## Verified at the exact failure point this time

Reproduced first, then fixed, rather than inferred:

    before:  clojure -M:libdatahike -e "(require 'datahike.cli)"
             -> Could not locate konserve_s3/core...      (the CI error)
    after:   -> :COMPILED

`bb ni-compile` now gets through "Compiling Clojure namespaces ... Done" and
"Packaging uber jar ... Done" — the step that failed in CI — and stops only on
GRAALVM_HOME being unset in my shell.

X-Ray remains absent from both classpaths: 0 jars under `:libdatahike` and 0
under `:native-cli`.

The jar build is unaffected: it does not resolve konserve-s3 and shipped fine
from #1015 (0.8.1825) with this same require already in place.

Still not claiming a green image from here — the four CI legs are the check,
and that is twice now that a path I did not run is where this broke.
