### PR TITLE
Record core Datahike observability metrics

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,10 @@
         ;; in-place writes; streaming writes ignoring short reads and returned
         ;; counts; and Reader input splitting surrogate pairs. Six external
         ;; review rounds; the last reported no remaining High or Medium.
-        org.replikativ/konserve                     {:mvn/version "0.9.389"}
+        ;; 0.9.391 adds guarded, process-wide metrics sinks around API, blob I/O
+        ;; and lock waits. With no sink installed its measurement sites take the
+        ;; allocation-free fast path.
+        org.replikativ/konserve                     {:mvn/version "0.9.391"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}
@@ -69,6 +72,7 @@
         environ/environ                             {:mvn/version "1.2.0"}
         nrepl/bencode                               {:mvn/version "1.2.0"}
         org.replikativ/logging                      {:mvn/version "0.1.3"}
+        org.replikativ/metrics                      {:mvn/version "0.1.4"}
         junit/junit                                 {:mvn/version "4.13.2"}
         medley/medley                               {:mvn/version "1.4.0"}
         metosin/spec-tools                          {:mvn/version "0.10.8"}

--- a/src/datahike/metrics.cljc
+++ b/src/datahike/metrics.cljc
@@ -1,0 +1,78 @@
+(ns datahike.metrics
+  "Datahike's process-level metric instruments.
+
+   Recording is intentionally independent of exposition: the writer records
+   durable commits and branch-head conflicts into `replikativ.metrics`, while
+   a host may snapshot and expose that registry however it chooses. Labels use
+   the stable store id and branch, never storage paths or credentials."
+  (:require [datahike.store :as store]
+            [replikativ.metrics :as metrics]))
+
+(def descriptions
+  {:datahike_commit_seconds
+   {:type :histogram
+    :help "Time to make one writer batch durable, including the fenced branch-head write."}
+
+   :datahike_transactions_total
+   {:type :counter
+    :help "Transactions made durable."}
+
+   :datahike_transacted_datoms_total
+   {:type :counter
+    :help "Datoms written by durable transactions."}
+
+   :datahike_head_conflicts_total
+   {:type :counter
+    :help "Transaction invocations whose branch head moved, by whether they were retried or failed."}})
+
+(defn describe!
+  "Install Datahike's metric descriptions into the process registry.
+
+   This is public chiefly so tests or hosts that deliberately reset the global
+   registry can restore the descriptions. Ordinary processes get them when the
+   namespace loads."
+  []
+  (doseq [[metric description] descriptions]
+    (metrics/describe! metric description))
+  nil)
+
+;; Namespace loading installs descriptions; repeated loads are safe because
+;; replikativ.metrics/describe! is idempotent.
+(describe!)
+
+(defn- keyword-label [k]
+  (if-let [keyword-namespace (namespace k)]
+    (str keyword-namespace "/" (name k))
+    (name k)))
+
+(defn db-labels
+  "Low-cardinality labels for the database `config` describes."
+  [config]
+  {:database (some-> (store/store-identity (:store config)) str)
+   :branch   (keyword-label (:branch config :db))})
+
+(defn commit!
+  "Record one durable writer batch.
+
+   `milliseconds` is the batch's durable commit time, `transactions` is the
+   number of transaction reports it made durable, and `datoms` is their total
+   written datom count. A batch is one duration observation but may represent
+   more than one transaction."
+  [config milliseconds transactions datoms]
+  (let [labels (db-labels config)]
+    (metrics/observe! :datahike_commit_seconds labels (/ milliseconds 1000.0))
+    (when (pos? transactions)
+      (metrics/inc! :datahike_transactions_total labels transactions))
+    (when (pos? datoms)
+      (metrics/inc! :datahike_transacted_datoms_total labels datoms)))
+  nil)
+
+(defn head-conflict!
+  "Record one transaction invocation whose branch-head fence was rejected.
+
+   `outcome` is `:retried` after the invocation was queued for replay, or
+   `:failed` when its caller was given the conflict."
+  [config outcome]
+  (metrics/inc! :datahike_head_conflicts_total
+                (assoc (db-labels config) :outcome (name outcome)))
+  nil)

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -3,6 +3,7 @@
             [replikativ.logging :as log]
             [datahike.core]
             [datahike.config :as dc]
