### PR TITLE
Preserve scalar bind selectivity in query plans

### DIFF
--- a/src/datahike/query/lower.cljc
+++ b/src/datahike/query/lower.cljc
@@ -905,13 +905,15 @@
      (plan/source-cards {:kind :pattern :classified (scan->classified node) :db db
                          :bound-var-cards bound-var-cards})
 
-     ;; Function binds whose var advertises :datahike/output-cardinality (e.g.
-     ;; a graph algorithm whose result size is data-dependent). Without this the
-     ;; bind is opaque and downstream patterns over its output var fall back to
-     ;; the full attribute extent. Only the binding's own free vars are bounded.
+     ;; Scalar/tuple binds preserve the cardinality of their input relation;
+     ;; collection/relation binds may advertise :datahike/output-cardinality
+     ;; (e.g. a graph algorithm whose result size is data-dependent). Without
+     ;; either signal the bind is opaque and downstream patterns over its output
+     ;; var fall back to the full attribute extent. Only the binding's own free
+     ;; vars are bounded.
      (ir/bind? node)
      (plan/source-cards {:kind :bind :classified (bind->classified node) :db db
-                         :provenance provenance})
+                         :provenance provenance :bound-var-cards bound-var-cards})
 
      :else nil)))
 
@@ -1202,9 +1204,15 @@
                                        (merge-bindings (node-binding-vars logical-plan n)))))))
                  {:cards {} :bvc initial-bvc}
                  ordered-nodes))
-        ;; Pre-compute bvc per node from PRECEDING source-idx nodes'
-        ;; outputs (cardinality, scan-only) and bindings (every binder
-        ;; node).
+        ;; Pre-compute bvc per node from PRECEDING source-idx nodes' outputs
+        ;; (cardinality, scan-only) and bindings (every binder node). Also fold
+        ;; in a DIRECT function-bind producer of one of this node's vars when
+        ;; that producer has a numeric output estimate. Datalog clause order is
+        ;; not semantic: a cheap scalar conversion may be written after the
+        ;; indexed pattern that consumes its output. Restricting this
+        ;; order-independent edge to an actual producer/consumer var and a
+        ;; known card avoids reviving the sibling-pattern over-binding that the
+        ;; directional source-order rule prevents.
         node->bvc (into {}
                         (map (fn [n]
                                (let [my-idx (node->src-idx n)
@@ -1219,7 +1227,23 @@
                                                      (merge-cards (node->output-cards o))
                                                      (seq (node->binding-vars o))
                                                      (merge-bindings (node->binding-vars o))))
-                                                 initial-bvc prior)]
+                                                 initial-bvc prior)
+                                     consumed-vars (set (node->binding-vars n))
+                                     direct-bind-producers
+                                     (filter (fn [other]
+                                               (let [outs (node->output-cards other)]
+                                                 (and (not (identical? other n))
+                                                      (ir/bind? other)
+                                                      (seq outs)
+                                                      (every? number? (vals outs))
+                                                      (seq (clojure.set/intersection
+                                                            consumed-vars
+                                                            (set (keys outs)))))))
+                                             nodes)
+                                     bvc (reduce (fn [acc producer]
+                                                   (merge-cards
+                                                    acc (node->output-cards producer)))
+                                                 bvc direct-bind-producers)]
                                  [n bvc])))
                         nodes)
 

--- a/src/datahike/query/plan.cljc
+++ b/src/datahike/query/plan.cljc
@@ -139,6 +139,7 @@
         bound-aware (when (seq bound-var-cards)
                       (estimate/estimate-pattern-with-bindings
                        db pattern-info schema-info bound-var-cards))
+        output-est (long (or bound-aware est))
         scan-est (cond
                    (empty? bound-var-cards) est
                    ;; Non-indexed attr with v as the only bound free var:
@@ -162,7 +163,16 @@
               :schema-info schema-info
               :pushdown-preds effective-preds
               :estimated-card est
+              ;; Logical rows emitted after bound-value/probe filtering. This
+              ;; is deliberately distinct from :scan-card: an unindexed
+              ;; `attr = ?bound` scan may inspect the whole AEVT slice while
+              ;; emitting only a small fraction of it.
+              :output-card output-est
               :scan-card scan-est
+              ;; Keep downstream var-card propagation conservative. The
+              ;; filtered :output-card is used for this entity group's local
+              ;; scan/merge choice only; exporting it here changes unrelated
+              ;; inter-group/rule ordering contracts.
               :output-var-cards (pattern-output-var-cards pattern-info est)
               :join-method join-method
               :vars (:vars pattern-info)
@@ -284,6 +294,8 @@
    instead of a singleton."
   100)
 
