### PR TITLE
ci: say where the native-image tests are running when Windows fails

### DIFF
--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -16,6 +16,23 @@ DTHK=./dthk
 TESTDIR=./target/native-image-tests
 mkdir -p "$TESTDIR"
 
+# The binary is a native Windows program, so it resolves a relative path against
+# ITS notion of the working directory, not Git Bash's. Those agree here, but the
+# agreement is an assumption and it is the assumption that failed: a run whose
+# very first command died with
+#
+#     Error executing command: target\native-image-tests
+#
+# i.e. the store's PARENT reported missing, immediately after this `mkdir -p`
+# reported success. So say where we are and what is actually on disk; a
+# one-line failure with no context cost two CI rounds already.
+echo "native-image tests: cwd=$(pwd) testdir=$TESTDIR"
+if [ ! -d "$TESTDIR" ]; then
+  echo "Exception: $TESTDIR does not exist after mkdir -p."
+  ls -la . || true
+  exit 1
+fi
+
 TMPSTORE=$TESTDIR/dh-test-store
 CBOR_STORE=$TESTDIR/dh-cbor-writer-store
 CBOR_OUT_FILE=$TESTDIR/cbor-out


### PR DESCRIPTION
ci: say where the native-image tests are running when Windows fails

macOS is green again after #1019. Windows fails on the FIRST command of
run-native-image-tests with one line and no context:

    ❌ Error executing command: target\native-image-tests

That is the store's PARENT reported missing — the same shape as the `\tmp`
failure #1014 fixed — except this time the directory is created by
`mkdir -p "$TESTDIR"` sixteen lines earlier, under `set -o errexit`, and macOS
runs the identical script.

I cannot tell from that line which of those is untrue, and I would rather not
guess a third time. What the log DOES settle is that the working directory is
right: dthk read `bb/resources/native-image-tests/testconfig.attr-refs.edn`, a
relative path, before it failed. So relative resolution works and the CWD is the
repo root.

This adds the context needed to tell the remaining possibilities apart — that
the directory was created somewhere else, that it was created and removed, or
that "missing" is not what the exception actually means:

    echo "native-image tests: cwd=$(pwd) testdir=$TESTDIR"
    if [ ! -d "$TESTDIR" ]; then
      echo "Exception: $TESTDIR does not exist after mkdir -p."
      ls -la .
      exit 1
    fi

No behaviour change on any platform that passes. Two CI rounds have now been
spent on a failure that printed a bare path, which is reason enough for the
script to say what it is looking at.