+            [datahike.metrics :as metrics]
             [datahike.writing :as w]
             [datahike.tx-preds :as txp]
             [datahike.gc :as gc]
@@ -577,6 +578,10 @@
                                  :as commit-db} (<?- (w/commit! db merge-parents false last-cid head-rev))
                                 commit-time (- (get-time-ms) start-ts)]
                             (log/trace :datahike/commit-time {:duration-ms commit-time})
+                            (metrics/commit! (:config db)
+                                             commit-time
+                                             (count txs)
+                                             (reduce + 0 (map (comp count :tx-data first) txs)))
                             ;; The head is durable now, so the background build's
                             ;; pin can be released. Do this BEFORE publishing
                             ;; `commit-db` through the connection or callback:
@@ -667,17 +672,21 @@
                                              (not @writer-down?)
                                              (put! retry-queue
                                                    (assoc invocation :datahike/attempt attempt)))
-                                      (log/trace :datahike/head-conflict-retry {:op op :attempt attempt})
-                                      (put! callback
-                                            (ex-info (str "The branch head moved while this transaction was being "
-                                                          "prepared, so it was NOT applied — another writer committed "
-                                                          "first. Nothing was lost and nothing partially applied; "
-                                                          "re-read and transact again.")
-                                                     {:type    :datahike/head-conflict
-                                                      :branch  (:branch (:config db))
-                                                      :op      op
-                                                      :attempt attempt
-                                                      :error   e}))))))
+                                      (do
+                                        (metrics/head-conflict! (:config db) :retried)
+                                        (log/trace :datahike/head-conflict-retry {:op op :attempt attempt}))
+                                      (do
+                                        (metrics/head-conflict! (:config db) :failed)
+                                        (put! callback
+                                              (ex-info (str "The branch head moved while this transaction was being "
+                                                            "prepared, so it was NOT applied — another writer committed "
+                                                            "first. Nothing was lost and nothing partially applied; "
+                                                            "re-read and transact again.")
+                                                       {:type    :datahike/head-conflict
+                                                        :branch  (:branch (:config db))
+                                                        :op      op
+                                                        :attempt attempt
+                                                        :error   e})))))))
                               :else
                               (do
                             ;; Close the queues BEFORE delivering the failed

--- a/test/datahike/test/metrics_test.cljc
+++ b/test/datahike/test/metrics_test.cljc
@@ -1,0 +1,78 @@
+(ns datahike.test.metrics-test
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer [deftest is testing]])
+            [datahike.metrics :as dhm]
+            [replikativ.metrics :as metrics]
+            #?(:clj [datahike.api :as d])))
+
+(def test-id #uuid "1065f77a-f8e7-4fd8-91d8-d60fc51ca441")
+
+(def test-config
+  {:store {:backend :memory :id test-id}
+   :branch :audit
+   :schema-flexibility :read})
+
+(def labels {:database (str test-id) :branch "audit"})
+
+(defn- fresh-registry! []
+  (metrics/reset!)
+  (dhm/describe!))
+
+(deftest labels-preserve-the-full-branch-identity
+  (is (= {:database (str test-id) :branch "tenant/audit"}
+         (dhm/db-labels (assoc test-config :branch :tenant/audit)))))
+
+(deftest descriptions-can-be-restored-after-a-registry-reset
+  (fresh-registry!)
+  (let [snapshot (metrics/snapshot)]
+    (is (= :histogram (get-in snapshot [:datahike_commit_seconds :type])))
+    (is (= :counter (get-in snapshot [:datahike_transactions_total :type])))
+    (is (= :counter (get-in snapshot [:datahike_transacted_datoms_total :type])))
+    (is (= :counter (get-in snapshot [:datahike_head_conflicts_total :type])))
+    (is (every? seq (map :help (vals snapshot)))
+        "every exported Datahike metric explains what it measures")
+    (is (every? empty? (map :series (vals snapshot)))
+        "describing instruments does not manufacture samples")))
+
+(deftest one-durable-batch-counts-every-transaction
+  (fresh-registry!)
+  (dhm/commit! test-config 125 3 7)
+  (let [snapshot (metrics/snapshot)
+        duration (get-in snapshot [:datahike_commit_seconds :series labels])]
+    (testing "one batch has one duration but can make several transactions durable"
+      (is (= 1 (:count duration)))
+      (is (= 0.125 (:sum duration)))
+      (is (= 3 (get-in snapshot [:datahike_transactions_total :series labels])))
+      (is (= 7 (get-in snapshot [:datahike_transacted_datoms_total :series labels]))))))
+
+(deftest conflicts-are-labelled-by-caller-outcome
+  (fresh-registry!)
+  (dhm/head-conflict! test-config :retried)
+  (dhm/head-conflict! test-config :retried)
+  (dhm/head-conflict! test-config :failed)
+  (let [series (get-in (metrics/snapshot) [:datahike_head_conflicts_total :series])]
+    (is (= 2 (get series (assoc labels :outcome "retried"))))
+    (is (= 1 (get series (assoc labels :outcome "failed"))))))
+
+#?(:clj
+   (deftest a-real-transaction-records-the-durable-result
+     (let [config (assoc test-config :branch :db)]
+       (when (d/database-exists? config)
+         (d/delete-database config))
+       (d/create-database config)
+       (let [conn (d/connect config)]
+         (try
+           ;; Database creation is itself durable but is not a user transaction.
+           ;; Isolate the transaction below after the connection is established.
+           (fresh-registry!)
+           (let [report   (d/transact conn [{:name "Ada"} {:name "Grace"}])
+                 expected (count (:tx-data report))
+                 labels   {:database (str test-id) :branch "db"}
+                 snapshot (metrics/snapshot)]
+             (is (= 1 (get-in snapshot [:datahike_commit_seconds :series labels :count])))
+             (is (= 1 (get-in snapshot [:datahike_transactions_total :series labels])))
+             (is (= expected
+                    (get-in snapshot [:datahike_transacted_datoms_total :series labels]))))
+           (finally
+             (d/release conn)
+             (d/delete-database config)))))))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -33,6 +33,7 @@
             [datahike.test.query-binding-seam-test]
             ;; Background GC (start-background-gc! / gc-storage!) — portable smoke.
             [datahike.test.background-gc-test]
