### PR TITLE
feat: add standalone server config precedence

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -156,6 +156,7 @@
                                ring/ring-jetty-adapter       {:mvn/version "1.15.5"}
                                metosin/reitit                {:mvn/version "0.10.1"}
                                ring-cors/ring-cors           {:mvn/version "0.1.13"}
+                               org.clojure/tools.cli         {:mvn/version "1.4.256"}
 
                                ;; secondary index integrations (for testing)
                                org.replikativ/proximum       {:mvn/version "0.1.36"}
@@ -217,6 +218,7 @@
                                       metosin/reitit          {:mvn/version "0.10.1"}
                                       ring-cors/ring-cors     {:mvn/version "0.1.13"}
                                       nrepl/bencode           {:mvn/version "1.2.0"}
+                                      org.clojure/tools.cli   {:mvn/version "1.4.256"}
                                       org.slf4j/slf4j-simple  {:mvn/version "2.0.18"}
 
                                       ;; Batteries included for the standalone server. File,

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -301,8 +301,18 @@ The HTTP server provides a **REST/RPC interface** for conventional integrations 
 To build locally, clone the repository and run `bb http-server-uber` to create the jar. Run the server with:
 
 ```bash
-java -jar datahike-http-server-VERSION.jar path/to/config.edn
+java -jar datahike-http-server-VERSION.jar --config path/to/config.edn
 ```
