### PR TITLE
Expose server build information and bundle common backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ repl-mcp.log
 npm-package/output.txt
 /.internal/
 resources/DATAHIKE_VERSION
+resources/DATAHIKE_GIT_SHA
 
 # Auto-generated code (regenerate with bb codegen-*)
 java/src-generated/

--- a/bb.edn
+++ b/bb.edn
@@ -234,6 +234,7 @@
                                       "--no-fallback"
                                       "--enable-url-protocols=http,https"
                                       "-H:IncludeResources=DATAHIKE_VERSION"
+                                      "-H:IncludeResources=DATAHIKE_GIT_SHA"
                                       "-J-Xmx5g"
                                       "-o" "dthk")))
                          (clojure "-M:native-cli"))}

--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -19,12 +19,15 @@
                     aliases (assoc :aliases aliases))))
 
 (defn write-version-resource
-  "Writes version string to resources/DATAHIKE_VERSION for embedding in builds"
+  "Writes version and commit resources for embedding in builds."
   [repo-config]
-  (print "Writing version resource file...")
-  (fs/create-dirs "resources")
-  (spit "resources/DATAHIKE_VERSION" (version/string repo-config))
-  (println "Done. Version:" (version/string repo-config)))
+  (let [version (version/string repo-config)
+        git-sha (version/current-commit)]
+    (print "Writing build metadata resources...")
+    (fs/create-dirs "resources")
+    (spit "resources/DATAHIKE_VERSION" version)
+    (spit "resources/DATAHIKE_GIT_SHA" git-sha)
+    (println "Done. Version:" version "Git SHA:" git-sha)))
 
 (defn compile-java
   ([] (compile-java (read-edn-file "config.edn")))

--- a/deps.edn
+++ b/deps.edn
@@ -99,9 +99,9 @@
                                ;; Optional `datahike/s3` browser entry. The
                                ;; regular browser bundle does not require this
                                ;; namespace, so Closure keeps S3 signing code out.
-                               ;; 0.1.39: all 45 reflective S3 calls hinted
+                               ;; 0.1.39+: all 45 reflective S3 calls hinted
                                ;; (konserve-s3#19).
-                               org.replikativ/konserve-s3 {:mvn/version "0.1.39"}}
+                               org.replikativ/konserve-s3 {:mvn/version "0.1.42"}}
                                
                   :extra-paths ["test"]}
 
