### PR TITLE
Add HTTP liveness and readiness endpoints

### DIFF
--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -339,6 +339,24 @@ exports Datahike, connection, and JVM metrics. An embedding host that wants
 Konserve metrics can register `replikativ.metrics.konserve/sink` with
 `konserve.metrics/add-sink!` under its own id and remove it during shutdown.
 
+### Health checks
+
+The server exposes two unauthenticated, plain-text health endpoints for
+orchestrators and load balancers:
+
+- `GET /health/live` returns 200 while the HTTP process can answer requests.
+- `GET /health/ready` returns 200 only when every database store currently held
+  by the server, plus its configured `:auth-db`, accepts a non-mutating Konserve
+  read. It returns 503 otherwise.
+
+Both responses intentionally contain only `live`, `ready`, or `not ready`. The
+server log identifies a failed store and the exception class/type without
+copying exception messages or data that might contain credentials. Data
+databases are supplied dynamically by API clients today, so readiness covers
+the live connections the server knows about.
+Once the planned system database provides a durable database catalog, readiness
+can also cover its eagerly reconnected entries.
+
 `datahike.http.server/start-server` and `stop-server` do the same from a
 REPL; `stop-server` releases every database the server opened, the auth
 database included. `app` takes the config and a connections atom, for hosts

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -13,6 +13,7 @@
    [reitit.swagger-ui :as swagger-ui]
    [ring.middleware.cors :refer [wrap-cors]]
    [datahike.tools :refer [datahike-version]]
+   [konserve.core :as k]
    [konserve.metrics :as konserve-metrics]
    [replikativ.metrics :as registry]
    [replikativ.metrics.jvm :as jvm-metrics]
@@ -23,6 +24,72 @@
 
 (def ^:private prometheus-content-type
   "text/plain; version=0.0.4; charset=utf-8")