+
+The old positional `path/to/config.edn` form remains supported. Run with
+`--help` for all deployment overrides. Configuration precedence is explicit
+CLI flags, then `DATAHIKE_*` environment variables, then the EDN file. The
+supported environment variables are `DATAHIKE_PORT`, `DATAHIKE_HOST`,
+`DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`, and
+`DATAHIKE_AUTH_DB_PATH`. `DATAHIKE_TOKEN_FILE` reads the token from a Docker or
+Kubernetes secret mount without putting it in the process environment. CLI
+uses the corresponding `--port`, `--host`, `--token`, `--dev-mode`, `--level`,
+`--auth-db-path`, and `--token-file` options.
 
 The edn configuration file looks like:
 

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -1,0 +1,172 @@
+(ns datahike.http.config
+  "Standalone-server configuration from EDN, environment, and CLI.
+
+   The EDN file remains the complete configuration surface. Environment and
+   command-line options deliberately cover the small set operators need to
+   change at deployment time. Precedence is CLI > environment > file."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.tools.cli :refer [parse-opts]]))
+
+(defn- parse-port [value]
+  (let [port (parse-long value)]
+    (when-not (and port (<= 0 port 65535))
+      (throw (ex-info "must be an integer from 0 through 65535" {})))
+    port))
+
+(defn- parse-bool [value]
+  (case (str/lower-case value)
+    "true" true
+    "false" false
+    (throw (ex-info "must be true or false" {}))))
+
+(def ^:private levels #{:trace :debug :info :warn :error :fatal})
+
+(defn- parse-level [value]
+  (let [level (keyword (str/lower-case value))]
+    (when-not (levels level)
+      (throw (ex-info "must be trace, debug, info, warn, error, or fatal" {})))
+    level))
+
+(defn- non-blank [value]
+  (when (str/blank? value)
+    (throw (ex-info "must not be blank" {})))
+  value)
+
+(def ^:private settings
+  [{:key :port         :parse parse-port}
+   {:key :host         :parse non-blank}
+   {:key :token        :parse non-blank}
+   {:key :dev-mode     :parse parse-bool}
+   {:key :level        :parse parse-level}
+   ;; A deployment-friendly shorthand for the full
+   ;; {:auth-db {:store {:backend :file :path ...}}} EDN shape.
+   {:key :auth-db-path :parse non-blank}])
+
+(defn env-name
+  "The mechanical DATAHIKE_* name for a supported top-level config key."
+  [key]
+  (str "DATAHIKE_"
+       (-> key name str/upper-case (str/replace "-" "_"))))
+
+(def ^:private cli-options
+  [["-f" "--config FILE" "Base EDN configuration file"]
+   ["-p" "--port PORT" "HTTP port" :parse-fn parse-port]
+   ["-H" "--host HOST" "HTTP bind address" :parse-fn non-blank]
+   [nil "--token TOKEN" "Shared authentication token" :parse-fn non-blank]
+   [nil "--token-file FILE" "Read the shared token from FILE" :parse-fn non-blank]
+   [nil "--dev-mode BOOLEAN" "Enable or disable development authentication" :parse-fn parse-bool]
+   ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
+   [nil "--auth-db-path PATH" "File-backed permissions database path" :parse-fn non-blank]
+   ["-h" "--help" "Show this help"]
+   [nil "--version" "Show the Datahike version"]])
+
+(defn- read-token-file [path]
+  (try
+    (let [token (some-> (slurp (io/file path)) str/trim-newline not-empty)]
+      (or token
+          (throw (ex-info "Token file is empty"
+                          {:type :datahike.http/invalid-token-file :path path}))))
+    (catch clojure.lang.ExceptionInfo e
+      (throw e))
+    (catch Exception e
+      (throw (ex-info (str "Cannot read token file " path)
+                      {:type :datahike.http/invalid-token-file
+                       :path path
+                       :cause-class (.getName (class e))}
+                      e)))))
+
+(defn- token-from-layer [config token-file source]
+  (when (and (:token config) token-file)
+    (throw (ex-info (str source " sets both token and token-file")
+                    {:type :datahike.http/ambiguous-token-source
+                     :source source})))
+  (cond-> config
+    token-file (assoc :token (read-token-file token-file))))
+
+(defn- env-setting [env {:keys [key parse]}]
+  (when-some [value (get env (env-name key))]
+    [key (try
+           (parse value)
+           (catch Exception e
+             (throw (ex-info (str "Invalid " (env-name key))
+                             {:type :datahike.http/invalid-environment
+                              :variable (env-name key)
+                              :cause-class (.getName (class e))}
+                             e))))]))
+
+(defn env-config
+  "The supported server overrides present in environment map `env`."
+  [env]
+  (let [config (into {} (keep #(env-setting env %)) settings)]
+    (token-from-layer config (get env "DATAHIKE_TOKEN_FILE") "environment")))
+
+(defn- cli-config [options]
+  (let [config (select-keys options (map :key settings))]
+    (token-from-layer config (:token-file options) "command line")))
+
+(defn- file-config [path]
+  (if-not path
+    {}
+    (try
+      (let [config (edn/read-string (slurp (io/file path)))]
+        (when-not (map? config)
+          (throw (ex-info "Server config must be an EDN map" {})))
+        config)
+      (catch Exception e
+        ;; EDN reader messages can quote the malformed value. Do not copy one
+        ;; into startup logs: the same map commonly contains the bearer token.
+        (throw (ex-info (str "Cannot read server config file " path)
+                        {:type :datahike.http/invalid-config-file
+                         :path path
+                         :cause-class (.getName (class e))}
+                        e))))))
+
+(defn- normalize-shorthands [config]
+  (if (contains? config :auth-db-path)
+    (let [path (non-blank (:auth-db-path config))]
+      (-> config
+          (dissoc :auth-db-path)
+          (assoc-in [:auth-db :store :backend] :file)
+          (assoc-in [:auth-db :store :path] path)))
+    config))
+
+(defn usage [summary]
+  (str "Usage: java -jar datahike-http-server.jar [options] [config.edn]\n\n"
+       "Configuration precedence: command line > DATAHIKE_* environment > EDN file.\n\n"
+       summary))
+
+(defn resolve-config
+  "Parse `args` and resolve a server action. The two-argument form accepts an
+   environment map for tests and embedding launchers."
+  ([args] (resolve-config args (System/getenv)))
+  ([args env]
+   (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)
+         positional-file (first arguments)]
+     (cond
+       (:help options)
+       {:action :help :message (usage summary)}
+
+       (:version options)
+       {:action :version}
+
+       (seq errors)
+       (throw (ex-info (str "Invalid command line: " (str/join "; " errors))
+                       {:type :datahike.http/invalid-command-line}))
+
+       (> (count arguments) 1)
+       (throw (ex-info "Only one positional config file is allowed"
+                       {:type :datahike.http/invalid-command-line}))
+
+       (and (:config options) positional-file)
+       (throw (ex-info "Use either --config or a positional config file, not both"
+                       {:type :datahike.http/invalid-command-line}))
+
+       :else
+       (let [path   (or (:config options) positional-file)
+             config (-> (merge (file-config path)
+                               (env-config env)
+                               (cli-config options))
+                        normalize-shorthands)]
+         {:action :run :config config})))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -4,8 +4,8 @@
    eacl-backed permissions. Embedding hosts want `datahike.http.routes`."
   (:gen-class)
   (:require
-   [clojure.edn :as edn]
    [datahike.http.backends]
+   [datahike.http.config :as server-config]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
@@ -239,9 +239,18 @@
                        (swap! owned dissoc server)))))))))))
 
 (defn -main [& args]
-  (let [{:keys [level] :as config} (edn/read-string (slurp (first args)))]
-    (when (#{:trace :debug :info nil} level)
-      (println "Datahike HTTP Server" tools/datahike-version "- https://datahike.io"))
-    (log/info :datahike/http-server-config {:config (routes/redact config)})
-    (start-server config)
-    (log/info :datahike/http-server-started "Server started")))
+  (try
+    (let [{:keys [action message config]} (server-config/resolve-config args)]
+      (case action
+        :help (println message)
+        :version (println "Datahike HTTP Server" tools/datahike-version)
+        :run (let [{:keys [level]} config]
+               (when (#{:trace :debug :info nil} level)
+                 (println "Datahike HTTP Server" tools/datahike-version "- https://datahike.io"))
+               (log/info :datahike/http-server-config {:config (routes/redact config)})
+               (start-server config)
+               (log/info :datahike/http-server-started "Server started"))))
+    (catch Exception e
+      (binding [*out* *err*]
+        (println "Datahike HTTP Server:" (ex-message e)))
+      (System/exit 1))))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -1,0 +1,85 @@
+(ns datahike.test.http.config-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.http.config :as config]))
+
+(defn- temp-file [contents]
+  (doto (java.io.File/createTempFile "datahike-server-config-" ".edn")
+    (.deleteOnExit)
+    (spit contents)))
+
+(deftest environment-names-are-mechanical
+  (is (= "DATAHIKE_PORT" (config/env-name :port)))
+  (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
+  (is (= "DATAHIKE_AUTH_DB_PATH" (config/env-name :auth-db-path))))
+
+(deftest command-line-overrides-environment-overrides-file
+  (let [file (temp-file (pr-str {:port 1001
+                                 :host "file-host"
+                                 :token "file-token"
+                                 :dev-mode false
+                                 :level :info
+                                 :metrics false
+                                 :auth-db {:store {:backend :memory}}}))
+        env  {"DATAHIKE_PORT" "2002"
+              "DATAHIKE_HOST" "env-host"
+              "DATAHIKE_TOKEN" "env-token"
+              "DATAHIKE_DEV_MODE" "true"
+              "DATAHIKE_LEVEL" "warn"
+              "DATAHIKE_AUTH_DB_PATH" "/env/auth"}
+        args ["--config" (.getPath file)
+              "--port" "3003"
+              "--host" "cli-host"
+              "--token" "cli-token"
+              "--dev-mode" "false"
+              "--level" "error"
+              "--auth-db-path" "/cli/auth"]
+        resolved (:config (config/resolve-config args env))]
+    (is (= 3003 (:port resolved)))
+    (is (= "cli-host" (:host resolved)))
+    (is (= "cli-token" (:token resolved)))
+    (is (false? (:dev-mode resolved)))
+    (is (= :error (:level resolved)))
+    (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
+    (is (= {:backend :file :path "/cli/auth"}
+           (get-in resolved [:auth-db :store])))))
+
+(deftest positional-config-remains-backward-compatible
+  (let [file (temp-file "{:port 4444}")]
+    (is (= {:action :run :config {:port 4444}}
+           (config/resolve-config [(.getPath file)] {})))))
+
+(deftest token-files-are-secret-mount-friendly-and-layered
+  (let [env-token (temp-file "environment-secret\n")
+        cli-token (temp-file "cli-secret\r\n")]
+    (is (= "environment-secret"
+           (get-in (config/resolve-config [] {"DATAHIKE_TOKEN_FILE" (.getPath env-token)})
+                   [:config :token])))
+    (is (= "cli-secret"
+           (get-in (config/resolve-config ["--token-file" (.getPath cli-token)]
+                                          {"DATAHIKE_TOKEN" "environment-secret"})
+                   [:config :token]))
+        "a CLI token file overrides the environment layer")
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"both token and token-file"
+                          (config/resolve-config []
+                                                 {"DATAHIKE_TOKEN" "secret"
+                                                  "DATAHIKE_TOKEN_FILE" (.getPath env-token)})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"both token and token-file"
+                          (config/resolve-config ["--token" "secret"
+                                                  "--token-file" (.getPath cli-token)] {})))))
+
+(deftest invalid-input-fails-before-the-server-starts
+  (testing "typed environment and CLI values are strict"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_PORT"
+                          (config/resolve-config [] {"DATAHIKE_PORT" "not-a-port"})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid command line"
+                          (config/resolve-config ["--dev-mode" "perhaps"] {}))))
+  (testing "config parse errors never echo the possibly secret EDN value"
+    (let [secret "must-not-appear"
+          file   (temp-file (str "{:token \"" secret "\" :broken"))]
+      (try
+        (config/resolve-config [(.getPath file)] {})
+        (is false "malformed config must fail")
+        (catch Exception e
+          (is (not (re-find (re-pattern secret) (ex-message e))))))))
+  (is (= :help (:action (config/resolve-config ["--help"] {}))))
+  (is (= :version (:action (config/resolve-config ["--version"] {})))))


### PR DESCRIPTION
## Summary

- resolve standalone-server configuration with explicit CLI > DATAHIKE_* environment > EDN precedence
- add strict operator-facing CLI flags, backward-compatible positional config, and DATAHIKE_TOKEN_FILE secret mounts
- preserve EDN as the complete configuration surface and document the deployment contract

## Verification

- focused config tests: 15 tests, 60 assertions
- complete HTTP namespace selection: 96 tests, 1011 assertions
- bb reflection
- clojure -M:format
- bb http-server-uber
- packaged jar --help and --version exit 0
- packaged jar invalid port exits 1 before binding
- live packaged-jar smoke: CLI port 39091 overrode DATAHIKE_PORT=39090 and /version reported the resolved config

The known konserve-dynamodb HashMap reflection warning appears while loading bundled third-party backends; the Datahike reflection gate remains clean.