### PR TITLE
deps: konserve 0.9.388 — the Windows delete-store fix

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,7 +13,13 @@
         ;; and hasch. Datahike compiles konserve into `dthk`, where a reflective
         ;; call resolves at run time and so works only if it was registered when
         ;; the image was built.
-        org.replikativ/konserve                     {:mvn/version "0.9.387"}
+        ;; 0.9.388: the file store no longer fails `delete-store` on Windows
+        ;; (konserve#186). It fsyncs the parent directory after removing an
+        ;; entry, Windows cannot open a directory as a channel, and the catch
+        ;; around it RETURNED the exception — which superv.async's <?- then
+        ;; re-threw. That was the whole of "Error executing command:
+        ;; target\native-image-tests", five Windows CI rounds long.
+        org.replikativ/konserve                     {:mvn/version "0.9.388"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}


### PR DESCRIPTION
deps: konserve 0.9.388 — the Windows delete-store fix

Picks up konserve#186. The file store fsyncs the parent directory after
removing an entry; Windows cannot open a directory as a FileChannel and throws
AccessDeniedException with the bare path as its message; and the catch around
that call returned the exception as a value, which superv.async's `<?-`
re-threw into datahike. That chain is the entirety of

    ❌ Error executing command: target\native-image-tests

on the first `dthk delete-database` of every Windows CI run since #1014 — five
rounds, each fixing the test harness around a bug that was not in it.

With #1022 the CLI now prints the exception class too, so a further failure
will name itself rather than printing a path.

Verified: the released 0.9.388 jar carries the tolerant `sync-base` and no
remaining `(catch Exception e e)`; `bb format` and `bb reflection` clean here.
The `migrate` suite (277 tests, heaviest user of the file store) is running and
its result will be posted on this PR. Windows CI is the real check.
