### PR TITLE
Push safe OFFSET + LIMIT demand into direct queries

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -4133,6 +4133,19 @@
     (cond->> result
       qreturnmaps (convert-to-return-maps qreturnmaps))))
 
+(defn- unordered-result-demand
+  "Return the number of distinct tuples an unordered executor may need in
+   order to satisfy OFFSET + LIMIT, or nil when execution must remain
+   unbounded.  The executor is still responsible for declining this hint when
+   it cannot count final distinct tuples while scanning (post-filters,
+   projection duplicates, historical results, and so on)."
+  [order-spec offset limit]
+  (when (and (nil? order-spec) (some? limit) (pos? limit))
+    (let [n (+ (long (max 0 (or offset 0))) (long limit))]
+      ;; The direct executor uses int-sized counters. A larger demand cannot
+      ;; save work and narrowing it would stop too early.
+      (when (<= n 2147483647) n))))
+
 (defn- plan-sub-ops
   "Flatten plan ops into leaf sub-ops (expanding entity-groups)."
   [plan]
@@ -4861,7 +4874,7 @@
 (defn- execute-planned-direct
   "Direct HashSet path: write tuples directly, no Relations.
    Returns result set or nil if not eligible."
-  [plan db qfind find-elements context-in query stats? qreturnmaps]
+  [plan db qfind find-elements context-in query stats? qreturnmaps max-results]
   (let [prepared? (prepared-execution?)
         direct-eligible? (and (instance? FindRel qfind)
                               (not stats?)
@@ -4891,10 +4904,10 @@
                                  :cljs execute/execute-plan-prepared)]
             ;; pass the context so a NOT-JOIN sub-plan keeps its sources and cancel flag
             (exec-prepared plan db find-var-syms (:rels context-in) (:consts context-in)
-                           nil (:cancel context-in) context-in))
+                           max-results (:cancel context-in) context-in))
           (let [exec-direct #?(:clj (requiring-resolve 'datahike.query.execute/execute-plan-direct)
                                :cljs execute/execute-plan-direct)]
-            (exec-direct plan db find-var-syms nil (:consts context-in) (:cancel context-in)
+            (exec-direct plan db find-var-syms max-results (:consts context-in) (:cancel context-in)
                          context-in)))))))
 
 (defn- post-process-result
@@ -5020,6 +5033,7 @@
         result-arity  (count find-elements)
         order-spec    (when (and order-by (instance? FindRel qfind))
                         (parse-order-by order-by find-elements))
+        result-demand (unordered-result-demand order-spec offset limit)
 
         ;; Find the primary db for planning: $ if available, else first eligible source
         primary-db (let [sources (:sources context-in)]
@@ -5205,7 +5219,8 @@
             ;; lookup-ref-reverse-map. The direct paths would leak raw eids.
             (if-let [direct-result (when-not lookup-ref-reverse-map
                                      (execute-planned-direct
-                                      plan db qfind find-elements context-in query stats? qreturnmaps))]
+                                      plan db qfind find-elements context-in query stats? qreturnmaps
+                                      result-demand))]
               (let [result (apply-result-transforms direct-result order-spec offset limit qreturnmaps)]
                 #?(:clj
                    (when *profile?*

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -3395,6 +3395,49 @@
             (recur (inc i) (conj! s (adopt-vector (result-list-get result-list i))))
             s))))))
 
