### PR TITLE
deps: konserve 0.9.389 — close the target before the move, and the hardening behind it

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,13 +13,17 @@
         ;; and hasch. Datahike compiles konserve into `dthk`, where a reflective
         ;; call resolves at run time and so works only if it was registered when
         ;; the image was built.
-        ;; 0.9.388: the file store no longer fails `delete-store` on Windows
-        ;; (konserve#186). It fsyncs the parent directory after removing an
-        ;; entry, Windows cannot open a directory as a channel, and the catch
-        ;; around it RETURNED the exception — which superv.async's <?- then
-        ;; re-threw. That was the whole of "Error executing command:
-        ;; target\native-image-tests", five Windows CI rounds long.
-        org.replikativ/konserve                     {:mvn/version "0.9.388"}
+        ;; 0.9.389 (konserve#187): the second Windows fix and a hardening of
+        ;; the whole file-store write path behind it. The target blob is closed
+        ;; before `.new` is moved over it — Windows refuses to replace an open
+        ;; file — and the review of that change found and fixed: a shared
+        ;; staging path two writers could interleave into (now per-writer);
+        ;; `dissoc` bypassing the sidecar fence; `k/revision` handing out a
+        ;; token without making the key fenceable; no truncation on shorter
+        ;; in-place writes; streaming writes ignoring short reads and returned
+        ;; counts; and Reader input splitting surrogate pairs. Six external
+        ;; review rounds; the last reported no remaining High or Medium.
+        org.replikativ/konserve                     {:mvn/version "0.9.389"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}


### PR DESCRIPTION
deps: konserve 0.9.389 — close the target before the move, and the hardening behind it

The second Windows fix. `create-database` failed on the first write:

    …\dh-test-store\03ac….ksv.new -> …\dh-test-store\03ac….ksv

`AccessDeniedException(source, target, null)` from `Files/move`: Windows
refuses to replace a file with an open handle, and konserve held the target
open — and locked — across the move. 0.9.389 releases both before the move.

The review of that change (six rounds, gpt-5.6-sol) found the release exposed
a shared staging path, and then kept going: per-writer staging names, `dissoc`
ordered by the sidecar fence, `k/revision` making the key fenceable, truncation
on shorter in-place writes, full writes with honest strides on JVM and Node,
Reader input encoded statefully. Final verdict: no remaining High or Medium.
konserve's suites: JVM 262 tests / 4302 assertions, Node 66 / 424, 0 failures.

Verified here: `bb format` and `bb reflection` clean; migrate suite result
posted on this PR. Windows CI is the real check.
