### PR TITLE
HTTP API: embeddable routes, one gate, validators, per-call authorization, eacl permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ When something is added, it's typically marked *Experimental*. When the API cont
   **The HTTP client now defaults to CBOR** (`:format :cbor` in the remote
   peer); pass `:format :transit`, `:edn` or `:json` to keep the old wire
   format.
+- **The HTTP API authenticates through validators and authorizes per call.**
+  *Experimental.* Besides `:token`, the server config takes `:validator`
+  (`(fn [request] → principal | nil)`, kabel's shape — JWT/JWKS via
+  `kabel.auth.jwt`) and `:auth :upstream`; every request carries its
+  principal, and `:authorize` (`(fn [{:keys [op principal db payload]}])`) is
+  asked for each database a call reaches. With `:auth-db` the server keeps an
+  eacl permission graph (users, server admins, database owners/writers/readers)
+  in a Datahike database of its own and manages it through
+  `/permissions/*`. Token auth no longer uses buddy; the header is
+  `authorization: token <token>` as before.
 
 - **Index warming is unified across the stack, and real on ClojureScript.**
   The breadth-first walk moved to persistent-sorted-set (>= 0.5.142), where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ When something is added, it's typically marked *Experimental*. When the API cont
   bodies, fails writer operations the server does not implement by name
   instead of with a 404, and returns database handles that can make remote
   calls.
+  **The HTTP client now defaults to CBOR** (`:format :cbor` in the remote
+  peer); pass `:format :transit`, `:edn` or `:json` to keep the old wire
+  format.
 
 - **Index warming is unified across the stack, and real on ClojureScript.**
   The breadth-first walk moved to persistent-sorted-set (>= 0.5.142), where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ When something is added, it's typically marked *Experimental*. When the API cont
   map entry per entity, is no longer returned by default; ask for it with
   `(metrics db {:per-entity-counts? true})`. **Status change:** the key is
   optional in `SMetrics` now.
+- **The HTTP API is embeddable.** *Experimental.* `datahike.http.routes/handler`
+  returns the server's routes as a Ring handler for mounting inside a host
+  application, under a prefix, sharing the host's connection registry
+  (`:connections`), with the token checked and the body capped *before*
+  anything is decoded. `datahike.http.server` is now a thin shell around it.
+  See [doc/http-routes.md](doc/http-routes.md).
+  **Breaking for embedders of the server namespace:** `datahike.http.server/app`
+  now takes `(app config connections)`; `start-server`/`stop-server`/`-main`
+  are unchanged, and `stop-server` now releases the databases the server
+  opened. The `:datahike-server` writer no longer sends its token in request
+  bodies, fails writer operations the server does not implement by name
+  instead of with a 404, and returns database handles that can make remote
+  calls.
+
 - **Index warming is unified across the stack, and real on ClojureScript.**
   The breadth-first walk moved to persistent-sorted-set (>= 0.5.142), where
   every consumer shares it; `datahike.index.persistent-set.warm` is now the

--- a/deps.edn
+++ b/deps.edn
@@ -141,7 +141,13 @@
                                                                            io.replikativ/konserve]}
 
                                ;; http server
-                               buddy/buddy-auth              {:mvn/version "3.0.323"}
+                               io.github.whilo/eacl {:git/url "https://github.com/whilo/eacl.git"
+                                                     :git/sha "c11c3f855a5f795a2b66a0293a64dde7fe82d898"
+                                                     :deps/root "modules/eacl-datahike"
+                                                     ;; The fork's source-only datahike backend, until
+                                                     ;; upstream dev.eacl/eacl-datahike ships a jar that
+                                                     ;; is not AOT-compiled for a newer JDK.
+                                                     :exclusions [org.replikativ/datahike]}
                                ring/ring-core                {:mvn/version "1.15.5"}
                                ring/ring-jetty-adapter       {:mvn/version "1.15.5"}
                                metosin/reitit                {:mvn/version "0.10.1"}
