### PR TITLE
chore: one convention for temporary directories, resolvable off POSIX

### DIFF
--- a/bb/src/tools/reflection.clj
+++ b/bb/src/tools/reflection.clj
@@ -62,10 +62,19 @@
             (System/exit 1))
         form (str "(set! *warn-on-reflection* true)"
                   "(doseq [n '" (pr-str (vec (map symbol nses))) "]"
-                  "  (try (require n) (catch Throwable _ nil)))")
+                  "  (require n))")
         _ (println (format "Compiling %d namespaces with *warn-on-reflection*..."
                            (count nses)))
-        {:keys [err]} (p/sh "clojure" "-M:libdatahike" "-e" form)
+        {:keys [err exit]} (p/sh "clojure" "-M:libdatahike" "-e" form)
+        ;; A namespace that does not load is a hard failure, not a skip. The
+        ;; old form caught every Throwable, so a broken require was silently
+        ;; dropped and the gate reported "no reflective calls" over whatever
+        ;; happened to compile — the same silent pass the empty-list guard
+        ;; below exists to prevent, one level down.
+        _ (when-not (zero? exit)
+            (println "Compilation failed (exit" exit ") — the reflection gate did not run:")
+            (println err)
+            (System/exit 1))
         warnings (->> (str/split-lines (or err ""))
                       (filter #(str/starts-with? % "Reflection warning"))
                       (filter #(str/includes? % "datahike/"))

--- a/bb/src/tools/reflection.clj
+++ b/bb/src/tools/reflection.clj
@@ -16,6 +16,27 @@
 
 (def ^:private src-roots ["src" "libdatahike/src"])
 
+(defn- ns-name-of
+  "The namespace the file at `path` (found under `root`) declares, or nil if the
+   file is not a Clojure source.
+
+   Separator-agnostic on purpose. `File/getPath` hands back `src\\datahike\\api.cljc`
+   on Windows, where a `\"^src/\"` prefix strip and a `\"/\"` -> `\".\"` replace both
+   silently miss — and this gate reacts to a namespace it cannot name by
+   swallowing the failure, so the whole check would pass having compiled
+   nothing. A gate that reports success without looking is worse than no gate."
+  [root path]
+  (let [->slash #(str/replace % "\\" "/")
+        root    (str/replace (->slash root) #"/+$" "")
+        path    (->slash path)
+        prefix  (str root "/")]
+    (when (and (str/starts-with? path prefix)
+               (re-find #"\.cljc?$" path))
+      (-> (subs path (count prefix))
+          (str/replace #"\.cljc?$" "")
+          (str/replace "/" ".")
+          (str/replace "_" "-")))))
+
 (defn- namespaces
   "Every namespace under `src-roots`, as the compiler would name it."
   []
@@ -23,13 +44,7 @@
        (mapcat #(->> (file-seq (java.io.File. ^String %))
                      (filter (fn [^java.io.File f] (.isFile f)))
                      (map (fn [^java.io.File f] [% (.getPath f)]))))
-       (keep (fn [[root path]]
-               (when (re-find #"\.cljc?$" path)
-                 (-> path
-                     (str/replace (re-pattern (str "^" root "/")) "")
-                     (str/replace #"\.cljc?$" "")
-                     (str/replace "/" ".")
-                     (str/replace "_" "-")))))
+       (keep (fn [[root path]] (ns-name-of root path)))
        ;; data_readers.clj is a data file, not a namespace.
        (remove #{"data-readers"})
        sort
@@ -39,6 +54,12 @@
   "Compile every namespace with *warn-on-reflection* and fail on any warning."
   [& _]
   (let [nses (namespaces)
+        ;; An empty list would compile nothing and report "no reflective calls",
+        ;; which is how a broken path convention used to hide here.
+        _ (when (empty? nses)
+            (println "No namespaces found under" (pr-str src-roots)
+                     "- the reflection gate cannot check anything.")
+            (System/exit 1))
         form (str "(set! *warn-on-reflection* true)"
                   "(doseq [n '" (pr-str (vec (map symbol nses))) "]"
                   "  (try (require n) (catch Throwable _ nil)))")

--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -91,7 +91,9 @@
 
 (defn python []
   (if (fs/exists? "./libdatahike/target")
-    (p/shell "./bb/resources/native-image-tests/run-python-tests")
+    ;; Through bash, like `native-image` and `libdatahike` above: the script
+    ;; carries a shebang, which Windows does not honour.
+    (p/shell "bash" "./bb/resources/native-image-tests/run-python-tests")
     (println "libdatahike binaries missing. Please run 'bb ni-compile' and try again.")))
 
 (defn specs []

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -465,7 +465,7 @@ Secondary indices are declared via schema transactions:
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `:path` | Directory for Lucene index files | `/tmp/scriptum-<uuid>` |
+| `:path` | Directory for Lucene index files | a fresh directory under the system temp dir (`java.io.tmpdir`) |
 | `:branch` | Git branch name for versioning | `"main"` |
 
 ### Proximum Config

--- a/src-secondary/datahike/index/secondary/scriptum.clj
+++ b/src-secondary/datahike/index/secondary/scriptum.clj
@@ -12,6 +12,7 @@
    [datahike.index.audit :as audit]
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
+   [datahike.migrate.fs :as fs]
    [scriptum.core :as sc]
    [replikativ.logging :as log]))
 
@@ -259,7 +260,12 @@
 (sec/register-index-type!
  :scriptum
  (fn [config _db]
-   (let [path (or (:path config) (str "/tmp/scriptum-" (random-uuid)))
+   ;; No `:path` means a throwaway index, so it belongs under the system temp
+   ;; directory — `java.io.tmpdir`, not a hardcoded `/tmp`, which Java resolves
+   ;; against the CURRENT DRIVE on Windows and so points at a directory that
+   ;; does not exist. `temp-dir!` also CREATES the directory, unique per index
+   ;; instance, which is what the uuid was for.
+   (let [path (or (:path config) (fs/temp-dir! "scriptum-"))
          branch (or (:branch config) "main")
          writer (sc/create-index path branch
                                  (select-keys config [:crypto-hash?]))]

--- a/src/datahike/migrate/fs.cljc
+++ b/src/datahike/migrate/fs.cljc
@@ -148,17 +148,26 @@
                 prefix (make-array java.nio.file.attribute.FileAttribute 0)))
      :cljs (str (.mkdtempSync (fs) (join (.tmpdir (os*)) prefix)))))
 
+(defonce ^:private store-root
+  ;; ONE created directory per process, under which every `temp-store-path!`
+  ;; is a not-yet-existing child. A fresh `temp-dir!` per call gave each store
+  ;; its own parent that `delete-database` never removed, so a suite run left
+  ;; one empty directory per test under the system temp dir. The uuid keeps
+  ;; the child unique; the root keeps the leak to one directory per run.
+  (delay (temp-dir! "dh-stores-")))
+
 (defn temp-store-path!
-  "A unique path that does NOT exist yet, inside a freshly created temp directory.
+  "A unique path that does NOT exist yet, under this process's temp root.
 
    `temp-dir!` CREATES the directory it names, which is exactly what a dump
    wants — the exporter writes its files into it. A konserve file store is the
    opposite: `create-store` REFUSES a path that already exists, so a store
-   cannot be created at a `temp-dir!` at all. Wrapping the name one level down
-   keeps both properties a temp path is wanted for — a portable root and
-   uniqueness — while handing back something nothing has created yet."
+   cannot be created at a `temp-dir!` at all. Naming a child of a directory
+   created once per process keeps both properties a temp path is wanted for —
+   a portable root and uniqueness — while handing back something nothing has
+   created yet."
   [prefix]
-  (join (temp-dir! prefix) "store"))
+  (join @store-root (str prefix (random-uuid))))
 
 (defonce ^:private temp-seq (atom 0))
 

--- a/src/datahike/migrate/fs.cljc
+++ b/src/datahike/migrate/fs.cljc
@@ -148,6 +148,18 @@
                 prefix (make-array java.nio.file.attribute.FileAttribute 0)))
      :cljs (str (.mkdtempSync (fs) (join (.tmpdir (os*)) prefix)))))
 
+(defn temp-store-path!
+  "A unique path that does NOT exist yet, inside a freshly created temp directory.
+
+   `temp-dir!` CREATES the directory it names, which is exactly what a dump
+   wants — the exporter writes its files into it. A konserve file store is the
+   opposite: `create-store` REFUSES a path that already exists, so a store
+   cannot be created at a `temp-dir!` at all. Wrapping the name one level down
+   keeps both properties a temp path is wanted for — a portable root and
+   uniqueness — while handing back something nothing has created yet."
+  [prefix]
+  (join (temp-dir! prefix) "store"))
+
 (defonce ^:private temp-seq (atom 0))
 
 (defn temp-file!

--- a/test/datahike/backward_compatibility_test/src/backward_test.clj
+++ b/test/datahike/backward_compatibility_test/src/backward_test.clj
@@ -8,7 +8,16 @@
               :db/cardinality :db.cardinality/one
               :db/valueType   :db.type/long}])
 (def cfg {:store  {:backend :file
-                   :path "/tmp/datahike-backward-comp-test"
+                   ;; NOT a freshly created temp directory, unlike the rest of
+                   ;; the suite: `bb test back-compat` runs `write` in a JVM
+                   ;; started inside a CLONE of the last release (which carries
+                   ;; its OWN copy of this file) and `read` in a second JVM at
+                   ;; the repo root. The two processes have to agree on the path
+                   ;; by name, so it stays fixed — only the temp ROOT is looked
+                   ;; up rather than assumed to be `/tmp`, which is what makes it
+                   ;; resolvable off POSIX.
+                   :path (.getPath (java.io.File. (System/getProperty "java.io.tmpdir")
+                                                  "datahike-backward-comp-test"))
                    :id #uuid "550e8400-e29b-41d4-a716-446655440000"}
           :keep-history? true
           :schema-flexibility :write

--- a/test/datahike/backward_compatibility_test/src/backward_test.clj
+++ b/test/datahike/backward_compatibility_test/src/backward_test.clj
@@ -8,16 +8,17 @@
               :db/cardinality :db.cardinality/one
               :db/valueType   :db.type/long}])
 (def cfg {:store  {:backend :file
-                   ;; NOT a freshly created temp directory, unlike the rest of
-                   ;; the suite: `bb test back-compat` runs `write` in a JVM
-                   ;; started inside a CLONE of the last release (which carries
-                   ;; its OWN copy of this file) and `read` in a second JVM at
-                   ;; the repo root. The two processes have to agree on the path
-                   ;; by name, so it stays fixed — only the temp ROOT is looked
-                   ;; up rather than assumed to be `/tmp`, which is what makes it
-                   ;; resolvable off POSIX.
-                   :path (.getPath (java.io.File. (System/getProperty "java.io.tmpdir")
-                                                  "datahike-backward-comp-test"))
+                   ;; Deliberately the one `/tmp` literal left in the suite.
+                   ;; `bb test back-compat` runs `write` in a JVM started inside
+                   ;; a CLONE of the last release — which carries its OWN copy of
+                   ;; this file, frozen with this exact string — and `read` in a
+                   ;; second JVM here. Both must open the same directory, so this
+                   ;; side has to spell whatever the released copy spells. A
+                   ;; `java.io.tmpdir` lookup here only agrees with `/tmp` by
+                   ;; coincidence on Linux, and disagrees on macOS and Windows.
+                   ;; Moving it is a two-release step: change both sides in one
+                   ;; release, then the clone carries the new spelling too.
+                   :path "/tmp/datahike-backward-comp-test"
                    :id #uuid "550e8400-e29b-41d4-a716-446655440000"}
           :keep-history? true
           :schema-flexibility :write

--- a/test/datahike/integration_test/config_record_file_test.clj
+++ b/test/datahike/integration_test/config_record_file_test.clj
@@ -1,8 +1,9 @@
 (ns datahike.integration-test.config-record-file-test
   (:require [clojure.test :refer :all]
-            [datahike.integration-test :as it]))
+            [datahike.integration-test :as it]
+            [datahike.migrate.fs :as fs]))
 
-(def config {:store {:backend :file :path "/tmp/file-test-1" :id #uuid "f11e0001-0000-0000-0000-000000000001"}})
+(def config {:store {:backend :file :path (fs/temp-dir! "dh-file-test-1") :id #uuid "f11e0001-0000-0000-0000-000000000001"}})
 
 (defn config-record-file-test-fixture [f]
   (it/integration-test-fixture config)

--- a/test/datahike/integration_test/config_record_file_test.clj
+++ b/test/datahike/integration_test/config_record_file_test.clj
@@ -3,7 +3,7 @@
             [datahike.integration-test :as it]
             [datahike.migrate.fs :as fs]))
 
-(def config {:store {:backend :file :path (fs/temp-dir! "dh-file-test-1") :id #uuid "f11e0001-0000-0000-0000-000000000001"}})
+(def config {:store {:backend :file :path (fs/temp-store-path! "dh-file-test-1") :id #uuid "f11e0001-0000-0000-0000-000000000001"}})
 
 (defn config-record-file-test-fixture [f]
   (it/integration-test-fixture config)

--- a/test/datahike/integration_test/depr_config_uri_test.clj
+++ b/test/datahike/integration_test/depr_config_uri_test.clj
@@ -2,6 +2,12 @@
   (:require [clojure.test :refer :all]
             [datahike.integration-test :as it]))
 
+;; The one store path in the suite still spelled `/tmp` literally. It is not a
+;; path here, it is the PATH COMPONENT OF A URI, and `uri->config` parses it with
+;; `java.net.URI` — a Windows temp directory (`C:\Users\…\Temp`) is not a legal
+;; URI path at all, so making this portable means URI-encoding a filesystem path
+;; rather than swapping in a helper. Not worth it on the deprecated URI config
+;; form, which is what this test exists to keep working.
 (def config "datahike:file:///tmp/file-test-3?id=5c6e0000-0000-0000-0000-000000000003")
 
 (defn depr-config-uri-fixture [f]

--- a/test/datahike/integration_test/depr_config_uri_test.clj
+++ b/test/datahike/integration_test/depr_config_uri_test.clj
@@ -2,12 +2,13 @@
   (:require [clojure.test :refer :all]
             [datahike.integration-test :as it]))
 
-;; The one store path in the suite still spelled `/tmp` literally. It is not a
-;; path here, it is the PATH COMPONENT OF A URI, and `uri->config` parses it with
-;; `java.net.URI` — a Windows temp directory (`C:\Users\…\Temp`) is not a legal
-;; URI path at all, so making this portable means URI-encoding a filesystem path
-;; rather than swapping in a helper. Not worth it on the deprecated URI config
-;; form, which is what this test exists to keep working.
+;; A `/tmp` literal, and a real one: the fixture below DOES create, connect and
+;; delete a store at this path, so this test is not portable to Windows. It is
+;; left as is because the path travels inside a URI — a Windows temp directory
+;; (`C:\Users\…\Temp`) is not a legal URI path, `java.net.URI` hands back
+;; `/C:/…` for the encoded form, and `io/file` cannot open that — so making it
+;; portable means teaching the deprecated `uri->config` form Windows drive
+;; letters. This test runs on Linux CI only (`bb test integration`).
 (def config "datahike:file:///tmp/file-test-3?id=5c6e0000-0000-0000-0000-000000000003")
 
 (defn depr-config-uri-fixture [f]

--- a/test/datahike/integration_test/tiered_storage_test.clj
+++ b/test/datahike/integration_test/tiered_storage_test.clj
@@ -29,7 +29,7 @@
            :id store-id
            :frontend-config frontend-cfg
            :backend-config {:backend :file
-                            :path (fs/temp-dir! "dh-tiered-storage-test")
+                            :path (fs/temp-store-path! "dh-tiered-storage-test")
                             :id store-id}}
    :keep-history? false
    :schema-flexibility :read

--- a/test/datahike/integration_test/tiered_storage_test.clj
+++ b/test/datahike/integration_test/tiered_storage_test.clj
@@ -17,6 +17,7 @@
    storage regardless of how `k/get` returned the value."
   (:require [clojure.test :refer [deftest is]]
             [datahike.api :as d]
+            [datahike.migrate.fs :as fs]
             [konserve.store :as ks]))
 
 (def store-id #uuid "0e7000b9-0000-0000-0000-00000e100001")
@@ -28,7 +29,7 @@
            :id store-id
            :frontend-config frontend-cfg
            :backend-config {:backend :file
-                            :path "/tmp/datahike-tiered-storage-test"
+                            :path (fs/temp-dir! "dh-tiered-storage-test")
                             :id store-id}}
    :keep-history? false
    :schema-flexibility :read

--- a/test/datahike/kabel/walker_test.cljc
+++ b/test/datahike/kabel/walker_test.cljc
@@ -36,7 +36,7 @@
 
 (defn- rand-uuid [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
-(defn- tmp-path [id] (fs/temp-dir! (str "dh-walker-" id "-")))
+(defn- tmp-path [id] (fs/temp-store-path! (str "dh-walker-" id "-")))
 
 (defn- str->bytes [s]
   #?(:clj (.getBytes ^String s "UTF-8") :cljs (js/Buffer.from s "utf-8")))

--- a/test/datahike/kabel/walker_test.cljc
+++ b/test/datahike/kabel/walker_test.cljc
@@ -11,6 +11,7 @@
   #?(:clj  (:require [clojure.test :refer [deftest is testing]]
                      [datahike.api :as d]
                      [datahike.blob :as blob]
+                     [datahike.migrate.fs :as fs]
                      [datahike.kabel.walker :as w]
                      [datahike.test.async :refer [deftest-async]]
                      [konserve.core :as k]
@@ -18,11 +19,11 @@
      :cljs (:require [cljs.test :refer [deftest is testing] :include-macros true]
                      [datahike.api :as d]
                      [datahike.blob :as blob]
+                     [datahike.migrate.fs :as fs]
                      [datahike.kabel.walker :as w]
                      [datahike.test.async :refer-macros [deftest-async]]
                      [konserve.node-filestore]        ;; register :file backend on Node
                      [konserve.core :as k]
-                     [cljs.nodejs :as nodejs]
                      [clojure.core.async :as a :refer [<!] :refer-macros [go]])))
 
 (def ^:private schema
@@ -35,10 +36,7 @@
 
 (defn- rand-uuid [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
-(defn- tmp-path [id]
-  #?(:clj  (str (System/getProperty "java.io.tmpdir") "/dh-walker-" id)
-     :cljs (let [^js os (nodejs/require "os") ^js p (nodejs/require "path")]
-             (.join p (.tmpdir os) (str "dh-walker-" id)))))
+(defn- tmp-path [id] (fs/temp-dir! (str "dh-walker-" id "-")))
 
 (defn- str->bytes [s]
   #?(:clj (.getBytes ^String s "UTF-8") :cljs (js/Buffer.from s "utf-8")))

--- a/test/datahike/test/background_gc_test.cljc
+++ b/test/datahike/test/background_gc_test.cljc
@@ -12,6 +12,7 @@
                      [datahike.api :as d]
                      [datahike.gc :as gc]
                      [datahike.gc-guard :as guard]
+                     [datahike.migrate.fs :as fs]
                      [datahike.versioning :as v]
                      [datahike.writing :as dw]
                      [datahike.test.async :refer [deftest-async]]
@@ -22,13 +23,13 @@
                      [datahike.api :as d]
                      [datahike.gc :as gc]
                      [datahike.gc-guard :as guard]
+                     [datahike.migrate.fs :as fs]
                      [datahike.test.async :refer-macros [deftest-async]]
                      ;; register the :file backend on Node (the smoke test needs a
                      ;; FLUSHING store — GC's mark walk requires stored index nodes,
                      ;; so :memory, which keeps the tree inline, does not apply).
                      [konserve.node-filestore]
                      [konserve.core :as k]
-                     [cljs.nodejs :as nodejs]
                      [clojure.core.async :as a :refer [<!] :refer-macros [go]])))
 
 (def ^:private schema
@@ -37,10 +38,7 @@
 
 (defn- now-date [] (#?(:clj java.util.Date. :cljs js/Date.)))
 
-(defn- tmp-path [id]
-  #?(:clj  (str (System/getProperty "java.io.tmpdir") "/dh-bgc-portable-" id)
-     :cljs (let [^js os (nodejs/require "os") ^js p (nodejs/require "path")]
-             (.join p (.tmpdir os) (str "dh-bgc-portable-" id)))))
+(defn- tmp-path [id] (fs/temp-dir! (str "dh-bgc-portable-" id "-")))
 
 ;; ---------------------------------------------------------------------------
 ;; Portable smoke test — JVM + Node cljs (file backend, since GC needs a
@@ -222,7 +220,7 @@
        [tag]
        (let [id (java.util.UUID/randomUUID)]
          {:backend :file
-          :path (str (System/getProperty "java.io.tmpdir") "/dh-bgc-" tag "-" id)
+          :path (fs/temp-dir! (str "dh-bgc-" tag "-"))
           :id id}))
 
      (deftest background-gc-under-pipelined-writes

--- a/test/datahike/test/background_gc_test.cljc
+++ b/test/datahike/test/background_gc_test.cljc
@@ -38,7 +38,7 @@
 
 (defn- now-date [] (#?(:clj java.util.Date. :cljs js/Date.)))
 
-(defn- tmp-path [id] (fs/temp-dir! (str "dh-bgc-portable-" id "-")))
+(defn- tmp-path [id] (fs/temp-store-path! (str "dh-bgc-portable-" id "-")))
 
 ;; ---------------------------------------------------------------------------
 ;; Portable smoke test — JVM + Node cljs (file backend, since GC needs a
@@ -220,7 +220,7 @@
        [tag]
        (let [id (java.util.UUID/randomUUID)]
          {:backend :file
-          :path (fs/temp-dir! (str "dh-bgc-" tag "-"))
+          :path (fs/temp-store-path! (str "dh-bgc-" tag "-"))
           :id id}))
 
      (deftest background-gc-under-pipelined-writes

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -117,7 +117,7 @@
     ;; `file-path` is bound ONCE: file-start and file-index differ only in
     ;; :index, and that is the whole setup — two different paths would be two
     ;; different store identities and the test would assert the wrong error.
-    (let [file-path  (fs/temp-dir! "dh-store-identity-test")
+    (let [file-path  (fs/temp-store-path! "dh-store-identity-test")
           mem-start  {:store {:backend :memory
                               :id #uuid "51de0715-1000-0000-0000-000000000001"}}
           mem-other  {:store {:backend :memory
@@ -158,7 +158,7 @@
   (testing "different connections with equal identities"
     ;; as above: one path, bound once — file-index has to reach the store
     ;; file-start is already connected to.
-    (let [file-path  (fs/temp-dir! "dh-store-connection-test")
+    (let [file-path  (fs/temp-store-path! "dh-store-connection-test")
           mem-start  {:store {:backend :memory
                               :id #uuid "51dec000-ec71-0000-0000-000000000001"}}
           mem-other  {:store {:backend :memory

--- a/test/datahike/test/config_test.cljc
+++ b/test/datahike/test/config_test.cljc
@@ -7,6 +7,7 @@
    [datahike.api :as d]
    [datahike.index :as di]
    [datahike.index.hitchhiker-tree :as dih]
+   [datahike.migrate.fs :as fs]
    [datahike.connector :as conn]))
 
 #?(:cljs (def Throwable js/Error))
@@ -19,6 +20,9 @@
   (is (c/bool-from-env :foo true)))
 
 (deftest uri-test
+  ;; The only /tmp literals in this namespace that stay: nothing here opens a
+  ;; store, `uri->config` just parses. The path is the parser's INPUT and its
+  ;; expected output, so it has to be spelled the same on both sides.
   (let [mem-uri "datahike:mem://config-test"
         file-uri "datahike:file:///tmp/config-test"]
 
@@ -110,16 +114,20 @@
 
 (deftest store-identity-config-test
   (testing "different configs with equal identities"
-    (let [mem-start  {:store {:backend :memory
+    ;; `file-path` is bound ONCE: file-start and file-index differ only in
+    ;; :index, and that is the whole setup — two different paths would be two
+    ;; different store identities and the test would assert the wrong error.
+    (let [file-path  (fs/temp-dir! "dh-store-identity-test")
+          mem-start  {:store {:backend :memory
                               :id #uuid "51de0715-1000-0000-0000-000000000001"}}
           mem-other  {:store {:backend :memory
                               :id #uuid "a107be12-1de0-7157-0000-000000000001"}}
           file-start {:store {:backend :file
-                              :path "/tmp/store-identity-test"
+                              :path file-path
                               :id #uuid "1de07157-0000-0000-0000-000000000001"}}
           file-index {:index :datahike.index/hitchhiker-tree
                       :store {:backend :file
-                              :path "/tmp/store-identity-test"
+                              :path file-path
                               :id #uuid "1de07157-0000-0000-0000-000000000001"}}
           mem-named  {:name "has-name"
                       :store {:backend :memory
@@ -148,16 +156,19 @@
 
 (deftest store-identity-connection-test
   (testing "different connections with equal identities"
-    (let [mem-start  {:store {:backend :memory
+    ;; as above: one path, bound once — file-index has to reach the store
+    ;; file-start is already connected to.
+    (let [file-path  (fs/temp-dir! "dh-store-connection-test")
+          mem-start  {:store {:backend :memory
                               :id #uuid "51dec000-ec71-0000-0000-000000000001"}}
           mem-other  {:store {:backend :memory
                               :id #uuid "a107be12-c000-ec71-0000-000000000001"}}
           file-start {:store {:backend :file
-                              :path "/tmp/store-connection-test"
+                              :path file-path
                               :id #uuid "c000ec71-0000-0000-0000-000000000001"}}
           file-index {:index :datahike.index/hitchhiker-tree
                       :store {:backend :file
-                              :path "/tmp/store-connection-test"
+                              :path file-path
                               :id #uuid "c000ec71-0000-0000-0000-000000000001"}}
           mem-named  {:name "has-name"
                       :store {:backend :memory

--- a/test/datahike/test/gc_test.cljc
+++ b/test/datahike/test/gc_test.cljc
@@ -27,9 +27,9 @@
 
 (def cfg {:store              {:backend :file
                                ;; every deftest below overrides this; it is a
-                               ;; created temp directory rather than a literal so
-                               ;; no path in this namespace assumes a POSIX /tmp
-                               :path (fs/temp-dir! "dh-gc-base")
+                               ;; temp path rather than a literal so no path in
+                               ;; this namespace assumes a POSIX /tmp
+                               :path (fs/temp-store-path! "dh-gc-base")
                                :id #uuid "9c000000-0000-0000-0000-000000000001"}
           ;; These tests assert what a SINGLE-PROCESS collector reclaims, and say
           ;; so: under the default (shared) ownership the sweep carries a
@@ -45,7 +45,7 @@
               :db/valueType   :db.type/long}])
 
 (deftest datahike-gc-test
-  (let [cfg (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-test"))
+  (let [cfg (assoc-in cfg [:store :path] (fs/temp-store-path! "dh-gc-test"))
         conn (do
                (d/delete-database cfg)
                (d/create-database cfg)
@@ -79,7 +79,7 @@
     (d/release conn)))
 
 (deftest datahike-gc-versioning-test
-  (let [cfg          (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-versioning-test"))
+  (let [cfg          (assoc-in cfg [:store :path] (fs/temp-store-path! "dh-gc-versioning-test"))
         conn         (do
                        (d/delete-database cfg)
                        (d/create-database cfg)
@@ -108,7 +108,7 @@
 
     (testing "Removed branch and after gc check."
       ;; the same store as above — reconnecting is the point, so the path is
-      ;; the one already bound rather than a second temp directory
+      ;; the one already bound rather than a second temp path
       (let [conn         (d/connect cfg)
             ;; create two more branches
             cfg1         (assoc cfg :branch :branch1)
@@ -122,7 +122,7 @@
         (d/release conn-branch1)))))
 
 (deftest datahike-gc-range-test
-  (let [cfg           (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-range-test"))
+  (let [cfg           (assoc-in cfg [:store :path] (fs/temp-store-path! "dh-gc-range-test"))
         conn          (do
                         (d/delete-database cfg)
                         (d/create-database cfg)
@@ -193,7 +193,7 @@
 (deftest min-age-spares-recent-garbage
   (testing "an object young enough is spared even though the mark called it
             garbage — the property an offline collector rests on"
-    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age"))]
+    (let [conn (churned-conn (fs/temp-store-path! "dh-gc-min-age"))]
       (try
         (let [before (count-store @conn)
               swept  (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))]
@@ -216,7 +216,7 @@
     (is (zero? datahike.gc/DEFAULT_SWEEP_MIN_AGE_MS))
     (is (zero? (datahike.gc/default-min-age-ms
                 {:writer {:backend :self :writer-ownership :exclusive}})))
-    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-default"))]
+    (let [conn (churned-conn (fs/temp-store-path! "dh-gc-min-age-default"))]
       (try
         (is (seq (<?? S (d/gc-storage conn (Date.))))
             "the default collects the garbage it always did")
@@ -234,7 +234,7 @@
     (is (= datahike.gc/DEFAULT_SHARED_SWEEP_MIN_AGE_MS
            (datahike.gc/default-min-age-ms {:writer {:backend :datahike-server}}))
         "a remote writer means the writes happen elsewhere entirely")
-    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-shared")
+    (let [conn (churned-conn (fs/temp-store-path! "dh-gc-min-age-shared")
                              {:writer {:backend :self :writer-ownership :shared}})]
       (try
         (let [before (count-store @conn)]
@@ -250,7 +250,7 @@
 (deftest min-age-is-a-floor-not-a-replacement
   (testing "cutoff is the MINIMUM of the guard and the floor, so the floor can
             only ever collect LESS — never more than the safe point allows"
-    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-floor"))]
+    (let [conn (churned-conn (fs/temp-store-path! "dh-gc-min-age-floor"))]
       (try
         (let [with-floor (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))
               no-floor   (<?? S (d/gc-storage conn (Date.) {:min-age-ms 0}))]

--- a/test/datahike/test/gc_test.cljc
+++ b/test/datahike/test/gc_test.cljc
@@ -8,6 +8,7 @@
    [datahike.index.interface :refer [-mark]]
    [datahike.versioning :refer [branch! delete-branch! merge!
                                 branch-history]]
+   [datahike.migrate.fs :as fs]
    [konserve.core :as k]
    [datahike.gc]
    [datahike.test.core-test])
@@ -25,7 +26,10 @@
 (def txs (vec (for [i (range 1000)] {:age i})))
 
 (def cfg {:store              {:backend :file
-                               :path "/tmp/gc-test"
+                               ;; every deftest below overrides this; it is a
+                               ;; created temp directory rather than a literal so
+                               ;; no path in this namespace assumes a POSIX /tmp
+                               :path (fs/temp-dir! "dh-gc-base")
                                :id #uuid "9c000000-0000-0000-0000-000000000001"}
           ;; These tests assert what a SINGLE-PROCESS collector reclaims, and say
           ;; so: under the default (shared) ownership the sweep carries a
@@ -41,7 +45,7 @@
               :db/valueType   :db.type/long}])
 
 (deftest datahike-gc-test
-  (let [cfg (assoc-in cfg [:store :path] "/tmp/dh-gc-test")
+  (let [cfg (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-test"))
         conn (do
                (d/delete-database cfg)
                (d/create-database cfg)
@@ -75,7 +79,7 @@
     (d/release conn)))
 
 (deftest datahike-gc-versioning-test
-  (let [cfg          (assoc-in cfg [:store :path] "/tmp/dh-gc-versioning-test")
+  (let [cfg          (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-versioning-test"))
         conn         (do
                        (d/delete-database cfg)
                        (d/create-database cfg)
@@ -103,8 +107,9 @@
     (d/release conn-branch2)
 
     (testing "Removed branch and after gc check."
-      (let [cfg          (assoc-in cfg [:store :path] "/tmp/dh-gc-versioning-test")
-            conn         (d/connect cfg)
+      ;; the same store as above — reconnecting is the point, so the path is
+      ;; the one already bound rather than a second temp directory
+      (let [conn         (d/connect cfg)
             ;; create two more branches
             cfg1         (assoc cfg :branch :branch1)
             conn-branch1 (d/connect cfg1)
@@ -117,7 +122,7 @@
         (d/release conn-branch1)))))
 
 (deftest datahike-gc-range-test
-  (let [cfg           (assoc-in cfg [:store :path] "/tmp/dh-gc-range-test")
+  (let [cfg           (assoc-in cfg [:store :path] (fs/temp-dir! "dh-gc-range-test"))
         conn          (do
                         (d/delete-database cfg)
                         (d/create-database cfg)
@@ -188,7 +193,7 @@
 (deftest min-age-spares-recent-garbage
   (testing "an object young enough is spared even though the mark called it
             garbage — the property an offline collector rests on"
-    (let [conn (churned-conn "/tmp/dh-gc-min-age")]
+    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age"))]
       (try
         (let [before (count-store @conn)
               swept  (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))]
@@ -211,7 +216,7 @@
     (is (zero? datahike.gc/DEFAULT_SWEEP_MIN_AGE_MS))
     (is (zero? (datahike.gc/default-min-age-ms
                 {:writer {:backend :self :writer-ownership :exclusive}})))
-    (let [conn (churned-conn "/tmp/dh-gc-min-age-default")]
+    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-default"))]
       (try
         (is (seq (<?? S (d/gc-storage conn (Date.))))
             "the default collects the garbage it always did")
@@ -229,7 +234,7 @@
     (is (= datahike.gc/DEFAULT_SHARED_SWEEP_MIN_AGE_MS
            (datahike.gc/default-min-age-ms {:writer {:backend :datahike-server}}))
         "a remote writer means the writes happen elsewhere entirely")
-    (let [conn (churned-conn "/tmp/dh-gc-min-age-shared"
+    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-shared")
                              {:writer {:backend :self :writer-ownership :shared}})]
       (try
         (let [before (count-store @conn)]
@@ -245,7 +250,7 @@
 (deftest min-age-is-a-floor-not-a-replacement
   (testing "cutoff is the MINIMUM of the guard and the floor, so the floor can
             only ever collect LESS — never more than the safe point allows"
-    (let [conn (churned-conn "/tmp/dh-gc-min-age-floor")]
+    (let [conn (churned-conn (fs/temp-dir! "dh-gc-min-age-floor"))]
       (try
         (let [with-floor (<?? S (d/gc-storage conn (Date.) {:min-age-ms 86400000}))
               no-floor   (<?? S (d/gc-storage conn (Date.) {:min-age-ms 0}))]

--- a/test/datahike/test/http/writer_test.clj
+++ b/test/datahike/test/http/writer_test.clj
@@ -62,7 +62,7 @@
                                 :token    "securerandompassword"})]
       (try
         (let [cfg    {:store              {:backend :file
-                                           :path  (fs/temp-dir! "dh-distributed-writer")
+                                           :path  (fs/temp-store-path! "dh-distributed-writer")
                                            :id #uuid "17100000-0000-0000-0000-000000000001"}
                       :keep-history?      true
                       :schema-flexibility :read

--- a/test/datahike/test/http/writer_test.clj
+++ b/test/datahike/test/http/writer_test.clj
@@ -6,6 +6,7 @@
    [datahike.http.server :refer [start-server stop-server]]
    [datahike.http.writer :as http-writer]
    [datahike.writer :as writer]
+   [datahike.migrate.fs :as fs]
    [datahike.api :as d]))
 
 (def remote-store-id #uuid "19000000-0000-0000-0000-000000000019")
@@ -61,7 +62,7 @@
                                 :token    "securerandompassword"})]
       (try
         (let [cfg    {:store              {:backend :file
-                                           :path  "/tmp/distributed_writer"
+                                           :path  (fs/temp-dir! "dh-distributed-writer")
                                            :id #uuid "17100000-0000-0000-0000-000000000001"}
                       :keep-history?      true
                       :schema-flexibility :read

--- a/test/datahike/test/insert.cljc
+++ b/test/datahike/test/insert.cljc
@@ -49,7 +49,7 @@
     (duplicate-test config)))
 
 (deftest duplicate-file
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-duplicate") :id #uuid "1a5e0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-duplicate") :id #uuid "1a5e0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write}]
     (duplicate-test config)))
 
@@ -87,20 +87,20 @@
     (insert-history-test config)))
 
 (deftest insert-history-file
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-hist-hht") :id #uuid "1a5e0000-0000-0000-0000-000000000002"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-insert-hist-hht") :id #uuid "1a5e0000-0000-0000-0000-000000000002"}
                 :schema-flexibility :write
                 :keep-history? true}]
     (insert-history-test config)))
 
 (deftest insert-history-file-with-attr-refs
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-hist-attr-refs") :id #uuid "1a5e0000-0000-0000-0000-000000000003"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-insert-hist-attr-refs") :id #uuid "1a5e0000-0000-0000-0000-000000000003"}
                 :schema-flexibility :write
                 :keep-history? true
                 :attribute-refs? true}]
     (insert-history-test config)))
 
 (deftest insert-read-handlers
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-read-handlers-9") :id #uuid "1a5e0000-0000-0000-0000-000000000004"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-insert-read-handlers-9") :id #uuid "1a5e0000-0000-0000-0000-000000000004"}
                 :schema-flexibility :write
                 :keep-history? false}
         schema [{:db/ident       :block/string

--- a/test/datahike/test/insert.cljc
+++ b/test/datahike/test/insert.cljc
@@ -2,7 +2,8 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
-   [datahike.api :as d]))
+   [datahike.api :as d]
+   [datahike.migrate.fs :as fs]))
 
 #?(:cljs
    (def Throwable js/Error))
@@ -48,7 +49,7 @@
     (duplicate-test config)))
 
 (deftest duplicate-file
-  (let [config {:store {:backend :file :path "/tmp/duplicate" :id #uuid "1a5e0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-duplicate") :id #uuid "1a5e0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write}]
     (duplicate-test config)))
 
@@ -86,20 +87,20 @@
     (insert-history-test config)))
 
 (deftest insert-history-file
-  (let [config {:store {:backend :file :path "/tmp/insert-hist-hht" :id #uuid "1a5e0000-0000-0000-0000-000000000002"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-hist-hht") :id #uuid "1a5e0000-0000-0000-0000-000000000002"}
                 :schema-flexibility :write
                 :keep-history? true}]
     (insert-history-test config)))
 
 (deftest insert-history-file-with-attr-refs
-  (let [config {:store {:backend :file :path "/tmp/insert-hist-attr-refs" :id #uuid "1a5e0000-0000-0000-0000-000000000003"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-hist-attr-refs") :id #uuid "1a5e0000-0000-0000-0000-000000000003"}
                 :schema-flexibility :write
                 :keep-history? true
                 :attribute-refs? true}]
     (insert-history-test config)))
 
 (deftest insert-read-handlers
-  (let [config {:store {:backend :file :path "/tmp/insert-read-handlers-9" :id #uuid "1a5e0000-0000-0000-0000-000000000004"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-insert-read-handlers-9") :id #uuid "1a5e0000-0000-0000-0000-000000000004"}
                 :schema-flexibility :write
                 :keep-history? false}
         schema [{:db/ident       :block/string

--- a/test/datahike/test/migrate_export_xform_test.clj
+++ b/test/datahike/test/migrate_export_xform_test.clj
@@ -27,6 +27,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [datahike.api :as d]
             [datahike.migrate :as m]
+            [datahike.migrate.fs :as fs]
             [datahike.test.utils :as utils]))
 
 (defn- fresh-conn []
@@ -75,7 +76,7 @@
 (defn- dump-values
   "The `:n` values that survive an export-db → import-db round trip under `xform`."
   [conn xform]
-  (let [dir (str "/tmp/claude-1000/xform-test-" (System/currentTimeMillis) "-" (rand-int 100000))
+  (let [dir (fs/temp-dir! "dh-xform-test")
         tgt (fresh-conn)]
     (m/export-transformed @conn dir xform {})
     (m/import-db tgt dir)

--- a/test/datahike/test/migrate_import_hostile_test.clj
+++ b/test/datahike/test/migrate_import_hostile_test.clj
@@ -458,8 +458,8 @@
             and feeds the secondary `v` (correct). The double-hash was a symptom
             of the missing value, not a separate defect."
     (require 'datahike.index.secondary.scriptum)
-    (let [p1 (str "/tmp/dh-hostile-so-" (java.util.UUID/randomUUID))
-          p2 (str "/tmp/dh-hostile-so-" (java.util.UUID/randomUUID))
+    (let [p1 (fs/temp-dir! "dh-hostile-so-")
+          p2 (fs/temp-dir! "dh-hostile-so-")
           src (conn! (cfg true))]
       (d/transact src [{:db/ident :doc/body :db/valueType :db.type/string
                         :db/cardinality :db.cardinality/one :db.secondary/only true}])
@@ -562,7 +562,7 @@
             one value repeated, the other absent from the backup entirely."
     (require 'datahike.index.secondary.scriptum)
     (let [conn (conn! (cfg true))
-          p (str "/tmp/dh-hostile-cm-" (java.util.UUID/randomUUID))]
+          p (fs/temp-dir! "dh-hostile-cm-")]
       (try
         (d/transact conn [{:db/ident :doc/tag :db/valueType :db.type/string
                            :db/cardinality :db.cardinality/many :db.secondary/only true}])
@@ -599,7 +599,7 @@
             data, reporting success."
     (require 'datahike.index.secondary.scriptum)
     (let [conn (conn! (cfg true))
-          p (str "/tmp/dh-hostile-hist-" (java.util.UUID/randomUUID))]
+          p (fs/temp-dir! "dh-hostile-hist-")]
       (try
         (d/transact conn [{:db/ident :doc/body :db/valueType :db.type/string
                            :db/cardinality :db.cardinality/one :db.secondary/only true}])

--- a/test/datahike/test/migrate_init_build_test.clj
+++ b/test/datahike/test/migrate_init_build_test.clj
@@ -278,6 +278,8 @@
             a real tree — so the refusal has to happen at this boundary."
     (doseq [f [:eavtt :temporal-eavt nil "eavt"]]
       (is (= :init/unknown-index-family
+             ;; the directory argument is never touched — `sort-family!` refuses
+             ;; the family first, which is what this asserts
              (try (init/sort-family! [] f 10 "/tmp") nil
                   (catch clojure.lang.ExceptionInfo e (:error (ex-data e)))))
           (str "sort-family! must refuse " (pr-str f)))

--- a/test/datahike/test/migrate_retention_test.clj
+++ b/test/datahike/test/migrate_retention_test.clj
@@ -33,6 +33,7 @@
   (:require [clojure.test :refer [deftest testing is]]
             [datahike.api :as d]
             [datahike.migrate :as m]
+            [datahike.migrate.fs :as fs]
             [datahike.test.utils :as utils]
             [clojure.core.async :as a])
   (:import [java.lang.ref WeakReference]))
@@ -108,7 +109,7 @@
             leave `write-chunked!` holding the whole dump."
     (let [conn (populate! (fresh-conn))
           seen (atom [])
-          dir  (str "/tmp/claude-1000/retention-" (System/currentTimeMillis))]
+          dir  (fs/temp-dir! "dh-retention")]
       (with-redefs [m/sorted-record-seq (watching-sorted-record-seq seen)]
         (a/<!! (m/export-db @conn dir {:history? true :sync? false})))
       (is (seq @seen) "precondition: sorted-record-seq was called")

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -12,6 +12,7 @@
             [datahike.migrate.manifest :as mman]
             [datahike.migrate.cbor :as mcbor]
             [datahike.migrate.blobs :as mblobs]
+            [datahike.migrate.fs :as fs]
             [datahike.migrate.compress :as mz]
             [datahike.migrate.digest :as dig]
             [datahike.blob :as blob]
@@ -694,7 +695,7 @@
    never written here — i.e. a blob living outside this store, which is the case
    a dump cannot carry."
   []
-  (let [path (str "/tmp/dh-blob-test-" (java.util.UUID/randomUUID))
+  (let [path (fs/temp-dir! "dh-blob-test-")
         cfg  {:store {:backend :file :path path :id (java.util.UUID/randomUUID)}
               :schema-flexibility :write :keep-history? true}
         _    (d/create-database cfg)
@@ -723,7 +724,7 @@
   ;; Without carrying the bytes the datom restores perfectly and names an object
   ;; that is not in the target store — a backup that silently lost its blobs.
   (let [{:keys [conn payload id]} (blob-fixture)
-        dump (str "/tmp/dh-blob-dump-" (java.util.UUID/randomUUID))]
+        dump (fs/temp-dir! "dh-blob-dump-")]
     (.mkdirs (io/file dump))
     (let [manifest (m/export-db @conn dump {})]
       (testing "the manifest declares what it carries"
@@ -733,7 +734,7 @@
       (testing "the bytes are in the dump, named by their content id"
         ;; the file name IS the checksum, so verification needs no side table
         (is (.exists (io/file dump mblobs/dir-name (str id))))))
-    (let [path2 (str "/tmp/dh-blob-target-" (java.util.UUID/randomUUID))
+    (let [path2 (fs/temp-dir! "dh-blob-target-")
           cfg2  {:store {:backend :file :path path2 :id (java.util.UUID/randomUUID)}
                  :schema-flexibility :write :keep-history? true}
           _     (d/create-database cfg2)
@@ -792,7 +793,7 @@
   ;; datahike's backwards-compat commitment. So the dump declares what it NEEDS,
   ;; and the reader compares against what it HAS.
   (let [{:keys [conn id]} (blob-fixture)
-        dump (str "/tmp/dh-cap-dump-" (java.util.UUID/randomUUID))]
+        dump (fs/temp-dir! "dh-cap-dump-")]
     (d/transact conn [{:db/ident :doc/vec :db/valueType :db.type/double-array
                        :db/cardinality :db.cardinality/one}])
     (d/transact conn [{:doc/name "vec" :doc/vec (double-array [1.5 2.5])}])
@@ -836,7 +837,7 @@
   ;; dump is unrestorable. Reporting :ok? true there is exactly the reassurance
   ;; nobody should get.
   (let [{:keys [conn id]} (blob-fixture)
-        dump (str "/tmp/dh-verify-blob-" (java.util.UUID/randomUUID))]
+        dump (fs/temp-dir! "dh-verify-blob-")]
     (.mkdirs (io/file dump))
     (m/export-db @conn dump {})
     (testing "an intact dump verifies, and says what it checked"
@@ -1258,10 +1259,10 @@
             blob set that is gigabytes written to be told the target was never
             eligible."
     (let [{:keys [conn payload id]} (blob-fixture)
-          dump (str "/tmp/dh-guard-dump-" (java.util.UUID/randomUUID))]
+          dump (fs/temp-dir! "dh-guard-dump-")]
       (.mkdirs (io/file dump))
       (m/export-db @conn dump {})
-      (let [path2 (str "/tmp/dh-guard-target-" (java.util.UUID/randomUUID))
+      (let [path2 (fs/temp-dir! "dh-guard-target-")
             cfg2  {:store {:backend :file :path path2 :id (java.util.UUID/randomUUID)}
                    :schema-flexibility :write :keep-history? true}
             _     (d/create-database cfg2)
@@ -1685,6 +1686,9 @@
           conn (d/connect cfg)]
       (try
         (d/transact conn [{:name "Amara"}])
+        ;; The two literal paths below stay literal: the refusal happens on the
+        ;; `conn`-instead-of-`@conn` argument BEFORE anything looks at the
+        ;; target, and the point is that nothing is ever written there.
         (doseq [[label f] {"export-db"      #(m/export-db conn "/tmp/should-not-exist")
                            "export-to-sink" #(m/export-to-sink conn {:open (fn [_] nil)
                                                                      :write (fn [c _] c)

--- a/test/datahike/test/migrate_test.clj
+++ b/test/datahike/test/migrate_test.clj
@@ -695,7 +695,7 @@
    never written here — i.e. a blob living outside this store, which is the case
    a dump cannot carry."
   []
-  (let [path (fs/temp-dir! "dh-blob-test-")
+  (let [path (fs/temp-store-path! "dh-blob-test-")
         cfg  {:store {:backend :file :path path :id (java.util.UUID/randomUUID)}
               :schema-flexibility :write :keep-history? true}
         _    (d/create-database cfg)
@@ -734,7 +734,7 @@
       (testing "the bytes are in the dump, named by their content id"
         ;; the file name IS the checksum, so verification needs no side table
         (is (.exists (io/file dump mblobs/dir-name (str id))))))
-    (let [path2 (fs/temp-dir! "dh-blob-target-")
+    (let [path2 (fs/temp-store-path! "dh-blob-target-")
           cfg2  {:store {:backend :file :path path2 :id (java.util.UUID/randomUUID)}
                  :schema-flexibility :write :keep-history? true}
           _     (d/create-database cfg2)
@@ -1262,7 +1262,7 @@
           dump (fs/temp-dir! "dh-guard-dump-")]
       (.mkdirs (io/file dump))
       (m/export-db @conn dump {})
-      (let [path2 (fs/temp-dir! "dh-guard-target-")
+      (let [path2 (fs/temp-store-path! "dh-guard-target-")
             cfg2  {:store {:backend :file :path path2 :id (java.util.UUID/randomUUID)}
                    :schema-flexibility :write :keep-history? true}
             _     (d/create-database cfg2)

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -107,6 +107,17 @@
   (let [dir (path.join (os.tmpdir) (str "datahike-node-test-" (rand-int 100000)))]
     dir))
 
+(defn tmp-path
+  "`nm` under the platform's temp directory.
+
+   The paths built with this are deliberately FIXED, unlike everything reached
+   through `tmp-dir` above: each one is either an artifact a JVM script drops
+   for a probe test to pick up, or a store left behind on purpose so the
+   buffering can be inspected afterwards. A fresh unique directory would defeat
+   both. Only the ROOT stops being assumed to be a POSIX `/tmp`."
+  [nm]
+  (path.join (os.tmpdir) nm))
+
 (deftest bigdec-roundtrip-test
   ;; :db.type/bigdec must accept a fress `Bigdec` (unscaled js/BigInt + scale) in
   ;; cljs and round-trip it. The spec was `(complement any?)` — it rejected EVERY
@@ -465,7 +476,7 @@
 ;; buffered-leaf projection (Branch.child) reconstructs identical datoms cross-host.
 ;; The store + reference datoms are produced by /tmp/dh_exchange_build.clj on the JVM;
 ;; this test is a no-op (passes) when that artifact is absent (e.g. normal CI).
-(def ^:private exchange-expected-file "/tmp/dh-exchange-expected.edn")
+(def ^:private exchange-expected-file (tmp-path "dh-exchange-expected.edn"))
 
 (deftest jvm-opbuf-exchange-test
   (async done
@@ -503,7 +514,7 @@
 ;; avoiding the pre-existing cross-host connect bug). Incremental commits make leaves
 ;; content-only dirty → buffered leaf slots in the root → on cold reopen they project back.
 ;; Writes to a FIXED dir (not deleted) so buffering can be confirmed externally (grep slots).
-(def ^:private cljs-opbuf-dir "/tmp/dh-cljs-opbuf")
+(def ^:private cljs-opbuf-dir (tmp-path "dh-cljs-opbuf"))
 
 (deftest cljs-opbuf-write-roundtrip-test
   (let [sid #uuid "00000000-0000-0000-0000-00000000c1c5"
@@ -546,7 +557,7 @@
 ;; diff-buf phase-2 gate: cljs $remove path (retractions → leaf underflow → merge/borrow,
 ;; exercising the rotate/merge/merge-split slot-carry). Insert 2000, retract the even ones,
 ;; cold-reopen and verify the surviving odd set exactly.
-(def ^:private cljs-opbuf-rm-dir "/tmp/dh-cljs-opbuf-rm")
+(def ^:private cljs-opbuf-rm-dir (tmp-path "dh-cljs-opbuf-rm"))
 
 (deftest cljs-opbuf-remove-roundtrip-test
   (let [sid #uuid "00000000-0000-0000-0000-0000000c1c5b"
@@ -593,7 +604,7 @@
 ;; diff-buf phase-2 gate: cljs $replace path. A cardinality-one re-assertion (upsert with an
 ;; old value) routes through psset/replace → Branch.$replace for eavt/aevt. Insert 1000 ids
 ;; with :n 0, then update each :n to its id in small commits, cold-reopen and verify :n == id.
-(def ^:private cljs-opbuf-rep-dir "/tmp/dh-cljs-opbuf-rep")
+(def ^:private cljs-opbuf-rep-dir (tmp-path "dh-cljs-opbuf-rep"))
 
 (deftest cljs-opbuf-replace-roundtrip-test
   (let [sid #uuid "00000000-0000-0000-0000-0000000c1c5c"
@@ -640,7 +651,7 @@
 ;; diff-buf phase-2 soundness gate: randomized insert/retract churn under a SMALL diff-buf
 ;; budget (more frequent buffer/write decisions, merges, borrows, splits) with periodic cold
 ;; reopens, compared against a reference set. Seeded LCG ⇒ deterministic/reproducible.
-(def ^:private cljs-opbuf-gen-dir "/tmp/dh-cljs-opbuf-gen")
+(def ^:private cljs-opbuf-gen-dir (tmp-path "dh-cljs-opbuf-gen"))
 
 (deftest cljs-opbuf-generative-test
   (let [sid  #uuid "00000000-0000-0000-0000-0000000c1c5d"
@@ -750,9 +761,9 @@
   (async done
          (go
            (try
-             (if-not (fs.existsSync "/tmp/kons-probe")
+             (if-not (fs.existsSync (tmp-path "kons-probe"))
                (is true "kons-probe artifact absent — skipped")
-               (let [store (<! (nfs/connect-fs-store "/tmp/kons-probe" :opts {:sync? false}))
+               (let [store (<! (nfs/connect-fs-store (tmp-path "kons-probe") :opts {:sync? false}))
                      v     (<! (k/get store :probe nil {:sync? false}))]
                  (is (= :datahike.index/persistent-set (:ns-kw v)) (str ":ns-kw = " (pr-str (:ns-kw v))))
                  (is (= :db.type/long (:ns-kw2 v)) (str ":ns-kw2 = " (pr-str (:ns-kw2 v))))

--- a/test/datahike/test/online_gc_test.cljc
+++ b/test/datahike/test/online_gc_test.cljc
@@ -10,6 +10,7 @@
       :clj  [clojure.test :as t :refer [is deftest testing]])
    [datahike.api :as d]
    [datahike.online-gc :as online-gc]
+   [datahike.migrate.fs :as fs]
    [konserve.core :as k]
    #?(:clj [clojure.core.async :as async]
       :cljs [cljs.core.async :as async]))
@@ -28,7 +29,7 @@
   (count (get-freed-addresses db)))
 
 (def base-cfg {:store              {:backend :file
-                                    :path "/tmp/online-gc-test"
+                                    :path (fs/temp-dir! "online-gc-test")
                                     :id #uuid "a0000000-0000-0000-0000-000000000001"}
                :keep-history?      false
                :schema-flexibility :write
@@ -48,7 +49,7 @@
 (deftest precise-freed-count-tracking-test
   (testing "Track exact number of freed addresses per transaction"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-precise-freed-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-precise-freed-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disabled to accumulate
           conn (do
                  (d/delete-database cfg)
@@ -95,7 +96,7 @@
 (deftest precise-gc-deletion-test
   (testing "Verify freed addresses are actually deleted from storage"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-precise-deletion-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-precise-deletion-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 1000}))
@@ -140,7 +141,7 @@
 (deftest manual-gc-freed-count-test
   (testing "Manual GC invocation returns exact deletion count"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-manual-count-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-manual-count-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disabled for manual control
           conn (do
                  (d/delete-database cfg)
@@ -183,7 +184,7 @@
 (deftest recycling-all-at-once-test
   (testing "Address recycling processes all eligible addresses at once"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-recycle-all-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-recycle-all-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Start disabled
           conn (do
                  (d/delete-database cfg)
@@ -223,7 +224,7 @@
 
 (deftest online-gc-disabled-test
   (testing "Online GC disabled by default - addresses accumulate"
-    (let [cfg (assoc-in base-cfg [:store :path] "/tmp/online-gc-disabled-test")
+    (let [cfg (assoc-in base-cfg [:store :path] (fs/temp-dir! "online-gc-disabled-test"))
           conn (do
                  (d/delete-database cfg)
                  (d/create-database cfg)
@@ -242,7 +243,7 @@
 (deftest online-gc-with-reconnect-test
   (testing "Data integrity verified via reconnect after GC"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-reconnect-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-reconnect-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 1000}))
@@ -277,7 +278,7 @@
 (deftest grace-period-accumulation-test
   (testing "Grace period causes freed addresses to accumulate"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-grace-accumulation-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-grace-accumulation-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 300000  ;; 5 minutes
                                      :max-batch 1000}))
@@ -307,7 +308,7 @@
 (deftest online-gc-large-dataset-test
   (testing "Online GC integration with larger dataset"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-integration-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-integration-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 10000}))
@@ -344,7 +345,7 @@
 (deftest get-and-clear-eligible-freed-test
   (testing "get-and-clear-eligible-freed! correctly filters by timestamp"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-filter-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-filter-test"))
                   (assoc :online-gc {:enabled? false}))
           conn (do
                  (d/delete-database cfg)
@@ -378,7 +379,7 @@
 (deftest background-gc-test
   (testing "Background GC runs periodically"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-background-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-background-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disable automatic GC in commit
           conn (do
                  (d/delete-database cfg)
@@ -423,7 +424,7 @@
 (deftest multi-branch-safety-test
   (testing "Multi-branch databases skip online GC entirely for safety"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] "/tmp/online-gc-multi-branch-test")
+                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-multi-branch-test"))
                   (assoc :online-gc {:enabled? false})
                   (assoc :crypto-hash? false))
           conn (do

--- a/test/datahike/test/online_gc_test.cljc
+++ b/test/datahike/test/online_gc_test.cljc
@@ -29,7 +29,7 @@
   (count (get-freed-addresses db)))
 
 (def base-cfg {:store              {:backend :file
-                                    :path (fs/temp-dir! "online-gc-test")
+                                    :path (fs/temp-store-path! "online-gc-test")
                                     :id #uuid "a0000000-0000-0000-0000-000000000001"}
                :keep-history?      false
                :schema-flexibility :write
@@ -49,7 +49,7 @@
 (deftest precise-freed-count-tracking-test
   (testing "Track exact number of freed addresses per transaction"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-precise-freed-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-precise-freed-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disabled to accumulate
           conn (do
                  (d/delete-database cfg)
@@ -96,7 +96,7 @@
 (deftest precise-gc-deletion-test
   (testing "Verify freed addresses are actually deleted from storage"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-precise-deletion-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-precise-deletion-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 1000}))
@@ -141,7 +141,7 @@
 (deftest manual-gc-freed-count-test
   (testing "Manual GC invocation returns exact deletion count"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-manual-count-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-manual-count-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disabled for manual control
           conn (do
                  (d/delete-database cfg)
@@ -184,7 +184,7 @@
 (deftest recycling-all-at-once-test
   (testing "Address recycling processes all eligible addresses at once"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-recycle-all-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-recycle-all-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Start disabled
           conn (do
                  (d/delete-database cfg)
@@ -224,7 +224,7 @@
 
 (deftest online-gc-disabled-test
   (testing "Online GC disabled by default - addresses accumulate"
-    (let [cfg (assoc-in base-cfg [:store :path] (fs/temp-dir! "online-gc-disabled-test"))
+    (let [cfg (assoc-in base-cfg [:store :path] (fs/temp-store-path! "online-gc-disabled-test"))
           conn (do
                  (d/delete-database cfg)
                  (d/create-database cfg)
@@ -243,7 +243,7 @@
 (deftest online-gc-with-reconnect-test
   (testing "Data integrity verified via reconnect after GC"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-reconnect-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-reconnect-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 1000}))
@@ -278,7 +278,7 @@
 (deftest grace-period-accumulation-test
   (testing "Grace period causes freed addresses to accumulate"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-grace-accumulation-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-grace-accumulation-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 300000  ;; 5 minutes
                                      :max-batch 1000}))
@@ -308,7 +308,7 @@
 (deftest online-gc-large-dataset-test
   (testing "Online GC integration with larger dataset"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-integration-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-integration-test"))
                   (assoc :online-gc {:enabled? true
                                      :grace-period-ms 0
                                      :max-batch 10000}))
@@ -345,7 +345,7 @@
 (deftest get-and-clear-eligible-freed-test
   (testing "get-and-clear-eligible-freed! correctly filters by timestamp"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-filter-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-filter-test"))
                   (assoc :online-gc {:enabled? false}))
           conn (do
                  (d/delete-database cfg)
@@ -379,7 +379,7 @@
 (deftest background-gc-test
   (testing "Background GC runs periodically"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-background-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-background-test"))
                   (assoc :online-gc {:enabled? false}))  ;; Disable automatic GC in commit
           conn (do
                  (d/delete-database cfg)
@@ -424,7 +424,7 @@
 (deftest multi-branch-safety-test
   (testing "Multi-branch databases skip online GC entirely for safety"
     (let [cfg (-> base-cfg
-                  (assoc-in [:store :path] (fs/temp-dir! "online-gc-multi-branch-test"))
+                  (assoc-in [:store :path] (fs/temp-store-path! "online-gc-multi-branch-test"))
                   (assoc :online-gc {:enabled? false})
                   (assoc :crypto-hash? false))
           conn (do

--- a/test/datahike/test/s3_concurrency_runner.cljs
+++ b/test/datahike/test/s3_concurrency_runner.cljs
@@ -8,6 +8,7 @@
   (:require [cljs.core.async :refer [<!]]
             [datahike.api :as d]
             [datahike.connector :as connector]
+            [datahike.migrate.fs :as dfs]
             [konserve-s3.core]
             [konserve.node-filestore]
             [taoensso.trove :as trove]
@@ -16,12 +17,13 @@
 
 (def store-id #uuid "8f487c89-5ca7-4ae8-bd9d-ae8e00d59531")
 
+;; Node filestore checks the directory while connecting the cache tier, so it has
+;; to exist before the connect — `temp-dir!` creates it, and resolves it against
+;; `os.tmpdir()` rather than assuming a POSIX `/tmp`. The pid keeps the two
+;; orchestrated processes' cache tiers apart by name as well as by uniqueness.
+;; Browser IndexedDB has no equivalent filesystem precondition.
 (def local-tier-path
-  (str "/tmp/datahike-s3-concurrency-" (.-pid js/process)))
-
-;; Node filestore checks the directory while connecting the cache tier. Browser
-;; IndexedDB has no equivalent filesystem precondition.
-(.mkdirSync (js/require "fs") local-tier-path #js {:recursive true})
+  (dfs/temp-dir! (str "datahike-s3-concurrency-" (.-pid js/process) "-")))
 
 (trove/set-log-fn! (trove-console/get-log-fn {:min-level :warn}))
 

--- a/test/datahike/test/schema_test.cljc
+++ b/test/datahike/test/schema_test.cljc
@@ -6,9 +6,9 @@
    [datahike.db.interface :as dbi]
    [datahike.db.transaction :as dbt]
    [datahike.datom :as da]
-   [datahike.constants :as const])
-  (:import [java.lang System]
-           [java.util UUID]))
+   [datahike.constants :as const]
+   [datahike.migrate.fs :as fs])
+  (:import [java.util UUID]))
 
 #?(:cljs (def Throwable js/Error))
 
@@ -298,10 +298,7 @@
 
 (deftest test-schema-persistence
   (testing "test file persistence"
-    (let [os (System/getProperty "os.name")
-          path (case os
-                 "Windows 10"  (str (System/getProperty "java.io.tmpdir") "dh-test-persistence")
-                 "/tmp/dh-test-persistence")
+    (let [path (fs/temp-dir! "dh-test-persistence")
           cfg {:store {:backend :file
                        :path path
                        :id #uuid "5c6e0000-0000-0000-0000-000000000001"}

--- a/test/datahike/test/schema_test.cljc
+++ b/test/datahike/test/schema_test.cljc
@@ -298,7 +298,7 @@
 
 (deftest test-schema-persistence
   (testing "test file persistence"
-    (let [path (fs/temp-dir! "dh-test-persistence")
+    (let [path (fs/temp-store-path! "dh-test-persistence")
           cfg {:store {:backend :file
                        :path path
                        :id #uuid "5c6e0000-0000-0000-0000-000000000001"}

--- a/test/datahike/test/secondary_dynamic_test.clj
+++ b/test/datahike/test/secondary_dynamic_test.clj
@@ -222,7 +222,7 @@
     ;; cannot run at all ("Index needs to be properly flushed before marking").
     (let [cfg {:store {:backend :file
                        :id (random-uuid)
-                       :path (fs/temp-dir! "datahike-sec-deltas-")}
+                       :path (fs/temp-store-path! "datahike-sec-deltas-")}
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
@@ -404,7 +404,7 @@
 
 (deftest recovery-after-crash-scans-the-journaled-transactions
   (testing "a datom journaled by the crashed process is indexed on reconnect"
-    (let [path (fs/temp-dir! "datahike-sec-crash-")
+    (let [path (fs/temp-store-path! "datahike-sec-crash-")
           cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path path}
@@ -451,7 +451,7 @@
 
 (deftest test-secondary-index-recovery-on-reconnect
   (testing "secondary index in :building state is recovered after reconnect"
-    (let [path (fs/temp-dir! "datahike-sec-recovery-")
+    (let [path (fs/temp-store-path! "datahike-sec-recovery-")
           cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path path}

--- a/test/datahike/test/secondary_dynamic_test.clj
+++ b/test/datahike/test/secondary_dynamic_test.clj
@@ -7,6 +7,7 @@
    [datahike.gc-roots :as roots]
    [konserve.core :as k]
    [datahike.index.secondary :as sec]
+   [datahike.migrate.fs :as fs]
    [datahike.writing :as writing]
    [superv.async :refer [<?? S]]))
 
@@ -221,7 +222,7 @@
     ;; cannot run at all ("Index needs to be properly flushed before marking").
     (let [cfg {:store {:backend :file
                        :id (random-uuid)
-                       :path (str "/tmp/datahike-sec-deltas-" (random-uuid))}
+                       :path (fs/temp-dir! "datahike-sec-deltas-")}
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
@@ -403,7 +404,7 @@
 
 (deftest recovery-after-crash-scans-the-journaled-transactions
   (testing "a datom journaled by the crashed process is indexed on reconnect"
-    (let [path (str "/tmp/datahike-sec-crash-" (random-uuid))
+    (let [path (fs/temp-dir! "datahike-sec-crash-")
           cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path path}
@@ -450,7 +451,7 @@
 
 (deftest test-secondary-index-recovery-on-reconnect
   (testing "secondary index in :building state is recovered after reconnect"
-    (let [path (str "/tmp/datahike-sec-recovery-" (random-uuid))
+    (let [path (fs/temp-dir! "datahike-sec-recovery-")
           cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
                        :path path}

--- a/test/datahike/test/secondary_integration_test.clj
+++ b/test/datahike/test/secondary_integration_test.clj
@@ -10,6 +10,7 @@
    [datahike.index.secondary.scriptum]
    [datahike.index.secondary.stratum]
    [datahike.migrate :as m]
+   [datahike.migrate.fs :as fs]
    [stratum.api :as st]
    [datahike.test.query-aggregates-test :refer [aggregate-contract]]))
 
@@ -99,7 +100,7 @@
   (testing "create, index documents, search, delete"
     (let [idx (sec/create-index :scriptum
                                 {:attrs #{:person/name :person/bio}
-                                 :path (str "/tmp/scriptum-test-" (random-uuid))}
+                                 :path (fs/temp-dir! "scriptum-test-")}
                                 nil)]
       (is (= #{:person/name :person/bio} (sec/-indexed-attrs idx)))
 
@@ -161,7 +162,7 @@
                                       nil)
             ft-idx (sec/create-index :scriptum
                                      {:attrs #{:person/bio}
-                                      :path (str "/tmp/scriptum-cross-" (random-uuid))}
+                                      :path (fs/temp-dir! "scriptum-cross-")}
                                      nil)
           ;; Transact vectors
             vec-idx (-> vec-idx
@@ -210,11 +211,11 @@
                   :person/bio {}
                   :idx/fulltext {:db.secondary/type :scriptum
                                  :db.secondary/attrs [:person/name :person/bio]
-                                 :db.secondary/config {:path (str "/tmp/scriptum-tx-" (random-uuid))}}}
+                                 :db.secondary/config {:path (fs/temp-dir! "scriptum-tx-")}}}
           empty-db (db/empty-db schema)
           ft-idx (sec/create-index :scriptum
                                    {:attrs [:person/name :person/bio]
-                                    :path (str "/tmp/scriptum-tx-" (random-uuid))}
+                                    :path (fs/temp-dir! "scriptum-tx-")}
                                    empty-db)
           db (assoc empty-db :secondary-indices {:idx/fulltext ft-idx})
           db2 (d/db-with db [{:db/id 1 :person/name "Alice" :person/bio "ML researcher"}
@@ -430,13 +431,13 @@
                   :person/dept {}
                   :idx/fulltext {:db.secondary/type :scriptum
                                  :db.secondary/attrs [:person/bio]
-                                 :db.secondary/config {:path (str "/tmp/scriptum-cross-strat-" (random-uuid))}}
+                                 :db.secondary/config {:path (fs/temp-dir! "scriptum-cross-strat-")}}
                   :idx/analytics {:db.secondary/type :stratum
                                   :db.secondary/attrs [:person/salary :person/dept]}}
           empty-db (db/empty-db schema)
           ft-idx (sec/create-index :scriptum
                                    {:attrs #{:person/bio}
-                                    :path (str "/tmp/scriptum-cross-strat-" (random-uuid))}
+                                    :path (fs/temp-dir! "scriptum-cross-strat-")}
                                    empty-db)
           st-idx (sec/create-index :stratum
                                    {:attrs #{:person/salary :person/dept}}
@@ -483,11 +484,11 @@
                   :person/salary {}
                   :idx/fulltext {:db.secondary/type :scriptum
                                  :db.secondary/attrs [:person/bio]
-                                 :db.secondary/config {:path (str "/tmp/scriptum-fused-" (random-uuid))}}}
+                                 :db.secondary/config {:path (fs/temp-dir! "scriptum-fused-")}}}
           empty-db (db/empty-db schema)
           ft-idx (sec/create-index :scriptum
                                    {:attrs #{:person/bio}
-                                    :path (str "/tmp/scriptum-fused-" (random-uuid))}
+                                    :path (fs/temp-dir! "scriptum-fused-")}
                                    empty-db)
           db (assoc empty-db :secondary-indices {:idx/fulltext ft-idx})
           db (d/db-with db [{:db/id 1 :person/name "Alice" :person/bio "ML researcher" :person/salary 90000}
@@ -520,7 +521,7 @@
     (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
                :keep-history? true
                :schema-flexibility :write}
-          scriptum-path (str "/tmp/scriptum-purge-test-" (random-uuid))
+          scriptum-path (fs/temp-dir! "scriptum-purge-test-")
           _ (d/create-database cfg)
           conn (d/connect cfg)]
       (try
@@ -813,7 +814,7 @@
                            :db/cardinality :db.cardinality/one :db.secondary/only true}])
         (d/transact conn [{:db/ident :idx/ft :db.secondary/type :scriptum
                            :db.secondary/attrs [:doc/body :doc/title]
-                           :db.secondary/config {:path (str "/tmp/dh-retr-" (java.util.UUID/randomUUID))}}])
+                           :db.secondary/config {:path (fs/temp-dir! "dh-retr-")}}])
         (Thread/sleep 800)
         (let [eid (get-in (d/transact conn [{:db/id -1 :doc/body "the whole document"
                                              :doc/title "My Title"}])
@@ -837,7 +838,7 @@
           (testing "so the database can still be backed up — the export refuses
                     any :db.secondary/only value it cannot recover, and this one
                     is recoverable again"
-            (is (map? (m/export-db @conn (str "/tmp/dh-retr-dump-" (java.util.UUID/randomUUID)) {})))))
+            (is (map? (m/export-db @conn (fs/temp-dir! "dh-retr-dump-") {})))))
         (finally (d/release conn))))))
 
 (deftest proximum-covers-exactly-one-attribute

--- a/test/datahike/test/secondary_only_test.clj
+++ b/test/datahike/test/secondary_only_test.clj
@@ -6,6 +6,7 @@
             [datahike.api :as d]
             [datahike.index.secondary :as sec]
             [datahike.index.entity-set :as es]
+            [datahike.migrate.fs :as fs]
             datahike.index.secondary.scriptum))
 
 (defn- fresh-conn []
@@ -17,7 +18,7 @@
 (defn- with-secondary [conn attrs]
   (d/transact conn [{:db/ident :idx/ft :db.secondary/type :scriptum
                      :db.secondary/attrs attrs
-                     :db.secondary/config {:path (str "/tmp/dh-so-test-" (random-uuid))}}])
+                     :db.secondary/config {:path (fs/temp-dir! "dh-so-test-")}}])
   (Thread/sleep 400))
 
 (deftest secondary-only-stores-hash-in-primary

--- a/test/datahike/test/secondary_versioning_test.clj
+++ b/test/datahike/test/secondary_versioning_test.clj
@@ -7,6 +7,7 @@
    [datahike.index.secondary :as sec]
    [datahike.index.entity-set :as es]
    [datahike.index.secondary.scriptum]
+   [datahike.migrate.fs :as fs]
    [konserve.core :as k]))
 
 (defrecord HistoricalBranchRecorder [attrs values]
@@ -89,7 +90,7 @@
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
-          scriptum-path (str "/tmp/scriptum-ver-test-" (random-uuid))
+          scriptum-path (fs/temp-dir! "scriptum-ver-test-")
           _ (d/create-database cfg)
           conn (d/connect cfg)]
       (try
@@ -206,11 +207,11 @@
   (testing "secondary index state survives release + reconnect"
     (let [cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
-                       :path (str "/tmp/datahike-ver-test-" (random-uuid))}
+                       :path (fs/temp-dir! "datahike-ver-test-")}
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}
-          scriptum-path (str "/tmp/scriptum-persist-" (random-uuid))
+          scriptum-path (fs/temp-dir! "scriptum-persist-")
           _ (d/create-database cfg)
           conn (d/connect cfg)]
       (try

--- a/test/datahike/test/secondary_versioning_test.clj
+++ b/test/datahike/test/secondary_versioning_test.clj
@@ -207,7 +207,7 @@
   (testing "secondary index state survives release + reconnect"
     (let [cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
-                       :path (fs/temp-dir! "datahike-ver-test-")}
+                       :path (fs/temp-store-path! "datahike-ver-test-")}
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}

--- a/test/datahike/test/store_ref_test.cljc
+++ b/test/datahike/test/store_ref_test.cljc
@@ -17,6 +17,7 @@
                      [datahike.api :as d]
                      [datahike.gc :as gc]
                      [datahike.blob :as blob]
+                     [datahike.migrate.fs :as fs]
                      [datahike.gc-guard :as guard :refer [with-unreferenced-writes]]
                      [datahike.test.async :refer [deftest-async]]
                      [konserve.core :as k]
@@ -27,13 +28,13 @@
                      [datahike.api :as d]
                      [datahike.gc :as gc]
                      [datahike.blob :as blob]
+                     [datahike.migrate.fs :as fs]
                      [datahike.gc-guard :as guard :refer-macros [with-unreferenced-writes]]
                      [datahike.test.async :refer-macros [deftest-async]]
                      ;; register the :file backend on Node — GC's mark walk needs a
                      ;; flushing store (a store-ref names an object that lives there).
                      [konserve.node-filestore]
                      [konserve.core :as k]
-                     [cljs.nodejs :as nodejs]
                      [clojure.core.async :as a :refer [<!] :refer-macros [go]])))
 
 (def ^:private schema
@@ -51,10 +52,13 @@
 
 (defn- rand-uuid [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
-(defn- tmp-path [id]
-  #?(:clj  (str (System/getProperty "java.io.tmpdir") "/dh-store-ref-" id)
-     :cljs (let [^js os (nodejs/require "os") ^js p (nodejs/require "path")]
-             (.join p (.tmpdir os) (str "dh-store-ref-" id)))))
+(defn- tmp-path
+  "A fresh store directory, created under the platform's temp location.
+   `fs/temp-dir!` is the one spelling both runtimes share; `id` only makes the
+   directory identifiable in a listing, since the uniqueness comes from the
+   helper."
+  [id]
+  (fs/temp-dir! (str "dh-store-ref-" id "-")))
 
 (defn- str->bytes [s]
   #?(:clj  (.getBytes ^String s "UTF-8")

--- a/test/datahike/test/store_ref_test.cljc
+++ b/test/datahike/test/store_ref_test.cljc
@@ -53,12 +53,13 @@
 (defn- rand-uuid [] #?(:clj (java.util.UUID/randomUUID) :cljs (random-uuid)))
 
 (defn- tmp-path
-  "A fresh store directory, created under the platform's temp location.
-   `fs/temp-dir!` is the one spelling both runtimes share; `id` only makes the
-   directory identifiable in a listing, since the uniqueness comes from the
-   helper."
+  "A fresh store path under the platform's temp location. NOT created — konserve
+   creates the store, and refuses a path that already exists.
+   `fs/temp-store-path!` is the one spelling both runtimes share; `id` only
+   makes the directory identifiable in a listing, since the uniqueness comes
+   from the helper."
   [id]
-  (fs/temp-dir! (str "dh-store-ref-" id "-")))
+  (fs/temp-store-path! (str "dh-store-ref-" id "-")))
 
 (defn- str->bytes [s]
   #?(:clj  (.getBytes ^String s "UTF-8")

--- a/test/datahike/test/store_test.cljc
+++ b/test/datahike/test/store_test.cljc
@@ -2,8 +2,8 @@
   (:require
    #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
       :clj  [clojure.test :as t :refer        [is deftest testing]])
-   [datahike.api :as d])
-  (:import [java.lang System]))
+   [datahike.api :as d]
+   [datahike.migrate.fs :as fs]))
 
 (defn test-store [cfg]
   (let [_ (d/delete-database cfg)]
@@ -23,9 +23,7 @@
 
 (deftest test-db-file-store
   (test-store {:store {:backend :file
-                       :path (case (System/getProperty "os.name")
-                               "Windows 10" (str (System/getProperty "java.io.tmpdir") "api-fs")
-                               "/tmp/api-fs")
+                       :path (fs/temp-dir! "dh-api-fs")
                        :id #uuid "f11e0000-0000-0000-0000-00000000000f"}}))
 
 (deftest test-db-mem-store
@@ -114,7 +112,7 @@
      ;; collapsing the two entries and dropping the removal → a stale old datom survives reopen.
      (testing "many value-changing upserts survive store→reopen with no stale/duplicate datoms (diff-buf)"
        (let [cfg {:store {:backend :file
-                          :path (str (System/getProperty "java.io.tmpdir") "/dh-diffbuf-upsert-" (java.util.UUID/randomUUID))
+                          :path (fs/temp-dir! "dh-diffbuf-upsert")
                           :id #uuid "d1ffb000-0000-0000-0000-00000000d1ff"}
                   :schema-flexibility :write :keep-history? false
                   :index-config {:diff-buf-size 256 :branching-factor 16}}
@@ -150,7 +148,7 @@
      ;; reconnect mid-stream.
      (testing "commits keep succeeding across reopen+mutate on a deep tree"
        (let [cfg {:store {:backend :file
-                          :path (str (System/getProperty "java.io.tmpdir") "/dh-detached-count-" (java.util.UUID/randomUUID))
+                          :path (fs/temp-dir! "dh-detached-count")
                           :id #uuid "d1ffb000-0000-0000-0000-00000000dead"}
                   :schema-flexibility :write :keep-history? true
                   :index-config {:branching-factor 16}}

--- a/test/datahike/test/store_test.cljc
+++ b/test/datahike/test/store_test.cljc
@@ -23,7 +23,7 @@
 
 (deftest test-db-file-store
   (test-store {:store {:backend :file
-                       :path (fs/temp-dir! "dh-api-fs")
+                       :path (fs/temp-store-path! "dh-api-fs")
                        :id #uuid "f11e0000-0000-0000-0000-00000000000f"}}))
 
 (deftest test-db-mem-store
@@ -112,7 +112,7 @@
      ;; collapsing the two entries and dropping the removal → a stale old datom survives reopen.
      (testing "many value-changing upserts survive store→reopen with no stale/duplicate datoms (diff-buf)"
        (let [cfg {:store {:backend :file
-                          :path (fs/temp-dir! "dh-diffbuf-upsert")
+                          :path (fs/temp-store-path! "dh-diffbuf-upsert")
                           :id #uuid "d1ffb000-0000-0000-0000-00000000d1ff"}
                   :schema-flexibility :write :keep-history? false
                   :index-config {:diff-buf-size 256 :branching-factor 16}}
@@ -148,7 +148,7 @@
      ;; reconnect mid-stream.
      (testing "commits keep succeeding across reopen+mutate on a deep tree"
        (let [cfg {:store {:backend :file
-                          :path (fs/temp-dir! "dh-detached-count")
+                          :path (fs/temp-store-path! "dh-detached-count")
                           :id #uuid "d1ffb000-0000-0000-0000-00000000dead"}
                   :schema-flexibility :write :keep-history? true
                   :index-config {:branching-factor 16}}

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -22,6 +22,7 @@
             [datahike.api :as d]
             [datahike.index.secondary :as sec]
             [datahike.index.secondary.stratum]
+            [datahike.migrate.fs :as fs]
             [datahike.versioning :as dv]
             [stratum.api :as st]))
 
@@ -157,7 +158,7 @@
 (defn- file-cfg []
   {:store {:backend :file
            :id (java.util.UUID/randomUUID)
-           :path (str "/tmp/datahike-stratum-vt-test-" (random-uuid))}
+           :path (fs/temp-dir! "datahike-stratum-vt-test-")}
    :keep-history? true
    :schema-flexibility :write})
 

--- a/test/datahike/test/stratum_vt_test.clj
+++ b/test/datahike/test/stratum_vt_test.clj
@@ -158,7 +158,7 @@
 (defn- file-cfg []
   {:store {:backend :file
            :id (java.util.UUID/randomUUID)
-           :path (fs/temp-dir! "datahike-stratum-vt-test-")}
+           :path (fs/temp-store-path! "datahike-stratum-vt-test-")}
    :keep-history? true
    :schema-flexibility :write})
 

--- a/test/datahike/test/stress_test.cljc
+++ b/test/datahike/test/stress_test.cljc
@@ -1,5 +1,6 @@
 (ns datahike.test.stress-test
   (:require [datahike.api :as d]
+            [datahike.migrate.fs :as fs]
             #?(:cljs [cljs.test    :as t :refer-macros [is deftest testing]]
                :clj  [clojure.test :as t :refer        [is deftest testing]])))
 
@@ -22,7 +23,7 @@
                    :db/index       avet?
                    :db/valueType   :db.type/long}]
 
-          cfg {:store  {:backend :file :path "/tmp/dh-stress"
+          cfg {:store  {:backend :file :path (fs/temp-dir! "dh-stress")
                         :id #uuid "57e55000-0000-0000-0000-000000000001"
                         :config {:sync-blob? true :in-place? false}}
                :keep-history? false

--- a/test/datahike/test/stress_test.cljc
+++ b/test/datahike/test/stress_test.cljc
@@ -23,7 +23,7 @@
                    :db/index       avet?
                    :db/valueType   :db.type/long}]
 
-          cfg {:store  {:backend :file :path (fs/temp-dir! "dh-stress")
+          cfg {:store  {:backend :file :path (fs/temp-store-path! "dh-stress")
                         :id #uuid "57e55000-0000-0000-0000-000000000001"
                         :config {:sync-blob? true :in-place? false}}
                :keep-history? false

--- a/test/datahike/test/upsert_impl_test.cljc
+++ b/test/datahike/test/upsert_impl_test.cljc
@@ -9,6 +9,7 @@
    [datahike.test.utils :refer [setup-db conn-id]]
    [datahike.constants :as const]
    [datahike.db :as db]
+   [datahike.migrate.fs :as fs]
    [datahike.api :as d]))
 
 (defn upsert-helper
@@ -181,7 +182,7 @@
         (d/release conn)))))
 
 (deftest upsert-read-handlers
-  (let [config {:store {:backend :file :path "/tmp/upsert-read-handlers" :id #uuid "ab1d0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-upsert-read-handlers") :id #uuid "ab1d0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write
                 :keep-history? false}
         schema [{:db/ident       :block/string

--- a/test/datahike/test/upsert_impl_test.cljc
+++ b/test/datahike/test/upsert_impl_test.cljc
@@ -182,7 +182,7 @@
         (d/release conn)))))
 
 (deftest upsert-read-handlers
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-upsert-read-handlers") :id #uuid "ab1d0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-upsert-read-handlers") :id #uuid "ab1d0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write
                 :keep-history? false}
         schema [{:db/ident       :block/string

--- a/test/datahike/test/upsert_test.cljc
+++ b/test/datahike/test/upsert_test.cljc
@@ -228,13 +228,13 @@
     (temporal-history-test config)))
 
 (deftest temporal-history-file
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-temp-hist-hht") :id #uuid "ab5e0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-temp-hist-hht") :id #uuid "ab5e0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write
                 :keep-history? true}]
     (temporal-history-test config)))
 
 (deftest temporal-history-file-with-attr-refs
-  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-temp-hist-attr-refs") :id #uuid "ab5e0000-0000-0000-0000-000000000002"}
+  (let [config {:store {:backend :file :path (fs/temp-store-path! "dh-temp-hist-attr-refs") :id #uuid "ab5e0000-0000-0000-0000-000000000002"}
                 :schema-flexibility :write
                 :keep-history? true
                 :attribute-refs? true}]
@@ -243,11 +243,11 @@
 (deftest test-upsert-after-large-coll
   (let [ascii-ish (map char (concat (range 48 58) (range 65 91) (range 97 123)))
         file-cfg {:store {:backend :file
-                          :path (fs/temp-dir! "dh-upsert-large-test")
+                          :path (fs/temp-store-path! "dh-upsert-large-test")
                           :id #uuid "ab5e0000-0000-0000-0000-000000000003"}}
         file-pss-cfg {:store {:backend :file
                               :index :datahike.index/persistent-set
-                              :path    (fs/temp-dir! "dh-upsert-large-pss-test")
+                              :path    (fs/temp-store-path! "dh-upsert-large-pss-test")
                               :id #uuid "ab5e0000-0000-0000-0000-000000000004"}}
         mem-cfg {:store {:backend :memory
                          :id #uuid "90000000-0000-0000-0000-000000000009"}}

--- a/test/datahike/test/upsert_test.cljc
+++ b/test/datahike/test/upsert_test.cljc
@@ -3,6 +3,7 @@
    #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
       :clj  [clojure.test :as t :refer        [is are deftest testing]])
    [datahike.api :as d]
+   [datahike.migrate.fs :as fs]
    [datahike.db :as db]
    [datahike.impl.entity :as de]
    [datahike.constants :as const]
@@ -227,13 +228,13 @@
     (temporal-history-test config)))
 
 (deftest temporal-history-file
-  (let [config {:store {:backend :file :path "/tmp/temp-hist-hht" :id #uuid "ab5e0000-0000-0000-0000-000000000001"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-temp-hist-hht") :id #uuid "ab5e0000-0000-0000-0000-000000000001"}
                 :schema-flexibility :write
                 :keep-history? true}]
     (temporal-history-test config)))
 
 (deftest temporal-history-file-with-attr-refs
-  (let [config {:store {:backend :file :path "/tmp/temp-hist-attr-refs" :id #uuid "ab5e0000-0000-0000-0000-000000000002"}
+  (let [config {:store {:backend :file :path (fs/temp-dir! "dh-temp-hist-attr-refs") :id #uuid "ab5e0000-0000-0000-0000-000000000002"}
                 :schema-flexibility :write
                 :keep-history? true
                 :attribute-refs? true}]
@@ -242,11 +243,11 @@
 (deftest test-upsert-after-large-coll
   (let [ascii-ish (map char (concat (range 48 58) (range 65 91) (range 97 123)))
         file-cfg {:store {:backend :file
-                          :path "/tmp/upsert-large-test"
+                          :path (fs/temp-dir! "dh-upsert-large-test")
                           :id #uuid "ab5e0000-0000-0000-0000-000000000003"}}
         file-pss-cfg {:store {:backend :file
                               :index :datahike.index/persistent-set
-                              :path    "/tmp/upsert-large-pss-test"
+                              :path    (fs/temp-dir! "dh-upsert-large-pss-test")
                               :id #uuid "ab5e0000-0000-0000-0000-000000000004"}}
         mem-cfg {:store {:backend :memory
                          :id #uuid "90000000-0000-0000-0000-000000000009"}}

--- a/test/datahike/test/versioning_test.cljc
+++ b/test/datahike/test/versioning_test.cljc
@@ -13,7 +13,7 @@
 (deftest datahike-versioning-test
   (testing "Testing versioning functionality."
     (let [cfg {:store              {:backend :file
-                                    :path    (fs/temp-dir! "dh-versioning-test")
+                                    :path    (fs/temp-store-path! "dh-versioning-test")
                                     :id #uuid "1e510000-0000-0000-0000-00000000001e"}
                :keep-history?      true
                :schema-flexibility :write

--- a/test/datahike/test/versioning_test.cljc
+++ b/test/datahike/test/versioning_test.cljc
@@ -6,13 +6,14 @@
               commit-id commit-as-db]]
             [datahike.db.utils :refer [db?]]
             [datahike.api :as d]
+            [datahike.migrate.fs :as fs]
             [konserve.core :as k]
             [superv.async :refer [<?? S]]))
 
 (deftest datahike-versioning-test
   (testing "Testing versioning functionality."
     (let [cfg {:store              {:backend :file
-                                    :path    "/tmp/dh-versioning-test"
+                                    :path    (fs/temp-dir! "dh-versioning-test")
                                     :id #uuid "1e510000-0000-0000-0000-00000000001e"}
                :keep-history?      true
                :schema-flexibility :write


### PR DESCRIPTION
chore: one convention for temporary directories, resolvable off POSIX

The test suite chose temporary store paths eleven different ways, and
seventy-eight of them were the literal `/tmp`. On Windows, Java resolves
`/tmp/x` to `\tmp\x` on the current drive, which does not exist — the same
shape as the native-image test failures fixed in #1014, applied across the
whole suite. Nothing here runs on Windows CI yet; this is what makes it
possible to.

## One convention

`datahike.migrate.fs/temp-dir!` already existed and was already right: it
resolves against `java.io.tmpdir` (`os.tmpdir()` on Node), builds the path
with the platform separator, and returns a unique directory. Every site now
goes through it — with one distinction the first pass got wrong and the second
commit corrects:

`temp-dir!` CREATES the directory, and konserve's `create-store` REFUSES a path
that already exists. That failed twenty-one tests, and hid in most of the
rest because they `delete-database` first, which removed the directory the
helper had just made. So a store gets `temp-store-path!` — a not-yet-existing
child of one temp root per process — and a dump or Lucene directory, which
must exist, keeps `temp-dir!`. The root-per-process is itself a fix from
review: one created parent per test was one leaked directory per test.

## Also

- Two `case (System/getProperty "os.name") "Windows 10" …` sniffs deleted:
  they matched only that literal, so `Windows Server 2022` fell through to
  `/tmp` anyway.
- Three duplicated `tmp-path` helpers collapsed into the shared one.
- `src-secondary/.../scriptum.clj` shipped `(str "/tmp/scriptum-" (random-uuid))`
  as the DEFAULT index path — library code, a user-facing Windows bug.
  Fixed, with its doc row.
- `bb test python` routed through `bash` like its siblings (a shebang, which
  Windows does not honour).
- `tools.reflection` derived namespace names with `/` and a `^root/` strip.
  On Windows `.getPath` yields backslashes, neither fires, and the gate
  reported "no reflective calls" having compiled nothing. Separator-agnostic
  now, an empty namespace list fails, and — from review — a namespace that
  fails to load fails the gate with the compiler's stderr instead of being
  silently skipped.
- A leaked agent-scratchpad path, `/tmp/claude-1000/…`, committed in #930 in
  two tests. Gone.

## Deliberately left alone, each annotated in place

- `migrate_test.clj`'s `/tmp/should-not-exist` and `migrate_init_build_test`'s
  `"/tmp"` — refused before the path is read.
- `config_test.cljc:27/33` — URI parsing, the output must spell the input.
- `backward_test.clj` — the WRITER runs the last release's frozen copy of the
  file, which spells `/tmp` literally; this side must match it. Moving it is a
  two-release step, and the comment says how.
- `depr_config_uri_test.clj` — the deprecated URI form does open a store at
  `/tmp`; making it portable means teaching `uri->config` Windows drive
  letters. Linux CI only. Its comment now says so, truthfully.

## Verified

External review (gpt-5.6-sol, medium): four findings, all addressed in the
third commit — the frozen-writer mismatch, the untruthful URI comment, the
gate swallowing load failures, the leaked parent directory. Cleared
explicitly: the temp-dir!/temp-store-path! split at every site, no test
needing a stable path broken, no assertion weakened, `.cljs` sites on Node
APIs, the scriptum default equivalent on Linux.

Rebased onto main after #1022/#1025/#974. `bb format` and `bb reflection`
clean on the rebased tree; `clj-pss` and `migrate` results are posted below.