@@ -173,8 +173,17 @@
                                is.simm/distributed-scope     {:mvn/version "0.1.9"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
 
-                               ;; S3-compatible store integration test (migrate-s3-test, needs docker; runs Garage)
-                               org.replikativ/konserve-s3    {:mvn/version "0.1.39"}
+                               ;; Standalone-server backends. Keep these versions in sync with
+                               ;; :http-server below: tests load the same registration namespace
+                               ;; that the shipped server does.
+                               org.replikativ/konserve-s3    {:mvn/version "0.1.42"
+                                                               :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
+                               org.replikativ/konserve-jdbc  {:mvn/version "0.2.101"}
+                               org.replikativ/konserve-dynamodb
+                               {:mvn/version "0.1.33"
+                                :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
+                               org.replikativ/konserve-redis {:mvn/version "0.1.29"}
+                               org.postgresql/postgresql     {:mvn/version "42.7.13"}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            ;; Datomic Pro peer API, for `datahike.migrate.datomic` and its
@@ -208,7 +217,25 @@
                                       metosin/reitit          {:mvn/version "0.10.1"}
                                       ring-cors/ring-cors     {:mvn/version "0.1.13"}
                                       nrepl/bencode           {:mvn/version "1.2.0"}
-                                      org.slf4j/slf4j-simple  {:mvn/version "2.0.18"}}
+                                      org.slf4j/slf4j-simple  {:mvn/version "2.0.18"}
+
+                                      ;; Batteries included for the standalone server. File,
+                                      ;; memory and tiered ship with Konserve itself. GCS stays
+                                      ;; optional because its SDK graph is exceptionally large;
+                                      ;; RocksDB/LMDB stay optional because they add native and
+                                      ;; platform constraints to an otherwise portable jar.
+                                      org.replikativ/konserve-s3
+                                      {:mvn/version "0.1.42"
+                                       :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
+                                      org.replikativ/konserve-jdbc
+                                      {:mvn/version "0.2.101"}
+                                      org.replikativ/konserve-dynamodb
+                                      {:mvn/version "0.1.33"
+                                       :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
+                                      org.replikativ/konserve-redis
+                                      {:mvn/version "0.1.29"}
+                                      org.postgresql/postgresql
+                                      {:mvn/version "42.7.13"}}
                          :main-opts ["-m" "datahike.http.server"]}
 
            ;; konserve-s3 is here for the same reason it is in :native-cli, and it
@@ -223,7 +250,7 @@
            :libdatahike {:main-opts ["-e" "(set! *warn-on-reflection* true)"]
                          :extra-paths ["libdatahike/src"]
                          :extra-deps {org.replikativ/konserve-s3
-                                      {:mvn/version "0.1.40"
+                                      {:mvn/version "0.1.42"
                                        :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}}}
 
            :native-cli {:main-opts ["-e" "(set! *warn-on-reflection* true)"
@@ -240,6 +267,7 @@
                                     ;; config rather than a missing handler.
                                     "--enable-url-protocols=http,https"
                                     "-H:IncludeResources=DATAHIKE_VERSION"
+                                    "-H:IncludeResources=DATAHIKE_GIT_SHA"
                                     ; "--future-defaults=all"
                                     ;; 5g, not 4g: pulling in konserve-s3 brings the
                                     ;; AWS SDK with it, and the analysis then needs
@@ -273,7 +301,7 @@
                          ;; loses differs by builder — the same source built on
                          ;; Oracle GraalVM 25.0.1 and failed on GraalVM Community in
                          ;; CI. Excluding the jar removes the question.
-                         org.replikativ/konserve-s3 {:mvn/version "0.1.40"
+                         org.replikativ/konserve-s3 {:mvn/version "0.1.42"
                                                      :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
                          com.cognitect/transit-clj {:mvn/version "1.1.363"}
                          babashka/pods             {:git/url "https://github.com/babashka/pods"

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -357,6 +357,20 @@ the live connections the server knows about.
 Once the planned system database provides a durable database catalog, readiness
 can also cover its eagerly reconnected entries.
 
+`GET /version` returns build and runtime metadata: the Datahike version and Git
+SHA, Konserve version, registered Konserve backends, and the server
+configuration with credential-valued fields replaced by `REDACTED`. Unlike the
+health endpoints, it requires the server's normal authentication because even
+redacted configuration exposes deployment topology. Send an `Accept` header
+such as `application/json` or `application/edn` to choose the response format.
+
+The standalone server artifact registers the built-in file, memory, and tiered
+stores plus the official S3, JDBC, DynamoDB, and Redis backends. It includes the
+PostgreSQL JDBC driver. GCS remains an opt-in dependency because of its large
+SDK graph; RocksDB and LMDB remain opt-in because they impose native and
+platform-specific runtime requirements. Embedding applications can load any
+additional Konserve backend, and `/version` reports it automatically.
+
 `datahike.http.server/start-server` and `stop-server` do the same from a
 REPL; `stop-server` releases every database the server opened, the auth
 database included. `app` takes the config and a connections atom, for hosts

--- a/http-server/datahike/http/backends.clj
+++ b/http-server/datahike/http/backends.clj
@@ -1,0 +1,11 @@
+(ns datahike.http.backends
+  "Backend registrations bundled by the standalone HTTP server.
+
+   Konserve dispatches by multimethod, so putting a backend jar on the
+   classpath is not enough: its namespace must be loaded. Keeping those
+   requires in one namespace makes the artifact's supported surface explicit
+   and leaves the Datahike library jar free of optional backend dependencies."
+  (:require [konserve-dynamodb.core]
+            [konserve-jdbc.core]
+            [konserve-redis.core]
+            [konserve-s3.core]))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -5,6 +5,7 @@
   (:gen-class)
   (:require
    [clojure.edn :as edn]
+   [datahike.http.backends]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
@@ -12,9 +13,10 @@
    [reitit.swagger :as swagger]
    [reitit.swagger-ui :as swagger-ui]
    [ring.middleware.cors :refer [wrap-cors]]
-   [datahike.tools :refer [datahike-version]]
+   [datahike.tools :as tools]
    [konserve.core :as k]
    [konserve.metrics :as konserve-metrics]
+   [konserve.store]
    [replikativ.metrics :as registry]
    [replikativ.metrics.jvm :as jvm-metrics]
    [replikativ.metrics.konserve :as metrics-konserve]
@@ -91,6 +93,30 @@
                           (text-response 200 "ready\n")
                           (text-response 503 "not ready\n")))}}]])
 
+(defn- registered-konserve-backends []
+  ;; Konserve backends become usable by registering a connect-store method.
+  ;; Report the runtime truth, including third-party backends loaded by an
+  ;; embedding host, rather than maintaining a second hard-coded list here.
+  (if-let [connect-store (ns-resolve 'konserve.store '-connect-store)]
+    (->> (methods @connect-store)
+         keys
+         (remove #{:default})
+         sort
+         vec)
+    []))
+
+(defn- version-route [server-config]
+  ["/version"
+   {:get {:no-doc    true
+          :metric-op :version
+          :handler   (fn [_]
+                       {:status 200
+                        :body   {:datahike-version  tools/datahike-version
+                                 :git-sha           tools/datahike-git-sha
+                                 :konserve-version  tools/konserve-version
+                                 :konserve-backends (registered-konserve-backends)
+                                 :config            (routes/redact server-config)}})}}])
+
 (defn- metrics-route [config connections]
   (when-not (false? (:metrics config))
     ["/prometheus"
@@ -126,11 +152,13 @@
    sink: an embedding host owns that lifecycle. `start-server` installs and
    reference-counts the standalone server's sink."
   [config connections]
-  (let [config  (if (:auth-db config) (permissions/configure config) config)
+  (let [server-config config
+        config  (if (:auth-db config) (permissions/configure config) config)
         handler (routes/handler config
                                 {:connections     connections
                                  :extra-routes    (concat [swagger-route]
                                                           (health-routes config connections)
+                                                          [(version-route server-config)]
                                                           (keep identity [(metrics-route config connections)])
                                                           (permissions/routes config))
                                  :default-handler (ring/routes
@@ -213,7 +241,7 @@
 (defn -main [& args]
   (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]
     (when (#{:trace :debug :info nil} level)
-      (println "Datahike HTTP Server" datahike-version "- https://datahike.io"))
+      (println "Datahike HTTP Server" tools/datahike-version "- https://datahike.io"))
     (log/info :datahike/http-server-config {:config (routes/redact config)})
     (start-server config)
     (log/info :datahike/http-server-started "Server started")))

--- a/src/datahike/tools.cljc
+++ b/src/datahike/tools.cljc
@@ -2,6 +2,7 @@
   (:require
    [superv.async :refer [throw-if-exception-]]
    [clojure.core.async.impl.protocols :as async-impl]
+   [clojure.string :as str]
    [hasch.core :refer [uuid]]
    [clojure.core.async :as async]
    #?(:clj [clojure.java.io :as io])
@@ -276,7 +277,20 @@
            (let [props (doto (Properties.) (.load stream))]
              (.getProperty props "version")))))))
 
-#?(:clj (def datahike-version (or (get-version 'org.replikativ/datahike) "DEVELOPMENT")))
+#?(:clj
+   (defn- build-resource
+     [resource-name]
+     (try
+       (some-> (io/resource resource-name) slurp str/trim not-empty)
+       (catch Exception _ nil))))
+
+#?(:clj (def datahike-version
+          (or (build-resource "DATAHIKE_VERSION")
+              (get-version 'org.replikativ/datahike)
+              "DEVELOPMENT")))
+
+#?(:clj (def datahike-git-sha
+          (or (build-resource "DATAHIKE_GIT_SHA") "DEVELOPMENT")))
 
 #?(:clj (def hitchhiker-tree-version
           (try (get-version 'io.replikativ/hitchhiker-tree)

--- a/test/datahike/test/http/version_test.clj
+++ b/test/datahike/test/http/version_test.clj
@@ -1,0 +1,50 @@
+(ns datahike.test.http.version-test
+  (:require [clojure.edn :as edn]
+            [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.http.server :as server]
+            [datahike.tools :as tools]))
+
+(def token "version-test-token")
+
+(defn- get-version [handler authorization]
+  (handler {:request-method :get
+            :uri            "/version"
+            :headers        (cond-> {"accept" "application/edn"}
+                              authorization
+                              (assoc "authorization" authorization))}))
+
+(deftest version-is-authenticated-content-negotiated-operational-metadata
+  (let [config  {:token token
+                 :port  8080
+                 :database {:store {:backend  :jdbc
+                                    :user     "datahike"
+                                    :password "database-secret"}}
+                 :nested {:access-key "access-secret"
+                          :secret-key "secret-secret"}}
+        handler (with-redefs [tools/datahike-version "1.2.3"
+                              tools/datahike-git-sha "0123456789abcdef0123456789abcdef01234567"
+                              tools/konserve-version "9.8.7"]
+                  (server/app config (atom {})))]
+    (is (= 401 (:status (get-version handler nil)))
+        "build metadata and deployment topology are not public")
+    (with-redefs [tools/datahike-version "1.2.3"
+                  tools/datahike-git-sha "0123456789abcdef0123456789abcdef01234567"
+                  tools/konserve-version "9.8.7"]
+      (let [response (get-version handler (str "token " token))
+            info     (edn/read-string (slurp (:body response)))]
+        (is (= 200 (:status response)))
+        (is (= "application/edn; charset=utf-8"
+               (get-in response [:headers "Content-Type"])))
+        (is (= "1.2.3" (:datahike-version info)))
+        (is (= "0123456789abcdef0123456789abcdef01234567" (:git-sha info)))
+        (is (= "9.8.7" (:konserve-version info)))
+        (is (set/subset? #{:dynamodb :file :jdbc :memory :redis :s3 :tiered}
+                         (set (:konserve-backends info))))
+        (is (not (some #{:default} (:konserve-backends info))))
+        (testing "configuration remains useful without exposing credentials"
+          (is (= 8080 (get-in info [:config :port])))
+          (is (= "REDACTED" (get-in info [:config :token])))
+          (is (= "REDACTED" (get-in info [:config :database :store :password])))
+          (is (= "REDACTED" (get-in info [:config :nested :access-key])))
+          (is (= "REDACTED" (get-in info [:config :nested :secret-key]))))))))


### PR DESCRIPTION
## Summary

- add authenticated, content-negotiated GET /version with Datahike version, embedded Git SHA, Konserve version, registered backend dispatch values, and recursively redacted server config
- embed DATAHIKE_GIT_SHA alongside DATAHIKE_VERSION in jars and native resources
- make the standalone server artifact batteries-included for file, memory, tiered, S3, JDBC/PostgreSQL, DynamoDB, and Redis
- load backend registration namespaces explicitly while keeping the core Datahike library jar lean
- update all shipped S3 aliases to the current 0.1.42 release

GCS remains opt-in because its SDK graph is unusually large. RocksDB and LMDB remain opt-in because they impose native/platform runtime constraints.

## Verification

- focused and combined HTTP suites: 99 tests, 1053 assertions, 0 failures
- clojure -M:format
- bb reflection: no reflective calls in Datahike sources
- bb http-server-uber succeeds; packaged jar is 92 MB
- packaged jar contains all four optional backend registrations, PostgreSQL Driver, version, and Git SHA resources
- end-to-end jar smoke test returned the expected authenticated /version response with all seven backends and a redacted token
- git diff --check

## Note

Konserve DynamoDB currently emits its pre-existing unresolved HashMap constructor reflection warning while loading. It does not prevent JVM AOT compilation, artifact startup, or the Datahike reflection gate.