@@ -186,7 +192,13 @@
            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.5"}}}
 
            :http-server {:extra-paths ["http-server"]
-                         :extra-deps {buddy/buddy-auth        {:mvn/version "3.0.323"}
+                         :extra-deps {io.github.whilo/eacl {:git/url "https://github.com/whilo/eacl.git"
+                                                     :git/sha "c11c3f855a5f795a2b66a0293a64dde7fe82d898"
+                                                     :deps/root "modules/eacl-datahike"
+                                                     ;; The fork's source-only datahike backend, until
+                                                     ;; upstream dev.eacl/eacl-datahike ships a jar that
+                                                     ;; is not AOT-compiled for a newer JDK.
+                                                     :exclusions [org.replikativ/datahike]}
                                       ring/ring-core          {:mvn/version "1.15.5"}
                                       ring/ring-jetty-adapter {:mvn/version "1.15.5"}
                                       metosin/reitit          {:mvn/version "0.10.1"}

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -66,6 +66,10 @@ You can now use the normal `datahike.api` as usual and all operations changing a
 database, e.g. `create-database`, `delete-database` and `transact` are sent to
 the server while all other calls are executed locally.
 
+The server side is either the standalone `datahike.http.server`, or the same
+routes mounted inside your own application — see
+[Embedding the HTTP API](http-routes.md).
+
 ### AWS lambda
 
 An example setup to run Datahike distributed in AWS lambda without a server can

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -68,7 +68,8 @@ config map — authentication (`:token`, `:validator`, `:dev-mode`,
 The handler adds no middleware beyond what the API itself needs — CORS,
 static files, TLS and the rest of your application are yours. It carries
 its connections atom as metadata: `(routes/release-all! handler)` releases
-everything the routes opened when the host shuts down.
+every connection in that atom — the routes' and, if you shared yours, the
+host's own — so call it when the process shuts down.
 
 ### The request contract
 
@@ -140,7 +141,9 @@ which the clients raise as an exception.
 | `:admin` | `gc-storage` |
 
 `db` is `{:store-id uuid :branch keyword}`; `payload` is the call's argument
-vector. Without `:authorize`, every authenticated caller may do everything —
+vector. The arguments are searched in full, transaction data included: a
+transaction function can be handed a connection or database value for
+another database, and that database is then part of the call. Without `:authorize`, every authenticated caller may do everything —
 today's behaviour.
 
 ### Permissions in an auth database (eacl)
@@ -158,6 +161,11 @@ local read. Give the server one and it is on:
  :validator …                                    ; everyone else, by JWT
  :auth-db  {:store {:backend :file :path "/var/lib/datahike/auth"}}}
 ```
+
+A durable store without an `:id` gets one derived from its path, the same
+on every start; a memory store gets a fresh one per server, so two servers
+in one process never share an auth database by accident. Servers that do
+share one share its admins.
 
 The graph (`datahike.http.permissions/schema`):
 
@@ -268,8 +276,8 @@ your service — or give that client a `:self` writer.
 
 ## Security
 
-- Tokens travel in the `authorization` header only: the writer client strips
-  its credentials from what it sends, the server strips `:writer` and
+- Tokens travel in the `authorization` header only: the clients strip their
+  credentials from the configs they send, the server strips `:writer` and
   `:remote-peer` from any config it receives, and neither logs request
   bodies.
 - Error bodies (500) carry the exception's message and `ex-data` with

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -1,0 +1,198 @@
+# Embedding the HTTP API
+
+`datahike.http.routes` is the HTTP API of the Datahike server as a Ring
+handler you mount inside your own application, instead of running
+`datahike.http.server` as a separate process. Same routes, same clients,
+same authentication — under a prefix of your choosing, sharing the databases
+your application already has open.
+
+This is what you want when your service *is* the writer: it holds the
+database, other processes read the storage directly ([distributed
+mode](distributed.md)) and send their transactions to your service. The
+standalone server stays the right choice when nothing else lives in that
+process — see [Running the server](#running-the-standalone-server).
+
+The namespace lives in the `http-server` source path; add the `:http-server`
+alias (or the path) to your deps, plus a Ring adapter (Jetty below).
+
+## Quick start
+
+```clojure
+(ns my.app
+  (:require [datahike.api :as d]
+            [datahike.connections :refer [*connections*]]
+            [datahike.http.routes :as routes]
+            [ring.adapter.jetty :refer [run-jetty]]))
+
+(def connections (atom {}))
+
+(def datahike
+  (routes/handler {:token (System/getenv "DATAHIKE_TOKEN")}
+                  {:prefix "/datahike" :connections connections}))
+
+(defn app [request]
+  (if (clojure.string/starts-with? (:uri request) "/datahike")
+    (datahike request)
+    my-own-handler))
+
+(run-jetty app {:port 8080 :join? false})
+```
+
+Any Datahike client now talks to `http://host:8080/datahike`:
+
+```clojure
+;; a reader that sends its writes to your service
+{:store  {:backend :file :path "/shared/store" :id #uuid "…"}
+ :writer {:backend :datahike-server :url "http://host:8080/datahike" :token "…"}}
+
+;; or the full remote API (no local storage at all)
+(require '[datahike.http.client :as client])
+(client/connect {:store {:backend :memory :id #uuid "…"}
+                 :remote-peer {:backend :datahike-server
+                               :url "http://host:8080/datahike" :token "…" :format :cbor}})
+```
+
+## What `handler` gives you
+
+`(routes/handler config opts)` returns a Ring handler. `config` is the server
+config map (`:token`, `:dev-mode`, `:max-body-bytes`); `opts`:
+
+| option | default | meaning |
+|---|---|---|
+| `:prefix` | none (mount at `/`) | Path every route is nested under. `"/datahike"`, `"datahike/"` and `"/datahike/"` all mean `/datahike`. |
+| `:connections` | a fresh atom | The connection registry the routes use. Pass your own to share databases with the host (below). |
+| `:extra-routes` | none | Your own reitit routes on the same router, under the same prefix; the server adds `/swagger.json` this way. Mark a route `:public? true` to exempt it from the token gate. |
+
+Requests the router does not match fall through with a 404 from
+`reitit.ring/create-default-handler`. CORS, static files, TLS and the rest of
+your application are yours — the handler adds no middleware beyond what the
+API itself needs.
+
+### The request contract
+
+Every request the router matches goes through `routes/wrap-api`, in this order:
+
+1. **The gate, before any decoding.** A public route passes. Every other
+   route requires the token *here*: `authorization: token <token>` (also the
+   `token` header), or `:dev-mode true` in the config. A request without it
+   is answered `401` without its body ever being parsed. Then the body is
+   capped at `:max-body-bytes` (default 64 MiB) — by `Content-Length` and by
+   the stream itself, so a chunked body cannot skip the check — with `413`.
+2. **The registry.** `datahike.connections/*connections*` is bound to your
+   atom for the *whole* request, decoding included. Every route — `connect`,
+   `q`, `release`, the writer routes, a database handle inside a body —
+   resolves connections in that atom, never in the process-wide default.
+
+A handler with no `:token` and no `:dev-mode` admits nobody; that is the
+secure default, not a bug.
+
+### Sharing connections with the host
+
+Connections are keyed by store identity and branch, so the host's connection
+and one the API opens for the same config are *the same object* when they are
+looked up in the same atom. Bind the atom when the host connects:
+
+```clojure
+(def conn (binding [*connections* connections]
+            (d/connect cfg)))
+
+;; a client's `connect` with the same config now returns this connection,
+;; and what it transacts is visible on `@conn` immediately.
+```
+
+If the host does not bind, the host's connection lives in the default
+registry and the API opens its own — two connections to one store, which is
+allowed (they share the storage and coordinate through it) but wastes memory
+and, for the writer routes, means your service transacts through a connection
+it does not hold.
+
+Two rules that follow from sharing:
+
+- **Leases.** The writer routes hold *one* connection per database in the
+  atom, opened on first use, and never release it per request; ordinary
+  `connect`/`release` routes count leases exactly as the API does for a local
+  caller. Call `(routes/release-all! connections)` when your service shuts
+  down.
+- **Deletion is process-wide.** `delete-database` through the API releases
+  and invalidates *every* connection to that database in the atom, the host's
+  included — as it would if the host called it itself. If your service must
+  keep a database, do not hand out the token that can delete it.
+
+### What the writer routes accept
+
+A `:datahike-server` writer sends `create-database`, `delete-database` and
+`transact!` to your service. Other writer-side operations
+(`load-entities`, `merge-db!`, `gc-storage!`, `publish-built-db!`) are not
+available over this writer; a client calling them gets an error naming the
+operation. Run those where the writer runs — in your service — or give that
+client a `:self` writer.
+
+## Authentication and security
+
+- The token is a shared secret; put it in an environment variable or a
+  secrets manager, never in the config file you commit. Use different tokens
+  per environment and rotate them.
+- Tokens travel in a header, never in the body: the writer client strips its
+  own credentials from what it sends, and the server strips `:writer` and
+  `:remote-peer` from any config it receives before using it.
+- Error bodies (500) carry the exception's message and `ex-data` with
+  credential-valued keys (`:token`, `:secret`, `:access-key`, `:secret-key`,
+  `:password`) redacted.
+- TLS is your reverse proxy's job (nginx, Caddy, a cloud load balancer). Do
+  not send tokens over plain HTTP outside a private network.
+- `:dev-mode true` disables authentication entirely. Never deploy with it.
+- For anything beyond a shared token — OAuth, JWT, mTLS, per-user
+  authorization — wrap the handler in your own middleware and run Datahike
+  with `:dev-mode true` *behind* it, so that only your middleware decides who
+  gets in. The API has no notion of users; authorization is per token.
+
+Checklist: token set · `:dev-mode` false · token in env/secret store · TLS at
+the edge · `release-all!` on shutdown · deletion token held only by whoever
+may delete.
+
+## Running the standalone server
+
+The server is the same routes with Swagger UI at `/`, `/swagger.json`, CORS
+and Jetty around them:
+
+```bash
+clojure -M:http-server -m datahike.http.server config.edn
+```
+
+```clojure
+;; config.edn
+{:port     4444
+ :join?    false
+ :token    "securerandompassword"
+ :dev-mode false
+ :level    :info}
+```
+
+`datahike.http.server/start-server` and `stop-server` do the same from a
+REPL; `stop-server` releases every database the server opened. `app` takes
+the config and a connections atom, for hosts that want the server's exact
+handler (Swagger included) inside their own Jetty.
+
+## Migrating from the standalone server
+
+Nothing changes for clients: `:url` now points at your prefix. On the server
+side, replace `start-server` with `handler` mounted in your app, pass your
+atom, and bind it where the host connects. The server's `app` now takes
+`(app config connections)`; `start-server config` is unchanged.
+
+## Troubleshooting
+
+- **401 on everything** — no `:token` in the config and no `:dev-mode`. Set
+  the token; the client must send `authorization: token <token>`.
+- **404 under the prefix** — the prefix is normalized, but the *host* must
+  route the prefixed paths to the handler; check the host's dispatch.
+- **413** — raise `:max-body-bytes`, or transact in smaller batches.
+- **The host does not see what a client wrote** — the host connected outside
+  `(binding [*connections* connections] …)`; two connections, two views.
+- **A client gets "not available over the :datahike-server writer"** — it
+  called a writer-side operation the HTTP writer does not carry; run it in the
+  service.
+
+Credit: the embedding mode, its documentation shape and the security
+checklist grew out of Alex Oloo's proposal in
+[#755](https://github.com/replikativ/datahike/pull/755).

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -55,36 +55,171 @@ Any Datahike client now talks to `http://host:8080/datahike`:
 ## What `handler` gives you
 
 `(routes/handler config opts)` returns a Ring handler. `config` is the server
-config map (`:token`, `:dev-mode`, `:max-body-bytes`); `opts`:
+config map — authentication (`:token`, `:validator`, `:dev-mode`,
+`:auth :upstream`), `:authorize`, `:max-body-bytes`; `opts`:
 
 | option | default | meaning |
 |---|---|---|
 | `:prefix` | none (mount at `/`) | Path every route is nested under. `"/datahike"`, `"datahike/"` and `"/datahike/"` all mean `/datahike`. |
 | `:connections` | a fresh atom | The connection registry the routes use. Pass your own to share databases with the host (below). |
-| `:extra-routes` | none | Your own reitit routes on the same router, under the same prefix; the server adds `/swagger.json` this way. Mark a route `:public? true` to exempt it from the token gate. |
+| `:extra-routes` | none | Your own reitit routes on the same router, under the same prefix and behind the gate; the server adds `/swagger.json` and the permission routes this way. Mark a route `:public? true` to exempt it from authentication (not from the body cap). |
+| `:default-handler` | reitit's 404 | What answers a request the router does not match (the server puts swagger-ui here). |
 
-Requests the router does not match fall through with a 404 from
-`reitit.ring/create-default-handler`. CORS, static files, TLS and the rest of
-your application are yours — the handler adds no middleware beyond what the
-API itself needs.
+The handler adds no middleware beyond what the API itself needs — CORS,
+static files, TLS and the rest of your application are yours. It carries
+its connections atom as metadata: `(routes/release-all! handler)` releases
+everything the routes opened when the host shuts down.
 
 ### The request contract
 
-Every request the router matches goes through `routes/wrap-api`, in this order:
+Every request the router matches for its method goes through the gate, in
+this order — a request it does not match, or matches for another method (an
+OPTIONS preflight, a wrong method), is handed on untouched, to your CORS
+middleware, reitit's 405 or the `:default-handler`:
 
-1. **The gate, before any decoding.** A public route passes. Every other
-   route requires the token *here*: `authorization: token <token>` (also the
-   `token` header), or `:dev-mode true` in the config. A request without it
-   is answered `401` without its body ever being parsed. Then the body is
-   capped at `:max-body-bytes` (default 64 MiB) — by `Content-Length` and by
-   the stream itself, so a chunked body cannot skip the check — with `413`.
-2. **The registry.** `datahike.connections/*connections*` is bound to your
+1. **The body is read in full and capped** at `:max-body-bytes` (default
+   64 MiB), by `Content-Length` and by actually reading it, public route or
+   not, before any decoder sees a byte: `413` past the cap. No decoder ever
+   gets an unbounded stream, and a body a decoder would read only the first
+   form of is still measured whole.
+2. **Authentication, before decoding.** Unless the route is `:public? true`
+   (`/swagger.json`), the caller must be accepted by one of the validators
+   `config` describes (next section), or gets `401` with nothing parsed. The
+   principal is put on the request as `:datahike/principal`.
+3. **The registry.** `datahike.connections/*connections*` is bound to your
    atom for the *whole* request, decoding included. Every route — `connect`,
    `q`, `release`, the writer routes, a database handle inside a body —
    resolves connections in that atom, never in the process-wide default.
+4. **Authorization, after decoding**, per route, with the databases the call
+   reaches (below).
 
-A handler with no `:token` and no `:dev-mode` admits nobody; that is the
-secure default, not a bug.
+A handler with no `:token`, no `:validator`, no `:dev-mode` and no
+`:auth :upstream` admits nobody; that is the secure default, not a bug.
+
+## Authentication: who is calling
+
+The config describes a chain of validators, each
+`(fn [ring-request] → principal | nil)`, tried in order; the first principal
+wins. A principal is a map with `:sub`, the subject's id — the same shape
+`kabel.auth.jwt/build-bearer-validator` returns, so one validator can serve
+the HTTP API and a kabel WebSocket peer.
+
+| config | who gets in |
+|---|---|
+| `:token "…"` | Whoever sends `authorization: token <token>`, as the principal `:token-subject` (`"root"` by default). The shared secret; keep it in an environment variable or a secrets manager. |
+| `:validator f` | Whoever `f` accepts. JWT, JWKS-backed OIDC (WorkOS, Clerk, Auth0), mTLS-derived identity — `kabel.auth.jwt` has the JWT ones ready. |
+| `:auth :upstream` | Everyone, as the `:datahike/principal` your own middleware put on the request (or `{:sub "upstream"}`). For a host that authenticates before the request reaches Datahike. Only ever behind such middleware. |
+| `:dev-mode true` | Everyone, as `{:sub "dev"}`. Local development only; never deploy with it. |
+
+```clojure
+(require '[kabel.auth.jwt :as jwt])   ; kabel's :auth alias
+
+(routes/handler {:token     (System/getenv "DATAHIKE_TOKEN")        ; break-glass
+                 :validator (jwt/build-bearer-validator             ; everyone else
+                             {:issuers {"https://issuer" {:alg :RS256 :jwks-url "…"}}
+                              :key-resolver (jwks/make-key-resolver)})}
+                {:prefix "/datahike" :connections connections})
+```
+
+## Authorization: what they may do
+
+`:authorize` is one function, `(fn [{:keys [op principal db payload]}] → boolean)`,
+asked per call for every database the call reaches — a config, a connection,
+a database value or any history/as-of/since/filtered view of one, positional
+or in the map form — and once with `:db nil` for a call that reaches none.
+Every database must be allowed, or the call is `403` with
+`{:type :datahike.http/forbidden :op … :databases […]}` in its ex-data,
+which the clients raise as an exception.
+
+| `op` | routes |
+|---|---|
+| `:read` | every GET (`q`, `pull`, `datoms`, `history`, `as-of`, `metrics`, …) and the POSTs that only open, inspect or close: `connect`, `release`, `db`, `database-exists?`, `branches`, `branch-as-db`, `commit-as-db` |
+| `:transact` | `transact`, `load-entities`, `merge-db`, `branch!`, and the writer's `transact!` |
+| `:create` | `create-database`, the writer's too |
+| `:delete` | `delete-database`, `delete-branch!`, the writer's `delete-database` |
+| `:admin` | `gc-storage` |
+
+`db` is `{:store-id uuid :branch keyword}`; `payload` is the call's argument
+vector. Without `:authorize`, every authenticated caller may do everything —
+today's behaviour.
+
+### Permissions in an auth database (eacl)
+
+The server ships a policy so you need not write one: relationship-based
+authorization in the [SpiceDB](https://authzed.com/spicedb) model via
+[eacl](https://github.com/theronic/eacl), *situated* — the permission graph
+lives in a Datahike database of its own, `:auth-db`, and every check is a
+local read. Give the server one and it is on:
+
+```clojure
+;; config.edn
+{:port     4444
+ :token    "…"                                   ; the break-glass identity
+ :validator …                                    ; everyone else, by JWT
+ :auth-db  {:store {:backend :file :path "/var/lib/datahike/auth"}}}
+```
+
+The graph (`datahike.http.permissions/schema`):
+
+```
+definition user {}
+definition server {
+  relation admin: user
+  permission administer = admin
+  permission create = admin
+}
+definition database {
+  relation owner: user
+  relation writer: user
+  relation reader: user
+  permission admin = owner
+  permission grant = owner
+  permission delete = owner
+  permission transact = writer + owner
+  permission read = reader + writer + owner
+}
+```
+
+Users are principals by their `:sub`; the one server has admins who may do
+everything; a database — by store id, its branches share it — has owners,
+writers and readers, and `grant` is the permission to edit that database's
+relationships, so permission administration is one more permission in the
+graph rather than a special case. The token principal (`:token-subject`,
+`"root"`) is seeded as a server admin on every start, so the shared secret
+stays the break-glass identity and everyone else is granted:
+
+```clojure
+;; as root: alice may write to the database, bob may read it
+(client/request-cbor :post "permissions/relationships!" root-peer
+  [{:operation :touch :relationship {:subject  {:type :user :id "alice"}
+                                     :relation :writer
+                                     :resource {:type :database :id "<store uuid>"}}}
+   {:operation :touch :relationship {:subject  {:type :user :id "bob"}
+                                     :relation :reader
+                                     :resource {:type :database :id "<store uuid>"}}}])
+```
+
+Routes, all behind the gate, bodies as maps, objects as
+`{:type :user|:database|:server :id "…"}`:
+
+- `POST /permissions/check` `{:subject :permission :resource}` → `{:allowed}`.
+  Anyone may ask about themselves (omit `:subject`); about others only who may
+  grant on the resource.
+- `POST /permissions/relationships` `{:resource}` → the relationships on it,
+  for who may grant on it.
+- `POST /permissions/relationships!` `[{:operation :touch|:create|:delete :relationship {…}} …]`,
+  each allowed by grant on its resource (server admins anywhere).
+
+Only server admins create databases — the creator then grants an owner —
+and only owners delete. A database's permissions apply to what the server
+mediates: the full remote API, and the writer routes for a process that
+reads storage directly and sends its writes here. Such a process has read
+access by holding the storage credentials; the server governs its writes.
+
+Embedding hosts get the same by calling `permissions/configure` on their
+config and adding `(permissions/routes config)` to `:extra-routes`; the
+`datahike.http.permissions` namespace needs eacl on the classpath, which the
+`:http-server` alias brings and `datahike.http.routes` does not need.
 
 ### Sharing connections with the host
 
@@ -108,15 +243,17 @@ it does not hold.
 
 Two rules that follow from sharing:
 
-- **Leases.** The writer routes hold *one* connection per database in the
-  atom, opened on first use, and never release it per request; ordinary
-  `connect`/`release` routes count leases exactly as the API does for a local
-  caller. Call `(routes/release-all! connections)` when your service shuts
+- **Leases.** The writer routes hold one base lease per database, taken on
+  first use, so the connection and its writer survive between requests; each
+  request pins the connection for its duration and lets go. `connect` and
+  `release` through the API count leases exactly as the API does for a local
+  caller; decoding a database handle takes none. Call
+  `(routes/release-all! handler)` (or with the atom) when your service shuts
   down.
 - **Deletion is process-wide.** `delete-database` through the API releases
   and invalidates *every* connection to that database in the atom, the host's
   included — as it would if the host called it itself. If your service must
-  keep a database, do not hand out the token that can delete it.
+  keep a database, do not grant `delete` on it.
 
 ### What the writer routes accept
 
@@ -124,31 +261,26 @@ A `:datahike-server` writer sends `create-database`, `delete-database` and
 `transact!` to your service. Other writer-side operations
 (`load-entities`, `merge-db!`, `gc-storage!`, `publish-built-db!`) are not
 available over this writer; a client calling them gets an error naming the
-operation. Run those where the writer runs — in your service — or give that
-client a `:self` writer.
+operation and the writer stays usable. Run those where the writer runs — in
+your service — or give that client a `:self` writer.
 
-## Authentication and security
+## Security
 
-- The token is a shared secret; put it in an environment variable or a
-  secrets manager, never in the config file you commit. Use different tokens
-  per environment and rotate them.
-- Tokens travel in a header, never in the body: the writer client strips its
-  own credentials from what it sends, and the server strips `:writer` and
-  `:remote-peer` from any config it receives before using it.
+- Tokens travel in the `authorization` header only: the writer client strips
+  its credentials from what it sends, the server strips `:writer` and
+  `:remote-peer` from any config it receives, and neither logs request
+  bodies.
 - Error bodies (500) carry the exception's message and `ex-data` with
   credential-valued keys (`:token`, `:secret`, `:access-key`, `:secret-key`,
   `:password`) redacted.
 - TLS is your reverse proxy's job (nginx, Caddy, a cloud load balancer). Do
   not send tokens over plain HTTP outside a private network.
-- `:dev-mode true` disables authentication entirely. Never deploy with it.
-- For anything beyond a shared token — OAuth, JWT, mTLS, per-user
-  authorization — wrap the handler in your own middleware and run Datahike
-  with `:dev-mode true` *behind* it, so that only your middleware decides who
-  gets in. The API has no notion of users; authorization is per token.
+- `:dev-mode true` disables authentication entirely; `:auth :upstream`
+  trusts whatever reached the handler. Never deploy either exposed.
 
-Checklist: token set · `:dev-mode` false · token in env/secret store · TLS at
-the edge · `release-all!` on shutdown · deletion token held only by whoever
-may delete.
+Checklist: a token or validator set · `:dev-mode` false · secrets in
+env/secret store · TLS at the edge · `release-all!` on shutdown · `delete`
+granted only to owners who may.
 
 ## Running the standalone server
 
@@ -169,9 +301,10 @@ clojure -M:http-server -m datahike.http.server config.edn
 ```
 
 `datahike.http.server/start-server` and `stop-server` do the same from a
-REPL; `stop-server` releases every database the server opened. `app` takes
-the config and a connections atom, for hosts that want the server's exact
-handler (Swagger included) inside their own Jetty.
+REPL; `stop-server` releases every database the server opened, the auth
+database included. `app` takes the config and a connections atom, for hosts
+that want the server's exact handler (Swagger, CORS, permissions) inside
+their own Jetty.
 
 ## Migrating from the standalone server
 
@@ -182,11 +315,17 @@ atom, and bind it where the host connects. The server's `app` now takes
 
 ## Troubleshooting
 
-- **401 on everything** — no `:token` in the config and no `:dev-mode`. Set
-  the token; the client must send `authorization: token <token>`.
+- **401 on everything** — no `:token`, `:validator`, `:dev-mode` or
+  `:auth :upstream` in the config. The client sends
+  `authorization: token <token>`.
+- **403** — the call reaches a database the principal has no permission on;
+  the ex-data names the op and the databases. Grant, or check the principal
+  your validator returns.
 - **404 under the prefix** — the prefix is normalized, but the *host* must
   route the prefixed paths to the handler; check the host's dispatch.
 - **413** — raise `:max-body-bytes`, or transact in smaller batches.
+- **A permission does not take effect** — objects are keyed by exact `:sub`
+  and store id; check `POST /permissions/relationships` as root.
 - **The host does not see what a client wrote** — the host connected outside
   `(binding [*connections* connections] …)`; two connections, two views.
 - **A client gets "not available over the :datahike-server writer"** — it

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -107,7 +107,7 @@ the HTTP API and a kabel WebSocket peer.
 | config | who gets in |
 |---|---|
 | `:token "…"` | Whoever sends `authorization: token <token>`, as the principal `:token-subject` (`"root"` by default). The shared secret; keep it in an environment variable or a secrets manager. |
-| `:validator f` | Whoever `f` accepts. JWT, JWKS-backed OIDC (WorkOS, Clerk, Auth0), mTLS-derived identity — `kabel.auth.jwt` has the JWT ones ready. |
+| `:validator f` | Whoever `f` accepts. JWT, JWKS-backed OIDC (WorkOS, Clerk, Auth0), mTLS-derived identity — `kabel.auth.jwt` has the JWT ones ready. A principal claiming the token's subject is refused: subjects share one namespace and that one is reserved. |
 | `:auth :upstream` | Everyone, as the `:datahike/principal` your own middleware put on the request (or `{:sub "upstream"}`). For a host that authenticates before the request reaches Datahike. Only ever behind such middleware. |
 | `:dev-mode true` | Everyone, as `{:sub "dev"}`. Local development only; never deploy with it. |
 
@@ -247,7 +247,9 @@ Two rules that follow from sharing:
   first use, so the connection and its writer survive between requests; each
   request pins the connection for its duration and lets go. `connect` and
   `release` through the API count leases exactly as the API does for a local
-  caller; decoding a database handle takes none. Call
+  caller — one lease per call; a client's `release-all?` is ignored, since it
+  would close a connection the host and other callers share — and decoding a
+  database handle takes none. Call
   `(routes/release-all! handler)` (or with the atom) when your service shuts
   down.
 - **Deletion is process-wide.** `delete-database` through the API releases

--- a/http-server/datahike/http/middleware.clj
+++ b/http-server/datahike/http/middleware.clj
@@ -1,8 +1,5 @@
 (ns datahike.http.middleware
   (:require
-   [buddy.auth :refer [authenticated?]]
-   [buddy.auth.backends :as buddy-auth-backends]
-   [buddy.auth.middleware :as buddy-auth-middleware]
    [clojure.edn :as edn]
    [clojure.walk :as cw]
    [datahike.json :as json]
@@ -12,27 +9,40 @@
   (:import
    [clojure.lang ExceptionInfo]))
 
-(defn auth
-  "Middleware used in routes that require authentication. If request is not
-   authenticated a 401 not authorized response will be returned.
-   Dev mode always authenticates."
-  [config handler]
-  (fn [request]
-    (if (or (:dev-mode config) (authenticated? request))
-      (handler request)
-      {:status 401 :error "Not authorized"})))
+(defn- bearer [request]
+  (some->> (get-in request [:headers "authorization"])
+           (re-find #"(?i)^token\s+(\S+)\s*$")
+           second))
 
-(defn token-auth
-  "Middleware used on routes requiring token authentication"
-  [config handler]
-  (buddy-auth-middleware/wrap-authentication
-   handler
-   (buddy-auth-backends/token {:token-name "token"
-                               :authfn     (fn [_ token]
-                                             (let [valid-token?  (not (nil? token))
-                                                   correct-auth? (= (:token config) token)]
-                                               (when (and correct-auth? valid-token?)
-                                                 "authenticated-user")))})))
+(defn validators
+  "The authentication chain `config` describes, each a
+   `(fn [request] -> principal | nil)` — the shape kabel's
+   `kabel.auth.jwt/build-bearer-validator` returns, so one validator serves
+   both transports. In order:
+
+   - `:dev-mode true` — everyone is `{:sub \"dev\"}`. Never in production.
+   - `:auth :upstream` — the host's own middleware authenticated already; its
+     `:datahike/principal` on the request, or `{:sub \"upstream\"}`.
+   - `:token` — the shared secret, sent as `authorization: token <token>`;
+     the principal is `:token-subject`, \"root\" by default.
+   - `:validator` — yours.
+
+   A principal is a map with `:sub`, the subject's id."
+  [{:keys [dev-mode auth token token-subject validator]}]
+  (remove nil?
+          [(when dev-mode
+             (constantly {:sub "dev" :auth :dev-mode}))
+           (when (= :upstream auth)
+             (fn [request] (or (:datahike/principal request) {:sub "upstream" :auth :upstream})))
+           (when token
+             (fn [request] (when (= token (bearer request))
+                             {:sub (or token-subject "root") :auth :token})))
+           validator]))
+
+(defn authenticate
+  "The principal the first accepting validator returns, or nil."
+  [validators request]
+  (some #(% request) validators))
 
 ;; TOOD map more errors
 (defn cause->status-code [cause]

--- a/http-server/datahike/http/middleware.clj
+++ b/http-server/datahike/http/middleware.clj
@@ -14,6 +14,10 @@
            (re-find #"(?i)^token\s+(\S+)\s*$")
            second))
 
+(defn- same-secret? [^String expected ^String given]
+  (and expected given
+       (java.security.MessageDigest/isEqual (.getBytes expected "UTF-8") (.getBytes given "UTF-8"))))
+
 (defn validators
   "The authentication chain `config` describes, each a
    `(fn [request] -> principal | nil)` — the shape kabel's
@@ -27,17 +31,25 @@
      the principal is `:token-subject`, \"root\" by default.
    - `:validator` — yours.
 
-   A principal is a map with `:sub`, the subject's id."
+   A principal is a map with `:sub`, the subject's id. Subjects share one
+   namespace, so the token's subject is reserved: a `:validator` principal
+   claiming it is refused rather than let an outside identity become the
+   break-glass one."
   [{:keys [dev-mode auth token token-subject validator]}]
-  (remove nil?
-          [(when dev-mode
-             (constantly {:sub "dev" :auth :dev-mode}))
-           (when (= :upstream auth)
-             (fn [request] (or (:datahike/principal request) {:sub "upstream" :auth :upstream})))
-           (when token
-             (fn [request] (when (= token (bearer request))
-                             {:sub (or token-subject "root") :auth :token})))
-           validator]))
+  (let [token-subject (or token-subject "root")]
+    (remove nil?
+            [(when dev-mode
+               (constantly {:sub "dev" :auth :dev-mode}))
+             (when (= :upstream auth)
+               (fn [request] (or (:datahike/principal request) {:sub "upstream" :auth :upstream})))
+             (when token
+               (fn [request] (when (same-secret? token (bearer request))
+                               {:sub token-subject :auth :token})))
+             (when validator
+               (fn [request]
+                 (when-let [principal (validator request)]
+                   (when-not (= token-subject (:sub principal))
+                     (assoc principal :auth :validator)))))])))
 
 (defn authenticate
   "The principal the first accepting validator returns, or nil."

--- a/http-server/datahike/http/permissions.clj
+++ b/http-server/datahike/http/permissions.clj
@@ -23,7 +23,8 @@
 
    `configure` opens the database and returns the config with `:authorize`
    set; `routes` are the permission management routes, authorized by the same
-   graph."
+   graph. Servers that share one auth database share its admins: the `server`
+   object is one per auth database, not per server."
   (:require
    [clojure.string :as str]
    [datahike.api :as d]
@@ -73,10 +74,16 @@ definition database {
 (defn- open-auth-db!
   "Connect to the auth database, creating it with eacl's attributes if it is new."
   [auth-db]
-  (let [cfg (-> (merge eschema/default-config auth-db)
-                (update-in [:store :id]
-                           #(or % (java.util.UUID/nameUUIDFromBytes
-                                   (.getBytes (str "datahike-auth-db:" (get-in auth-db [:store :path])))))))]
+  (let [path (get-in auth-db [:store :path])
+        cfg  (-> (merge eschema/default-config auth-db)
+                 ;; A durable store without an id gets one from its path, the
+                 ;; same on every start; a store without a path (memory) gets
+                 ;; a fresh one, so two servers in one process do not share
+                 ;; an auth database by accident.
+                 (update-in [:store :id]
+                            #(or % (if path
+                                     (java.util.UUID/nameUUIDFromBytes (.getBytes (str "datahike-auth-db:" path)))
+                                     (random-uuid)))))]
     (if (d/database-exists? cfg)
       (d/connect cfg)
       (do (d/create-database cfg)

--- a/http-server/datahike/http/permissions.clj
+++ b/http-server/datahike/http/permissions.clj
@@ -1,0 +1,203 @@
+(ns datahike.http.permissions
+  "Who may do what, kept in a Datahike database of its own.
+
+   Authentication says who a caller is (`datahike.http.middleware/validators`);
+   this namespace says what they may do, with eacl — relationship-based
+   authorization in the SpiceDB model, situated: the permission graph lives in
+   an `:auth-db` next to the server's data, and checks are local reads.
+
+   The graph has three kinds of object. `user`s are principals, by their
+   `:sub`. The one `server` has `admin`s, who may do everything — create
+   databases, administer any of them, grant. A `database` (by store id; its
+   branches share it) has `owner`s, `writer`s and `reader`s:
+
+     read     = reader + writer + owner
+     transact = writer + owner
+     delete, admin, grant = owner
+
+   and `grant` is the permission to edit a database's own relationships —
+   permission administration is one more permission in the graph, not a
+   special case. The shared-token principal (`:token-subject`, \"root\") is
+   seeded as a server admin, so the token stays the break-glass identity and
+   everyone else is granted through `/permissions/relationships!`.
+
+   `configure` opens the database and returns the config with `:authorize`
+   set; `routes` are the permission management routes, authorized by the same
+   graph."
+  (:require
+   [clojure.string :as str]
+   [datahike.api :as d]
+   [datahike.http.routes :as routes]
+   [eacl.core :as eacl]
+   [eacl.datahike.core :as ed]
+   [eacl.datahike.schema :as eschema]))
+
+(def schema
+  "The permission graph, in SpiceDB's schema language."
+  "definition user {}
+
+definition server {
+  relation admin: user
+  permission administer = admin
+  permission create = admin
+}
+
+definition database {
+  relation owner: user
+  relation writer: user
+  relation reader: user
+  permission admin = owner
+  permission grant = owner
+  permission delete = owner
+  permission transact = writer + owner
+  permission read = reader + writer + owner
+}")
+
+;; eacl ids are global, not per type, so the type is part of the id.
+
+(defn- object [type id]
+  (eacl/spice-object type (str (name type) ":" id)))
+
+(defn- <-object [{:keys [type id]}]
+  {:type type :id (str/replace-first id (str (name type) ":") "")})
+
+(def ^:private server (object :server "datahike"))
+(defn- user [principal] (object :user (:sub principal)))
+(defn- database [store-id] (object :database (str store-id)))
+
+(defn- ensure-objects!
+  "eacl relates objects that exist; `:eacl/id` is an identity, so this is idempotent."
+  [conn objects]
+  (d/transact conn (vec (for [{:keys [id]} objects] {:eacl/id id}))))
+
+(defn- open-auth-db!
+  "Connect to the auth database, creating it with eacl's attributes if it is new."
+  [auth-db]
+  (let [cfg (-> (merge eschema/default-config auth-db)
+                (update-in [:store :id]
+                           #(or % (java.util.UUID/nameUUIDFromBytes
+                                   (.getBytes (str "datahike-auth-db:" (get-in auth-db [:store :path])))))))]
+    (if (d/database-exists? cfg)
+      (d/connect cfg)
+      (do (d/create-database cfg)
+          (doto (d/connect cfg)
+            (d/transact (eschema/merge-schema)))))))
+
+(defn- admin? [acl principal]
+  (eacl/can? acl (user principal) :administer server))
+
+(defn- policy
+  "The `:authorize` fn: server admins may do everything; anyone else what the
+   database's relationships grant. Nobody unauthenticated, and nobody creates
+   a database but an admin — who then grants its owner."
+  [acl]
+  (fn [{:keys [op principal db]}]
+    (boolean
+     (and principal
+          (or (admin? acl principal)
+              (and db (not= op :create)
+                   (eacl/can? acl (user principal) op (database (:store-id db)))))))))
+
+(defn configure
+  "Open `(:auth-db config)` — a Datahike config, `:store` at least — write the
+   schema, seed the token principal as server admin, and return `config` with
+   `:authorize` set."
+  [{:keys [auth-db token-subject] :as config}]
+  (let [conn (open-auth-db! auth-db)
+        acl  (ed/make-client conn {})
+        root (object :user (or token-subject "root"))]
+    (eacl/write-schema! acl schema)
+    (ensure-objects! conn [root server])
+    (eacl/write-relationship! acl :touch root :admin server)
+    (assoc config :authorize (policy acl) ::acl acl ::conn conn)))
+
+(defn close! [config]
+  (when-let [conn (::conn config)]
+    (d/release conn)))
+
+;; ---------------------------------------------------------------------------
+;; Routes
+;; ---------------------------------------------------------------------------
+
+(defn- kw [x] (if (keyword? x) x (keyword (str x))))
+
+(defn- ->object [{:keys [type id]}] (object (kw type) (str id)))
+
+(defn- may-grant?
+  "May `principal` edit relationships on `resource`? Server admins anywhere;
+   a database's owners on it."
+  [acl principal resource]
+  (or (admin? acl principal)
+      (and (= :database (:type resource))
+           (eacl/can? acl (user principal) :grant resource))))
+
+(defn- guarded
+  "Errors as the decodable 500 the API routes produce."
+  [f]
+  (fn [request]
+    (try (f request)
+         (catch Exception e (routes/error-response e)))))
+
+(defn- relationship->map [r]
+  {:subject  (<-object (:subject r))
+   :relation (:relation r)
+   :resource (<-object (:resource r))})
+
+(defn routes
+  "The permission routes for a `configure`d config; none without `:auth-db`.
+   Bodies are maps; objects are `{:type :user|:database|:server :id \"…\"}`.
+
+   - POST /permissions/check `{:subject :permission :resource}` → `{:allowed}`.
+     Anyone may ask about themselves (`:subject` omitted); about others only
+     who may grant on the resource.
+   - POST /permissions/relationships `{:resource}` → the relationships on it.
+   - POST /permissions/relationships! `[{:operation :touch|:create|:delete
+     :relationship {:subject :relation :resource}} …]`, each allowed by
+     `may-grant?` on its resource."
+  [{::keys [acl conn]}]
+  (when acl
+    (let [tags {:tags ["Permissions"]}]
+      [["/permissions/check"
+        {:swagger tags
+         :post {:summary    "Is a subject allowed a permission on a resource?"
+                :parameters {:body :any}
+                :handler
+                (guarded
+                 (fn [{{body :body} :parameters principal :datahike/principal}]
+                  (let [subject  (if (:subject body) (->object (:subject body)) (user principal))
+                        resource (->object (:resource body))]
+                    (if (or (= subject (user principal)) (may-grant? acl principal resource))
+                      {:status 200 :body {:allowed (eacl/can? acl subject (kw (:permission body)) resource)}}
+                      (routes/forbidden :grant [])))))}}]
+       ["/permissions/relationships"
+        {:swagger tags
+         :post {:summary    "The relationships on a resource."
+                :parameters {:body :any}
+                :handler
+                (guarded
+                 (fn [{{body :body} :parameters principal :datahike/principal}]
+                  (let [resource (->object (:resource body))]
+                    (if (may-grant? acl principal resource)
+                      {:status 200
+                       :body   (mapv relationship->map
+                                     (:data (eacl/read-relationships acl {:resource/type (:type resource)
+                                                                          :resource/id   (:id resource)})))}
+                      (routes/forbidden :grant [])))))}}]
+       ["/permissions/relationships!"
+        {:swagger tags
+         :post {:summary    "Create, touch or delete relationships."
+                :parameters {:body :any}
+                :handler
+                (guarded
+                 (fn [{{body :body} :parameters principal :datahike/principal}]
+                  (let [updates (for [{:keys [operation relationship]} body]
+                                  {:operation (kw operation)
+                                   :subject   (->object (:subject relationship))
+                                   :relation  (kw (:relation relationship))
+                                   :resource  (->object (:resource relationship))})]
+                    (if (every? #(may-grant? acl principal (:resource %)) updates)
+                      (do (ensure-objects! conn (mapcat (juxt :subject :resource) updates))
+                          (doseq [{:keys [operation subject relation resource]} updates]
+                            (eacl/write-relationship! acl operation subject relation resource))
+                          {:status 200 :body {:written (count updates)}})
+                      (routes/forbidden :grant [])))))}}]])))

--- a/http-server/datahike/http/permissions.clj
+++ b/http-server/datahike/http/permissions.clj
@@ -197,7 +197,10 @@ definition database {
                                    :resource  (->object (:resource relationship))})]
                     (if (every? #(may-grant? acl principal (:resource %)) updates)
                       (do (ensure-objects! conn (mapcat (juxt :subject :resource) updates))
-                          (doseq [{:keys [operation subject relation resource]} updates]
-                            (eacl/write-relationship! acl operation subject relation resource))
+                          ;; One transaction: the batch lands whole or not at all.
+                          (eacl/write-relationships!
+                           acl
+                           (for [{:keys [operation subject relation resource]} updates]
+                             (eacl/->RelationshipUpdate operation (eacl/->Relationship subject relation resource))))
                           {:status 200 :body {:written (count updates)}})
                       (routes/forbidden :grant [])))))}}]])))

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -44,7 +44,9 @@
    [reitit.ring.middleware.multipart :as multipart]
    [reitit.ring.middleware.parameters :as parameters]
    [muuntaja.core :as m]
-   [replikativ.logging :as log]))
+   [replikativ.logging :as log])
+  (:import [datahike.datom Datom]
+           [datahike.impl.entity Entity]))
 
 ;; ---------------------------------------------------------------------------
 ;; Errors, secrets, authorization