+(defn- direct-group-output-may-duplicate?
+  "Whether one entity group can emit the same projected find tuple more than
+   once.  Shared by the finalizer's dedup choice and demand pushdown so those
+   two correctness decisions cannot drift apart."
+  [g find-vars]
+  (let [scan-op (entity-group-scan-op g)
+        merge-ops (entity-group-merge-ops g)
+        e-var (first (:clause scan-op))
+        v-var (nth (:clause scan-op) 2 nil)]
+    ;; A card-many merge can multiply one driving row; omitting the entity can
+    ;; collapse different entities; omitting a card-many driver's value can
+    ;; collapse that entity's several driving rows.
+    (or (some #(not (get-in % [:schema-info :card-one?] true)) merge-ops)
+        (not (some #{e-var} find-vars))
+        (and (not (get-in scan-op [:schema-info :card-one?] true))
+             (symbol? v-var)
+             (analyze/free-var? v-var)
+             (not (some #{v-var} find-vars))))))
+
+(defn- direct-group-output-unique?
+  "Whether one entity group's emitted find tuples are already distinct.
+
+   Keeping this explicit matters for demand pushdown: the scan loops count
+   emitted candidates, so stopping at OFFSET + LIMIT is only sound when no
+   later deduplication can shrink that prefix."
+  [g find-vars temporal]
+  (and (not= :historical (when temporal (:type temporal)))
+       (not (direct-group-output-may-duplicate? g find-vars))))
+
+(defn- safe-direct-demand
+  "Accept a caller's result demand only when scan emission is the final,
+   distinct result stream.  Predicates/functions/NOT-JOINs and attached
+   predicates run after scan collection; multiple groups materialize and
+   combine intermediate relations.  Both must remain unbounded for now."
+  [requested groups ops find-vars temporal]
+  (let [g (first groups)]
+    (when (and requested
+               (= 1 (count groups))
+               (every? #(#{:entity-group :pattern-scan} (:op %)) ops)
+               (empty? (:attached-preds g))
+               (direct-group-output-unique? g find-vars temporal))
+      requested)))
+
 (defn- try-point-group
   "Point-shape fast path: a single entity group whose (rebound) scan is an
    AVET ground-value seek and whose merges are all card-one same-entity EAVT
@@ -3515,6 +3558,11 @@
                              (vec (distinct (mapcat :vars groups))))
             emit-vars (if has-post-ops? all-group-vars find-vars)
             n-groups (count groups)
+            ;; Callers pass OFFSET + LIMIT as a demand hint.  Most direct plans
+            ;; cannot use it yet because their loops collect candidates before
+            ;; post-filtering/deduplication.  Narrow it to the proven-safe
+            ;; single-group subset rather than silently under-filling results.
+            max-results (safe-direct-demand max-results groups ops find-vars temporal)
             ;; Prepared mode: ArrayList grows amortized-O(1), so a small
             ;; initial capacity avoids a 4000-slot backing array per point
             ;; query. Stock mode keeps the historical pre-sizing.
@@ -3932,28 +3980,11 @@
                               var-index)]
               (project-tuples result-list find-vars var-index consts))))
         ;; Convert result-list → final result with appropriate dedup strategy
-        (let [has-card-many-dupes?
-              (some (fn [g]
-                      (let [scan-op (entity-group-scan-op g)
-                            mops (entity-group-merge-ops g)]
-                        (or (some (fn [op] (not (get-in op [:schema-info :card-one?] true))) mops)
-                            ;; Entity var not in find-vars → different entities can produce same tuple
-                            (let [e-var (first (:clause scan-op))]
-                              (not (some #{e-var} find-vars)))
-                            ;; DRIVING scan on a card-many attribute whose value
-                            ;; var is projected away → one tuple per value with
-                            ;; identical projection. (Found by the generative
-                            ;; differential test: [?e :tag ?t] chosen as the
-                            ;; driving scan with :find [?e] emitted duplicate
-                            ;; [e] tuples into the no-dedup QueryResult path.)
-                            (let [v-var (nth (:clause scan-op) 2 nil)]
-                              (and (not (get-in scan-op [:schema-info :card-one?] true))
-                                   (symbol? v-var) (analyze/free-var? v-var)
-                                   (not (some #{v-var} find-vars)))))))
-                    groups)
+        (let [has-output-dupes?
+              (some #(direct-group-output-may-duplicate? % find-vars) groups)
               is-historical? (= :historical (when temporal (:type temporal)))
               dedup-strategy (cond
-                               has-card-many-dupes? :hash
+                               has-output-dupes? :hash
                                is-historical? :adjacent
                                :else nil)]
           (finalize-direct-result result-list dedup-strategy))))))
@@ -4121,7 +4152,14 @@
                  (pss-instance? (:eavt db))
                  #?(:clj (not (:attribute-refs? (dbi/-config db))) :cljs true))
           (do (check-cancel! cancel)
-              (run-point-program prog db consts max-results cancel))
+              ;; A compiled point program applies attached predicates and hash
+              ;; dedup only after its scan.  Bound only the already-distinct,
+              ;; filter-free variant.
+              (run-point-program prog db consts
+                                 (when (and (nil? (:dedup prog))
+                                            (empty? (:attached prog)))
+                                   max-results)
+                                 cancel))
           (let [plan' (if (seq rel-consts) (bind-plan-consts plan rel-consts) plan)]
             (when plan'
               (execute-plan-direct plan' db find-vars max-results consts

--- a/test/datahike/test/query_limit_demand_test.clj
+++ b/test/datahike/test/query_limit_demand_test.clj
@@ -1,0 +1,128 @@
+(ns datahike.test.query-limit-demand-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.db :as db]
+   [datahike.query :as q]
+   [datahike.query.execute :as execute]))
+
+(defn- fixture-db []
+  (d/db-with
+   (db/empty-db nil {:schema-flexibility :write
+                     :keep-history? true})
+   (into
+    [{:db/ident :probe/n
+      :db/valueType :db.type/long
+      :db/cardinality :db.cardinality/one}
+     {:db/ident :probe/group
+      :db/valueType :db.type/keyword
+      :db/cardinality :db.cardinality/one
+      :db/index true}]
+    (map (fn [i]
+           {:db/id (+ 1000 i)
+            :probe/n i
+            :probe/group (if (< i 50) :x :y)})
+         (range 100)))))
+
+(defn- counting-cancel []
+  (let [derefs (atom 0)]
+    [derefs
+     (reify clojure.lang.IDeref
+       (deref [_]
+         (swap! derefs inc)
+         false))]))
+
+(defn- uncached-q [query-map]
+  (binding [q/*disable-planner* false
+            q/*query-result-cache?* false]
+    (d/q query-map)))
+
+(deftest direct-limit-demand
+  (let [db (fixture-db)]
+    (testing "an unordered distinct scan stops after offset + limit tuples"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?e :where [?e :probe/n ?n]]
+                     :args [db]
+                     :offset 7
+                     :limit 5
+                     :cancel cancel})]
+        (is (= 5 (count result)))
+        (is (= 12 @derefs)
+            "the direct scan must not traverse the remainder of the attribute")))
+
+    (testing "prepared direct execution receives the same demand"
+      (let [[derefs cancel] (counting-cancel)
+            result (binding [execute/*prepared-execution* true
+                             q/*fold-scalar-ins* false
+                             q/*query-result-cache?* false]
+                     (d/q {:query '[:find ?e
+                                    :in $ ?group
+                                    :where [?e :probe/group ?group]]
+                           :args [db :x]
+                           :offset 7
+                           :limit 5
+                           :cancel cancel}))]
+        (is (= 5 (count result)))
+        (is (= 12 @derefs))))))
+
+(deftest unsafe-demand-remains-unbounded
+  (let [db (fixture-db)]
+    (testing "a post-filter cannot under-fill a requested page"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?e
+                              :where
+                              [?e :probe/n ?n]
+                              [(even? ?n)]]
+                     :args [db]
+                     :offset 7
+                     :limit 5
+                     :cancel cancel})]
+        (is (= 5 (count result)))
+        (is (= 100 @derefs)
+            "scan candidates are filtered only after direct collection")))
+
+    (testing "projection duplicates cannot consume the result demand"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?group
+                              :where [?e :probe/group ?group]]
+                     :args [db]
+                     :limit 2
+                     :cancel cancel})]
+        (is (= #{[:x] [:y]} result))
+        (is (= 100 @derefs)
+            "both distinct values must survive post-scan hash deduplication")))
+
+    (testing "ORDER BY still sees the complete input before sorting"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?e ?n :where [?e :probe/n ?n]]
+                     :args [db]
+                     :order-by '[?n :desc]
+                     :limit 5
+                     :cancel cancel})]
+        (is (= [99 98 97 96 95] (mapv second result)))
+        (is (= 100 @derefs))))
+
+    (testing "offset + limit cannot overflow the executor's int counter"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?e :where [?e :probe/n ?n]]
+                     :args [db]
+                     :offset Integer/MAX_VALUE
+                     :limit 1
+                     :cancel cancel})]
+        (is (empty? result))
+        (is (= 100 @derefs))))
+
+    (testing "historical scans retain their adjacent-dedup pass"
+      (let [[derefs cancel] (counting-cancel)
+            result (uncached-q
+                    {:query '[:find ?e :where [?e :probe/n ?n]]
+                     :args [(d/history db)]
+                     :limit 1
+                     :cancel cancel})]
+        (is (= 1 (count result)))
+        (is (= 100 @derefs))))))

--- a/test/datahike/test/query_limit_demand_test.clj
+++ b/test/datahike/test/query_limit_demand_test.clj
@@ -53,7 +53,8 @@
 
     (testing "prepared direct execution receives the same demand"
       (let [[derefs cancel] (counting-cancel)
-            result (binding [execute/*prepared-execution* true
+            result (binding [q/*disable-planner* false
+                             execute/*prepared-execution* true
                              q/*fold-scalar-ins* false
                              q/*query-result-cache?* false]
                      (d/q {:query '[:find ?e


### PR DESCRIPTION
## Summary

- propagate unordered `OFFSET + LIMIT` demand into ordinary and prepared direct execution
- accept the bound only when scan emission is already the final distinct result stream
- share the projection-duplicate proof between early termination and final deduplication
- retain unbounded execution for ordering, post-filters/functions/negation, multi-group joins, projection duplicates, and historical scans

## Why the guard is necessary

The direct executor already accepted `max-results`, but `raw-q*` always passed `nil`. Passing `offset + limit` unconditionally would be incorrect because its scan loops count emitted candidates before later post-filtering and hash/adjacent deduplication. A candidate prefix can therefore contain fewer than the requested number of final tuples.

This change limits only a single group with no post-ops or attached predicates, where the existing finalizer's schema/projection proof says no deduplication is needed. Pushdown predicates, ground checks, anti-merges, and optional merges execute before emission and remain eligible.

## Evidence

A counting `:cancel` probe over 100 matching rows shows:

| shape | rows inspected before | rows inspected after |
|---|---:|---:|
| unordered `OFFSET 7 LIMIT 5` | 100 | 12 |
| prepared unordered `OFFSET 7 LIMIT 5` | 100 | 12 |
| post-filtered | 100 | 100 |
| projected duplicates | 100 | 100 |
| ordered | 100 | 100 |
| historical | 100 | 100 |

The latter cases deliberately remain unbounded and have result-correctness assertions.

## Validation

- `clojure -M:ffix`
- `clojure -M:format`
- new namespace across all configured CLJ suites: 6 tests, 42 assertions
- prepared execution, query engine parity, query API, and planner-temporal suites: 162 tests, 1431 assertions
- a full `:clj-pss` run reached 1093 tests / 13246 assertions; its only failures were two issues in the new tests (an incorrectly constructed non-historical fixture and an over-specific cancellation count), both corrected and rerun green in the focused suites

Repository-wide `bb lint` continues to report the existing generated/API and reader-conditional findings; the changed files introduce no new lint category, and formatting/diff checks are clean.

## Deliberately deferred

- relation/legacy execution has no demand channel
- aggregates, pull, and `:with` need demand after their semantic reduction boundary
- ordered demand needs an index-order proof or bounded top-N implementation
- multi-group/cartesian demand needs join-aware cardinality accounting
- secondary ordered retrieval must account for recheck and valid-time filtering before treating a candidate limit as final
