### PR TITLE
cli: print the exception class, not only its message

### DIFF
--- a/src/datahike/cli.clj
+++ b/src/datahike/cli.clj
@@ -165,7 +165,15 @@
                       options)]
           (report (:format options) result))
         (catch Exception e
-          (println "❌ Error executing command:" (.getMessage e))
+          ;; Class AND message. A java.nio.file exception carries only the
+          ;; offending path as its message, so on its own the line reads as
+          ;; "Error executing command: target\native-image-tests" — a bare
+          ;; path that says nothing about whether it was missing, locked, or
+          ;; (as it was on Windows) a directory that cannot be fsynced. That
+          ;; one line cost five CI rounds; the class turns it into a diagnosis.
+          (println "❌ Error executing command:" (.getName (class e)) "-" (.getMessage e))
+          (when-let [cause (.getCause e)]
+            (println "   caused by:" (.getName (class cause)) "-" (.getMessage cause)))
           (when (>= (:verbosity options) 2)
             (.printStackTrace e))
           (exit 1 "")))


### PR DESCRIPTION
cli: print the exception class, not only its message

Five Windows CI rounds produced this line and nothing else:

    ❌ Error executing command: target\native-image-tests

A java.nio.file exception carries only the offending path as its message. So
that line cannot say whether the path was missing, locked, or — as it turned
out — a directory that Windows refuses to open as a FileChannel for an fsync
(AccessDeniedException). Every one of those was hypothesised in turn; the class
name would have settled it on the first round.

Now: class and message, plus the cause chain's first link when there is one.

    ❌ Error executing command: java.nio.file.AccessDeniedException - target\native-image-tests

Verbosity >= 2 still prints the full trace as before. Nothing else changes.