@@ -80,9 +82,10 @@
 
 (defn- config-of
   "The database config behind an argument: a config map, a DB (or a history,
-   as-of, since or filtered view of one), or a connection."
+   as-of, since or filtered view of one), a connection, or an entity."
   [x]
   (cond (instance? clojure.lang.IDeref x) (config-of @x)
+        (instance? Entity x) (config-of (.-db ^Entity x))
         ;; A DB carries its konserve store under :store too, so :config first.
         (map? x) (cond (:config x)        (config-of (:config x))
                        (:origin-db x)     (config-of (:origin-db x))
@@ -96,14 +99,27 @@
     (when-let [store-id (datahike.store/store-identity store)]
       {:store-id store-id :branch (or branch :db)})))
 
+(defn- descend?
+  "Walk into collections that can carry a database — not into a DB's own
+   internals, a datom, or bytes."
+  [x]
+  (and (coll? x) (nil? (database-of x)) (not (instance? Datom x))))
+
 (defn databases
-  "The databases an API call's argument vector reaches — as positional
-   arguments or inside the map form (`:conn`, `:db`, the `:args` of a query)."
-  [args]
-  (->> (concat args (mapcat #(when (map? %) (concat [(:conn %) (:db %)] (:args %))) args))
-       (keep database-of)
-       distinct
-       vec))
+  "The databases `op` with `args` reaches. A write's first argument names its
+   database — the connection, or the map form's `:conn` — and its transaction
+   data is not walked; everything else (queries, pulls, views) is searched in
+   full, so a database nested in a query's inputs is found."
+  [op args]
+  (let [roots (case op
+                (:transact :create :delete :admin)
+                (let [x (first args)] (if (map? x) [(:conn x) (:db x) x] [x]))
+                args)]
+    (->> roots
+         (mapcat #(tree-seq descend? seq %))
+         (keep database-of)
+         distinct
+         vec)))
 
 (defn authorize
   "The 403 for `op` with `args` under `config`'s `:authorize`, or nil when the
@@ -113,7 +129,7 @@
    every authenticated caller may do everything."
   [config request op args]
   (when-let [policy (:authorize config)]
-    (let [dbs       (databases args)
+    (let [dbs       (databases op args)
           principal (:datahike/principal request)
           ask       (fn [db] (policy {:op op :principal principal :db db :payload args}))]
       (when-not (if (seq dbs) (every? ask dbs) (ask nil))
@@ -172,7 +188,7 @@
 ;; The API routes
 ;; ---------------------------------------------------------------------------
 
-(defn generic-handler [config op f]
+(defn- generic-handler [config op f]
   (fn [request]
     (try
       (let [{{body :body} :parameters
@@ -211,16 +227,16 @@
 
 (declare create-routes)
 
-(defn extract-first-sentence [doc]
+(defn- extract-first-sentence [doc]
   (str (first (str/split doc #"\.\s")) "."))
 
-(defn has-cat-operators?
+(defn- has-cat-operators?
   "Check if args list contains :cat-specific operators like [:* ...], [:+ ...], [:alt ...], etc.
    These operators are only valid in :cat schemas, not in :tuple schemas."
   [args]
   (some #(and (vector? %) (#{:* :+ :? :alt :altn} (first %))) args))
 
-(defn extract-input-schema
+(defn- extract-input-schema
   "Extract input schema from malli function schema for HTTP body validation.
    Converts [:=> [:cat Type1 Type2] ret] to [:tuple Type1 Type2]
    or [:function [:=> [:cat T1] ret] [:=> [:cat T1 T2] ret]] to [:or [:tuple T1] [:tuple T1 T2]]
@@ -266,7 +282,7 @@
 ;; and the result is immutable.
 (def ^:private cbor-registry (rcbor/server-registry))
 
-(def muuntaja-with-opts
+(def ^:private muuntaja-with-opts
   (m/create
    (-> m/default-options
        ;; `application/cbor` is an addition, not a replacement — it takes its
@@ -285,7 +301,7 @@
        (assoc-in [:formats "application/transit+json" :encoder-opts]
                  {:handlers transit/write-handlers}))))
 
-(defn default-route-opts [muuntaja-with-opts]
+(defn- default-route-opts [muuntaja-with-opts]
   {:data      {:coercion   (reitit.coercion.malli/create
                             {:compile mu/closed-schema
                              :strip-extra-keys true
@@ -309,7 +325,7 @@
 ;; This code expands and evals the server route construction given the
 ;; API specification.
 (eval
- `(defn ~'create-routes [~'config]
+ `(defn- ~'create-routes [~'config]
     ~(vec
       (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
             :when supports-remote?]
@@ -442,8 +458,13 @@
         (let [match (reitit/match-by-path rtr (:uri request))]
           (if-not (and match (contains? (:data match) (:request-method request)))
             (ring-handler request)
-            (let [principal (middleware/authenticate validators request)
-                  body      (when (:body request) (read-body (:body request) max-bytes))]
+            (let [body (when (:body request) (read-body (:body request) max-bytes))
+                  ;; Buffered before anyone reads it: a validator that looks
+                  ;; at the body (a signed request, say) gets its own copy and
+                  ;; the route still gets the whole thing.
+                  buffered  (fn [] (cond-> request body (assoc :body (java.io.ByteArrayInputStream. body))))
+                  principal (when-not (= ::too-large body)
+                              (middleware/authenticate validators (buffered)))]
               (cond
                 (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
                 too-large
@@ -451,8 +472,7 @@
                 (and (not (get-in match [:data :public?])) (nil? principal))
                 {:status 401 :body "Not authorized"}
                 :else
-                (ring-handler (cond-> (assoc request :datahike/principal principal)
-                                body (assoc :body (java.io.ByteArrayInputStream. body))))))))))))
+                (ring-handler (assoc (buffered) :datahike/principal principal))))))))))
 
 (defn handler
   "A Ring handler serving Datahike's HTTP API, for mounting in a host app.

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -1,23 +1,15 @@
 (ns datahike.http.routes
-  "Datahike's HTTP API as Ring routes, for embedding.
+  "Datahike's HTTP API as a Ring handler, for embedding.
 
-   Everything the server serves is here as DATA — reitit route vectors built
-   from `datahike.api.specification` — plus the muuntaja instance and middleware
-   chain that make them work: edn, json, transit and CBOR, malli coercion of
-   request bodies, token auth. `datahike.http.server` is a thin main over this
-   namespace; an application with its own Ring stack takes `handler` (or the
-   route data itself) and mounts it where it likes.
-
-   Two things an embedding host needs beyond the routes, both explicit here:
-
-   - `handler` takes a `:prefix`, so the API can live under `/datahike` (or
-     anything) in a host that already owns `/`. A remote writer or client then
-     names that prefix in its `:url`.
-   - The connections the routes open live in an atom the host passes in (or
-     one made for it), bound as `datahike.connections/*connections*` for every
-     request. A host that also uses those databases directly shares them by
-     binding the same atom — one connection per database per process, not one
-     per caller.
+   Everything the server serves is here — reitit route data built from
+   `datahike.api.specification`, the muuntaja instance (edn, json, transit,
+   CBOR), malli coercion, the writer routes — behind ONE composition unit,
+   `handler`, that adds what the routes cannot do for themselves: authenticate
+   before anything is decoded, cap the body, bind the connection registry for
+   the whole request, and authorize each call. `datahike.http.server` is a thin
+   main over it; an application with its own Ring stack mounts it under a
+   `:prefix`, shares its databases through `:connections`, and lets its own
+   auth in through `:validator`/`:authorize`. See doc/http-routes.md.
 
    The shape follows alekcz's `datahike.http.router` (#755): routes without a
    server, a mountable handler, a shared registry. What differs is that nothing
@@ -54,18 +46,22 @@
    [muuntaja.core :as m]
    [replikativ.logging :as log]))
 
+;; ---------------------------------------------------------------------------
+;; Errors, secrets, authorization
+;; ---------------------------------------------------------------------------
+
 (def ^:private secret-keys
   "Config keys whose values must never leave the server in an error body."
   #{:token :secret :access-key :secret-key :password})
 
-(defn- redact
-  "ex-data with secret-valued keys blanked, at any depth."
+(defn redact
+  "`x` with secret-valued keys blanked, at any depth."
   [x]
   (cond (map? x)  (into {} (map (fn [[k v]] [k (if (secret-keys k) "REDACTED" (redact v))])) x)
         (coll? x) (into (empty x) (map redact) x)
         :else     x))
 
-(defn- error-response
+(defn error-response
   "The 500 body the clients decode into a throwable: message plus ex-data,
    with credentials redacted — a backend config in ex-data used to carry them
    straight to the caller."
@@ -73,60 +69,139 @@
   {:status 500
    :body   {:msg (ex-message e) :ex-data (redact (ex-data e))}})
 
-(defn- borrow-connection
-  "The server's ONE connection to `cfg`'s database, opened on first use.
+(defn forbidden
+  "The 403 for `op` on `databases` (`[{:store-id :branch}]`, may be empty)."
+  [op databases]
+  {:status 403
+   :body   {:msg     (str "Forbidden: " (name op)
+                          (when (seq databases)
+                            (str " on " (str/join ", " (map (comp str :store-id) databases)))))
+            :ex-data {:type :datahike.http/forbidden :op op :databases databases}}})
 
-   `api/connect` on a cached connection increments a ref count that a request
-   would never decrement, so the writer routes borrow the existing connection
-   from `*connections*` and connect only when there is none. The server holds
-   exactly one lease per database and releases it on shutdown
-   (`release-all!`); requests change no counts."
-  [cfg]
-  (let [conn-id [(datahike.store/store-identity (:store cfg)) (:branch cfg :db)]]
-    (or (get-in @*connections* [conn-id :conn])
-        (api/connect cfg))))
+(defn- config-of
+  "The database config behind an argument: a config map, a DB (or a history,
+   as-of, since or filtered view of one), or a connection."
+  [x]
+  (cond (instance? clojure.lang.IDeref x) (config-of @x)
+        ;; A DB carries its konserve store under :store too, so :config first.
+        (map? x) (cond (:config x)        (config-of (:config x))
+                       (:origin-db x)     (config-of (:origin-db x))
+                       (:unfiltered-db x) (config-of (:unfiltered-db x))
+                       (:store x)         x
+                       :else              nil)
+        :else nil))
+
+(defn- database-of [x]
+  (when-let [{:keys [store branch]} (config-of x)]
+    (when-let [store-id (datahike.store/store-identity store)]
+      {:store-id store-id :branch (or branch :db)})))
+
+(defn databases
+  "The databases an API call's argument vector reaches — as positional
+   arguments or inside the map form (`:conn`, `:db`, the `:args` of a query)."
+  [args]
+  (->> (concat args (mapcat #(when (map? %) (concat [(:conn %) (:db %)] (:args %))) args))
+       (keep database-of)
+       distinct
+       vec))
+
+(defn authorize
+  "The 403 for `op` with `args` under `config`'s `:authorize`, or nil when the
+   call may proceed. `:authorize` is `(fn [{:keys [op principal db payload]}])`
+   and is asked once per database the call reaches — every one must be
+   allowed — or once with `:db nil` when it reaches none. Without `:authorize`
+   every authenticated caller may do everything."
+  [config request op args]
+  (when-let [policy (:authorize config)]
+    (let [dbs       (databases args)
+          principal (:datahike/principal request)
+          ask       (fn [db] (policy {:op op :principal principal :db db :payload args}))]
+      (when-not (if (seq dbs) (every? ask dbs) (ask nil))
+        (forbidden op dbs)))))
+
+(defn route-op
+  "What an API function does, for authorization: every GET is a `:read`, and
+   so are the POSTs that only open, inspect or close; the rest write."
+  [n referentially-transparent?]
+  (cond referentially-transparent? :read
+        ('#{create-database} n) :create
+        ('#{delete-database delete-branch!} n) :delete
+        ('#{connect release db database-exists? branches branch-as-db commit-as-db} n) :read
+        ('#{gc-storage} n) :admin
+        :else :transact))
+
+;; ---------------------------------------------------------------------------
+;; Connections the routes hold
+;; ---------------------------------------------------------------------------
+
+(defn- conn-id [cfg]
+  [(datahike.store/store-identity (:store cfg)) (:branch cfg :db)])
+
+(defn- with-connection
+  "Run `f` with a connection to `cfg`'s database, pinned for the duration.
+
+   Two leases are at work. This request's own — `api/connect` validates the
+   config against the cached connection and counts one up, `api/release` in
+   `finally` counts it back — which keeps a concurrent release or delete from
+   pulling the connection out from under the call. And the server's base
+   lease, taken once per database under `leases` so that the connection (and
+   its writer) survives between requests instead of being rebuilt for each;
+   it is dropped by `release-all!` on shutdown, or by a delete."
+  [cfg leases f]
+  (let [id (conn-id cfg)]
+    (locking leases
+      (when-not (and (@leases id) (get-in @*connections* [id :conn]))
+        (api/connect cfg)
+        (swap! leases conj id)))
+    (let [conn (api/connect cfg)]
+      (try (f conn)
+           (finally (api/release conn))))))
 
 (defn release-all!
-  "Release every connection in `connections`, for a server shutting down."
-  [connections]
-  (doseq [[_ {:keys [conn]}] @connections]
-    (when conn
-      (try (api/release conn true) (catch Exception _)))))
+  "Release every connection the routes hold, for a host shutting down. Takes
+   the connections atom or the handler `handler` returned."
+  [handler-or-connections]
+  (let [connections (or (::connections (meta handler-or-connections)) handler-or-connections)]
+    (binding [*connections* connections]
+      (doseq [[_ {:keys [conn]}] @connections]
+        (when conn
+          (try (api/release conn true) (catch Exception _)))))))
 
-(defn generic-handler [config f]
+;; ---------------------------------------------------------------------------
+;; The API routes
+;; ---------------------------------------------------------------------------
+
+(defn generic-handler [config op f]
   (fn [request]
     (try
       (let [{{body :body} :parameters
-             :keys [headers params method]} request
-            _ (log/trace :datahike/http-handler-request {:handler f :body body})
-          ;; TODO move this to client
-            ret-body
-            (cond (= f #'api/create-database)
-                ;; remove remote-peer and re-add
-                  (assoc
-                   (apply f (dissoc (first body) :remote-peer) (rest body))
-                   :remote-peer (:remote-peer (first body)))
+             :keys [headers params method]} request]
+        (log/trace :datahike/http-handler-request {:handler f :op op})
+        (or (authorize config request op body)
+            (let [ret-body
+                  (cond (= f #'api/create-database)
+                        ;; remove remote-peer and re-add
+                        (assoc
+                         (apply f (dissoc (first body) :remote-peer) (rest body))
+                         :remote-peer (:remote-peer (first body)))
 
-                  (= f #'api/delete-database)
-                  (apply f (dissoc (first body) :remote-peer) (rest body))
+                        (= f #'api/delete-database)
+                        (apply f (dissoc (first body) :remote-peer) (rest body))
 
-                  :else
-                  (apply f body))]
-        (log/trace :datahike/http-handler-response {:body ret-body})
-        (merge
-         {:status 200
-          :body
-          (when-not (headers "no-return-value")
-            ret-body)}
-         (when (and (= method :get)
-                    (get params "args-id")
-                    (get-in config [:cache :get :max-age]))
-           {:headers {"Cache-Control" (str (when-not (:token config) "public, ")
-                                           "max-age=" (get-in config [:cache :get :max-age]))}})))
+                        :else
+                        (apply f body))]
+              (merge
+               {:status 200
+                :body
+                (when-not (headers "no-return-value")
+                  ret-body)}
+               (when (and (= method :get)
+                          (get params "args-id")
+                          (get-in config [:cache :get :max-age]))
+                 {:headers {"Cache-Control" (str (when (:dev-mode config) "public, ")
+                                                 "max-age=" (get-in config [:cache :get :max-age]))}})))))
       (catch Exception e
-        {:status 500
-         :body   {:msg (ex-message e)
-                  :ex-data (ex-data e)}}))))
+        (error-response e)))))
 
 (declare create-routes)
 
@@ -181,22 +256,6 @@
     ;; Fallback
     :else [:sequential :any]))
 
-;; This code expands and evals the server route construction given the
-;; API specification.
-(eval
- `(defn ~'create-routes [~'config]
-    ~(vec
-      (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
-            :when supports-remote?]
-        `[~(str "/" (->url n))
-          {:swagger {:tags ["API"]}
-           ~(if referentially-transparent? :get :post)
-           {:operationId ~(str n)
-            :summary     ~(extract-first-sentence doc)
-            :description ~doc
-            :parameters  {:body ~(extract-input-schema args)}
-            :handler     (generic-handler ~'config ~(resolve n))}}]))))
-
 ;; One registry per process, not per request: building it walks every handler
 ;; and the result is immutable.
 (def ^:private cbor-registry (rcbor/server-registry))
@@ -240,54 +299,78 @@
                             multipart/multipart-middleware
                             middleware/patch-swagger-json]}})
 
-(defn internal-writer-routes []
+
+;; This code expands and evals the server route construction given the
+;; API specification.
+(eval
+ `(defn ~'create-routes [~'config]
+    ~(vec
+      (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
+            :when supports-remote?]
+        `[~(str "/" (->url n))
+          {:swagger {:tags ["API"]}
+           ~(if referentially-transparent? :get :post)
+           {:operationId ~(str n)
+            :summary     ~(extract-first-sentence doc)
+            :description ~doc
+            :parameters  {:body ~(extract-input-schema args)}
+            :handler     (generic-handler ~'config ~(route-op n referentially-transparent?) ~(resolve n))}}]))))
+
+(defn- internal-writer-routes
+  "What a `:datahike-server` writer posts to. `leases` is the set of databases
+   the server holds a base lease on (see `with-connection`)."
+  [config leases]
   [["/delete-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
+            :handler     (fn [{{:keys [body]} :parameters :as request}]
                            ;; Deletion is process-wide by nature: it releases
                            ;; and invalidates every connection to the store,
                            ;; the host's included. A host sharing the atom
                            ;; must treat it as such.
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (try
-                               (try
-                                 (api/release (api/connect cfg) true)
-                                 (catch Exception _))
-                               {:status 200
-                                :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
-                               (catch Exception e
-                                 (error-response e)))))
+                             (or (authorize config request :delete [cfg])
+                                 (try
+                                   (swap! leases disj (conn-id cfg))
+                                   (try
+                                     (api/release (api/connect cfg) true)
+                                     (catch Exception _))
+                                   {:status 200
+                                    :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
+                                   (catch Exception e
+                                     (error-response e))))))
             :operationId "delete-database"},
      :swagger {:tags ["Internal"]}}]
    ["/create-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
+            :handler     (fn [{{:keys [body]} :parameters :as request}]
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (try
-                               {:status 200
-                                :body   (async/<!! (apply datahike.writing/create-database
-                                                          cfg
-                                                          (rest body)))}
-                               (catch Exception e
-                                 (error-response e)))))
+                             (or (authorize config request :create [cfg])
+                                 (try
+                                   {:status 200
+                                    :body   (async/<!! (apply datahike.writing/create-database
+                                                              cfg
+                                                              (rest body)))}
+                                   (catch Exception e
+                                     (error-response e))))))
             :operationId "create-database"},
      :swagger {:tags ["Internal"]}}]
    ["/transact!-writer"
     {:post {:parameters  {:body [:sequential :any]},
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
-                           (try
-                             (let [conn (borrow-connection (dissoc (first body) :remote-peer :writer))
-                                   res  @(apply datahike.writer/transact! conn (rest body))]
-                               {:status 200
-                                :body   res})
-                             (catch Exception e
-                               (error-response e))))
+            :handler     (fn [{{:keys [body]} :parameters :as request}]
+                           (let [cfg (dissoc (first body) :remote-peer :writer)]
+                             (or (authorize config request :transact [cfg])
+                                 (try
+                                   {:status 200
+                                    :body   (with-connection cfg leases
+                                              (fn [conn] @(apply datahike.writer/transact! conn (rest body))))}
+                                   (catch Exception e
+                                     (error-response e))))))
             :operationId "transact"},
      :swagger {:tags ["Internal"]}}]])
 
@@ -295,108 +378,102 @@
 ;; The embeddable surface
 ;; ---------------------------------------------------------------------------
 
-(defn- with-auth
-  "Every API route behind the token/auth middleware, as `app` always applied
-   them — an embedded handler must not be less protected than the server."
-  [config routes]
-  (map (fn [route]
-         (let [method (if (:get (second route)) :get :post)]
-           (assoc-in route [1 method :middleware]
-                     [(partial middleware/token-auth config)
-                      (partial middleware/auth config)])))
-       routes))
-
-(defn api-routes
-  "The API and internal writer routes as reitit route data, authenticated."
-  [config]
-  (with-auth config (concat (create-routes config)
-                            (internal-writer-routes))))
-
 (defn- normalize-prefix
   "\"/datahike/\" and \"datahike\" mean \"/datahike\"; \"\" and \"/\" mean none."
   [prefix]
   (let [p (str/replace (str prefix) #"^/*|/*$" "")]
     (when (seq p) (str "/" p))))
 
-(defn router
-  "A reitit router over `api-routes`, with Datahike's coercion, formats and
-   middleware. `:prefix` nests every route under a path; `:extra-routes` are
-   the host's own routes on the same router — the server adds `/swagger.json`
-   this way, marked `:public? true` so the gate lets it through unauthenticated."
-  [config {:keys [prefix extra-routes]}]
-  (let [routes (vec (concat extra-routes (api-routes config)))]
+(defn- router
+  [config {:keys [prefix extra-routes leases]}]
+  (let [routes (vec (concat extra-routes
+                            (create-routes config)
+                            (internal-writer-routes config leases)))]
     (ring/router (if-let [p (normalize-prefix prefix)] [p routes] routes)
                  (default-route-opts muuntaja-with-opts))))
 
 (def default-max-body-bytes (* 64 1024 1024))
 
-(defn- limited-stream
-  "`in`, failing past `limit` bytes and flagging `exceeded` — so a chunked
-   body cannot bypass the Content-Length check by omitting it."
-  [^java.io.InputStream in ^long limit exceeded]
-  (let [read-so-far (atom 0)
-        check!      (fn [n] (when (and (pos? n) (> (swap! read-so-far + n) limit))
-                              (reset! exceeded true)
-                              (throw (java.io.IOException. "Request body too large"))))]
-    (proxy [java.io.FilterInputStream] [in]
-      (read
-        ([] (let [b (.read in)] (check! (if (neg? b) 0 1)) b))
-        ([^bytes buf] (let [n (.read in buf)] (check! n) n))
-        ([^bytes buf off len] (let [n (.read in buf off len)] (check! n) n))))))
+(defn- read-body
+  "The whole body as bytes, or `::too-large` past `limit` — read up front, so
+   no decoder ever sees an unbounded stream and a body that a decoder would
+   read only the first form of is still measured in full."
+  [^java.io.InputStream in ^long limit]
+  (let [out (java.io.ByteArrayOutputStream.)
+        buf (byte-array 8192)]
+    (loop [total 0]
+      (let [n (.read in buf)]
+        (cond (neg? n)             (.toByteArray out)
+              (> (+ total n) limit) ::too-large
+              :else                (do (.write out buf 0 n)
+                                       (recur (+ total n))))))))
 
 (def ^:private too-large {:status 413 :body "Request body too large"})
 
-(defn wrap-api
+(defn- wrap-api
   "Everything a Datahike API request needs around the router's handler, in
    the order that matters:
 
-   1. The gate. Before ANY decoding: a request the router does not route is
-      handed on untouched (the host's, or the server's swagger-ui and 404); a
-      public route (`:public? true`, i.e. `/swagger.json`) passes; every other
-      route requires the token here, and its body is capped at
-      `:max-body-bytes` (default 64 MiB), Content-Length and stream alike. The
-      per-route auth middleware still runs — this only makes sure nothing is
-      parsed, and no database handle decoded, for a caller that has no token.
+   1. The gate, before ANY decoding. A request the router does not route, or
+      routes but not for that method (an OPTIONS preflight, a wrong method),
+      is handed on untouched — the host's, CORS, swagger-ui, 404, 405. For a
+      routed one: the body is read in full and capped at `:max-body-bytes`
+      (default 64 MiB), public route or not, so no decoder sees an unbounded
+      stream; then, unless the route is `:public? true` (`/swagger.json`),
+      the caller must authenticate — `:token`, `:validator`, `:dev-mode`,
+      `:auth :upstream`, see `middleware/validators` — or gets 401 with
+      nothing parsed. The principal is on the request as
+      `:datahike/principal` for the route's authorization.
    2. The registry. `*connections*` is bound to `connections` for the WHOLE
       request, decoding included, so every route — `connect`, `q`, `release`,
       a database handle inside a body — resolves the same connection a host
       holds under that atom."
   [ring-handler rtr config connections]
-  (let [max-bytes (or (:max-body-bytes config) default-max-body-bytes)
-        authed?   (fn [request]
-                    (or (:dev-mode config)
-                        (= (str "token " (:token config))
-                           (get-in request [:headers "authorization"]))))]
+  (let [max-bytes  (or (:max-body-bytes config) default-max-body-bytes)
+        validators (middleware/validators config)]
     (fn [request]
       (binding [*connections* connections]
-        (if-let [match (reitit/match-by-path rtr (:uri request))]
-          (cond
-            (get-in match [:data :public?]) (ring-handler request)
-            (not (authed? request))          {:status 401 :body "Not authorized"}
-            (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
-            too-large
-            :else
-            (let [exceeded (atom false)
-                  response (ring-handler (cond-> request
-                                           (:body request) (update :body limited-stream max-bytes exceeded)))]
-              (if @exceeded too-large response)))
-          (ring-handler request))))))
+        (let [match (reitit/match-by-path rtr (:uri request))]
+          (if-not (and match (contains? (:data match) (:request-method request)))
+            (ring-handler request)
+            (let [principal (middleware/authenticate validators request)
+                  body      (when (:body request) (read-body (:body request) max-bytes))]
+              (cond
+                (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
+                too-large
+                (= ::too-large body) too-large
+                (and (not (get-in match [:data :public?])) (nil? principal))
+                {:status 401 :body "Not authorized"}
+                :else
+                (ring-handler (cond-> (assoc request :datahike/principal principal)
+                                body (assoc :body (java.io.ByteArrayInputStream. body))))))))))))
 
 (defn handler
   "A Ring handler serving Datahike's HTTP API, for mounting in a host app.
 
      (routes/handler {:token \"…\"} {:prefix \"/datahike\" :connections conns})
 
-   Requests the router does not match fall through as 404 — CORS, static
-   files and the host's other routes are the host's business. `connections`
-   defaults to a fresh atom; pass your own to share databases with the host:
-   the host's `(binding [*connections* conns] (d/connect cfg))` and a client's
-   `/connect` then resolve the identical connection. Deletion through the API
-   invalidates every connection to that database, the host's included.
-   Call `release-all!` on the atom when the host shuts down."
+   `config` is the server config: `:token`, `:validator`, `:dev-mode`,
+   `:auth :upstream`, `:authorize`, `:max-body-bytes`. Options:
+
+   - `:prefix` — the path every route lives under; normalized.
+   - `:connections` — the registry, an atom; a fresh one by default. Pass
+     your own to share databases with the host: the host's
+     `(binding [*connections* conns] (d/connect cfg))` and a client's
+     `/connect` then resolve the identical connection. Deletion through the
+     API invalidates every connection to that database, the host's included.
+   - `:extra-routes` — your reitit routes on the same router, under the
+     prefix, behind the gate unless marked `:public? true`.
+   - `:default-handler` — what answers a request the router does not match;
+     reitit's default 404 unless given (the server puts swagger-ui here).
+
+   The returned fn carries the atom as metadata; `(release-all! handler)`
+   releases what the routes opened when the host shuts down."
   ([config] (handler config {}))
-  ([config {:keys [connections] :as opts}]
+  ([config {:keys [connections default-handler] :as opts}]
    (let [connections (or connections (atom {}))
-         rtr         (router config opts)]
-     (wrap-api (ring/ring-handler rtr (ring/create-default-handler))
-               rtr config connections))))
+         leases      (atom #{})
+         rtr         (router config (assoc opts :leases leases))
+         h           (wrap-api (ring/ring-handler rtr (or default-handler (ring/create-default-handler)))
+                               rtr config connections)]
+     (with-meta h {::connections connections}))))

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -188,6 +188,11 @@
                         (= f #'api/delete-database)
                         (apply f (dissoc (first body) :remote-peer) (rest body))
 
+                        ;; One caller releases one lease. `release-all?` would
+                        ;; close a connection the host and other callers share.
+                        (= f #'api/release)
+                        (f (first body))
+
                         :else
                         (apply f body))]
               (merge

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -206,9 +206,14 @@
    server's own."
   [{:keys [leases]} conn]
   (when-let [id (try (conn-id (:config @conn)) (catch Exception _ nil))]
-    (when (pos? (get-in @leases [id :api] 0))
-      (swap! leases update-in [id :api] dec)
-      (api/release conn))))
+    ;; Check and decrement in one swap: two releases racing on the last
+    ;; granted lease must not both succeed.
+    (let [[before after] (swap-vals! leases
+                                     (fn [m] (if (pos? (get-in m [id :api] 0))
+                                               (update-in m [id :api] dec)
+                                               m)))]
+      (when (not= before after)
+        (api/release conn)))))
 
 (defn release-all!
   "Release every connection in the registry — the routes' and, if the host
@@ -232,21 +237,26 @@
              :keys [headers params method]} request]
         (log/trace :datahike/http-handler-request {:handler f :op op})
         (or (authorize config request op body)
-            (let [ret-body
+            ;; The server IS the writer: a config's :writer names a client's
+            ;; way to reach one (possibly this very server, which would loop
+            ;; back over HTTP into a lock this route holds), never the
+            ;; server's own. :remote-peer likewise.
+            (let [local    (fn [cfg] (dissoc cfg :remote-peer :writer))
+                  ret-body
                   (cond (= f #'api/create-database)
                         ;; remove remote-peer and re-add
                         (assoc
-                         (apply f (dissoc (first body) :remote-peer) (rest body))
+                         (apply f (local (first body)) (rest body))
                          :remote-peer (:remote-peer (first body)))
 
                         (= f #'api/delete-database)
                         (with-exclusive state
                           (fn []
                             (swap! (:leases state) dissoc (conn-id (first body)))
-                            (apply f (dissoc (first body) :remote-peer) (rest body))))
+                            (apply f (local (first body)) (rest body))))
 
                         (= f #'api/connect)
-                        (granted! state (apply f body))
+                        (granted! state (apply f (cons (local (first body)) (rest body))))
 
                         ;; One caller releases one lease of its own.
                         ;; `release-all?` would close a connection the host

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -29,6 +29,8 @@
    [clojure.string :as str]
    [clojure.core.async :as async]
    [datahike.connections :refer [*connections*]]
+   [datahike.store]
+   [reitit.core :as reitit]
    [datahike.api.specification :refer [api-specification ->url]]
    [datahike.api.types :as types]
    [datahike.http.middleware :as middleware]
@@ -51,6 +53,45 @@
    [reitit.ring.middleware.parameters :as parameters]
    [muuntaja.core :as m]
    [replikativ.logging :as log]))
+
+(def ^:private secret-keys
+  "Config keys whose values must never leave the server in an error body."
+  #{:token :secret :access-key :secret-key :password})
+
+(defn- redact
+  "ex-data with secret-valued keys blanked, at any depth."
+  [x]
+  (cond (map? x)  (into {} (map (fn [[k v]] [k (if (secret-keys k) "REDACTED" (redact v))])) x)
+        (coll? x) (into (empty x) (map redact) x)
+        :else     x))
+
+(defn- error-response
+  "The 500 body the clients decode into a throwable: message plus ex-data,
+   with credentials redacted — a backend config in ex-data used to carry them
+   straight to the caller."
+  [e]
+  {:status 500
+   :body   {:msg (ex-message e) :ex-data (redact (ex-data e))}})
+
+(defn- borrow-connection
+  "The server's ONE connection to `cfg`'s database, opened on first use.
+
+   `api/connect` on a cached connection increments a ref count that a request
+   would never decrement, so the writer routes borrow the existing connection
+   from `*connections*` and connect only when there is none. The server holds
+   exactly one lease per database and releases it on shutdown
+   (`release-all!`); requests change no counts."
+  [cfg]
+  (let [conn-id [(datahike.store/store-identity (:store cfg)) (:branch cfg :db)]]
+    (or (get-in @*connections* [conn-id :conn])
+        (api/connect cfg))))
+
+(defn release-all!
+  "Release every connection in `connections`, for a server shutting down."
+  [connections]
+  (doseq [[_ {:keys [conn]}] @connections]
+    (when conn
+      (try (api/release conn true) (catch Exception _)))))
 
 (defn generic-handler [config f]
   (fn [request]
@@ -199,24 +240,25 @@
                             multipart/multipart-middleware
                             middleware/patch-swagger-json]}})
 
-(defn internal-writer-routes [server-connections]
+(defn internal-writer-routes []
   [["/delete-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters}]
-                           (binding [*connections* server-connections]
-                             (let [cfg (dissoc (first body) :remote-peer :writer)]
+                           ;; Deletion is process-wide by nature: it releases
+                           ;; and invalidates every connection to the store,
+                           ;; the host's included. A host sharing the atom
+                           ;; must treat it as such.
+                           (let [cfg (dissoc (first body) :remote-peer :writer)]
+                             (try
                                (try
-                                 (try
-                                   (api/release (api/connect cfg) true)
-                                   (catch Exception _))
-                                 {:status 200
-                                  :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
-                                 (catch Exception e
-                                   {:status 500
-                                    :body   {:msg (ex-message e)
-                                             :ex-data (ex-data e)}})))))
+                                 (api/release (api/connect cfg) true)
+                                 (catch Exception _))
+                               {:status 200
+                                :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
+                               (catch Exception e
+                                 (error-response e)))))
             :operationId "delete-database"},
      :swagger {:tags ["Internal"]}}]
    ["/create-database-writer"
@@ -231,9 +273,7 @@
                                                           cfg
                                                           (rest body)))}
                                (catch Exception e
-                                 {:status 500
-                                  :body   {:msg (ex-message e)
-                                           :ex-data (ex-data e)}}))))
+                                 (error-response e)))))
             :operationId "create-database"},
      :swagger {:tags ["Internal"]}}]
    ["/transact!-writer"
@@ -241,16 +281,13 @@
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters}]
-                           (binding [*connections* server-connections]
-                             (try
-                               (let [conn (api/connect (dissoc (first body) :remote-peer :writer)) ;; TODO maybe release?
-                                     res @(apply datahike.writer/transact! conn (rest body))]
-                                 {:status 200
-                                  :body   res})
-                               (catch Exception e
-                                 {:status 500
-                                  :body   {:msg (ex-message e)
-                                           :ex-data (ex-data e)}}))))
+                           (try
+                             (let [conn (borrow-connection (dissoc (first body) :remote-peer :writer))
+                                   res  @(apply datahike.writer/transact! conn (rest body))]
+                               {:status 200
+                                :body   res})
+                             (catch Exception e
+                               (error-response e))))
             :operationId "transact"},
      :swagger {:tags ["Internal"]}}]])
 
@@ -270,24 +307,80 @@
        routes))
 
 (defn api-routes
-  "The API and internal writer routes as reitit route data, authenticated.
-
-   `connections` is the atom the writer routes bind as `*connections*`. Pass
-   the same atom to `handler` and to any direct `datahike.api` use in the host
-   (under `binding`) to share one connection per database."
-  [config connections]
+  "The API and internal writer routes as reitit route data, authenticated."
+  [config]
   (with-auth config (concat (create-routes config)
-                            (internal-writer-routes connections))))
+                            (internal-writer-routes))))
+
+(defn- normalize-prefix
+  "\"/datahike/\" and \"datahike\" mean \"/datahike\"; \"\" and \"/\" mean none."
+  [prefix]
+  (let [p (str/replace (str prefix) #"^/*|/*$" "")]
+    (when (seq p) (str "/" p))))
 
 (defn router
   "A reitit router over `api-routes`, with Datahike's coercion, formats and
-   middleware. `:prefix` nests every route under a path (e.g. \"/datahike\");
-   `:extra-routes` are the host's own routes to serve from the same router,
-   which is how the server adds `/swagger.json`."
-  [config {:keys [connections prefix extra-routes]}]
-  (let [routes (concat extra-routes (api-routes config connections))]
-    (ring/router (if prefix [prefix (vec routes)] (vec routes))
+   middleware. `:prefix` nests every route under a path; `:extra-routes` are
+   the host's own routes on the same router — the server adds `/swagger.json`
+   this way, marked `:public? true` so the gate lets it through unauthenticated."
+  [config {:keys [prefix extra-routes]}]
+  (let [routes (vec (concat extra-routes (api-routes config)))]
+    (ring/router (if-let [p (normalize-prefix prefix)] [p routes] routes)
                  (default-route-opts muuntaja-with-opts))))
+
+(def default-max-body-bytes (* 64 1024 1024))
+
+(defn- limited-stream
+  "`in`, failing past `limit` bytes and flagging `exceeded` — so a chunked
+   body cannot bypass the Content-Length check by omitting it."
+  [^java.io.InputStream in ^long limit exceeded]
+  (let [read-so-far (atom 0)
+        check!      (fn [n] (when (and (pos? n) (> (swap! read-so-far + n) limit))
+                              (reset! exceeded true)
+                              (throw (java.io.IOException. "Request body too large"))))]
+    (proxy [java.io.FilterInputStream] [in]
+      (read
+        ([] (let [b (.read in)] (check! (if (neg? b) 0 1)) b))
+        ([^bytes buf] (let [n (.read in buf)] (check! n) n))
+        ([^bytes buf off len] (let [n (.read in buf off len)] (check! n) n))))))
+
+(def ^:private too-large {:status 413 :body "Request body too large"})
+
+(defn wrap-api
+  "Everything a Datahike API request needs around the router's handler, in
+   the order that matters:
+
+   1. The gate. Before ANY decoding: a request the router does not route is
+      handed on untouched (the host's, or the server's swagger-ui and 404); a
+      public route (`:public? true`, i.e. `/swagger.json`) passes; every other
+      route requires the token here, and its body is capped at
+      `:max-body-bytes` (default 64 MiB), Content-Length and stream alike. The
+      per-route auth middleware still runs — this only makes sure nothing is
+      parsed, and no database handle decoded, for a caller that has no token.
+   2. The registry. `*connections*` is bound to `connections` for the WHOLE
+      request, decoding included, so every route — `connect`, `q`, `release`,
+      a database handle inside a body — resolves the same connection a host
+      holds under that atom."
+  [ring-handler rtr config connections]
+  (let [max-bytes (or (:max-body-bytes config) default-max-body-bytes)
+        authed?   (fn [request]
+                    (or (:dev-mode config)
+                        (= (str "token " (:token config))
+                           (get-in request [:headers "authorization"]))))]
+    (fn [request]
+      (binding [*connections* connections]
+        (if-let [match (reitit/match-by-path rtr (:uri request))]
+          (cond
+            (get-in match [:data :public?]) (ring-handler request)
+            (not (authed? request))          {:status 401 :body "Not authorized"}
+            (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
+            too-large
+            :else
+            (let [exceeded (atom false)
+                  response (ring-handler (cond-> request
+                                           (:body request) (update :body limited-stream max-bytes exceeded)))]
+              (if @exceeded too-large response)))
+          (ring-handler request))))))
 
 (defn handler
   "A Ring handler serving Datahike's HTTP API, for mounting in a host app.
@@ -295,10 +388,15 @@
      (routes/handler {:token \"…\"} {:prefix \"/datahike\" :connections conns})
 
    Requests the router does not match fall through as 404 — CORS, static
-   files, and the host's other routes are the host's business. `connections`
-   defaults to a fresh atom; pass your own to share databases with the host."
+   files and the host's other routes are the host's business. `connections`
+   defaults to a fresh atom; pass your own to share databases with the host:
+   the host's `(binding [*connections* conns] (d/connect cfg))` and a client's
+   `/connect` then resolve the identical connection. Deletion through the API
+   invalidates every connection to that database, the host's included.
+   Call `release-all!` on the atom when the host shuts down."
   ([config] (handler config {}))
   ([config {:keys [connections] :as opts}]
-   (let [connections (or connections (atom {}))]
-     (ring/ring-handler (router config (assoc opts :connections connections))
-                        (ring/create-default-handler)))))
+   (let [connections (or connections (atom {}))
+         rtr         (router config opts)]
+     (wrap-api (ring/ring-handler rtr (ring/create-default-handler))
+               rtr config connections))))

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -107,20 +107,18 @@
   (and (coll? x) (nil? (database-of x)) (not (instance? Datom x))))
 
 (defn databases
-  "The databases `op` with `args` reaches. A write's first argument names its
-   database — the connection, or the map form's `:conn` — and its transaction
-   data is not walked; everything else (queries, pulls, views) is searched in
-   full, so a database nested in a query's inputs is found."
-  [op args]
-  (let [roots (case op
-                (:transact :create :delete :admin)
-                (let [x (first args)] (if (map? x) [(:conn x) (:db x) x] [x]))
-                args)]
-    (->> roots
-         (mapcat #(tree-seq descend? seq %))
-         (keep database-of)
-         distinct
-         vec)))
+  "Every database `args` reaches, searched in full — a write's transaction
+   data included, since a transaction function can be handed a connection or
+   database value for another database and read it. Handles are what the wire
+   formats decode them to (connections, DB values and their views, entities)
+   plus config maps; the walk is linear in the size of the arguments, which
+   the request already paid to decode."
+  [args]
+  (->> args
+       (mapcat #(tree-seq descend? seq %))
+       (keep database-of)
+       distinct
+       vec))
 
 (defn authorize
   "The 403 for `op` with `args` under `config`'s `:authorize`, or nil when the
@@ -130,7 +128,7 @@
    every authenticated caller may do everything."
   [config request op args]
   (when-let [policy (:authorize config)]
-    (let [dbs       (databases op args)
+    (let [dbs       (databases args)
           principal (:datahike/principal request)
           ask       (fn [db] (policy {:op op :principal principal :db db :payload args}))]
       (when-not (if (seq dbs) (every? ask dbs) (ask nil))
@@ -405,7 +403,7 @@
                            ;; the host's included. A host sharing the atom
                            ;; must treat it as such.
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (or (authorize config request :delete [cfg])
+                             (or (authorize config request :delete (cons cfg (rest body)))
                                  (try
                                    (with-exclusive state
                                      (fn []
@@ -425,7 +423,7 @@
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters :as request}]
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (or (authorize config request :create [cfg])
+                             (or (authorize config request :create (cons cfg (rest body)))
                                  (try
                                    {:status 200
                                     :body   (async/<!! (apply datahike.writing/create-database
@@ -441,7 +439,7 @@
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters :as request}]
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (or (authorize config request :transact [cfg])
+                             (or (authorize config request :transact (cons cfg (rest body)))
                                  (try
                                    {:status 200
                                     :body   (with-connection cfg state

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -46,7 +46,8 @@
    [muuntaja.core :as m]
    [replikativ.logging :as log])
   (:import [datahike.datom Datom]
-           [datahike.impl.entity Entity]))
+           [datahike.impl.entity Entity]
+           [java.util.concurrent.locks ReentrantReadWriteLock]))
 
 ;; ---------------------------------------------------------------------------
 ;; Errors, secrets, authorization
@@ -153,25 +154,61 @@
 (defn- conn-id [cfg]
   [(datahike.store/store-identity (:store cfg)) (:branch cfg :db)])
 
+(defn- new-state
+  "What the routes keep per handler: `leases`, per database — `:base`, whether
+   the server holds its base lease, and `:api`, how many leases it has handed
+   out through `connect` — and a read-write lock that lets a delete wait for
+   the calls pinned on the database it removes."
+  []
+  {:leases (atom {})
+   :lock   (ReentrantReadWriteLock.)})
+
 (defn- with-connection
   "Run `f` with a connection to `cfg`'s database, pinned for the duration.
 
    Two leases are at work. This request's own — `api/connect` validates the
    config against the cached connection and counts one up, `api/release` in
-   `finally` counts it back — which keeps a concurrent release or delete from
-   pulling the connection out from under the call. And the server's base
-   lease, taken once per database under `leases` so that the connection (and
-   its writer) survives between requests instead of being rebuilt for each;
-   it is dropped by `release-all!` on shutdown, or by a delete."
-  [cfg leases f]
+   `finally` counts it back — which keeps a concurrent release from pulling
+   the connection out from under the call. And the server's base lease, taken
+   once per database so that the connection (and its writer) survives between
+   requests instead of being rebuilt for each; `release-all!` drops it on
+   shutdown, a delete drops it. The call holds the read side of the lock, so
+   a delete (`with-exclusive`) waits for it."
+  [cfg {:keys [leases ^ReentrantReadWriteLock lock]} f]
   (let [id (conn-id cfg)]
-    (locking leases
-      (when-not (and (@leases id) (get-in @*connections* [id :conn]))
-        (api/connect cfg)
-        (swap! leases conj id)))
-    (let [conn (api/connect cfg)]
-      (try (f conn)
-           (finally (api/release conn))))))
+    (.lock (.readLock lock))
+    (try
+      (locking leases
+        (when-not (and (get-in @leases [id :base]) (get-in @*connections* [id :conn]))
+          (api/connect cfg)
+          (swap! leases assoc-in [id :base] true)))
+      (let [conn (api/connect cfg)]
+        (try (f conn)
+             (finally (api/release conn))))
+      (finally (.unlock (.readLock lock))))))
+
+(defn- with-exclusive
+  "Run `f`, a deletion, once every pinned call has finished and none starts."
+  [{:keys [^ReentrantReadWriteLock lock]} f]
+  (.lock (.writeLock lock))
+  (try (f)
+       (finally (.unlock (.writeLock lock)))))
+
+(defn- granted!
+  "Count a lease handed out through `connect`."
+  [{:keys [leases]} conn]
+  (swap! leases update-in [(conn-id (:config @conn)) :api] (fnil inc 0))
+  conn)
+
+(defn- give-back!
+  "Release one lease `connect` handed out — and only such a lease: a caller
+   releasing more often than it connected must not drain the host's or the
+   server's own."
+  [{:keys [leases]} conn]
+  (when-let [id (try (conn-id (:config @conn)) (catch Exception _ nil))]
+    (when (pos? (get-in @leases [id :api] 0))
+      (swap! leases update-in [id :api] dec)
+      (api/release conn))))
 
 (defn release-all!
   "Release every connection in the registry — the routes' and, if the host
@@ -188,7 +225,7 @@
 ;; The API routes
 ;; ---------------------------------------------------------------------------
 
-(defn- generic-handler [config op f]
+(defn- generic-handler [config state op f]
   (fn [request]
     (try
       (let [{{body :body} :parameters
@@ -203,12 +240,19 @@
                          :remote-peer (:remote-peer (first body)))
 
                         (= f #'api/delete-database)
-                        (apply f (dissoc (first body) :remote-peer) (rest body))
+                        (with-exclusive state
+                          (fn []
+                            (swap! (:leases state) dissoc (conn-id (first body)))
+                            (apply f (dissoc (first body) :remote-peer) (rest body))))
 
-                        ;; One caller releases one lease. `release-all?` would
-                        ;; close a connection the host and other callers share.
+                        (= f #'api/connect)
+                        (granted! state (apply f body))
+
+                        ;; One caller releases one lease of its own.
+                        ;; `release-all?` would close a connection the host
+                        ;; and other callers share.
                         (= f #'api/release)
-                        (f (first body))
+                        (give-back! state (first body))
 
                         :else
                         (apply f body))]
@@ -325,7 +369,7 @@
 ;; This code expands and evals the server route construction given the
 ;; API specification.
 (eval
- `(defn- ~'create-routes [~'config]
+ `(defn- ~'create-routes [~'config ~'state]
     ~(vec
       (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
             :when supports-remote?]
@@ -336,12 +380,11 @@
             :summary     ~(extract-first-sentence doc)
             :description ~doc
             :parameters  {:body ~(extract-input-schema args)}
-            :handler     (generic-handler ~'config ~(route-op n referentially-transparent?) ~(resolve n))}}]))))
+            :handler     (generic-handler ~'config ~'state ~(route-op n referentially-transparent?) ~(resolve n))}}]))))
 
 (defn- internal-writer-routes
-  "What a `:datahike-server` writer posts to. `leases` is the set of databases
-   the server holds a base lease on (see `with-connection`)."
-  [config leases]
+  "What a `:datahike-server` writer posts to; `state` as in `new-state`."
+  [config state]
   [["/delete-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
             :summary     "Internal endpoint. DO NOT USE!"
@@ -354,12 +397,14 @@
                            (let [cfg (dissoc (first body) :remote-peer :writer)]
                              (or (authorize config request :delete [cfg])
                                  (try
-                                   (swap! leases disj (conn-id cfg))
-                                   (try
-                                     (api/release (api/connect cfg) true)
-                                     (catch Exception _))
-                                   {:status 200
-                                    :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
+                                   (with-exclusive state
+                                     (fn []
+                                       (swap! (:leases state) dissoc (conn-id cfg))
+                                       (try
+                                         (api/release (api/connect cfg) true)
+                                         (catch Exception _))
+                                       {:status 200
+                                        :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}))
                                    (catch Exception e
                                      (error-response e))))))
             :operationId "delete-database"},
@@ -389,7 +434,7 @@
                              (or (authorize config request :transact [cfg])
                                  (try
                                    {:status 200
-                                    :body   (with-connection cfg leases
+                                    :body   (with-connection cfg state
                                               (fn [conn] @(apply datahike.writer/transact! conn (rest body))))}
                                    (catch Exception e
                                      (error-response e))))))
@@ -407,10 +452,10 @@
     (when (seq p) (str "/" p))))
 
 (defn- router
-  [config {:keys [prefix extra-routes leases]}]
+  [config {:keys [prefix extra-routes state]}]
   (let [routes (vec (concat extra-routes
-                            (create-routes config)
-                            (internal-writer-routes config leases)))]
+                            (create-routes config state)
+                            (internal-writer-routes config state)))]
     (ring/router (if-let [p (normalize-prefix prefix)] [p routes] routes)
                  (default-route-opts muuntaja-with-opts))))
 
@@ -498,8 +543,7 @@
   ([config] (handler config {}))
   ([config {:keys [connections default-handler] :as opts}]
    (let [connections (or connections (atom {}))
-         leases      (atom #{})
-         rtr         (router config (assoc opts :leases leases))
+         rtr         (router config (assoc opts :state (new-state)))
          h           (wrap-api (ring/ring-handler rtr (or default-handler (ring/create-default-handler)))
                                rtr config connections)]
      (with-meta h {::connections connections}))))

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -158,8 +158,9 @@
            (finally (api/release conn))))))
 
 (defn release-all!
-  "Release every connection the routes hold, for a host shutting down. Takes
-   the connections atom or the handler `handler` returned."
+  "Release every connection in the registry — the routes' and, if the host
+   shared its atom, the host's own — for a process shutting down. Takes the
+   connections atom or the handler `handler` returned."
   [handler-or-connections]
   (let [connections (or (::connections (meta handler-or-connections)) handler-or-connections)]
     (binding [*connections* connections]

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -81,6 +81,8 @@
                             (str " on " (str/join ", " (map (comp str :store-id) databases)))))
             :ex-data {:type :datahike.http/forbidden :op op :databases databases}}})
 
+(declare store-config?)
+
 (defn- config-of
   "The database config behind an argument: a config map, a DB (or a history,
    as-of, since or filtered view of one), a connection, or an entity."
@@ -91,14 +93,22 @@
         (map? x) (cond (:config x)        (config-of (:config x))
                        (:origin-db x)     (config-of (:origin-db x))
                        (:unfiltered-db x) (config-of (:unfiltered-db x))
-                       (:store x)         x
+                       (store-config? (:store x)) x
                        :else              nil)
         :else nil))
 
+(defn- store-config?
+  "A Datahike store config, not an application's own `:store` attribute: a
+   map naming a `:backend` and carrying the store's UUID."
+  [store]
+  (and (map? store)
+       (keyword? (:backend store))
+       (uuid? (datahike.store/store-identity store))))
+
 (defn- database-of [x]
   (when-let [{:keys [store branch]} (config-of x)]
-    (when-let [store-id (datahike.store/store-identity store)]
-      {:store-id store-id :branch (or branch :db)})))
+    (when (store-config? store)
+      {:store-id (datahike.store/store-identity store) :branch (or branch :db)})))
 
 (defn- descend?
   "Walk into collections that can carry a database — not into a DB's own

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -1,0 +1,304 @@
+(ns datahike.http.routes
+  "Datahike's HTTP API as Ring routes, for embedding.
+
+   Everything the server serves is here as DATA — reitit route vectors built
+   from `datahike.api.specification` — plus the muuntaja instance and middleware
+   chain that make them work: edn, json, transit and CBOR, malli coercion of
+   request bodies, token auth. `datahike.http.server` is a thin main over this
+   namespace; an application with its own Ring stack takes `handler` (or the
+   route data itself) and mounts it where it likes.
+
+   Two things an embedding host needs beyond the routes, both explicit here:
+
+   - `handler` takes a `:prefix`, so the API can live under `/datahike` (or
+     anything) in a host that already owns `/`. A remote writer or client then
+     names that prefix in its `:url`.
+   - The connections the routes open live in an atom the host passes in (or
+     one made for it), bound as `datahike.connections/*connections*` for every
+     request. A host that also uses those databases directly shares them by
+     binding the same atom — one connection per database per process, not one
+     per caller.
+
+   The shape follows alekcz's `datahike.http.router` (#755): routes without a
+   server, a mountable handler, a shared registry. What differs is that nothing
+   is re-implemented — the route generation, formats and auth are the server's
+   own, moved here, so the two cannot drift and CBOR (what the remote writer
+   speaks) comes along."
+  (:refer-clojure :exclude [read-string filter])
+  (:require
+   [clojure.string :as str]
+   [clojure.core.async :as async]
+   [datahike.connections :refer [*connections*]]
+   [datahike.api.specification :refer [api-specification ->url]]
+   [datahike.api.types :as types]
+   [datahike.http.middleware :as middleware]
+   [datahike.readers :refer [edn-readers]]
+   [datahike.transit :as transit]
+   [datahike.remote.cbor :as rcbor]
+   [datahike.http.cbor :as cbor]
+   [datahike.json :as json]
+   [datahike.api :refer :all :as api]
+   [datahike.writing]
+   [datahike.writer]
+   [reitit.ring :as ring]
+   [reitit.coercion.malli]
+   [malli.util :as mu]
+   [reitit.swagger :as swagger]
+   [reitit.ring.coercion :as coercion]
+   [reitit.ring.middleware.muuntaja :as muuntaja]
+   [reitit.ring.middleware.exception :as exception]
+   [reitit.ring.middleware.multipart :as multipart]
+   [reitit.ring.middleware.parameters :as parameters]
+   [muuntaja.core :as m]
+   [replikativ.logging :as log]))
+
+(defn generic-handler [config f]
+  (fn [request]
+    (try
+      (let [{{body :body} :parameters
+             :keys [headers params method]} request
+            _ (log/trace :datahike/http-handler-request {:handler f :body body})
+          ;; TODO move this to client
+            ret-body
+            (cond (= f #'api/create-database)
+                ;; remove remote-peer and re-add
+                  (assoc
+                   (apply f (dissoc (first body) :remote-peer) (rest body))
+                   :remote-peer (:remote-peer (first body)))
+
+                  (= f #'api/delete-database)
+                  (apply f (dissoc (first body) :remote-peer) (rest body))
+
+                  :else
+                  (apply f body))]
+        (log/trace :datahike/http-handler-response {:body ret-body})
+        (merge
+         {:status 200
+          :body
+          (when-not (headers "no-return-value")
+            ret-body)}
+         (when (and (= method :get)
+                    (get params "args-id")
+                    (get-in config [:cache :get :max-age]))
+           {:headers {"Cache-Control" (str (when-not (:token config) "public, ")
+                                           "max-age=" (get-in config [:cache :get :max-age]))}})))
+      (catch Exception e
+        {:status 500
+         :body   {:msg (ex-message e)
+                  :ex-data (ex-data e)}}))))
+
+(declare create-routes)
+
+(defn extract-first-sentence [doc]
+  (str (first (str/split doc #"\.\s")) "."))
+
+(defn has-cat-operators?
+  "Check if args list contains :cat-specific operators like [:* ...], [:+ ...], [:alt ...], etc.
+   These operators are only valid in :cat schemas, not in :tuple schemas."
+  [args]
+  (some #(and (vector? %) (#{:* :+ :? :alt :altn} (first %))) args))
+
+(defn extract-input-schema
+  "Extract input schema from malli function schema for HTTP body validation.
+   Converts [:=> [:cat Type1 Type2] ret] to [:tuple Type1 Type2]
+   or [:function [:=> [:cat T1] ret] [:=> [:cat T1 T2] ret]] to [:or [:tuple T1] [:tuple T1 T2]]
+
+   The HTTP body is a tuple/vector of arguments that matches the function signature.
+   For zero-arity functions, we use [:= []] to match an empty vector.
+   For functions with :cat operators ([:* ...], [:alt ...], etc), we use [:sequential :any]
+   since tuples can't express these dynamic patterns."
+  [schema]
+  (cond
+    ;; Multi-arity: [:function [:=> [:cat ...] ret] ...]
+    (and (vector? schema) (= :function (first schema)))
+    (let [input-schemas (for [arity-schema (rest schema)
+                              :when (and (vector? arity-schema)
+                                         (= :=> (first arity-schema)))
+                              :let [[_ input-schema _] arity-schema
+                                    args (when (and (vector? input-schema)
+                                                    (= :cat (first input-schema)))
+                                           (rest input-schema))]]
+                          (cond
+                            (not (seq args)) [:= []]  ;; Zero-arity
+                            (has-cat-operators? args) [:sequential :any]  ;; Has :cat operators - can't use tuple
+                            :else (vec (cons :tuple args))))]  ;; Fixed arity
+      (if (> (count input-schemas) 1)
+        (vec (cons :or input-schemas))
+        (first input-schemas)))
+
+    ;; Single arity: [:=> [:cat Type1 Type2] ret]
+    (and (vector? schema) (= :=> (first schema)))
+    (let [[_ input-schema _] schema]
+      (if (and (vector? input-schema) (= :cat (first input-schema)))
+        (let [args (rest input-schema)]
+          (cond
+            (not (seq args)) [:= []]  ;; Zero-arity
+            (has-cat-operators? args) [:sequential :any]  ;; Has :cat operators
+            :else (vec (cons :tuple args))))  ;; Fixed arity
+        [:sequential :any]))
+
+    ;; Fallback
+    :else [:sequential :any]))
+
+;; This code expands and evals the server route construction given the
+;; API specification.
+(eval
+ `(defn ~'create-routes [~'config]
+    ~(vec
+      (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
+            :when supports-remote?]
+        `[~(str "/" (->url n))
+          {:swagger {:tags ["API"]}
+           ~(if referentially-transparent? :get :post)
+           {:operationId ~(str n)
+            :summary     ~(extract-first-sentence doc)
+            :description ~doc
+            :parameters  {:body ~(extract-input-schema args)}
+            :handler     (generic-handler ~'config ~(resolve n))}}]))))
+
+;; One registry per process, not per request: building it walks every handler
+;; and the result is immutable.
+(def ^:private cbor-registry (rcbor/server-registry))
+
+(def muuntaja-with-opts
+  (m/create
+   (-> m/default-options
+       ;; `application/cbor` is an addition, not a replacement — it takes its
+       ;; place beside edn/json/transit and is reached only when a client asks
+       ;; for it by Accept or Content-Type. The format carries its own codec
+       ;; options, so there is no second place for them to drift from.
+       (assoc-in [:formats "application/cbor"] (cbor/cbor-format cbor-registry))
+       (assoc-in [:formats "application/edn" :decoder-opts]
+                 {:readers edn-readers})
+       (assoc-in [:formats "application/json" :decoder-opts]
+                 json/mapper-opts)
+       (assoc-in [:formats "application/json" :encoder-opts]
+                 json/mapper-opts)
+       (assoc-in [:formats "application/transit+json" :decoder-opts]
+                 {:handlers transit/read-handlers})
+       (assoc-in [:formats "application/transit+json" :encoder-opts]
+                 {:handlers transit/write-handlers}))))
+
+(defn default-route-opts [muuntaja-with-opts]
+  {:data      {:coercion   (reitit.coercion.malli/create
+                            {:compile mu/closed-schema
+                             :strip-extra-keys true
+                             :default-values true
+                             :options {:registry types/registry}})
+               :muuntaja   muuntaja-with-opts
+               :middleware [swagger/swagger-feature
+                            parameters/parameters-middleware
+                            muuntaja/format-negotiate-middleware
+                            muuntaja/format-response-middleware
+                            exception/exception-middleware
+                            muuntaja/format-request-middleware
+                            (middleware/encode-plain-value muuntaja-with-opts)
+                            middleware/support-embedded-edn-in-json
+                            coercion/coerce-response-middleware
+                            coercion/coerce-request-middleware
+                            multipart/multipart-middleware
+                            middleware/patch-swagger-json]}})
+
+(defn internal-writer-routes [server-connections]
+  [["/delete-database-writer"
+    {:post {:parameters  {:body [:sequential :any]},
+            :summary     "Internal endpoint. DO NOT USE!"
+            :no-doc      true
+            :handler     (fn [{{:keys [body]} :parameters}]
+                           (binding [*connections* server-connections]
+                             (let [cfg (dissoc (first body) :remote-peer :writer)]
+                               (try
+                                 (try
+                                   (api/release (api/connect cfg) true)
+                                   (catch Exception _))
+                                 {:status 200
+                                  :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
+                                 (catch Exception e
+                                   {:status 500
+                                    :body   {:msg (ex-message e)
+                                             :ex-data (ex-data e)}})))))
+            :operationId "delete-database"},
+     :swagger {:tags ["Internal"]}}]
+   ["/create-database-writer"
+    {:post {:parameters  {:body [:sequential :any]},
+            :summary     "Internal endpoint. DO NOT USE!"
+            :no-doc      true
+            :handler     (fn [{{:keys [body]} :parameters}]
+                           (let [cfg (dissoc (first body) :remote-peer :writer)]
+                             (try
+                               {:status 200
+                                :body   (async/<!! (apply datahike.writing/create-database
+                                                          cfg
+                                                          (rest body)))}
+                               (catch Exception e
+                                 {:status 500
+                                  :body   {:msg (ex-message e)
+                                           :ex-data (ex-data e)}}))))
+            :operationId "create-database"},
+     :swagger {:tags ["Internal"]}}]
+   ["/transact!-writer"
+    {:post {:parameters  {:body [:sequential :any]},
+            :summary     "Internal endpoint. DO NOT USE!"
+            :no-doc      true
+            :handler     (fn [{{:keys [body]} :parameters}]
+                           (binding [*connections* server-connections]
+                             (try
+                               (let [conn (api/connect (dissoc (first body) :remote-peer :writer)) ;; TODO maybe release?
+                                     res @(apply datahike.writer/transact! conn (rest body))]
+                                 {:status 200
+                                  :body   res})
+                               (catch Exception e
+                                 {:status 500
+                                  :body   {:msg (ex-message e)
+                                           :ex-data (ex-data e)}}))))
+            :operationId "transact"},
+     :swagger {:tags ["Internal"]}}]])
+
+;; ---------------------------------------------------------------------------
+;; The embeddable surface
+;; ---------------------------------------------------------------------------
+
+(defn- with-auth
+  "Every API route behind the token/auth middleware, as `app` always applied
+   them — an embedded handler must not be less protected than the server."
+  [config routes]
+  (map (fn [route]
+         (let [method (if (:get (second route)) :get :post)]
+           (assoc-in route [1 method :middleware]
+                     [(partial middleware/token-auth config)
+                      (partial middleware/auth config)])))
+       routes))
+
+(defn api-routes
+  "The API and internal writer routes as reitit route data, authenticated.
+
+   `connections` is the atom the writer routes bind as `*connections*`. Pass
+   the same atom to `handler` and to any direct `datahike.api` use in the host
+   (under `binding`) to share one connection per database."
+  [config connections]
+  (with-auth config (concat (create-routes config)
+                            (internal-writer-routes connections))))
+
+(defn router
+  "A reitit router over `api-routes`, with Datahike's coercion, formats and
+   middleware. `:prefix` nests every route under a path (e.g. \"/datahike\");
+   `:extra-routes` are the host's own routes to serve from the same router,
+   which is how the server adds `/swagger.json`."
+  [config {:keys [connections prefix extra-routes]}]
+  (let [routes (concat extra-routes (api-routes config connections))]
+    (ring/router (if prefix [prefix (vec routes)] (vec routes))
+                 (default-route-opts muuntaja-with-opts))))
+
+(defn handler
+  "A Ring handler serving Datahike's HTTP API, for mounting in a host app.
+
+     (routes/handler {:token \"…\"} {:prefix \"/datahike\" :connections conns})
+
+   Requests the router does not match fall through as 404 — CORS, static
+   files, and the host's other routes are the host's business. `connections`
+   defaults to a fresh atom; pass your own to share databases with the host."
+  ([config] (handler config {}))
+  ([config {:keys [connections] :as opts}]
+   (let [connections (or connections (atom {}))]
+     (ring/ring-handler (router config (assoc opts :connections connections))
+                        (ring/create-default-handler)))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -53,16 +53,22 @@
 (defn start-server [config]
   (let [connections (atom {})
         app         (app config connections)
-        server      (run-jetty app config)]
-    (swap! owned assoc server {:connections connections :config (::config (meta app))})
+        config      (::config (meta app))
+        server      (try (run-jetty app config)
+                         (catch Throwable t
+                           ;; Nothing owns what `app` opened if Jetty never started.
+                           (permissions/close! config)
+                           (throw t)))]
+    (swap! owned assoc server {:connections connections :config config})
     server))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]
-  (.stop server)
-  (when-let [{:keys [connections config]} (get @owned server)]
-    (swap! owned dissoc server)
-    (routes/release-all! connections)
-    (permissions/close! config)))
+  (try (.stop server)
+       (finally
+         (when-let [{:keys [connections config]} (get @owned server)]
+           (swap! owned dissoc server)
+           (routes/release-all! connections)
+           (permissions/close! config)))))
 
 (defn -main [& args]
   (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -1,259 +1,29 @@
 (ns datahike.http.server
-  "HTTP server implementation for Datahike."
+  "HTTP server implementation for Datahike: `datahike.http.routes` behind
+   Jetty, with swagger-ui at `/` and CORS. Embedding hosts want `routes`."
   (:gen-class)
-  (:refer-clojure :exclude [read-string filter])
   (:require
-   [clojure.string :as str]
    [clojure.edn :as edn]
-   [clojure.core.async :as async]
-   [datahike.connections :refer [*connections*]]
-   [datahike.api.specification :refer [api-specification ->url]]
-   [datahike.api.types :as types]
-   [datahike.http.middleware :as middleware]
-   [datahike.readers :refer [edn-readers]]
-   [datahike.transit :as transit]
-   [datahike.remote.cbor :as rcbor]
-   [datahike.http.cbor :as cbor]
-   [datahike.json :as json]
-   [datahike.api :refer :all :as api]
-   [datahike.writing]
-   [datahike.writer]
+   [datahike.http.routes :as routes]
    [reitit.ring :as ring]
-   [reitit.coercion.malli]
-   [malli.util :as mu]
    [reitit.swagger :as swagger]
    [reitit.swagger-ui :as swagger-ui]
-   [reitit.ring.coercion :as coercion]
-   [reitit.ring.middleware.muuntaja :as muuntaja]
-   [reitit.ring.middleware.exception :as exception]
-   [reitit.ring.middleware.multipart :as multipart]
-   [reitit.ring.middleware.parameters :as parameters]
    [ring.middleware.cors :refer [wrap-cors]]
-   [muuntaja.core :as m]
    [datahike.tools :refer [datahike-version]]
-   [datahike.impl.entity :as de]
    [replikativ.logging :as log]
-   [ring.adapter.jetty :refer [run-jetty]])
-  (:import [datahike.datom Datom]))
+   [ring.adapter.jetty :refer [run-jetty]]))
 
-(defn generic-handler [config f]
-  (fn [request]
-    (try
-      (let [{{body :body} :parameters
-             :keys [headers params method]} request
-            _ (log/trace :datahike/http-handler-request {:handler f :body body})
-          ;; TODO move this to client
-            ret-body
-            (cond (= f #'api/create-database)
-                ;; remove remote-peer and re-add
-                  (assoc
-                   (apply f (dissoc (first body) :remote-peer) (rest body))
-                   :remote-peer (:remote-peer (first body)))
-
-                  (= f #'api/delete-database)
-                  (apply f (dissoc (first body) :remote-peer) (rest body))
-
-                  :else
-                  (apply f body))]
-        (log/trace :datahike/http-handler-response {:body ret-body})
-        (merge
-         {:status 200
-          :body
-          (when-not (headers "no-return-value")
-            ret-body)}
-         (when (and (= method :get)
-                    (get params "args-id")
-                    (get-in config [:cache :get :max-age]))
-           {:headers {"Cache-Control" (str (when-not (:token config) "public, ")
-                                           "max-age=" (get-in config [:cache :get :max-age]))}})))
-      (catch Exception e
-        {:status 500
-         :body   {:msg (ex-message e)
-                  :ex-data (ex-data e)}}))))
-
-(declare create-routes)
-
-(defn extract-first-sentence [doc]
-  (str (first (str/split doc #"\.\s")) "."))
-
-(defn has-cat-operators?
-  "Check if args list contains :cat-specific operators like [:* ...], [:+ ...], [:alt ...], etc.
-   These operators are only valid in :cat schemas, not in :tuple schemas."
-  [args]
-  (some #(and (vector? %) (#{:* :+ :? :alt :altn} (first %))) args))
-
-(defn extract-input-schema
-  "Extract input schema from malli function schema for HTTP body validation.
-   Converts [:=> [:cat Type1 Type2] ret] to [:tuple Type1 Type2]
-   or [:function [:=> [:cat T1] ret] [:=> [:cat T1 T2] ret]] to [:or [:tuple T1] [:tuple T1 T2]]
-
-   The HTTP body is a tuple/vector of arguments that matches the function signature.
-   For zero-arity functions, we use [:= []] to match an empty vector.
-   For functions with :cat operators ([:* ...], [:alt ...], etc), we use [:sequential :any]
-   since tuples can't express these dynamic patterns."
-  [schema]
-  (cond
-    ;; Multi-arity: [:function [:=> [:cat ...] ret] ...]
-    (and (vector? schema) (= :function (first schema)))
-    (let [input-schemas (for [arity-schema (rest schema)
-                              :when (and (vector? arity-schema)
-                                         (= :=> (first arity-schema)))
-                              :let [[_ input-schema _] arity-schema
-                                    args (when (and (vector? input-schema)
-                                                    (= :cat (first input-schema)))
-                                           (rest input-schema))]]
-                          (cond
-                            (not (seq args)) [:= []]  ;; Zero-arity
-                            (has-cat-operators? args) [:sequential :any]  ;; Has :cat operators - can't use tuple
-                            :else (vec (cons :tuple args))))]  ;; Fixed arity
-      (if (> (count input-schemas) 1)
-        (vec (cons :or input-schemas))
-        (first input-schemas)))
-
-    ;; Single arity: [:=> [:cat Type1 Type2] ret]
-    (and (vector? schema) (= :=> (first schema)))
-    (let [[_ input-schema _] schema]
-      (if (and (vector? input-schema) (= :cat (first input-schema)))
-        (let [args (rest input-schema)]
-          (cond
-            (not (seq args)) [:= []]  ;; Zero-arity
-            (has-cat-operators? args) [:sequential :any]  ;; Has :cat operators
-            :else (vec (cons :tuple args))))  ;; Fixed arity
-        [:sequential :any]))
-
-    ;; Fallback
-    :else [:sequential :any]))
-
-;; This code expands and evals the server route construction given the
-;; API specification.
-(eval
- `(defn ~'create-routes [~'config]
-    ~(vec
-      (for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api-specification
-            :when supports-remote?]
-        `[~(str "/" (->url n))
-          {:swagger {:tags ["API"]}
-           ~(if referentially-transparent? :get :post)
-           {:operationId ~(str n)
-            :summary     ~(extract-first-sentence doc)
-            :description ~doc
-            :parameters  {:body ~(extract-input-schema args)}
-            :handler     (generic-handler ~'config ~(resolve n))}}]))))
-
-;; One registry per process, not per request: building it walks every handler
-;; and the result is immutable.
-(def ^:private cbor-registry (rcbor/server-registry))
-
-(def muuntaja-with-opts
-  (m/create
-   (-> m/default-options
-       ;; `application/cbor` is an addition, not a replacement — it takes its
-       ;; place beside edn/json/transit and is reached only when a client asks
-       ;; for it by Accept or Content-Type. The format carries its own codec
-       ;; options, so there is no second place for them to drift from.
-       (assoc-in [:formats "application/cbor"] (cbor/cbor-format cbor-registry))
-       (assoc-in [:formats "application/edn" :decoder-opts]
-                 {:readers edn-readers})
-       (assoc-in [:formats "application/json" :decoder-opts]
-                 json/mapper-opts)
-       (assoc-in [:formats "application/json" :encoder-opts]
-                 json/mapper-opts)
-       (assoc-in [:formats "application/transit+json" :decoder-opts]
-                 {:handlers transit/read-handlers})
-       (assoc-in [:formats "application/transit+json" :encoder-opts]
-                 {:handlers transit/write-handlers}))))
-
-(defn default-route-opts [muuntaja-with-opts]
-  {:data      {:coercion   (reitit.coercion.malli/create
-                            {:compile mu/closed-schema
-                             :strip-extra-keys true
-                             :default-values true
-                             :options {:registry types/registry}})
-               :muuntaja   muuntaja-with-opts
-               :middleware [swagger/swagger-feature
-                            parameters/parameters-middleware
-                            muuntaja/format-negotiate-middleware
-                            muuntaja/format-response-middleware
-                            exception/exception-middleware
-                            muuntaja/format-request-middleware
-                            (middleware/encode-plain-value muuntaja-with-opts)
-                            middleware/support-embedded-edn-in-json
-                            coercion/coerce-response-middleware
-                            coercion/coerce-request-middleware
-                            multipart/multipart-middleware
-                            middleware/patch-swagger-json]}})
-
-(defn internal-writer-routes [server-connections]
-  [["/delete-database-writer"
-    {:post {:parameters  {:body [:sequential :any]},
-            :summary     "Internal endpoint. DO NOT USE!"
-            :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
-                           (binding [*connections* server-connections]
-                             (let [cfg (dissoc (first body) :remote-peer :writer)]
-                               (try
-                                 (try
-                                   (api/release (api/connect cfg) true)
-                                   (catch Exception _))
-                                 {:status 200
-                                  :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}
-                                 (catch Exception e
-                                   {:status 500
-                                    :body   {:msg (ex-message e)
-                                             :ex-data (ex-data e)}})))))
-            :operationId "delete-database"},
-     :swagger {:tags ["Internal"]}}]
-   ["/create-database-writer"
-    {:post {:parameters  {:body [:sequential :any]},
-            :summary     "Internal endpoint. DO NOT USE!"
-            :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
-                           (let [cfg (dissoc (first body) :remote-peer :writer)]
-                             (try
-                               {:status 200
-                                :body   (async/<!! (apply datahike.writing/create-database
-                                                          cfg
-                                                          (rest body)))}
-                               (catch Exception e
-                                 {:status 500
-                                  :body   {:msg (ex-message e)
-                                           :ex-data (ex-data e)}}))))
-            :operationId "create-database"},
-     :swagger {:tags ["Internal"]}}]
-   ["/transact!-writer"
-    {:post {:parameters  {:body [:sequential :any]},
-            :summary     "Internal endpoint. DO NOT USE!"
-            :no-doc      true
-            :handler     (fn [{{:keys [body]} :parameters}]
-                           (binding [*connections* server-connections]
-                             (try
-                               (let [conn (api/connect (dissoc (first body) :remote-peer :writer)) ;; TODO maybe release?
-                                     res @(apply datahike.writer/transact! conn (rest body))]
-                                 {:status 200
-                                  :body   res})
-                               (catch Exception e
-                                 {:status 500
-                                  :body   {:msg (ex-message e)
-                                           :ex-data (ex-data e)}}))))
-            :operationId "transact"},
-     :swagger {:tags ["Internal"]}}]])
-
-(defn app [config route-opts server-connections]
+(defn app [config server-connections]
   (-> (ring/ring-handler
-       (ring/router
-        (concat
+       (routes/router
+        config
+        {:connections  server-connections
+         :extra-routes
          [["/swagger.json"
            {:get {:no-doc  true
                   :swagger {:info {:title       "Datahike API"
                                    :description "Transaction and query functions for Datahike.\n\nThe signatures match those of the Clojure API. All functions take their arguments passed as a vector/list in the POST request body."}}
-                  :handler (swagger/create-swagger-handler)}}]]
-         (map (fn [route]
-                (let [method (if (:get (second route)) :get :post)]
-                  (assoc-in route [1 method :middleware]
-                            [(partial middleware/token-auth config)
-                             (partial middleware/auth config)])))
-              (concat (create-routes config)
-                      (internal-writer-routes server-connections)))) route-opts)
+                  :handler (swagger/create-swagger-handler)}}]]})
        (ring/routes
         (swagger-ui/create-swagger-ui-handler
          {:path   "/"
@@ -265,7 +35,7 @@
                  :access-control-allow-methods [:get :put :post :delete])))
 
 (defn start-server [config]
-  (run-jetty (app config (default-route-opts muuntaja-with-opts) (atom {})) config))
+  (run-jetty (app config (atom {})) config))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]
   (.stop server))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -1,9 +1,11 @@
 (ns datahike.http.server
-  "HTTP server implementation for Datahike: `datahike.http.routes` behind
-   Jetty, with swagger-ui at `/` and CORS. Embedding hosts want `routes`."
+  "HTTP server implementation for Datahike: `datahike.http.routes/handler`
+   behind Jetty, with swagger-ui at `/`, CORS, and — given an `:auth-db` —
+   eacl-backed permissions. Embedding hosts want `datahike.http.routes`."
   (:gen-class)
   (:require
    [clojure.edn :as edn]
+   [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
    [reitit.ring :as ring]
    [reitit.swagger :as swagger]
@@ -13,51 +15,59 @@
    [replikativ.logging :as log]
    [ring.adapter.jetty :refer [run-jetty]]))
 
-(defn app [config server-connections]
-  (let [rtr (routes/router
-             config
-             {:extra-routes
-              [["/swagger.json"
-                {:public? true
-                 :get {:no-doc  true
-                  :swagger {:info {:title       "Datahike API"
-                                   :description "Transaction and query functions for Datahike.\n\nThe signatures match those of the Clojure API. All functions take their arguments passed as a vector/list in the POST request body."}}
-                  :handler (swagger/create-swagger-handler)}}]]})]
-    (routes/wrap-api
-     (-> (ring/ring-handler
-          rtr
-          (ring/routes
-           (swagger-ui/create-swagger-ui-handler
-            {:path   "/"
-             :config {:validatorUrl     nil
-                      :operationsSorter "alpha"}})
-           (ring/create-default-handler)))
-         (wrap-cors :access-control-allow-origin (or (:access-control-allow-origin config)
-                                                     [#"http://localhost" #"http://localhost:8080"])
-                    :access-control-allow-methods [:get :put :post :delete]))
-     rtr config server-connections)))
+(def ^:private swagger-route
+  ["/swagger.json"
+   {:public? true
+    :get {:no-doc  true
+          :swagger {:info {:title       "Datahike API"
+                           :description "Transaction and query functions for Datahike.\n\nThe signatures match those of the Clojure API. All functions take their arguments passed as a vector/list in the POST request body."}}
+          :handler (swagger/create-swagger-handler)}}])
 
-(defonce ^:private owned-connections
-  ;; server -> the atom its routes share, so `stop-server` can release the
-  ;; databases the server opened without changing its signature.
+(defn app
+  "The server's Ring handler over `connections`. With `:auth-db` in `config`
+   the permissions database is opened here; `(::config (meta app))` is the
+   configured config, for `stop-server`."
+  [config connections]
+  (let [config  (if (:auth-db config) (permissions/configure config) config)
+        handler (routes/handler config
+                                {:connections     connections
+                                 :extra-routes    (concat [swagger-route] (permissions/routes config))
+                                 :default-handler (ring/routes
+                                                   (swagger-ui/create-swagger-ui-handler
+                                                    {:path   "/"
+                                                     :config {:validatorUrl     nil
+                                                              :operationsSorter "alpha"}})
+                                                   (ring/create-default-handler))})]
+    ;; CORS outermost, so the gate's own 401/413 carry the headers too.
+    (with-meta (wrap-cors handler
+                          :access-control-allow-origin (or (:access-control-allow-origin config)
+                                                           [#"http://localhost" #"http://localhost:8080"])
+                          :access-control-allow-methods [:get :put :post :delete])
+      (assoc (meta handler) ::config config))))
+
+(defonce ^:private owned
+  ;; server -> what it opened, so `stop-server` can close it without a
+  ;; change of signature.
   (atom {}))
 
 (defn start-server [config]
   (let [connections (atom {})
-        server      (run-jetty (app config connections) config)]
-    (swap! owned-connections assoc server connections)
+        app         (app config connections)
+        server      (run-jetty app config)]
+    (swap! owned assoc server {:connections connections :config (::config (meta app))})
     server))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]
   (.stop server)
-  (when-let [connections (get @owned-connections server)]
-    (swap! owned-connections dissoc server)
-    (routes/release-all! connections)))
+  (when-let [{:keys [connections config]} (get @owned server)]
+    (swap! owned dissoc server)
+    (routes/release-all! connections)
+    (permissions/close! config)))
 
 (defn -main [& args]
-  (let [{:keys [level token] :as config} (edn/read-string (slurp (first args)))]
+  (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]
     (when (#{:trace :debug :info nil} level)
       (println "Datahike HTTP Server" datahike-version "- https://datahike.io"))
-    (log/info :datahike/http-server-config {:config (if token (assoc config :token "REDACTED") config)})
+    (log/info :datahike/http-server-config {:config (routes/redact config)})
     (start-server config)
     (log/info :datahike/http-server-started "Server started")))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -14,31 +14,45 @@
    [ring.adapter.jetty :refer [run-jetty]]))
 
 (defn app [config server-connections]
-  (-> (ring/ring-handler
-       (routes/router
-        config
-        {:connections  server-connections
-         :extra-routes
-         [["/swagger.json"
-           {:get {:no-doc  true
+  (let [rtr (routes/router
+             config
+             {:extra-routes
+              [["/swagger.json"
+                {:public? true
+                 :get {:no-doc  true
                   :swagger {:info {:title       "Datahike API"
                                    :description "Transaction and query functions for Datahike.\n\nThe signatures match those of the Clojure API. All functions take their arguments passed as a vector/list in the POST request body."}}
-                  :handler (swagger/create-swagger-handler)}}]]})
-       (ring/routes
-        (swagger-ui/create-swagger-ui-handler
-         {:path   "/"
-          :config {:validatorUrl     nil
-                   :operationsSorter "alpha"}})
-        (ring/create-default-handler)))
-      (wrap-cors :access-control-allow-origin (or (:access-control-allow-origin config)
-                                                  [#"http://localhost" #"http://localhost:8080"])
-                 :access-control-allow-methods [:get :put :post :delete])))
+                  :handler (swagger/create-swagger-handler)}}]]})]
+    (routes/wrap-api
+     (-> (ring/ring-handler
+          rtr
+          (ring/routes
+           (swagger-ui/create-swagger-ui-handler
+            {:path   "/"
+             :config {:validatorUrl     nil
+                      :operationsSorter "alpha"}})
+           (ring/create-default-handler)))
+         (wrap-cors :access-control-allow-origin (or (:access-control-allow-origin config)
+                                                     [#"http://localhost" #"http://localhost:8080"])
+                    :access-control-allow-methods [:get :put :post :delete]))
+     rtr config server-connections)))
+
+(defonce ^:private owned-connections
+  ;; server -> the atom its routes share, so `stop-server` can release the
+  ;; databases the server opened without changing its signature.
+  (atom {}))
 
 (defn start-server [config]
-  (run-jetty (app config (atom {})) config))
+  (let [connections (atom {})
+        server      (run-jetty (app config connections) config)]
+    (swap! owned-connections assoc server connections)
+    server))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]
-  (.stop server))
+  (.stop server)
+  (when-let [connections (get @owned-connections server)]
+    (swap! owned-connections dissoc server)
+    (routes/release-all! connections)))
 
 (defn -main [& args]
   (let [{:keys [level token] :as config} (edn/read-string (slurp (first args)))]

--- a/src/datahike/connections.cljc
+++ b/src/datahike/connections.cljc
@@ -10,6 +10,13 @@
 ;; instead of racing to build a second one.
 (def ^:dynamic *connections* (atom {}))
 
+(defn lookup-connection
+  "The connection under `conn-id` without taking a lease — for code that only
+   needs the store behind it, such as decoding a database handle, and would
+   otherwise leak one count per lookup."
+  [conn-id]
+  (get-in @*connections* [conn-id :conn]))
+
 (defn get-connection [conn-id]
   ;; Lookup and ref-count increment must be one registry operation. Otherwise a
   ;; concurrent invalidation can remove the entry between them and `update-in`

--- a/src/datahike/http/client.clj
+++ b/src/datahike/http/client.clj
@@ -232,6 +232,19 @@
                                                                        :args args}))
       (first remotes))))
 
+(defn- without-credentials
+  "The arguments as sent: a config's `:remote-peer` and `:writer` name how to
+   reach a server, and their tokens belong in the authorization header, not
+   the body."
+  [args]
+  (mapv (fn [a]
+          (if (map? a)
+            (cond-> a
+              (map? (:remote-peer a)) (update :remote-peer dissoc :token)
+              (map? (:writer a))      (update :writer dissoc :token))
+            a))
+        args))
+
 (doseq [[n {:keys [args doc supports-remote? referentially-transparent?]}] api/api-specification]
   (eval
    `(def
@@ -244,13 +257,18 @@
                             {:type     :remote-not-supported
                              :function ~(str n)}))
            `(binding [remote/*remote-peer* (get-remote ~'args)]
-              (let [format# (:format remote/*remote-peer*)]
-                (({:transit request-transit
-                   :edn     request-edn
-                   :json    request-json
-                   :cbor    request-cbor} (or format# :cbor))
-                 ~(if referentially-transparent? :get :post)
-                 ~(api/->url n)
-                 remote/*remote-peer* (vec ~'args)))))))))
+              (let [format# (:format remote/*remote-peer*)
+                    ~'result (({:transit request-transit
+                                :edn     request-edn
+                                :json    request-json
+                                :cbor    request-cbor} (or format# :cbor))
+                              ~(if referentially-transparent? :get :post)
+                              ~(api/->url n)
+                              remote/*remote-peer* (without-credentials (vec ~'args)))]
+                ;; The server echoes the config's :remote-peer as it received
+                ;; it — without the token. The caller's own peer goes back on.
+                ~(if (= n 'create-database)
+                   `(cond-> ~'result (map? ~'result) (assoc :remote-peer remote/*remote-peer*))
+                   'result))))))))
 
 (defmethod remote/remote-deref :datahike-server [conn] (db conn))

--- a/src/datahike/http/client.clj
+++ b/src/datahike/http/client.clj
@@ -23,7 +23,7 @@
         fmt                 "application/edn"
         url                 (str url "/" end-point)
         body                (remote/edn-replace-remote-literals (pr-str data))
-        _                   (log/trace :datahike/http-request {:url url :end-point end-point :data data})
+        _                   (log/trace :datahike/http-request {:url url :end-point end-point})
         response
         (try
           (http/request (merge
@@ -59,7 +59,7 @@
          out      (ByteArrayOutputStream. (or max-output-buffer-size MAX_OUTPUT_BUFFER_SIZE))
          writer   (transit/writer out :json {:handlers write-handlers})
          _        (transit/write writer data)
-         _        (log/trace :datahike/http-request {:url url :end-point end-point :data data})
+         _        (log/trace :datahike/http-request {:url url :end-point end-point})
          response
          (try
            (http/request (merge
@@ -162,7 +162,7 @@
          fmt      "application/json"
          url      (str url "/" end-point)
          out      (j/write-value-as-bytes data mapper)
-         _        (log/trace :datahike/http-request {:url url :end-point end-point :data data})
+         _        (log/trace :datahike/http-request {:url url :end-point end-point})
          response
          (try
            (http/request (merge
@@ -198,7 +198,7 @@
         fmt      "application/json"
         url      (str url "/" end-point)
         out      data
-        _        (log/trace :datahike/http-request {:url url :end-point end-point :data data})
+        _        (log/trace :datahike/http-request {:url url :end-point end-point})
         response
         (http/request (merge
                        {:method method

--- a/src/datahike/http/client.clj
+++ b/src/datahike/http/client.clj
@@ -43,7 +43,7 @@
                   (update data :body #(edn/read-string {:readers remote/edn-readers} %))]
               (throw (ex-info msg new-data)))))
         response            (:body response)]
-    (log/trace :datahike/http-response {:response response})
+    (log/trace :datahike/http-response {:end-point end-point})
     (edn/read-string {:readers remote/edn-readers} response)))
 
 (defn request-transit
@@ -85,7 +85,7 @@
                (throw (ex-info msg new-data)))))
          response (:body response)
          response (transit/read (transit/reader response :json {:handlers read-handlers}))]
-     (log/trace :datahike/http-response {:response response})
+     (log/trace :datahike/http-response {:end-point end-point})
      response)))
 
 ;; One registry per process; immutable once built. Private: its server twin
@@ -150,7 +150,7 @@
          ;; writer's `:db-after` came back unable to make a remote call.
          response (binding [remote/*remote-peer* remote-peer]
                     (boring/decode (:body response) (rcbor/decode-opts registry)))]
-     (log/trace :datahike/http-response {:response response})
+     (log/trace :datahike/http-response {:end-point end-point})
      response)))
 
 (defn request-json
@@ -189,7 +189,7 @@
                                (or (:ex-data (:body new-data)) new-data))))))
          response (:body response)
          response (j/read-value response mapper)]
-     (log/trace :datahike/http-response {:response response})
+     (log/trace :datahike/http-response {:end-point end-point})
      response)))
 
 (defn request-json-raw [method end-point remote-peer data]
@@ -213,7 +213,7 @@
                        (when (= method :get)
                          {:query-params {"args-id" (uuid data)}})))
         response (slurp (:body response))]
-    (log/trace :datahike/http-response {:response response})
+    (log/trace :datahike/http-response {:end-point end-point})
     response))
 
 (defn get-remote [args]

--- a/src/datahike/http/client.clj
+++ b/src/datahike/http/client.clj
@@ -248,7 +248,7 @@
                 (({:transit request-transit
                    :edn     request-edn
                    :json    request-json
-                   :cbor    request-cbor} (or format# :transit))
+                   :cbor    request-cbor} (or format# :cbor))
                  ~(if referentially-transparent? :get :post)
                  ~(api/->url n)
                  remote/*remote-peer* (vec ~'args)))))))))

--- a/src/datahike/http/client.clj
+++ b/src/datahike/http/client.clj
@@ -123,7 +123,7 @@
          fmt      "application/cbor"
          url      (str url "/" end-point)
          out      (boring/encode data (rcbor/encode-opts registry))
-         _        (log/trace :datahike/http-request {:url url :end-point end-point :data data})
+         _        (log/trace :datahike/http-request {:url url :end-point end-point})
          response
          (try
            (http/request (merge
@@ -145,7 +145,11 @@
                    new-data (update data :body decode-error-body registry)]
                (throw (ex-info (or (:msg (:body new-data)) msg)
                                (or (:ex-data (:body new-data)) new-data))))))
-         response (boring/decode (:body response) (rcbor/decode-opts registry))]
+         ;; Bound around decoding, as the generated client fns do: a database
+         ;; handle in the response carries this peer, and without it the
+         ;; writer's `:db-after` came back unable to make a remote call.
+         response (binding [remote/*remote-peer* remote-peer]
+                    (boring/decode (:body response) (rcbor/decode-opts registry)))]
      (log/trace :datahike/http-response {:response response})
      response)))
 

--- a/src/datahike/http/writer.clj
+++ b/src/datahike/http/writer.clj
@@ -40,7 +40,9 @@
                               (str op "-writer")
                               remote-peer
                               (vec (concat [(dissoc config :writer)] args)))
-                (catch Exception e
+                ;; Throwable: an Error on this thread must still deliver, or
+                ;; the caller waits on the promise forever.
+                (catch Throwable e
                   e))))
       p))
   (-shutdown [_])

--- a/src/datahike/http/writer.clj
+++ b/src/datahike/http/writer.clj
@@ -7,7 +7,7 @@
             [datahike.store :as ds]
             [datahike.tools :as dt :refer [throwable-promise]]
             [replikativ.logging :as log]
-            [clojure.core.async :refer [promise-chan put!]]))
+            [clojure.core.async :as async :refer [promise-chan put!]]))
 
 (defrecord DatahikeServerWriter [remote-peer conn]
   PWriter
@@ -16,14 +16,19 @@
           p (promise-chan)
           config (:config @(:wrapped-atom conn))]
       (log/debug :datahike/http-write-op {:op op})
-      (put! p
-            (try
+      ;; On a real thread: `-dispatch!` is called from inside the writer's go
+      ;; block, and a blocking HTTP call there occupies a core.async dispatch
+      ;; thread for the round trip — enough concurrent transactions starve the
+      ;; pool, and a server in the same JVM (tests, embedded hosts) deadlocks.
+      (async/thread
+        (put! p
+              (try
               ;; The server implements one writer operation. Say so here, with
               ;; the operation named, rather than let it become a 404.
-              (when-not (= "transact!" (name op))
-                (throw (ex-info (str op " is not available over the :datahike-server writer; "
-                                     "only transact! is. Run it where the writer runs, or use a :self writer.")
-                                {:type :remote-writer-unsupported-op :op op})))
+                (when-not (= "transact!" (name op))
+                  (throw (ex-info (str op " is not available over the :datahike-server writer; "
+                                       "only transact! is. Run it where the writer runs, or use a :self writer.")
+                                  {:type :remote-writer-unsupported-op :op op})))
               ;; CBOR, not JSON. This channel is machine-to-machine only —
               ;; never a browser, never read by a human — so JSON's
               ;; readability buys nothing here while its costs all apply: the
@@ -31,19 +36,19 @@
               ;; `write-to-generator`, and the server-side schema lookup that
               ;; re-infers types JSON could not carry. CBOR carries them.
               ;; `:writer` holds the token; the server strips it anyway.
-              (request-cbor :post
-                            (str op "-writer")
-                            remote-peer
-                            (vec (concat [(dissoc config :writer)] args)))
-              (catch Exception e
-                e)))
+                (request-cbor :post
+                              (str op "-writer")
+                              remote-peer
+                              (vec (concat [(dissoc config :writer)] args)))
+                (catch Exception e
+                  e))))
       p))
   (-shutdown [_])
   (-streaming? [_] false))
 
 (defmethod create-writer :datahike-server
   [config connection]
-  (log/debug :datahike/http-writer-create {:config (update config :writer dissoc :token)})
+  (log/debug :datahike/http-writer-create {:config (dissoc config :token)})
   (->DatahikeServerWriter config connection))
 
 (defmethod create-database :datahike-server

--- a/src/datahike/http/writer.clj
+++ b/src/datahike/http/writer.clj
@@ -16,19 +16,25 @@
           p (promise-chan)
           config (:config @(:wrapped-atom conn))]
       (log/debug :datahike/http-write-op {:op op})
-      (log/trace :datahike/http-write-args {:arg-map arg-map})
       (put! p
             (try
+              ;; The server implements one writer operation. Say so here, with
+              ;; the operation named, rather than let it become a 404.
+              (when-not (= "transact!" (name op))
+                (throw (ex-info (str op " is not available over the :datahike-server writer; "
+                                     "only transact! is. Run it where the writer runs, or use a :self writer.")
+                                {:type :remote-writer-unsupported-op :op op})))
               ;; CBOR, not JSON. This channel is machine-to-machine only —
               ;; never a browser, never read by a human — so JSON's
               ;; readability buys nothing here while its costs all apply: the
               ;; `!kw`/`!date` tagged-string encoding, the re-entrant
               ;; `write-to-generator`, and the server-side schema lookup that
               ;; re-infers types JSON could not carry. CBOR carries them.
+              ;; `:writer` holds the token; the server strips it anyway.
               (request-cbor :post
                             (str op "-writer")
                             remote-peer
-                            (vec (concat [config] args)))
+                            (vec (concat [(dissoc config :writer)] args)))
               (catch Exception e
                 e)))
       p))
@@ -37,7 +43,7 @@
 
 (defmethod create-writer :datahike-server
   [config connection]
-  (log/debug :datahike/http-writer-create {:config config})
+  (log/debug :datahike/http-writer-create {:config (update config :writer dissoc :token)})
   (->DatahikeServerWriter config connection))
 
 (defmethod create-database :datahike-server
@@ -50,7 +56,7 @@
                                    "create-database-writer"
                                    writer
                                    (vec (concat [(-> config
-                                                     (assoc :remote-peer writer)
+                                                     (assoc :remote-peer (dissoc writer :token))
                                                      (dissoc :writer))]
                                                 (rest args))))
                      (dissoc :remote-peer))
@@ -68,7 +74,7 @@
                                      "delete-database-writer"
                                      writer
                                      (vec (concat [(-> config
-                                                       (assoc :remote-peer writer)
+                                                       (assoc :remote-peer (dissoc writer :token))
                                                        (dissoc :writer))]
                                                   (rest args))))
                        (dissoc :remote-peer))

--- a/src/datahike/readers.cljc
+++ b/src/datahike/readers.cljc
@@ -1,5 +1,5 @@
 (ns datahike.readers
-  (:require [datahike.connections :refer [get-connection *connections*]]
+  (:require [datahike.connections :refer [lookup-connection *connections*]]
             [datahike.writing :as dw]
             [datahike.datom :refer [datom] :as dd]
             #?(:cljs [datahike.db :refer [HistoricalDB AsOfDB SinceDB]])
@@ -20,7 +20,7 @@
     #?(:cljs (throw (ex-info "Reader not supported." {:type   :reader-not-supported
                                                       :raw-db raw-db}))
        :clj
-       (if-let [conn (get-connection store-id)]
+       (if-let [conn (lookup-connection store-id)]
          (let [store (:store @conn)]
            (when-let [raw-db (k/get store commit-id nil {:sync? true})]
              (dw/stored->db-read-only raw-db store)))

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -119,3 +119,13 @@
         (client/delete-database (assoc cfg :remote-peer (peer root-token))))
       (finally
         (stop! @s)))))
+
+(deftest memory-auth-dbs-do-not-collide
+  (let [a (permissions/configure {:token "a" :auth-db {:store {:backend :memory}}})
+        b (permissions/configure {:token "b" :auth-db {:store {:backend :memory}}})]
+    (try
+      (is (not (identical? (::permissions/conn a) (::permissions/conn b))))
+      (is (true? ((:authorize a) {:op :create :principal {:sub "root"} :db nil})))
+      (is (true? ((:authorize b) {:op :create :principal {:sub "root"} :db nil})))
+      (finally (permissions/close! a) (permissions/close! b)))))
+

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -1,0 +1,106 @@
+(ns datahike.test.http.permissions-test
+  "The eacl-backed permissions of the server: who may read, write, delete and
+   grant, through the API and the remote writer, and across a restart."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.connections :as connections]
+   [datahike.http.client :as client]
+   [datahike.http.permissions :as permissions]
+   [datahike.http.routes :as routes]
+   [datahike.http.server :as server]
+   [datahike.migrate.fs :as fs]
+   [ring.adapter.jetty :refer [run-jetty]]))
+
+(def ^:private root-token "root-token")
+
+(defn- validator
+  "alice and bob, by token — what a JWT validator would return."
+  [request]
+  (case (some->> (get-in request [:headers "authorization"]) (re-find #"token (.+)") second)
+    "alice-token" {:sub "alice"}
+    "bob-token"   {:sub "bob"}
+    nil))
+
+(defn- forbidden? [f]
+  (try (f) false
+       (catch Exception e
+         (loop [e e]
+           (cond (= :datahike.http/forbidden (:type (ex-data e))) true
+                 (.getCause e) (recur (.getCause e))
+                 :else false)))))
+
+(deftest permissions-in-the-auth-db
+  (let [port     23210
+        url      (str "http://localhost:" port)
+        config   {:token root-token :validator validator
+                  :auth-db {:store {:backend :file :path (str (fs/temp-dir! "dh-auth-") "/auth")}}}
+        start!   (fn []
+                   (let [conns (atom {}) app (server/app config conns)]
+                     {:server (run-jetty app {:port port :join? false}) :app app :conns conns}))
+        stop!    (fn [{:keys [server app conns]}]
+                   (.stop server)
+                   (routes/release-all! conns)
+                   (permissions/close! (::server/config (meta app))))
+        peer     (fn [t] {:backend :datahike-server :url url :token t})
+        store-id (random-uuid)
+        cfg      {:store {:backend :file :path (str (fs/temp-dir! "dh-perm-") "/store") :id store-id}
+                  :schema-flexibility :read}
+        db-obj   {:type :database :id (str store-id)}
+        grant!   (fn [t updates] (client/request-cbor :post "permissions/relationships!" (peer t) updates))
+        s        (atom (start!))]
+    (try
+      (testing "root creates; nobody else may touch the database"
+        (client/create-database (assoc cfg :remote-peer (peer root-token)))
+        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
+
+      (testing "root grants alice writer; alice may read and write, not delete or grant"
+        (is (= {:written 1}
+               (grant! root-token [{:operation :touch
+                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
+        (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
+          (client/transact alice [{:name "Ada"}])
+          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
+          (is (forbidden? #(client/delete-database (assoc cfg :remote-peer (peer "alice-token")))))
+          (is (forbidden? #(grant! "alice-token" [{:operation :touch
+                                                   :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
+          (is (true? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                    {:permission :transact :resource db-obj}))))
+          (is (false? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                     {:permission :delete :resource db-obj}))))
+          (is (forbidden? #(client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                {:subject {:type :user :id "bob"} :permission :read :resource db-obj}))
+              "asking about someone else needs grant")
+          (client/release alice)))
+
+      (testing "bob has nothing"
+        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "bob-token"))))))
+
+      (testing "the remote writer is authorized the same way"
+        ;; Two processes, so two registries: in one, bob's connect would hand
+        ;; him alice's cached connection, writer token included.
+        (let [alice (d/connect (assoc cfg :writer {:backend :datahike-server :url url :token "alice-token"}))
+              bob   (binding [connections/*connections* (atom {})]
+                      (d/connect (assoc cfg :writer {:backend :datahike-server :url url :token "bob-token"})))]
+          (is (some? (:db-after (d/transact alice [{:name "Grace"}]))))
+          (is (forbidden? #(d/transact bob [{:name "Bob"}])))
+          (is (= #{["Ada"] ["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @alice)))
+          (d/release alice)
+          (d/release bob)))
+
+      (testing "relationships survive a restart, and root stays admin"
+        (stop! @s)
+        (reset! s (start!))
+        (is (= [{:subject {:type :user :id "alice"} :relation :writer :resource db-obj}]
+               (client/request-cbor :post "permissions/relationships" (peer root-token) {:resource db-obj})))
+        (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
+          (is (= #{["Ada"] ["Grace"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
+          (client/release alice))
+        (is (= {:written 1}
+               (grant! root-token [{:operation :delete
+                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
+        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
+            "a revoked grant is gone at once")
+        (client/delete-database (assoc cfg :remote-peer (peer root-token))))
+      (finally
+        (stop! @s)))))

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -54,10 +54,12 @@
         (client/create-database (assoc cfg :remote-peer (peer root-token)))
         (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
 
-      (testing "root grants alice writer; alice may read and write, not delete or grant"
-        (is (= {:written 1}
+      (testing "root grants alice writer and bob reader in one batch; alice may read and write, not delete or grant"
+        (is (= {:written 2}
                (grant! root-token [{:operation :touch
-                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
+                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}
+                                   {:operation :touch
+                                    :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
         (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
           (client/transact alice [{:name "Ada"}])
           (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
@@ -73,8 +75,11 @@
               "asking about someone else needs grant")
           (client/release alice)))
 
-      (testing "bob has nothing"
-        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "bob-token"))))))
+      (testing "bob reads and nothing else"
+        (let [bob (client/connect (assoc cfg :remote-peer (peer "bob-token")))]
+          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @bob)))
+          (is (forbidden? #(client/transact bob [{:name "Bob"}])))
+          (client/release bob)))
 
       (testing "the remote writer is authorized the same way"
         ;; Two processes, so two registries: in one, bob's connect would hand
@@ -91,8 +96,9 @@
       (testing "relationships survive a restart, and root stays admin"
         (stop! @s)
         (reset! s (start!))
-        (is (= [{:subject {:type :user :id "alice"} :relation :writer :resource db-obj}]
-               (client/request-cbor :post "permissions/relationships" (peer root-token) {:resource db-obj})))
+        (is (= #{{:subject {:type :user :id "alice"} :relation :writer :resource db-obj}
+                 {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}
+               (set (client/request-cbor :post "permissions/relationships" (peer root-token) {:resource db-obj}))))
         (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
           (is (= #{["Ada"] ["Grace"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
           (client/release alice))
@@ -101,6 +107,15 @@
                                     :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
         (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
             "a revoked grant is gone at once")
+        (is (try (grant! root-token [{:operation :touch
+                                      :relationship {:subject {:type :user :id "alice"} :relation :reader :resource db-obj}}
+                                     {:operation :touch
+                                      :relationship {:subject {:type :user :id "alice"} :relation :nonsense :resource db-obj}}])
+                 false
+                 (catch Exception _ true))
+            "a batch with a bad relationship is refused whole")
+        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
+            "…and its good half did not land")
         (client/delete-database (assoc cfg :remote-peer (peer root-token))))
       (finally
         (stop! @s)))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -221,6 +221,11 @@
       (testing "a rejected writer operation leaves the writer usable"
         (is (instance? Throwable (try @(d/load-entities conn [[1 :name "x" 1 true]]) (catch Exception e e))))
         (is (some? (:db-after (d/transact conn [{:name "after"}])))))
+      (testing "a client's release never closes the shared connection"
+        (let [api-conn (client/connect (assoc (dissoc cfg :writer) :remote-peer peer))]
+          (client/release api-conn true)
+          (is (some? (get-in @connections [[store-id :db] :conn]))
+              "release-all? from a client is ignored: the base lease stays")))
       (testing "release-all! empties the registry it is given, handler or atom"
         (routes/release-all! h)
         (is (empty? (filter (comp :conn val) @connections))))
@@ -253,6 +258,13 @@
             (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @bob)))
             (is (= :datahike.http/forbidden (:type (ex-data e))))
             (is (= :transact (:op (ex-data e))))))
+        (testing "a validator principal may not claim the token's subject"
+          (let [h2 (routes/handler {:token token :validator (fn [_] {:sub "root"})})]
+            (is (= 401 (:status (h2 {:request-method :post :uri "/transact" :headers {"authorization" "token whatever"}}))))
+            (is (not= 401 (:status (h2 {:request-method :post :uri "/transact"
+                                        :headers {"authorization" (str "token " token)}
+                                        :body (java.io.ByteArrayInputStream. (byte-array 0))})))
+                "the token itself still authenticates (and then fails coercion further in)")))
         (testing "a token no validator accepts is 401"
           (is (= 401 (:status (http/post (str url "/transact")
                                          {:throw false :headers {"authorization" "token nobody"} :body "x"}))))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -131,6 +131,8 @@
     (testing "no prefix, and an empty or root prefix, mount at /"
       (doseq [prefix [nil "" "/"]]
         (is (= 401 (:status ((routes/handler {:token token} {:prefix prefix}) (req "/transact")))) (pr-str prefix))))
+    (testing "HEAD is not a way around the gate: routes have no HEAD, so reitit answers 405"
+      (is (= 405 (:status ((routes/handler {:token token}) {:request-method :head :uri "/q" :headers {}})))))
     (testing "a handler without a token and without :dev-mode admits nobody"
       (is (= 401 (:status ((routes/handler {}) (req "/transact"))))))))
 

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -54,7 +54,7 @@
         (is (= 404 (:status (http/get (str url "/no-such-route") {:throw false})))))
 
       (testing "the gate: no or wrong token is 401 before anything is decoded"
-        (doseq [end-point ["q" "transact!-writer" "connect"]
+        (doseq [end-point ["transact" "transact!-writer" "connect"]
                 headers   [{} {"authorization" "token wrong"}]]
           (is (= 401 (:status (http/post (str url "/" end-point)
                                          {:throw   false
@@ -117,20 +117,22 @@
           (d/delete-database cfg)))
       (finally
         (.stop server)
-        (routes/release-all! connections)))))
+        (routes/release-all! connections)
+        (is (empty? (filter (comp :conn val) @connections))
+            "release-all! released the server's own leases, in the server's own atom")))))
 
 (deftest prefix-and-gate-without-a-server
   (let [req (fn [uri] {:request-method :post :uri uri :headers {}})]
     (testing "a prefix is normalized: leading and trailing slashes do not matter"
       (doseq [prefix ["/datahike" "datahike" "/datahike/" "datahike/"]]
         (let [h (routes/handler {:token token} {:prefix prefix})]
-          (is (= 401 (:status (h (req "/datahike/q")))) (pr-str prefix))
-          (is (= 404 (:status (h (req "/q")))) (pr-str prefix)))))
+          (is (= 401 (:status (h (req "/datahike/transact")))) (pr-str prefix))
+          (is (= 404 (:status (h (req "/transact")))) (pr-str prefix)))))
     (testing "no prefix, and an empty or root prefix, mount at /"
       (doseq [prefix [nil "" "/"]]
-        (is (= 401 (:status ((routes/handler {:token token} {:prefix prefix}) (req "/q")))) (pr-str prefix))))
+        (is (= 401 (:status ((routes/handler {:token token} {:prefix prefix}) (req "/transact")))) (pr-str prefix))))
     (testing "a handler without a token and without :dev-mode admits nobody"
-      (is (= 401 (:status ((routes/handler {}) (req "/q"))))))))
+      (is (= 401 (:status ((routes/handler {}) (req "/transact"))))))))
 
 (deftest the-server-app-shares-the-contract
   (let [port   23201
@@ -141,6 +143,119 @@
       (is (= 200 (:status (http/get (str url "/swagger.json") {:throw false}))) "swagger.json is public")
       (is (contains? #{200 302} (:status (http/get (str url "/") {:throw false :follow-redirects :never})))
           "the swagger UI at / is served outside the router, untouched by the gate")
-      (is (= 401 (:status (http/post (str url "/q") {:throw false :body "garbage"}))))
+      (is (= 401 (:status (http/post (str url "/transact") {:throw false :body "garbage"}))))
+      (is (= 200 (:status (http/request {:method :options :uri (str url "/q") :throw false
+                                         :headers {"origin" "http://localhost:8080"
+                                                   "access-control-request-method" "GET"}})))
+          "a CORS preflight carries no token and must reach the CORS middleware, not the gate")
+      (is (= 405 (:status (http/post (str url "/q") {:throw false
+                                                     :headers {"authorization" (str "token " token)}
+                                                     :body "garbage"})))
+          "a wrong method is reitit's 405, whoever asks")
       (finally
+        (.stop server)))))
+
+(defn- error-of [f]
+  (try (f) nil (catch Exception e e)))
+
+(deftest the-gate-caps-and-redacts
+  (let [port   23203
+        conns  (atom {})
+        server (run-jetty (server/app {:token token :dev-mode false :max-body-bytes 4096} conns)
+                          {:port port :join? false})
+        url    (str "http://localhost:" port)
+        big    (byte-array 10000 (byte 32))
+        auth   {"authorization" (str "token " token)}]
+    (try
+      (testing "a public route's body is capped too"
+        (is (= 413 (:status (http/request {:method :get :uri (str url "/swagger.json") :throw false :body big})))))
+      (testing "a body the decoder would read only the first form of is measured in full"
+        (is (= 413 (:status (http/post (str url "/transact")
+                                       {:throw   false
+                                        :headers (assoc auth "content-type" "application/edn")
+                                        :body    (java.io.ByteArrayInputStream.
+                                                  (.getBytes (str "[1]" (apply str (repeat 10000 " ")))))})))))
+      (testing "an unsupported content type over the limit is 413, not 400"
+        (is (= 413 (:status (http/post (str url "/transact")
+                                       {:throw false :headers (assoc auth "content-type" "text/plain") :body big})))))
+      (testing "the gate's own responses carry CORS headers"
+        (let [r (http/post (str url "/transact") {:throw false :headers {"origin" "http://localhost"} :body "x"})]
+          (is (= 401 (:status r)))
+          (is (= "http://localhost" (get-in r [:headers "access-control-allow-origin"])))))
+      (testing "an error body never carries a credential"
+        (let [peer {:backend :datahike-server :url url :token token}
+              e    (error-of #(client/connect {:store {:backend :file :path "/nonexistent/dh-routes-test"
+                                                       :id (random-uuid) :password "s3cret-pw"}
+                                               :remote-peer peer}))]
+          (is (some? e))
+          (is (not (str/includes? (str (ex-message e) (pr-str (ex-data e))) "s3cret-pw")))))
+      (finally
+        (.stop server)
+        (routes/release-all! conns)))))
+
+(deftest leases-and-concurrency
+  (let [port        23204
+        connections (atom {})
+        h           (routes/handler {:token token} {:connections connections})
+        server      (run-jetty h {:port port :join? false})
+        url         (str "http://localhost:" port)
+        peer        {:backend :datahike-server :url url :token token}
+        store-id    (random-uuid)
+        cfg         (assoc (file-config store-id)
+                           :writer {:backend :datahike-server :url url :token token})
+        conn        (do (d/create-database cfg) (d/connect cfg))]
+    (try
+      (testing "concurrent first transactions: every one succeeds, one connection, one base lease"
+        (let [go (promise)
+              fs (doall (repeatedly 16 #(future @go (d/transact conn [{:name (str (random-uuid))}]))))]
+          (deliver go true)
+          (is (every? some? (map (comp :db-after deref) fs)))
+          (is (= 16 (count (d/q '[:find ?n :where [?e :name ?n]] @conn))))
+          (is (= 1 (get-in @connections [[store-id :db] :count])))))
+      (testing "decoding a database handle takes no lease"
+        (let [api-conn (client/connect (assoc (dissoc cfg :writer) :remote-peer peer))
+              before   (get-in @connections [[store-id :db] :count])]
+          (dotimes [_ 5] (client/q '[:find ?n :where [?e :name ?n]] @api-conn))
+          (is (= before (get-in @connections [[store-id :db] :count])))
+          (client/release api-conn)))
+      (testing "a rejected writer operation leaves the writer usable"
+        (is (instance? Throwable (try @(d/load-entities conn [[1 :name "x" 1 true]]) (catch Exception e e))))
+        (is (some? (:db-after (d/transact conn [{:name "after"}])))))
+      (testing "release-all! empties the registry it is given, handler or atom"
+        (routes/release-all! h)
+        (is (empty? (filter (comp :conn val) @connections))))
+      (finally
+        ;; Deletion goes through the remote writer, so before the server stops.
+        (d/release conn)
+        (d/delete-database cfg)
+        (.stop server)))))
+
+(deftest validator-and-authorize
+  (let [port      23205
+        validator (fn [request]
+                    (case (some->> (get-in request [:headers "authorization"]) (re-find #"token (.+)") second)
+                      "alice-token" {:sub "alice"}
+                      "bob-token"   {:sub "bob"}
+                      nil))
+        h         (routes/handler {:validator validator
+                                   :authorize (fn [{:keys [op principal]}]
+                                                (or (= "alice" (:sub principal)) (= :read op)))})
+        server    (run-jetty h {:port port :join? false})
+        url       (str "http://localhost:" port)
+        peer      (fn [t] {:backend :datahike-server :url url :token t})
+        cfg       {:store {:backend :memory :id (random-uuid)} :schema-flexibility :read}]
+    (try
+      (let [alice (client/connect (client/create-database (assoc cfg :remote-peer (peer "alice-token"))))]
+        (client/transact alice [{:name "Ada"}])
+        (testing "bob may read but not write"
+          (let [bob (client/connect (assoc cfg :remote-peer (peer "bob-token")))
+                e   (error-of #(client/transact bob [{:name "x"}]))]
+            (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @bob)))
+            (is (= :datahike.http/forbidden (:type (ex-data e))))
+            (is (= :transact (:op (ex-data e))))))
+        (testing "a token no validator accepts is 401"
+          (is (= 401 (:status (http/post (str url "/transact")
+                                         {:throw false :headers {"authorization" "token nobody"} :body "x"}))))))
+      (finally
+        (routes/release-all! h)
         (.stop server)))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -147,12 +147,19 @@
             db   @conn
             id   {:store-id (get-in cfg [:store :id]) :branch :db}]
         (try
-          (is (= [id] (routes/databases :read [[db]])))
-          (is (= [id] (routes/databases :read [{:query '[:find ?e :in $ :where [?e]] :args [db]}])))
-          (is (= [id] (routes/databases :read [(d/history db)])))
-          (is (= [id] (routes/databases :read [(d/entity db 1)])))
-          (is (= [id] (routes/databases :transact [conn [{:db db}]])))
-          (is (= [id] (routes/databases :transact [{:conn conn :tx-data [{:db db}]}])))
+          (is (= [id] (routes/databases [[db]])))
+          (is (= [id] (routes/databases [{:query '[:find ?e :in $ :where [?e]] :args [db]}])))
+          (is (= [id] (routes/databases [(d/history db)])))
+          (is (= [id] (routes/databases [(d/entity db 1)])))
+          (is (= [id] (routes/databases [conn [{:db db}]])))
+          (is (= [id] (routes/databases [{:conn conn :tx-data [{:db db}]}])))
+          (let [cfg2  {:store {:backend :memory :id (random-uuid)} :schema-flexibility :read}
+                conn2 (do (d/create-database cfg2) (d/connect cfg2))
+                id2   {:store-id (get-in cfg2 [:store :id]) :branch :db}]
+            (try
+              (is (= #{id id2} (set (routes/databases [conn [[:db.fn/call :installed-fn conn2]]])))
+                  "a handle for another database inside transaction data is part of the call")
+              (finally (d/release conn2) (d/delete-database cfg2))))
           (finally (d/release conn) (d/delete-database cfg)))))
     (testing "HEAD is not a way around the gate: routes have no HEAD, so reitit answers 405"
       (is (= 405 (:status ((routes/handler {:token token}) {:request-method :head :uri "/q" :headers {}})))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -1,14 +1,19 @@
 (ns datahike.test.http.routes-test
   "Datahike's HTTP API mounted inside a host application, under a prefix,
-   driven by the real clients — the HTTP client and the remote writer."
+   driven by the real clients — the HTTP client and the remote writer — and
+   the contract `routes/handler` makes: one registry for the whole request,
+   nothing decoded before the token is checked, bodies capped."
   (:require
    [babashka.http-client :as http]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [datahike.api :as d]
+   [datahike.connections :as connections]
    [datahike.http.client :as client]
    [datahike.http.routes :as routes]
+   [datahike.http.server :as server]
    [datahike.migrate.fs :as fs]
+   [datahike.remote :as remote]
    [ring.adapter.jetty :refer [run-jetty]]))
 
 (def ^:private token "securerandompassword")
@@ -22,13 +27,25 @@
       (datahike-handler request)
       {:status 200 :headers {"content-type" "text/plain"} :body "host"})))
 
+(defn- file-config
+  "A file store under a fresh temp dir (konserve refuses a path that exists)."
+  [store-id]
+  {:store {:backend :file :path (str (fs/temp-dir! "dh-routes-") "/store") :id store-id}
+   :keep-history? true
+   :schema-flexibility :read})
+
+(defn- root-cause-message [^Throwable e]
+  (loop [e e]
+    (if-let [c (.getCause e)] (recur c) (ex-message e))))
+
 (deftest embedded-under-a-prefix
   (let [port        23200
         connections (atom {})
-        server      (run-jetty (host-app (routes/handler {:token token :dev-mode false}
+        server      (run-jetty (host-app (routes/handler {:token token :dev-mode false :max-body-bytes 4096}
                                                          {:prefix "/datahike" :connections connections}))
                                {:port port :join? false})
-        url         (str "http://localhost:" port "/datahike")]
+        url         (str "http://localhost:" port "/datahike")
+        peer        {:backend :datahike-server :url url :token token :format :transit}]
     (try
       (testing "the host still owns everything outside the prefix"
         (is (= "host" (:body (http/get (str "http://localhost:" port "/anything"))))))
@@ -36,29 +53,94 @@
       (testing "a request inside the prefix that matches nothing is a 404, not the host's page"
         (is (= 404 (:status (http/get (str url "/no-such-route") {:throw false})))))
 
-      (testing "the HTTP client works against the prefixed API"
-        (let [peer {:backend :datahike-server :url url :token token :format :transit}
-              cfg  (client/create-database {:store {:backend :memory
-                                                    :id #uuid "de110000-0000-0000-0000-00000000e0b1"}
-                                            :schema-flexibility :read
-                                            :remote-peer peer})
-              conn (client/connect cfg)]
-          (client/transact conn [{:name "Ada"}])
-          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @conn)))))
+      (testing "the gate: no or wrong token is 401 before anything is decoded"
+        (doseq [end-point ["q" "transact!-writer" "connect"]
+                headers   [{} {"authorization" "token wrong"}]]
+          (is (= 401 (:status (http/post (str url "/" end-point)
+                                         {:throw   false
+                                          :headers (assoc headers "content-type" "application/transit+json")
+                                          :body    "this is not transit"})))
+              (str end-point " with " (or (get headers "authorization") "no token")))))
 
-      (testing "the remote writer works through the prefix, and connects inside the host's registry"
-        (let [store-id #uuid "17100000-0000-0000-0000-00000000e0b2"
-              ;; A child of a fresh temp dir: konserve refuses a path that exists.
-              cfg      {:store {:backend :file :path (str (fs/temp-dir! "dh-routes-") "/store") :id store-id}
-                        :keep-history? true
-                        :schema-flexibility :read
-                        :writer {:backend :datahike-server :url url :token token}}
+      (testing "the gate: a body over :max-body-bytes is 413, with or without Content-Length"
+        (let [big (.getBytes (apply str (repeat 10000 "x")))
+              hdr {"authorization" (str "token " token) "content-type" "application/transit+json"}]
+          (is (= 413 (:status (http/post (str url "/transact") {:throw false :headers hdr :body big}))))
+          (is (= 413 (:status (http/post (str url "/transact") {:throw   false :headers hdr
+                                                                :body    (java.io.ByteArrayInputStream. big)})))
+              "chunked, no Content-Length: the stream itself is capped")))
+
+      (testing "the HTTP client works against the prefixed API, in transit and in CBOR"
+        (doseq [fmt [:transit :cbor]]
+          (let [cfg  (client/create-database {:store {:backend :memory :id (random-uuid)}
+                                              :schema-flexibility :read
+                                              :remote-peer (assoc peer :format fmt)})
+                conn (client/connect cfg)]
+            (client/transact conn [{:name "Ada"}])
+            (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @conn)) (name fmt)))))
+
+      (testing "one registry: the host's connection and the API's are the identical object"
+        (let [store-id  (random-uuid)
+              cfg       (file-config store-id)
+              host-conn (binding [connections/*connections* connections]
+                          (d/create-database cfg)
+                          (d/connect cfg))
+              api-conn  (client/connect (assoc cfg :remote-peer peer))]
+          (is (identical? host-conn (get-in @connections [[store-id :db] :conn])))
+          (client/transact api-conn [{:name "Grace"}])
+          (is (= #{["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @host-conn))
+              "what the client wrote through the API, the host reads on its own connection")
+          (is (= 1 (count (filter #(= store-id (ffirst %)) @connections))))
+          (is (nil? (get @connections/*connections* [store-id :db]))
+              "the process-wide registry was never touched")
+          (client/release api-conn)
+          (binding [connections/*connections* connections]
+            (d/release host-conn)
+            (d/delete-database cfg))))
+
+      (testing "the remote writer through the prefix: the server holds one lease, requests borrow it"
+        (let [store-id (random-uuid)
+              cfg      (assoc (file-config store-id)
+                              :writer {:backend :datahike-server :url url :token token})
               conn     (do (d/create-database cfg) (d/connect cfg))]
-          (d/transact conn [{:name "Grace"}])
-          (is (= #{["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @conn)))
-          (is (some? (get-in @connections [[store-id :db] :conn]))
-              "the writer route connected in the atom the host passed in — shared, not private")
+          (dotimes [i 3] (d/transact conn [{:name (str "Grace-" i)}]))
+          (is (= 3 (count (d/q '[:find ?n :where [?e :name ?n]] @conn))))
+          (is (= 1 (get-in @connections [[store-id :db] :count]))
+              "three transactions, one lease — the count is not per request")
+          (let [report (client/request-cbor :post "transact!-writer" peer [(dissoc cfg :writer) [{:name "Ada"}]])]
+            (is (= peer (remote/remote-peer (:db-after report)))
+                "a database handle in a CBOR response carries the peer it came from"))
+          (let [e (try @(d/load-entities conn [[1 :name "x" 1 true]]) (catch Exception e e))]
+            (is (str/includes? (str (root-cause-message e)) "not available over the :datahike-server writer")
+                "an operation the server does not implement fails by name, not with a 404"))
           (d/release conn)
           (d/delete-database cfg)))
+      (finally
+        (.stop server)
+        (routes/release-all! connections)))))
+
+(deftest prefix-and-gate-without-a-server
+  (let [req (fn [uri] {:request-method :post :uri uri :headers {}})]
+    (testing "a prefix is normalized: leading and trailing slashes do not matter"
+      (doseq [prefix ["/datahike" "datahike" "/datahike/" "datahike/"]]
+        (let [h (routes/handler {:token token} {:prefix prefix})]
+          (is (= 401 (:status (h (req "/datahike/q")))) (pr-str prefix))
+          (is (= 404 (:status (h (req "/q")))) (pr-str prefix)))))
+    (testing "no prefix, and an empty or root prefix, mount at /"
+      (doseq [prefix [nil "" "/"]]
+        (is (= 401 (:status ((routes/handler {:token token} {:prefix prefix}) (req "/q")))) (pr-str prefix))))
+    (testing "a handler without a token and without :dev-mode admits nobody"
+      (is (= 401 (:status ((routes/handler {}) (req "/q"))))))))
+
+(deftest the-server-app-shares-the-contract
+  (let [port   23201
+        conns  (atom {})
+        server (run-jetty (server/app {:token token :dev-mode false} conns) {:port port :join? false})
+        url    (str "http://localhost:" port)]
+    (try
+      (is (= 200 (:status (http/get (str url "/swagger.json") {:throw false}))) "swagger.json is public")
+      (is (contains? #{200 302} (:status (http/get (str url "/") {:throw false :follow-redirects :never})))
+          "the swagger UI at / is served outside the router, untouched by the gate")
+      (is (= 401 (:status (http/post (str url "/q") {:throw false :body "garbage"}))))
       (finally
         (.stop server)))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -131,6 +131,29 @@
     (testing "no prefix, and an empty or root prefix, mount at /"
       (doseq [prefix [nil "" "/"]]
         (is (= 401 (:status ((routes/handler {:token token} {:prefix prefix}) (req "/transact")))) (pr-str prefix))))
+    (testing "a validator that reads the body neither defeats the cap nor starves the route"
+      (let [seen (atom nil)
+            h    (routes/handler {:max-body-bytes 4
+                                  :validator (fn [req] (reset! seen (count (.readAllBytes ^java.io.InputStream (:body req)))) {:sub "v"})})
+            post (fn [s] (h {:request-method :post :uri "/transact" :headers {"content-type" "application/edn"}
+                             :body (java.io.ByteArrayInputStream. (.getBytes ^String s))}))]
+        (is (= 413 (:status (post "0123456789"))))
+        (is (nil? @seen) "over the cap, no validator ran")
+        (is (not= 401 (:status (post "[1]"))))
+        (is (= 3 @seen) "the validator saw the whole (buffered) body")))
+    (testing "databases are found nested in query inputs and inside entities, not in tx-data"
+      (let [cfg  {:store {:backend :memory :id (random-uuid)} :schema-flexibility :read}
+            conn (do (d/create-database cfg) (d/connect cfg))
+            db   @conn
+            id   {:store-id (get-in cfg [:store :id]) :branch :db}]
+        (try
+          (is (= [id] (routes/databases :read [[db]])))
+          (is (= [id] (routes/databases :read [{:query '[:find ?e :in $ :where [?e]] :args [db]}])))
+          (is (= [id] (routes/databases :read [(d/history db)])))
+          (is (= [id] (routes/databases :read [(d/entity db 1)])))
+          (is (= [id] (routes/databases :transact [conn [{:db db}]])))
+          (is (= [id] (routes/databases :transact [{:conn conn :tx-data [{:db db}]}])))
+          (finally (d/release conn) (d/delete-database cfg)))))
     (testing "HEAD is not a way around the gate: routes have no HEAD, so reitit answers 405"
       (is (= 405 (:status ((routes/handler {:token token}) {:request-method :head :uri "/q" :headers {}})))))
     (testing "a handler without a token and without :dev-mode admits nobody"

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -1,0 +1,64 @@
+(ns datahike.test.http.routes-test
+  "Datahike's HTTP API mounted inside a host application, under a prefix,
+   driven by the real clients — the HTTP client and the remote writer."
+  (:require
+   [babashka.http-client :as http]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.http.client :as client]
+   [datahike.http.routes :as routes]
+   [datahike.migrate.fs :as fs]
+   [ring.adapter.jetty :refer [run-jetty]]))
+
+(def ^:private token "securerandompassword")
+
+(defn- host-app
+  "A host that owns `/` and hands `/datahike/...` to Datahike — the shape of an
+   application embedding the API rather than running the server."
+  [datahike-handler]
+  (fn [request]
+    (if (str/starts-with? (:uri request) "/datahike")
+      (datahike-handler request)
+      {:status 200 :headers {"content-type" "text/plain"} :body "host"})))
+
+(deftest embedded-under-a-prefix
+  (let [port        23200
+        connections (atom {})
+        server      (run-jetty (host-app (routes/handler {:token token :dev-mode false}
+                                                         {:prefix "/datahike" :connections connections}))
+                               {:port port :join? false})
+        url         (str "http://localhost:" port "/datahike")]
+    (try
+      (testing "the host still owns everything outside the prefix"
+        (is (= "host" (:body (http/get (str "http://localhost:" port "/anything"))))))
+
+      (testing "a request inside the prefix that matches nothing is a 404, not the host's page"
+        (is (= 404 (:status (http/get (str url "/no-such-route") {:throw false})))))
+
+      (testing "the HTTP client works against the prefixed API"
+        (let [peer {:backend :datahike-server :url url :token token :format :transit}
+              cfg  (client/create-database {:store {:backend :memory
+                                                    :id #uuid "de110000-0000-0000-0000-00000000e0b1"}
+                                            :schema-flexibility :read
+                                            :remote-peer peer})
+              conn (client/connect cfg)]
+          (client/transact conn [{:name "Ada"}])
+          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @conn)))))
+
+      (testing "the remote writer works through the prefix, and connects inside the host's registry"
+        (let [store-id #uuid "17100000-0000-0000-0000-00000000e0b2"
+              ;; A child of a fresh temp dir: konserve refuses a path that exists.
+              cfg      {:store {:backend :file :path (str (fs/temp-dir! "dh-routes-") "/store") :id store-id}
+                        :keep-history? true
+                        :schema-flexibility :read
+                        :writer {:backend :datahike-server :url url :token token}}
+              conn     (do (d/create-database cfg) (d/connect cfg))]
+          (d/transact conn [{:name "Grace"}])
+          (is (= #{["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @conn)))
+          (is (some? (get-in @connections [[store-id :db] :conn]))
+              "the writer route connected in the atom the host passed in — shared, not private")
+          (d/release conn)
+          (d/delete-database cfg)))
+      (finally
+        (.stop server)))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -246,11 +246,14 @@
       (testing "a rejected writer operation leaves the writer usable"
         (is (instance? Throwable (try @(d/load-entities conn [[1 :name "x" 1 true]]) (catch Exception e e))))
         (is (some? (:db-after (d/transact conn [{:name "after"}])))))
-      (testing "a client's release never closes the shared connection"
+      (testing "a client's releases never close the shared connection"
         (let [api-conn (client/connect (assoc (dissoc cfg :writer) :remote-peer peer))]
           (client/release api-conn true)
           (is (some? (get-in @connections [[store-id :db] :conn]))
-              "release-all? from a client is ignored: the base lease stays")))
+              "release-all? from a client is ignored: the base lease stays")
+          (dotimes [_ 5] (client/release api-conn))
+          (is (= 1 (get-in @connections [[store-id :db] :count]))
+              "releasing more often than connecting gives back nothing the caller was not granted")))
       (testing "release-all! empties the registry it is given, handler or atom"
         (routes/release-all! h)
         (is (empty? (filter (comp :conn val) @connections))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -243,6 +243,22 @@
           (dotimes [_ 5] (client/q '[:find ?n :where [?e :name ?n]] @api-conn))
           (is (= before (get-in @connections [[store-id :db] :count])))
           (client/release api-conn)))
+      (testing "two releases racing on one granted lease give back one"
+        (let [api-conn (client/connect (assoc (dissoc cfg :writer) :remote-peer peer))]
+          (dotimes [_ 50]
+            (client/connect (assoc (dissoc cfg :writer) :remote-peer peer))
+            (let [fs (doall (repeatedly 2 #(future (client/release api-conn))))]
+              (run! deref fs))
+            (is (= 1 (get-in @connections [[store-id :db] :count]))))
+          (client/release api-conn)))
+      (testing "deleting a database whose config names this server as its writer does not deadlock"
+        (let [cfg2 (assoc (file-config (random-uuid))
+                          :writer {:backend :datahike-server :url url :token token}
+                          :remote-peer peer)]
+          (client/create-database cfg2)
+          (is (= true (client/database-exists? cfg2)))
+          (is (nil? (deref (future (client/delete-database cfg2)) 20000 ::timeout)))
+          (is (false? (client/database-exists? cfg2)))))
       (testing "a rejected writer operation leaves the writer usable"
         (is (instance? Throwable (try @(d/load-entities conn [[1 :name "x" 1 true]]) (catch Exception e e))))
         (is (some? (:db-after (d/transact conn [{:name "after"}])))))

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -159,6 +159,9 @@
             (try
               (is (= #{id id2} (set (routes/databases [conn [[:db.fn/call :installed-fn conn2]]])))
                   "a handle for another database inside transaction data is part of the call")
+              (is (= [id] (routes/databases [conn [{:shop/name "x" :store {:id 5}}
+                                                   {:store {:backend "file" :id (random-uuid)}}]]))
+                  "an application's own :store attribute is not a database config")
               (finally (d/release conn2) (d/delete-database cfg2))))
           (finally (d/release conn) (d/delete-database cfg)))))
     (testing "HEAD is not a way around the gate: routes have no HEAD, so reitit answers 405"


### PR DESCRIPTION
Supersedes #755 (thanks @alekcz — the embedding mode, its documentation shape and the security checklist grew out of it; co-authored).

## What this is

`datahike.http.routes/handler` — the server's HTTP API as a Ring handler for mounting in a host app under a `:prefix`, sharing the host's connection registry. `datahike.http.server` is a thin main over it. Everything a request needs is one composition unit (`wrap-api`), in this order: the body is read and capped (`:max-body-bytes`, default 64 MiB) before any decoder sees a byte, public routes included; the caller is authenticated before decoding; `*connections*` is bound for the whole request; each call is authorized after decoding for every database it reaches.

## Authentication and authorization

- Validators in kabel's shape, `(fn [request] → principal | nil)`: `:token` (as `:token-subject`, "root"; constant-time compare; subject reserved), `:validator` (JWT/JWKS via `kabel.auth.jwt`), `:auth :upstream`, `:dev-mode`. buddy removed. Every request carries `:datahike/principal`.
- `:authorize` `(fn [{:keys [op principal db payload]}] → bool)`, asked per database a call reaches — arguments searched in full, transaction data included (a transaction function can be handed another database's handle). Op classes from the API specification: `:read`, `:transact`, `:create`, `:delete`, `:admin`.
- `:auth-db`: an eacl permission graph in a Datahike database of its own — users, server admins, database owners/writers/readers, `grant` as a permission like any other — seeded with the token principal as admin, managed through `/permissions/check|relationships|relationships!` (batches atomic). Only admins create databases; owners delete and grant.

## Lifecycle

Writer routes hold one base lease per database and pin per request via `connect`/`release`; the server counts the leases it grants through `connect` so a `release` can only give back those; deletes take a write lock every pinned call holds the read side of; `release-all!`/`stop-server` release everything, auth db included, exception-safe.

## Fixed along the way (pre-existing)

- The `:datahike-server` writer made its blocking HTTP call inside the writer's go block — enough concurrent transactions starved the core.async pool (and deadlocked a same-JVM server). Now on a thread, delivering Throwables.
- Decoding any DB handle took a lease that was never released (`db-from-reader` → `get-connection`; now `lookup-connection`).
- Tokens travelled in request bodies and trace logs; 500 bodies carried backend credentials in ex-data. Stripped/redacted.
- The HTTP client now defaults to CBOR.

## Dependency note

eacl comes from the fork's source-only datahike backend (`io.github.whilo/eacl` @ c11c3f85, `modules/eacl-datahike`) because upstream `dev.eacl/eacl 8.0.0-SNAPSHOT` ships 777 AOT classes built on JDK 26 and fails on ≤25. One-line switch once upstream publishes a source jar.

## Review

Six rounds of codex gpt-5.6-sol (high) review; every High/Medium closed with a test. Docs: `doc/http-routes.md`; CHANGELOG entry (`app` arity is the one breaking change for embedders of the server namespace).

https://claude.ai/code/session_01J9RUNkHFidHP8EvQVCSqf3