+
+(def ^:private plain-text-content-type
+  "text/plain;charset=utf-8")
+
+(def ^:private readiness-probe-key ::readiness-probe)
+
+(defn- text-response [status body]
+  {:status  status
+   :headers {"content-type" plain-text-content-type}
+   ;; Keep format middleware from negotiating or encoding operational text.
+   :body    (java.io.ByteArrayInputStream.
+             (.getBytes ^String body "UTF-8"))})
+
+(defn- probe-connection!
+  "Touch one connection's logical Konserve store without relying on a cached
+   database key. A missing probe key is success: the read itself is the check."
+  [[store-id conn]]
+  (try
+    (let [;; Do not deref the Connection itself: shared writers refresh their
+          ;; branch on deref and may rebuild indices. Read its raw state so the
+          ;; health check performs exactly one cheap, non-mutating store read.
+          db    @(get conn :wrapped-atom)
+          store (:store db)]
+      (k/get store readiness-probe-key nil {:sync? true})
+      true)
+    (catch Throwable e
+      (log/warn :datahike/readiness-probe-failed
+                {:database (some-> store-id str)
+                 ;; Backend exceptions can carry URLs or credentials in their
+                 ;; message/ex-data. Health logs identify the target and error
+                 ;; class without copying those values.
+                 :error-type  (:type (ex-data e))
+                 :error-class (.getName (class e))})
+      false)))
+
+(defn- ready?
+  "Check every store the server currently owns: live API connections and the
+   configured auth database. Do not short-circuit, so one outage does not hide
+   another from the operator logs."
+  [config connections]
+  (let [targets (concat
+                 (for [[[store-id _branch] {:keys [conn]}] @connections
+                       :when conn]
+                   [store-id conn])
+                 (when-let [conn (get config ::permissions/conn)]
+                   [[:auth-db conn]]))]
+    (reduce (fn [ready target]
+              (let [target-ready? (probe-connection! target)]
+                (and ready target-ready?)))
+            true
+            targets)))
+
+(defn- health-routes [config connections]
+  [["/health/live"
+    {:public? true
+     :get {:no-doc    true
+           :metric-op :health
+           :handler   (fn [_] (text-response 200 "live\n"))}}]
+   ["/health/ready"
+    {:public? true
+     :get {:no-doc    true
+           :metric-op :health
+           :handler   (fn [_]
+                        (if (ready? config connections)
+                          (text-response 200 "ready\n")
+                          (text-response 503 "not ready\n")))}}]])
 
 (defn- metrics-route [config connections]
   (when-not (false? (:metrics config))
@@ -63,6 +130,7 @@
         handler (routes/handler config
                                 {:connections     connections
                                  :extra-routes    (concat [swagger-route]
+                                                          (health-routes config connections)
                                                           (keep identity [(metrics-route config connections)])
                                                           (permissions/routes config))
                                  :default-handler (ring/routes

--- a/test/datahike/test/http/health_test.clj
+++ b/test/datahike/test/http/health_test.clj
@@ -1,0 +1,99 @@
+(ns datahike.test.http.health-test
+  (:require [babashka.http-client :as http]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.connections :as connections]
+            [datahike.connector :as connector]
+            [datahike.http.permissions :as permissions]
+            [datahike.http.server :as server]
+            [konserve.core :as k]))
+
+(def token "health-test-token")
+
+(defn- request [handler uri]
+  (handler {:request-method :get :uri uri :headers {}}))
+
+(defn- body [response]
+  (slurp (:body response)))
+
+(deftest health-endpoints-are-public-and-plain-text
+  (let [handler (server/app {:token token :metrics false} (atom {}))
+        live    (request handler "/health/live")
+        ready   (request handler "/health/ready")]
+    (testing "orchestrators do not need API credentials"
+      (is (= 200 (:status live)))
+      (is (= 200 (:status ready))))
+    (is (= "text/plain;charset=utf-8" (get-in live [:headers "content-type"])))
+    (is (= "live\n" (body live)))
+    (is (= "ready\n" (body ready)))))
+
+(deftest liveness-is-usable-over-http-without-credentials
+  (let [instance (server/start-server {:port 0 :join? false :token token :metrics false})]
+    (try
+      (let [connector (first (.getConnectors instance))
+            port      (.getLocalPort ^org.eclipse.jetty.server.ServerConnector connector)
+            response  (http/get (str "http://localhost:" port "/health/live")
+                                {:throw false :as :string})]
+        (is (= 200 (:status response)))
+        (is (= "text/plain;charset=utf-8" (get-in response [:headers "content-type"])))
+        (is (= "live\n" (:body response))))
+      (finally
+        (server/stop-server instance)))))
+
+(deftest readiness-checks-live-and-auth-stores
+  (let [data-id   #uuid "7bea093b-af2e-49a2-a02e-7cf4be87a77b"
+        data-conn (connector/conn-from-db {:store ::data-store})
+        auth-conn (connector/conn-from-db {:store ::auth-store})
+        connections (atom {[data-id :db] {:conn data-conn :count 1}})
+        probed      (atom [])]
+    (with-redefs [permissions/configure
+                  #(assoc % ::permissions/conn auth-conn)
+                  connector/deref-conn
+                  (fn [_]
+                    (throw (ex-info "readiness must not refresh a connection" {})))
+                  k/get
+                  (fn [store key not-found opts]
+                    (swap! probed conj [store key not-found opts])
+                    nil)]
+      (let [handler  (server/app {:token token :metrics false :auth-db {}} connections)
+            response (request handler "/health/ready")]
+        (is (= 200 (:status response)))
+        (is (= #{::data-store ::auth-store} (set (map first @probed))))
+        (is (every? #(= {:sync? true} (nth % 3)) @probed))))))
+
+(deftest readiness-probes-a-real-datahike-store
+  (let [config {:store {:backend :memory
+                        :id      #uuid "cf570585-d8b7-4fcd-8fab-d4bb866eb255"}}
+        registry (atom {})]
+    (binding [connections/*connections* registry]
+      (try
+        (d/create-database config)
+        (let [conn     (d/connect config)
+              handler  (server/app {:token token :metrics false} registry)
+              response (request handler "/health/ready")]
+          (is (= 200 (:status response)))
+          (is (= "ready\n" (body response)))
+          (d/release conn))
+        (finally
+          (when (d/database-exists? config)
+            (d/delete-database config)))))))
+
+(deftest readiness-checks-all-stores-and-hides-failure-details
+  (let [healthy-id #uuid "df41d1cc-0ef3-4894-b00f-77334d09c3b0"
+        broken-id  #uuid "d5190805-a171-4eb4-83a8-d184f9a82a43"
+        connections (atom {[healthy-id :db] {:conn (connector/conn-from-db {:store ::healthy}) :count 1}
+                           [broken-id :db]  {:conn (connector/conn-from-db {:store ::broken}) :count 1}
+                           [(random-uuid) :db] {:conn nil :count 0}})
+        probed      (atom [])]
+    (with-redefs [k/get
+                  (fn [store _key _not-found _opts]
+                    (swap! probed conj store)
+                    (when (= ::broken store)
+                      (throw (ex-info "secret backend failure" {:credentials "must-not-leak"}))))]
+      (let [handler  (server/app {:token token :metrics false} connections)
+            response (request handler "/health/ready")]
+        (is (= 503 (:status response)))
+        (is (= "not ready\n" (body response)))
+        (is (= #{::healthy ::broken} (set @probed))
+            "a failed store does not prevent the remaining probes")
+        (is (not (re-find #"secret|credentials" (body response))))))))


### PR DESCRIPTION
## Summary

- add public plain-text GET /health/live and GET /health/ready endpoints
- make readiness perform one non-mutating Konserve read against every live data connection and the configured auth database
- avoid connection dereference so readiness cannot trigger shared-writer refresh or index rebuilding
- return only generic health text and keep backend exception messages/data out of responses and logs
- document the current dynamic-connection readiness boundary and future system-catalog extension

## Verification

- focused health tests across persistent-set, specs, and hitchhiker-tree: 15 tests, 51 assertions, 0 failures
- real in-memory Datahike store probe
- real unauthenticated Jetty liveness request
- failure-path coverage verifies all stores are checked and secrets are hidden
- clojure -M:format
- bb reflection
- git diff --check