+(declare args-free-vars)
+
 (defn source-cards
   "Unified produce-side cardinality seed for the planner's {var → card} map.
 
@@ -295,8 +307,10 @@
    Dispatch on :kind:
      {:kind :pattern :classified ci :db db}
         → attribute-stats estimate for an LScan's free output vars
-     {:kind :bind    :classified ci :db db :provenance prov}
-        → :datahike/output-cardinality estimate for an LBind's free vars
+     {:kind :bind    :classified ci :db db :provenance prov
+                     :bound-var-cards cards}
+        → scalar/tuple binds preserve their input-relation cardinality;
+          collection/relation binds use :datahike/output-cardinality metadata
           (ci carries :fn-sym / :args / :binding)
      {:kind :input   :shape <kw> :vars <syms>}
         → shape-based seed for :in vars: collection/relation bindings bind many
@@ -334,11 +348,25 @@
         (zipmap free-output-vars (repeat (long est)))))
 
     :bind
-    (let [{:keys [classified db provenance]} source
-          card (resolve-fn-output-cardinality
-                (:fn-sym classified) (:args classified) (:binding classified) db provenance)]
+    (let [{:keys [classified db provenance bound-var-cards]} source
+          binding (:binding classified)
+          shape (binding-shape binding)
+          ;; A scalar or tuple function bind emits at most one output tuple for
+          ;; each input tuple. Preserve the upstream relation cardinality so a
+          ;; downstream indexed pattern can cost the produced var as a probe
+          ;; rather than as an unconstrained attribute scan. Collection and
+          ;; relation binds remain data-dependent and use their explicit
+          ;; :datahike/output-cardinality contract below.
+          scalar-card (when (contains? #{:scalar :tuple} shape)
+                        (let [input-vars (args-free-vars (:args classified))
+                              cards (map bound-var-cards input-vars)]
+                          (when (every? number? cards)
+                            (reduce * 1 (map #(max 1 (long %)) cards)))))
+          card (or scalar-card
+                   (resolve-fn-output-cardinality
+                    (:fn-sym classified) (:args classified) binding db provenance))]
       (when card
-        (let [bvars (filter analyze/free-var? (analyze/extract-vars (:binding classified)))]
+        (let [bvars (filter analyze/free-var? (analyze/extract-vars binding))]
           (when (seq bvars)
             (zipmap bvars (repeat (long card)))))))
 
@@ -544,21 +572,28 @@
   [op]
   (long (or (:scan-card op) (:estimated-card op) 0)))
 
+(defn- output-card-of
+  "Rows a pattern is expected to emit after its bound probes/filters."
+  [op]
+  (long (or (:output-card op) (:estimated-card op) 0)))
+
 (defn dp-order-fuse-ops
   "For N pattern ops on same entity var, find optimal (scan, merge-order).
    Uses short-circuit AND ordering: sort merges by ascending
    merge-cost / (1 - pass-rate). Try each pattern as scan, pick minimum total cost.
 
-   Scan selection uses bound-aware :scan-card so a pattern whose value is
-   constrained by upstream context (smaller effective scan size) is preferred
-   over a pattern with all-free positions on the same attribute. Pass-rate
-   computation still uses :estimated-card (the base attribute count) to
-   preserve the existing per-entity match-probability semantics."
+   Scan selection separates physical :scan-card (datoms inspected) from
+   :output-card (rows surviving a bound probe/filter). This matters for an
+   unindexed `attr = ?bound`: the scan still reads the full AEVT attribute
+   slice, but choosing it as the driver can avoid merge lookups for all rows
+   that do not match."
   [db pattern-ops total-entities]
   (let [n (count pattern-ops)
-        ;; Pass-rate estimates use base (unconstrained) cardinality.
+        ;; Merge pass rates use logical output cardinality. For unconstrained
+        ;; patterns this is the base extent; for a bound value it is the
+        ;; estimated matching subset.
         estimates (mapv (fn [op]
-                          (max 1 (or (:estimated-card op) total-entities)))
+                          (max 1 (output-card-of op)))
                         pattern-ops)]
     (if (<= n 2)
       (let [;; Patterns with variable attribute can only be scan, not merge
@@ -590,10 +625,8 @@
                              (or (not has-non-optional?)
                                  (not (:optional? (nth pattern-ops si)))))]
               (let [scan-op (nth pattern-ops si)
-                    ;; Use bound-aware :scan-card for the scan-side cost; merges
-                    ;; still use the unconstrained :estimated-card via `estimates`
-                    ;; for pass-rate computation.
-                    scan-card (double (scan-cost-of scan-op))
+                    scan-work (double (scan-cost-of scan-op))
+                    scan-output (double (max 1 (output-card-of scan-op)))
                     merges (into [] (keep-indexed
                                      (fn [i op]
                                        (when (not= i si)
@@ -603,10 +636,10 @@
                                            {:op op :pass-rate pass-rate :sort-key sort-key}))))
                                  pattern-ops)
                     sorted-merges (sort-by :sort-key merges)
-                    total-cost (reduce (fn [[cost cum-pass] m]
-                                         [(+ cost (* scan-card cum-pass))
-                                          (* cum-pass (:pass-rate m))])
-                                       [scan-card 1.0]
+                    total-cost (reduce (fn [[cost rows] m]
+                                         [(+ cost rows)
+                                          (* rows (:pass-rate m))])
+                                       [scan-work scan-output]
                                        sorted-merges)]
                 {:scan scan-op
                  :merges (mapv :op sorted-merges)
@@ -867,9 +900,13 @@
                         (into (vec normal)
                               (mapv #(dissoc % ::anti-pass-rate) sorted-anti)))))
         ;; Estimate output cardinality
+        ;; Keep the entity group's exported cardinality contract conservative.
+        ;; :output-card only guides the LOCAL scan/merge choice above; using it
+        ;; here perturbs unrelated inter-group/rule ordering.
         scan-card (max 1 (or (:estimated-card scan) total-entities))
         group-card (reduce (fn [card merge-op]
-                             (let [merge-est (max 1 (or (:estimated-card merge-op) total-entities))
+                             (let [merge-est (max 1 (or (:estimated-card merge-op)
+                                                        total-entities))
                                    pass-rate (estimate/estimate-conditional-pass-rate merge-est total-entities)]
                                (cond
                                  ;; Optional merges don't filter — all entities pass

--- a/test/datahike/test/experimental/graph_planner_test.clj
+++ b/test/datahike/test/experimental/graph_planner_test.clj
@@ -79,11 +79,15 @@
                  [?n :node/name ?nm]]
                :node/name)))))
 
-(deftest scalar-binding-not-bounded
-  (testing "a scalar binding holds the whole result ⇒ metadata does not apply"
-    (is (< 16 (scan-card-of
-               '[[(datahike.experimental.graph-spec/attr-graph :follows) ?g]
-                 [(datahike.experimental.graph/transitive-closure ?g $ 100) ?whole]
-                 [?whole :node/name ?nm]]
-               :node/name))
-        "scalar ?whole is not a destructured collection")))
+(deftest scalar-binding-is-one-probe
+  (testing "a scalar binding holds the whole result, but emits one relation row"
+    ;; The transitive-closure metadata describes the number of elements when
+    ;; its result is destructured as a collection. Bound as a scalar, the whole
+    ;; result is one value and the downstream entity pattern is one point
+    ;; probe (which will normally find no matching entity).
+    (is (= 1 (scan-card-of
+              '[[(datahike.experimental.graph-spec/attr-graph :follows) ?g]
+                [(datahike.experimental.graph/transitive-closure ?g $ 100) ?whole]
+                [?whole :node/name ?nm]]
+              :node/name))
+        "scalar ?whole is one binding, not a destructured collection")))

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -35,6 +35,11 @@
     (is (= (set (seq legacy)) (set (seq compiled)))
         (str "Engines disagree on: " (pr-str query)))))
 
+(defn coerce-long
+  "Scalar bind used to model a cheap typed parameter conversion."
+  [value]
+  (long value))
+
 ;; ---------------------------------------------------------------------------
 ;; Test data
 
@@ -1038,3 +1043,62 @@
       (is (boolean (#'ex/probe-set-contains? ps (byte-array [1 2 3])))))
     (testing "seek values are the RAW arrays, never the wrapped keys"
       (is (every? arr/value-array? (#'ex/probe-set-seek-vals ps))))))
+
+(deftest scalar-bind-cardinality-drives-downstream-index-selection
+  ;; A scalar function emits one output tuple per input tuple. Losing that
+  ;; cardinality made the entity group drive from the 5k-row presence attr
+  ;; rather than the unique id produced by the bind — a point lookup became a
+  ;; full table scan. SQL parameter coercion is one real-world instance of this
+  ;; ordinary Datalog shape.
+  (let [db (d/db-with
+            (db/empty-db {:item/id      {:db/unique :db.unique/identity}
+                          :item/present {:db/index true}
+                          :item/value   {}})
+            (mapv (fn [i]
+                    {:item/id i :item/present true :item/value (str "v" i)})
+                  (range 5000)))
+        ;; Patterns deliberately precede their scalar producer. Datalog clause
+        ;; order is not semantic, and SQL normalization emits this shape.
+        query '[:find ?value :in $ ?raw :where
+                [?e :item/id ?id]
+                [?e :item/present true]
+                [?e :item/value ?value]
+                [(datahike.test.query-planner-test/coerce-long ?raw) ?id]]
+        explanation (q/explain query db 2500)]
+    (testing "the scalar output retains the one-row input cardinality"
+      ;; The scan op retains its base AEVT annotation; at execution the bound
+      ;; ?id relation turns it into an AVET point seek through SIP. The critical
+      ;; plan choice is that this selective clause drives the entity group.
+      (is (re-find #"scan: \[\?e :item/id \?id\]"
+                   explanation)))
+    (testing "both engines return the same point result"
+      (assert-engines-agree db query [2500])
+      (is (= #{["v2500"]} (d/q query db 2500))))))
+
+(deftest bound-unindexed-filter-separates-scan-work-from-output-cardinality
+  ;; Every candidate scan reads 5k datoms, but :item/category emits only 50
+  ;; matches. Driving from it avoids category lookups for the other 4,950
+  ;; entities; treating scanned datoms as emitted rows instead drove from the
+  ;; non-selective presence marker.
+  (let [db (d/db-with
+            (db/empty-db {:item/id      {:db/unique :db.unique/identity}
+                          :item/present {:db/index true}
+                          :item/category {}
+                          :item/value   {}})
+            (mapv (fn [i]
+                    {:item/id i
+                     :item/present true
+                     :item/category (mod i 100)
+                     :item/value (str "v" i)})
+                  (range 5000)))
+        query '[:find ?id :in $ ?raw :where
+                [?e :item/category ?category]
+                [?e :item/present true]
+                [?e :item/id ?id]
+                [(datahike.test.query-planner-test/coerce-long ?raw) ?category]]
+        explanation (q/explain query db 42)]
+    (testing "the selective unindexed attribute drives the fused scan"
+      (is (re-find #"scan: \[\?e :item/category \?category\]" explanation)))
+    (testing "the optimization preserves results on both engines"
+      (assert-engines-agree db query [42])
+      (is (= 50 (count (d/q query db 42)))))))


### PR DESCRIPTION
Separates physical scan work from logical output cardinality for local fused entity-group planning, and propagates scalar/tuple function-bind cardinality to direct consumers independent of clause order. This prevents SQL-style typed parameter binds from turning primary-key probes into full scans and lets selective unindexed filters drive their entity group. Scope is deliberately local: exported inter-group cardinality remains conservative. Validation: 255 tests, 24,333 assertions across planner, IR, engine parity, binding seam, query-shape corpus, and seeded differential suites. In the pg-datahike REPL at 100k rows, a prepared primary-key lookup fell from about 110 ms to 0.4 ms; a selective unindexed scan fell from about 59 ms to about 5 ms and scales linearly from 1k through 100k rows.