### PR TITLE
Preserve options embedded in query forms

### DIFF
--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -459,6 +459,22 @@
          (vswap! form-analysis-cache assoc k v)
          v))))
 
+(def ^:private extra-ks
+  [:offset :limit :order-by :stats? :count-fns? :settings :cancel])
+
+(defn- extras-in-query
+  "Pick the non-Datalog options out of a normalized query map. A vector query
+   collects everything following a key into a vector, so `:limit 5` arrives as
+   `[5]` and `:order-by [?v :desc]` as `[[?v :desc]]`; unwrap that so options
+   have the same shape as options supplied in a map query."
+  [query]
+  (reduce-kv (fn [m k v]
+               (assoc m k (if (and (sequential? v) (= 1 (count v)))
+                            (first v)
+                            v)))
+             {}
+             (select-keys query extra-ks)))
+
 (defn normalize-q-input
   "Turns input to q into a map with :query and :args fields.
    Also normalizes the query into a map representation."
@@ -478,16 +494,18 @@
                (do (when (seq arg-inputs)
                      (log/warn :datahike/query-input-ignored {:query query}))
                    (:args query-input))
-               arg-inputs)
-        extra-ks [:offset :limit :order-by :stats? :count-fns? :settings :cancel]]
-    (-> (cond-> {:query (-> (apply dissoc query extra-ks)
-                            normalize-list-fn-clauses
-                            normalize-repeated-vars)
-                 ;; Rules ride in as the argument bound to `%`; normalise their
-                 ;; bodies too, or a self-join inside a rule stays wrong on BOTH
-                 ;; engines.
-                 :args (normalize-rules-in-args query args)}
-          (map? query-input)
+               arg-inputs)]
+    (-> {:query (-> (apply dissoc query extra-ks)
+                    normalize-list-fn-clauses
+                    normalize-repeated-vars)
+         ;; Rules ride in as the argument bound to `%`; normalise their
+         ;; bodies too, or a self-join inside a rule stays wrong on BOTH
+         ;; engines.
+         :args (normalize-rules-in-args query args)}
+        ;; Options may sit in the query itself, in either syntax. Explicit
+        ;; options on an input envelope take precedence over nested options.
+        (merge (extras-in-query query))
+        (cond-> (map? query-input)
           (merge (select-keys query-input extra-ks)))
         auto-inject-built-in-rules)))
 

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -601,6 +601,20 @@
                                    :where [?e :name ?n]]
                                  :db))))
 
+  (testing "options embedded in a vector query"
+    (is (= {:query {:find '[?n]
+                    :where '[[?e :name ?n]]}
+            :args :db
+            :offset 2
+            :limit 5
+            :order-by '[?n :desc]}
+           (dq/normalize-q-input '[:find ?n
+                                   :where [?e :name ?n]
+                                   :offset 2
+                                   :limit 5
+                                   :order-by [?n :desc]]
+                                 :db))))
+
   (testing "query in :query field"
     (is (= {:query {:find '[?n]
                     :where '[[?e :name ?n]]}
@@ -631,6 +645,16 @@
                                   :limit 100
                                   :args [:db]}
                                  []))))
+
+  (testing "top-level options override options nested in :query"
+    (is (= 7
+           (:limit
+            (dq/normalize-q-input {:query '{:find [?n]
+                                            :where [[?e :name ?n]]
+                                            :limit 5}
+                                   :limit 7
+                                   :args [:db]}
+                                  [])))))
 
   (testing "query in top-level map"
     (is (= {:query {:find '[?e]


### PR DESCRIPTION
## Summary

- preserve `:offset`, `:limit`, `:order-by`, and the other query execution options when they are embedded in vector or map query forms
- normalize the parser single-value vector representation
- keep explicit top-level input-envelope options authoritative

This recovers the behavior from dangling commit `b7f1c94f` on current main and adds regression coverage for vector syntax and precedence.

## Validation

- focused `test-normalize-q-input` test passes on current main