+            [datahike.test.metrics-test]
             ;; :db.type/store-ref — blob GC contract, content-addressing, external
             ;; blobs (mark-without-sweep). Exercises with-unreferenced-writes on cljs.
             [datahike.test.store-ref-test]
@@ -802,6 +803,7 @@
                'datahike.test.array-test
                'datahike.test.query-binding-seam-test
                'datahike.test.background-gc-test
+               'datahike.test.metrics-test
                'datahike.test.store-ref-test
                'datahike.test.async-storage-test
                'datahike.kabel.walker-test

--- a/test/datahike/test/writer_alternating_test.clj
+++ b/test/datahike/test/writer_alternating_test.clj
@@ -18,10 +18,15 @@
             [datahike.db.transaction :as dbtx]
             [datahike.index.secondary :as sec]
             [datahike.index.secondary.stratum]
+            [datahike.metrics :as dhm]
             [datahike.writer :as w]
             [datahike.tx-preds :as txp]
             [datahike.writing :as dw]
-            [konserve.core :as k]))
+            [konserve.core :as k]
+            [replikativ.metrics :as metrics]))
+
+(defn- metric-value [metric labels]
+  (get-in (metrics/snapshot) [metric :series labels] 0))
 
 ;; A second `d/connect` with the same config normally returns the SAME cached
 ;; Connection out of the in-JVM registry — one writer, no race, nothing to test.
