### PR TITLE
ci: give the Windows native build the options the other platforms got

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -219,11 +219,22 @@
                          (do (run 'ni-cli-uber)
                              (let [jar (build/jar-path config (-> config :build :native-cli))
                                    ni (str (System/getenv "GRAALVM_HOME") "/bin/native-image.cmd")]
+                               ;; THESE MUST MATCH the :native-cli alias in
+                               ;; deps.edn. They are a hand-copied parallel of it
+                               ;; and have already drifted once: the alias moved
+                               ;; to 5g and gained --enable-url-protocols when S3
+                               ;; went in, this branch did not, and Windows spent
+                               ;; a CI round on the watchdog aborting a 4g build
+                               ;; (exit 30, "Maximum heap size: 3641") — after
+                               ;; which it would have shipped a binary whose S3
+                               ;; endpoint resolution cannot parse a URL.
+                               ;; Change one, change the other.
                                (shell ni "-jar" jar
                                       "--initialize-at-build-time"
                                       "--no-fallback"
+                                      "--enable-url-protocols=http,https"
                                       "-H:IncludeResources=DATAHIKE_VERSION"
-                                      "-J-Xmx4g"
+                                      "-J-Xmx5g"
                                       "-o" "dthk")))
                          (clojure "-M:native-cli"))}
 


### PR DESCRIPTION
ci: give the Windows native build the options the other platforms got

Windows fails earlier now — `Build native image`, before the tests the
diagnostics in #1020 were added for:

    Error: Image build request for 'dthk' failed with exit status 30
    === Used heap size: 3225
    === Maximum heap size: 3641
    === Image generator watchdog is aborting image generation

`Maximum heap size: 3641` is a 4g builder. The `:native-cli` alias says 5g. So
the flag never reached this build.

## Why: the Windows path is a hand-copied parallel

`ni-cli` branches on Windows (#1009) because clj.native-image passes the whole
classpath as `-cp`, which exceeds the 8191-character command line there; the
branch builds an uber jar and invokes native-image itself. In doing so it
re-states the option list rather than sharing it — and that copy has drifted.
When S3 went in, the alias gained `-J-Xmx5g` (the AWS SDK pushes the analysis
past 4g, where the builder thrashes and the watchdog aborts rather than
reporting an OOM) and `--enable-url-protocols=http,https` (the endpoint rules
engine resolves through `RuleUrl.parse` -> `new java.net.URL(..)`, and a native
image registers no URL protocol handlers). Neither reached the Windows branch.

That is worth stating plainly: this is the same S3 change failing a fourth time,
each time on a path the previous fix did not cover — first the class-init on
three platforms, then the libdatahike alias, now the Windows-only build branch.
The common thread is not the diagnosis each time, it is that a duplicated build
definition has no way to tell you it is out of date.

## The fix

Both options added to the Windows branch, and the two lists now agree exactly —
verified by extracting the flags from each and diffing them, not by reading:

    --enable-url-protocols=http,https   --initialize-at-build-time
    --no-fallback   -H:IncludeResources=DATAHIKE_VERSION   -J-Xmx5g

(`--future-defaults=all` appears in deps.edn but is commented out, so it is
absent from both.)

A comment on the branch names the alias it must track and records that it has
already drifted once. That is weaker than sharing one definition, which the two
mechanisms — a deps.edn `:main-opts` and a bb `shell` call — do not currently
allow without restructuring the Windows path. Worth doing separately; not worth
holding this behind, with main red.

The #1020 diagnostics stay: this build never reached them, so what they were
added to explain is still unexplained, and the test step will reach them next.
