### PR TITLE
ci: the exit trap must not run under errexit

### DIFF
--- a/bb/resources/native-image-tests/run-native-image-tests
+++ b/bb/resources/native-image-tests/run-native-image-tests
@@ -48,7 +48,14 @@ ATTR_REF_CONFIG=bb/resources/native-image-tests/testconfig.attr-refs.edn
 # with `Test successful.`, `CBOR remote-writer test successful.` and
 # `Positional input test successful.` still reported failure.
 cleanup() {
-  rm -rf "$TMPSTORE" "$CBOR_STORE" 2>/dev/null || true
+  # `errexit` is still in force inside a trap, and `kill` here is the command
+  # after the final `&&` — the one place in an `&&` list errexit DOES apply.
+  # The server was already killed above, so on Git Bash, where the dead child
+  # is gone rather than a zombie, that `kill` failed and took a fully passing
+  # run down with it: every test green, exit 1, nothing printed. macOS never
+  # showed it because there the child lingers unreaped and `kill` succeeds.
+  set +o errexit
+  rm -rf "$TMPSTORE" "$CBOR_STORE" 2>/dev/null
   [ -n "${CBOR_SERVER_PID:-}" ] && kill "$CBOR_SERVER_PID" 2>/dev/null
   return 0
 }


### PR DESCRIPTION
ci: the exit trap must not run under errexit

Windows went red on the konserve 0.9.389 bump with every test green:

    Test successful.
    CBOR remote-writer test successful.
    Positional input test successful.
    nil
    nil
    (exit 1, nothing else printed)

The two `nil`s are the closing `delete-database` calls, so the script ran to
its last line. What failed was `cleanup`, from #1016:

    [ -n "${CBOR_SERVER_PID:-}" ] && kill "$CBOR_SERVER_PID" 2>/dev/null

`errexit` is still in force inside a trap, and it does not apply to commands
in an `&&` list — EXCEPT the one after the final `&&`. That is the `kill`.
The server was already killed earlier in the script; on Git Bash the dead
child is gone, so this `kill` fails and errexit ends the shell with status 1
from inside the trap. macOS never showed it: there the child lingers as an
unreaped zombie, `kill` succeeds, and the same trap returns 0.

Reproduced both ways with a stub of the trap — a reaped pid gives exit 1, a
zombie gives exit 0 — and the fixed function gives 0 with the reaped pid.

`cleanup` now turns errexit off for itself, and nothing in it can decide the
script's status. This is the second time cleanup took a passing Windows run
down; the first was `rm` on a held directory. The lesson is written into the
function this time.