@@ -400,18 +405,23 @@
       (fresh-db! c)
       (let [{:keys [conn] :as p} (connect-as-separate-process c)]
         (try
-          (let [orig dw/commit!
-                left (atom 1)
-                r    (with-redefs [dw/commit!
-                                   (fn [db & args]
-                                     (if (pos? @left)
-                                       (do (swap! left dec)
-                                           (throw (ex-info "forced" {:type :konserve/revision-mismatch :key :db})))
-                                       (apply orig db args)))]
-                       (d/transact conn [{:db/id -1 :name "a"}]))]
+          (let [orig   dw/commit!
+                left   (atom 1)
+                labels (assoc (dhm/db-labels c) :outcome "retried")
+                before (metric-value :datahike_head_conflicts_total labels)
+                r      (with-redefs [dw/commit!
+                                     (fn [db & args]
+                                       (if (pos? @left)
+                                         (do (swap! left dec)
+                                             (throw (ex-info "forced" {:type :konserve/revision-mismatch :key :db})))
+                                         (apply orig db args)))]
+                         (d/transact conn [{:db/id -1 :name "a"}]))]
             (is (map? r) "the caller got a tx-report, not an error")
             (is (= ["a"] (map :v (d/datoms @conn :aevt :name)))
-                "and the transaction really landed"))
+                "and the transaction really landed")
+            (is (= (inc before)
+                   (metric-value :datahike_head_conflicts_total labels))
+                "the invocation is counted once as retried, not once per attempt"))
           (finally (release-separate-process p)))))))
 
 (deftest a-replayed-batch-keeps-its-order
@@ -493,16 +503,21 @@
       (fresh-db! c)
       (let [{:keys [conn] :as p} (connect-as-separate-process c)]
         (try
-          (let [calls (atom 0)
-                r     (with-redefs [dw/commit! (fn [& _]
-                                                 (swap! calls inc)
-                                                 (throw (ex-info "forced"
-                                                                 {:type :konserve/revision-mismatch :key :db})))]
-                        (try (d/transact conn [{:db/id -1 :name "x"}]) ::committed
-                             (catch Throwable e (ex-data e))))]
+          (let [calls  (atom 0)
+                labels (assoc (dhm/db-labels c) :outcome "failed")
+                before (metric-value :datahike_head_conflicts_total labels)
+                r      (with-redefs [dw/commit! (fn [& _]
+                                                  (swap! calls inc)
+                                                  (throw (ex-info "forced"
+                                                                  {:type :konserve/revision-mismatch :key :db})))]
+                         (try (d/transact conn [{:db/id -1 :name "x"}]) ::committed
+                              (catch Throwable e (ex-data e))))]
             (is (= 1 @calls) "exactly one commit attempt: no replay")
             (is (= :datahike/head-conflict (:type r)))
-            (is (= 1 (:attempt r))))
+            (is (= 1 (:attempt r)))
+            (is (= (inc before)
+                   (metric-value :datahike_head_conflicts_total labels))
+                "the invocation is counted as failed when its caller gets the conflict"))
           (finally (release-separate-process p))))))
 
   (testing "an out-of-range value is refused rather than coerced"


### PR DESCRIPTION
## Summary

- add the dependency-free `replikativ/metrics` registry and update to instrumented Konserve 0.9.391
- record durable batch latency, transaction and datom totals, and branch-head conflict outcomes
- label series only by stable store id and full branch identity
- preserve batching semantics: one duration observation per durable batch, but count every transaction in that batch
- add portable metric contract tests plus assertions on the real retry and failure paths

This is intentionally the core-only first slice of the server roadmap. HTTP request metrics, connection samples, Konserve sink ownership, Prometheus exposition, and operational endpoints follow separately so library recording remains independent of server lifecycle.

## Verification

- `clojure -M:format`
- `bb reflection`
- focused JVM metric and deterministic head-conflict tests
- `bb node-cljs-test` (310-file CLJS build; portable metric namespace executed)