### PR TITLE
feat: expose HTTP observability metrics

### DIFF
--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -310,6 +310,35 @@ clojure -M:http-server -m datahike.http.server config.edn
  :level    :info}
 ```
 
+### Prometheus metrics
+
+The standalone server exposes Prometheus text at
+`GET /prometheus`. The dedicated path is intentional: `GET /metrics` already
+belongs to Datahike's public API and returns database/index statistics from
+`d/metrics`.
+
+The endpoint requires the server's normal authentication by default:
+
+```bash
+curl -H 'Authorization: token securerandompassword' \
+  http://localhost:4444/prometheus
+```
+
+It includes durable transaction and conflict metrics, HTTP latency and
+rejections, live connection leases, Konserve operations, and JVM/process
+samples. A scraper on an otherwise protected private network can be admitted
+without a token with `:metrics {:public? true}`. Set `:metrics false` to omit
+the endpoint and keep the standalone server from installing the process-wide
+Konserve metrics sink.
+
+Multiple servers in one JVM share one reference-counted Konserve sink; stopping
+one does not interrupt the others, and the last stop removes it. Calling
+`datahike.http.server/app` directly does not claim ownership of that global
+sink—the embedding host owns its process lifecycle—but its endpoint still
+exports Datahike, connection, and JVM metrics. An embedding host that wants
+Konserve metrics can register `replikativ.metrics.konserve/sink` with
+`konserve.metrics/add-sink!` under its own id and remove it during shutdown.
+
 `datahike.http.server/start-server` and `stop-server` do the same from a
 REPL; `stop-server` releases every database the server opened, the auth
 database included. `app` takes the config and a connections atom, for hosts

--- a/http-server/datahike/http/permissions.clj
+++ b/http-server/datahike/http/permissions.clj
@@ -167,6 +167,7 @@ definition database {
       [["/permissions/check"
         {:swagger tags
          :post {:summary    "Is a subject allowed a permission on a resource?"
+                :metric-op  :read
                 :parameters {:body :any}
                 :handler
                 (guarded
@@ -179,6 +180,7 @@ definition database {
        ["/permissions/relationships"
         {:swagger tags
          :post {:summary    "The relationships on a resource."
+                :metric-op  :read
                 :parameters {:body :any}
                 :handler
                 (guarded
@@ -193,6 +195,7 @@ definition database {
        ["/permissions/relationships!"
         {:swagger tags
          :post {:summary    "Create, touch or delete relationships."
+                :metric-op  :admin
                 :parameters {:body :any}
                 :handler
                 (guarded

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -26,6 +26,7 @@
    [datahike.api.specification :refer [api-specification ->url]]
    [datahike.api.types :as types]
    [datahike.http.middleware :as middleware]
+   [datahike.metrics :as metrics]
    [datahike.readers :refer [edn-readers]]
    [datahike.transit :as transit]
    [datahike.remote.cbor :as rcbor]
@@ -44,6 +45,7 @@
    [reitit.ring.middleware.multipart :as multipart]
    [reitit.ring.middleware.parameters :as parameters]
    [muuntaja.core :as m]
+   [replikativ.metrics :as registry]
    [replikativ.logging :as log])
   (:import [datahike.datom Datom]
            [datahike.impl.entity Entity]
@@ -75,6 +77,7 @@
 (defn forbidden
   "The 403 for `op` on `databases` (`[{:store-id :branch}]`, may be empty)."
   [op databases]
+  (metrics/http-rejected! :forbidden)
   {:status 403
    :body   {:msg     (str "Forbidden: " (name op)
                           (when (seq databases)
@@ -395,6 +398,7 @@
           {:swagger {:tags ["API"]}
            ~(if referentially-transparent? :get :post)
            {:operationId ~(str n)
+            :metric-op   ~(route-op n referentially-transparent?)
             :summary     ~(extract-first-sentence doc)
             :description ~doc
             :parameters  {:body ~(extract-input-schema args)}
@@ -405,6 +409,7 @@
   [config state]
   [["/delete-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
+            :metric-op   :delete
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters :as request}]
@@ -429,6 +434,7 @@
      :swagger {:tags ["Internal"]}}]
    ["/create-database-writer"
     {:post {:parameters  {:body [:sequential :any]},
+            :metric-op   :create
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters :as request}]
@@ -445,6 +451,7 @@
      :swagger {:tags ["Internal"]}}]
    ["/transact!-writer"
     {:post {:parameters  {:body [:sequential :any]},
+            :metric-op   :transact
             :summary     "Internal endpoint. DO NOT USE!"
             :no-doc      true
             :handler     (fn [{{:keys [body]} :parameters :as request}]
@@ -518,24 +525,37 @@
         validators (middleware/validators config)]
     (fn [request]
       (binding [*connections* connections]
-        (let [match (reitit/match-by-path rtr (:uri request))]
-          (if-not (and match (contains? (:data match) (:request-method request)))
-            (ring-handler request)
-            (let [body (when (:body request) (read-body (:body request) max-bytes))
-                  ;; Buffered before anyone reads it: a validator that looks
-                  ;; at the body (a signed request, say) gets its own copy and
-                  ;; the route still gets the whole thing.
-                  buffered  (fn [] (cond-> request body (assoc :body (java.io.ByteArrayInputStream. body))))
-                  principal (when-not (= ::too-large body)
-                              (middleware/authenticate validators (buffered)))]
-              (cond
-                (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
-                too-large
-                (= ::too-large body) too-large
-                (and (not (get-in match [:data :public?])) (nil? principal))
-                {:status 401 :body "Not authorized"}
-                :else
-                (ring-handler (assoc (buffered) :datahike/principal principal))))))))))
+        (let [method     (:request-method request)
+              match      (reitit/match-by-path rtr (:uri request))
+              matched?   (and match (contains? (:data match) method))
+              metric-op  (get-in match [:data method :metric-op])
+              started    (when metric-op (registry/timer))
+              response
+              (if-not matched?
+                (ring-handler request)
+                (let [body (when (:body request) (read-body (:body request) max-bytes))
+                      ;; Buffered before anyone reads it: a validator that looks
+                      ;; at the body (a signed request, say) gets its own copy and
+                      ;; the route still gets the whole thing.
+                      buffered  (fn [] (cond-> request body (assoc :body (java.io.ByteArrayInputStream. body))))
+                      principal (when-not (= ::too-large body)
+                                  (middleware/authenticate validators (buffered)))]
+                  (cond
+                    (> (or (some-> (get-in request [:headers "content-length"]) parse-long) 0) max-bytes)
+                    (do (metrics/http-rejected! :too-large) too-large)
+
+                    (= ::too-large body)
+                    (do (metrics/http-rejected! :too-large) too-large)
+
+                    (and (not (get-in match [:data :public?])) (nil? principal))
+                    (do (metrics/http-rejected! :unauthorized)
+                        {:status 401 :body "Not authorized"})
+
+                    :else
+                    (ring-handler (assoc (buffered) :datahike/principal principal)))))]
+          (when started
+            (metrics/http-request! metric-op (:status response) started))
+          response)))))
 
 (defn handler
   "A Ring handler serving Datahike's HTTP API, for mounting in a host app.

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -128,10 +128,19 @@
   (try (.stop server)
        (finally
          (when-let [{:keys [connections config metrics-lease]} (get @owned server)]
-           (swap! owned dissoc server)
-           (routes/release-all! connections)
-           (permissions/close! config)
-           (release-metrics-sink! metrics-lease)))))
+           ;; Each cleanup owns an inner `finally`, so one failure cannot skip
+           ;; the remaining process-global cleanup. Forget ownership last: a
+           ;; failing permissions close must not strand the metrics lease.
+           (try
+             (routes/release-all! connections)
+             (finally
+               (try
+                 (permissions/close! config)
+                 (finally
+                   (try
+                     (release-metrics-sink! metrics-lease)
+                     (finally
+                       (swap! owned dissoc server)))))))))))
 
 (defn -main [& args]
   (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -5,6 +5,7 @@
   (:gen-class)
   (:require
    [clojure.edn :as edn]
+   [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
    [reitit.ring :as ring]
@@ -12,8 +13,34 @@
    [reitit.swagger-ui :as swagger-ui]
    [ring.middleware.cors :refer [wrap-cors]]
    [datahike.tools :refer [datahike-version]]
+   [konserve.metrics :as konserve-metrics]
+   [replikativ.metrics :as registry]
+   [replikativ.metrics.jvm :as jvm-metrics]
+   [replikativ.metrics.konserve :as metrics-konserve]
+   [replikativ.metrics.prometheus :as prometheus]
    [replikativ.logging :as log]
    [ring.adapter.jetty :refer [run-jetty]]))
+
+(def ^:private prometheus-content-type
+  "text/plain; version=0.0.4; charset=utf-8")
+
+(defn- metrics-route [config connections]
+  (when-not (false? (:metrics config))
+    ["/prometheus"
+     (cond-> {:get {:no-doc    true
+                    :metric-op :metrics
+                    :handler   (fn [_]
+                                 (let [body (prometheus/text
+                                             (registry/snapshot)
+                                             (concat (jvm-metrics/samples)
+                                                     (metrics/connection-samples connections)))]
+                                   {:status  200
+                                    :headers {"content-type" prometheus-content-type}
+                                    ;; Keep format middleware from negotiating or
+                                    ;; encoding Prometheus text as JSON/EDN.
+                                    :body    (java.io.ByteArrayInputStream.
+                                              (.getBytes ^String body "UTF-8"))}))}}
+       (true? (get-in config [:metrics :public?])) (assoc :public? true))]))
 
 (def ^:private swagger-route
   ["/swagger.json"
@@ -26,12 +53,18 @@
 (defn app
   "The server's Ring handler over `connections`. With `:auth-db` in `config`
    the permissions database is opened here; `(::config (meta app))` is the
-   configured config, for `stop-server`."
+   configured config, for `stop-server`.
+
+   This handler exposes process metrics but does not install a global Konserve
+   sink: an embedding host owns that lifecycle. `start-server` installs and
+   reference-counts the standalone server's sink."
   [config connections]
   (let [config  (if (:auth-db config) (permissions/configure config) config)
         handler (routes/handler config
                                 {:connections     connections
-                                 :extra-routes    (concat [swagger-route] (permissions/routes config))
+                                 :extra-routes    (concat [swagger-route]
+                                                          (keep identity [(metrics-route config connections)])
+                                                          (permissions/routes config))
                                  :default-handler (ring/routes
                                                    (swagger-ui/create-swagger-ui-handler
                                                     {:path   "/"
@@ -50,25 +83,55 @@
   ;; change of signature.
   (atom {}))
 
-(defn start-server [config]
+(defonce ^:private metrics-sink-leases (atom #{}))
+
+(def ^:private metrics-sink-id ::datahike)
+
+(defn- acquire-metrics-sink! []
+  (let [lease (Object.)]
+    (locking metrics-sink-leases
+      (when (empty? @metrics-sink-leases)
+        (metrics-konserve/describe!)
+        (konserve-metrics/add-sink! metrics-sink-id metrics-konserve/sink))
+      (swap! metrics-sink-leases conj lease))
+    lease))
+
+(defn- release-metrics-sink! [lease]
+  (when lease
+    (locking metrics-sink-leases
+      (swap! metrics-sink-leases disj lease)
+      (when (empty? @metrics-sink-leases)
+        (konserve-metrics/remove-sink! metrics-sink-id))))
+  nil)
+
+(defn start-server
+  "Start Jetty and acquire the standalone server's shared Konserve metric sink
+   unless `:metrics` is false. `stop-server` releases both."
+  [config]
   (let [connections (atom {})
         app         (app config connections)
         config      (::config (meta app))
+        metrics-lease (when-not (false? (:metrics config))
+                        (acquire-metrics-sink!))
         server      (try (run-jetty app config)
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
+                           (release-metrics-sink! metrics-lease)
                            (permissions/close! config)
                            (throw t)))]
-    (swap! owned assoc server {:connections connections :config config})
+    (swap! owned assoc server {:connections connections
+                               :config config
+                               :metrics-lease metrics-lease})
     server))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]
   (try (.stop server)
        (finally
-         (when-let [{:keys [connections config]} (get @owned server)]
+         (when-let [{:keys [connections config metrics-lease]} (get @owned server)]
            (swap! owned dissoc server)
            (routes/release-all! connections)
-           (permissions/close! config)))))
+           (permissions/close! config)
+           (release-metrics-sink! metrics-lease)))))
 
 (defn -main [& args]
   (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]

--- a/src/datahike/metrics.cljc
+++ b/src/datahike/metrics.cljc
@@ -23,7 +23,19 @@
 
    :datahike_head_conflicts_total
    {:type :counter
-    :help "Transaction invocations whose branch head moved, by whether they were retried or failed."}})
+    :help "Transaction invocations whose branch head moved, by whether they were retried or failed."}
+
+   :datahike_http_request_seconds
+   {:type :histogram
+    :help "Time to serve an HTTP API request, by operation and response status."}
+
+   :datahike_http_rejected_total
+   {:type :counter
+    :help "HTTP requests refused for missing credentials, missing permission, or excessive size."}
+
+   :datahike_connections
+   {:type :gauge
+    :help "Connection leases held in this process, by database and branch."}})
 
 (defn describe!
   "Install Datahike's metric descriptions into the process registry.
@@ -76,3 +88,36 @@
   (metrics/inc! :datahike_head_conflicts_total
                 (assoc (db-labels config) :outcome (name outcome)))
   nil)
+
+(defn http-request!
+  "Record an HTTP request for authorization operation `op`, response `status`,
+   and the monotonic timer value returned by `replikativ.metrics/timer`."
+  [op status started]
+  (metrics/observe-since! :datahike_http_request_seconds
+                          {:op (name op) :status (str status)}
+                          started)
+  nil)
+
+(defn http-rejected!
+  "Record a gate or authorization rejection.
+
+   `reason` is `:unauthorized`, `:forbidden`, or `:too-large`."
+  [reason]
+  (metrics/inc! :datahike_http_rejected_total {:reason (name reason)})
+  nil)
+
+(defn connection-samples
+  "Gauge samples for the live entries in a Datahike connection registry atom.
+
+   Reservations whose `:conn` is nil are omitted. The value is the registry's
+   reference count: one for its base lease plus any additional callers."
+  [connections]
+  (let [{:keys [type help]} (:datahike_connections descriptions)]
+    (for [[[store-id branch] {:keys [conn count]}] @connections
+          :when conn]
+      {:name   :datahike_connections
+       :type   type
+       :help   help
+       :labels {:database (str store-id)
+                :branch   (keyword-label (or branch :db))}
+       :value  (or count 1)})))

--- a/test/datahike/test/http/metrics_test.clj
+++ b/test/datahike/test/http/metrics_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.http.permissions :as permissions]
             [datahike.http.routes :as routes]
             [datahike.http.server :as server]
             [datahike.metrics :as dhm]
@@ -101,3 +102,14 @@
         (when-let [instance @first-server] (server/stop-server instance))
         (when-let [instance @second-server] (server/stop-server instance))
         (when-let [instance @disabled] (server/stop-server instance))))))
+
+(deftest shutdown-releases-the-process-sink-when-permission-cleanup-fails
+  (let [before   @konserve-metrics/sinks
+        instance (server/start-server {:port 0 :join? false :token token})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"forced permission cleanup failure"
+                          (with-redefs [permissions/close!
+                                        (fn [_]
+                                          (throw (ex-info "forced permission cleanup failure" {})))]
+                            (server/stop-server instance))))
+    (is (= before @konserve-metrics/sinks)
+        "permission cleanup failure does not strand the process metrics sink")))

--- a/test/datahike/test/http/metrics_test.clj
+++ b/test/datahike/test/http/metrics_test.clj
@@ -1,0 +1,103 @@
+(ns datahike.test.http.metrics-test
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.http.routes :as routes]
+            [datahike.http.server :as server]
+            [datahike.metrics :as dhm]
+            [konserve.metrics :as konserve-metrics]
+            [replikativ.metrics :as metrics]))
+
+(def token "metrics-test-token")
+
+(defn- reset-registry [f]
+  (metrics/reset!)
+  (dhm/describe!)
+  (try (f)
+       (finally
+         (metrics/reset!)
+         (dhm/describe!))))
+
+(use-fixtures :each reset-registry)
+
+(defn- series-value [metric labels]
+  (get-in (metrics/snapshot) [metric :series labels]))
+
+(deftest the-gate-records-duration-status-and-rejection-reason
+  (let [handler (routes/handler {:token token :max-body-bytes 4})
+        post    (fn [headers body]
+                  (handler {:request-method :post
+                            :uri            "/transact"
+                            :headers        headers
+                            :body           body}))]
+    (is (= 401 (:status (post {} nil))))
+    (is (= 413 (:status (post {"authorization" (str "token " token)}
+                              (java.io.ByteArrayInputStream. (.getBytes "too large"))))))
+    (is (= 403 (:status (routes/authorize {:authorize (constantly false)}
+                                          {:datahike/principal {:sub "nobody"}}
+                                          :read []))))
+    (testing "the request duration is observed once at the gate, including rejections"
+      (is (= 1 (:count (series-value :datahike_http_request_seconds
+                                     {:op "transact" :status "401"}))))
+      (is (= 1 (:count (series-value :datahike_http_request_seconds
+                                     {:op "transact" :status "413"})))))
+    (testing "operators can distinguish authentication, authorization, and capacity"
+      (is (= 1 (series-value :datahike_http_rejected_total {:reason "unauthorized"})))
+      (is (= 1 (series-value :datahike_http_rejected_total {:reason "too-large"})))
+      (is (= 1 (series-value :datahike_http_rejected_total {:reason "forbidden"}))))))
+
+(defn- get-metrics [handler headers]
+  (handler {:request-method :get :uri "/prometheus" :headers headers}))
+
+(deftest prometheus-exposition-is-protected-plain-text
+  (let [store-id    #uuid "5dcf9ca4-a6b8-4e16-a159-a6c05930be82"
+        connections (atom {[store-id :db] {:conn ::connection :count 3}})
+        handler     (server/app {:token token} connections)]
+    (is (= 401 (:status (get-metrics handler {})))
+        "metrics disclose database ids and traffic shape, so authentication is the default")
+    (let [response (get-metrics handler {"authorization" (str "token " token)})
+          body     (slurp (:body response))]
+      (is (= 200 (:status response)))
+      (is (= "text/plain; version=0.0.4; charset=utf-8"
+             (get-in response [:headers "content-type"])))
+      (is (str/includes? body "datahike_http_request_seconds_bucket"))
+      (is (str/includes? body "jvm_memory_used_bytes"))
+      (is (str/includes? body
+                         (str "datahike_connections{branch=\"db\",database=\"" store-id "\"} 3")))
+      (is (= 1 (:count (series-value :datahike_http_request_seconds
+                                     {:op "metrics" :status "200"})))))))
+
+(deftest metrics-can-be-public-or-disabled-explicitly
+  (let [public   (server/app {:metrics {:public? true}} (atom {}))
+        disabled (server/app {:token token :metrics false} (atom {}))]
+    (is (= 200 (:status (get-metrics public {}))))
+    (is (= 404 (:status (get-metrics disabled {"authorization" (str "token " token)}))))))
+
+(deftest server-instances-share-one-process-sink-until-the-last-stops
+  (let [before @konserve-metrics/sinks
+        first-server  (atom nil)
+        second-server (atom nil)
+        disabled      (atom nil)]
+    (try
+      (reset! first-server (server/start-server {:port 0 :join? false :token token}))
+      (let [after-first @konserve-metrics/sinks
+            added       (set/difference (set (keys after-first)) (set (keys before)))]
+        (is (= 1 (count added)))
+        (reset! second-server (server/start-server {:port 0 :join? false :token token}))
+        (is (= after-first @konserve-metrics/sinks)
+            "a second server neither replaces nor duplicates the process sink")
+        (server/stop-server @first-server)
+        (reset! first-server nil)
+        (is (= after-first @konserve-metrics/sinks)
+            "stopping one server leaves metrics active for the other")
+        (reset! disabled (server/start-server {:port 0 :join? false :token token :metrics false}))
+        (is (= after-first @konserve-metrics/sinks)
+            "a metrics-disabled server takes no sink lease")
+        (server/stop-server @second-server)
+        (reset! second-server nil)
+        (is (= before @konserve-metrics/sinks)
+            "the last metrics-enabled server releases the sink"))
+      (finally
+        (when-let [instance @first-server] (server/stop-server instance))
+        (when-let [instance @second-server] (server/stop-server instance))
+        (when-let [instance @disabled] (server/stop-server instance))))))

--- a/test/datahike/test/metrics_test.cljc
+++ b/test/datahike/test/metrics_test.cljc
@@ -54,6 +54,23 @@
     (is (= 2 (get series (assoc labels :outcome "retried"))))
     (is (= 1 (get series (assoc labels :outcome "failed"))))))
 
+(deftest connection-samples-omit-reservations-and-preserve-branches
+  (let [samples (dhm/connection-samples
+                 (atom {[test-id :db]           {:conn ::db :count 3}
+                        [test-id :tenant/audit] {:conn ::audit :count 1}
+                        [(random-uuid) :db]      {:conn nil :count 0}}))]
+    (is (= #{{:name   :datahike_connections
+              :type   :gauge
+              :help   "Connection leases held in this process, by database and branch."
+              :labels {:database (str test-id) :branch "db"}
+              :value  3}
+             {:name   :datahike_connections
+              :type   :gauge
+              :help   "Connection leases held in this process, by database and branch."
+              :labels {:database (str test-id) :branch "tenant/audit"}
+              :value  1}}
+           (set samples)))))
+
 #?(:clj
    (deftest a-real-transaction-records-the-durable-result
      (let [config (assoc test-config :branch :db)]


### PR DESCRIPTION
## Summary

- expose authenticated Prometheus text at GET /prometheus without colliding with the existing Datahike GET /metrics operation
- record HTTP latency/status and authentication, authorization, and size rejections using bounded labels
- export live connection lease gauges plus registry, Konserve, JVM, and process samples
- reference-count the standalone Konserve sink across multiple server instances, while leaving sink lifecycle to embedding hosts
- make shutdown cleanup failure-safe so connection, permission, and sink cleanup are each attempted
- allow an explicitly public endpoint with :metrics {:public? true}, or disable exposition and sink installation with :metrics false

## Design

/prometheus is the sole scrape path. A nested /prometheus/metrics path would create a namespace with no credible second Prometheus resource, while /metrics/prometheus would imply ownership of the already-established /metrics API path.

The scrape endpoint is protected by the normal server authentication by default because it exposes database identifiers and traffic shape. It returns a byte stream with the Prometheus content type so format middleware cannot re-encode it.

## Verification

- focused HTTP metrics tests: 5 tests, 24 assertions
- HTTP regression suite: 27 tests, 321 assertions
- forced permission-cleanup failure proves the process sink is still released
- full Node/CLJS test task
- reflection compilation: no reflective calls in Datahike sources
- formatting and diff checks
- targeted clj-kondo: no errors