### PR TITLE
fix: replace environ runtime reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Runtime defaults no longer collect the entire process environment.**
+  Datahike replaced Environ with a small reader for the database defaults it
+  actually supports. Environment variables and JVM properties keep their
+  existing names and precedence, while unrelated settings (including secrets
+  and the colliding `JAVA_HOME` / `java.home` pair) are ignored rather than
+  merged or printed in an overwrite warning.
 - **`metrics` is cheap on a large database.** Per-attribute counts (and the
   AVET and history counts derived from them) come from the indices' subtree
   counts — one O(log n) `count-slice` per attribute — instead of a walk over

--- a/deps.edn
+++ b/deps.edn
@@ -69,7 +69,6 @@
         ;; writer, which is what caught it. replikativ/boring#18.
         org.replikativ/boring                       {:mvn/version "0.1.28"}
         is.simm/partial-cps                         {:mvn/version "0.1.60"}
-        environ/environ                             {:mvn/version "1.2.0"}
         nrepl/bencode                               {:mvn/version "1.2.0"}
         org.replikativ/logging                      {:mvn/version "0.1.3"}
         org.replikativ/metrics                      {:mvn/version "0.1.4"}

--- a/doc/config.md
+++ b/doc/config.md
@@ -4,7 +4,7 @@ Datahike is highly configurable to support different deployment models and use c
 
 ## Configuration Methods
 
-Datahike uses the [environ library](https://github.com/weavejester/environ) for configuration, supporting three methods:
+Datahike reads its supported runtime defaults from three sources:
 
 1. **Environment variables** (lowest priority)
 2. **Java system properties** (middle priority)
@@ -56,19 +56,27 @@ Datahike supports multiple storage backends via [konserve](https://github.com/re
 
 ### Environment Variable Configuration
 
-When using environment variables or Java system properties, name them like:
+The database-default environment variables and equivalent Java system properties
+read by this configuration layer are:
 
 properties                  | envvar
 ----------------------------|--------------------------
 datahike.store.backend      | DATAHIKE_STORE_BACKEND
-datahike.store.username     | DATAHIKE_STORE_USERNAME
+datahike.index              | DATAHIKE_INDEX
+datahike.initial.tx         | DATAHIKE_INITIAL_TX
 datahike.schema.flexibility | DATAHIKE_SCHEMA_FLEXIBILITY
 datahike.keep.history       | DATAHIKE_KEEP_HISTORY
 datahike.attribute.refs     | DATAHIKE_ATTRIBUTE_REFS
-datahike.name               | DATAHIKE_NAME
-etc.
+datahike.search.cache.size  | DATAHIKE_SEARCH_CACHE_SIZE
+datahike.store.cache.size   | DATAHIKE_STORE_CACHE_SIZE
+datahike.index.config       | DATAHIKE_INDEX_CONFIG
+datahike.max.db.caches      | DATAHIKE_MAX_DB_CACHES
+schema.meta.cache.size      | SCHEMA_META_CACHE_SIZE
+schema.write.cache.size     | SCHEMA_WRITE_CACHE_SIZE
 
-**Note**: Do not use `:` in keyword strings for environment variables—it will be added automatically.
+Only the settings listed above are collected; unrelated process environment and
+JVM properties are ignored. Do not use `:` in keyword strings for environment
+variables—it will be added automatically.
 
 ### Backend Configuration Examples
 
@@ -84,7 +92,6 @@ Ephemeral storage for testing and development:
 Environment variables:
 ```bash
 DATAHIKE_STORE_BACKEND=memory
-DATAHIKE_STORE_CONFIG='{:id #uuid "550e8400-e29b-41d4-a716-446655440021"}'
 ```
 
 #### File (Built-in)
@@ -99,7 +106,6 @@ Persistent local file storage:
 Environment variables:
 ```bash
 DATAHIKE_STORE_BACKEND=file
-DATAHIKE_STORE_CONFIG='{:path "/var/db/datahike"}'
 ```
 
 #### LMDB (External Library)

--- a/src/datahike/codegen/esm.clj
+++ b/src/datahike/codegen/esm.clj
@@ -7,8 +7,8 @@
   plus a default export of the full API object.
 
   Why ESM matters: the previous CJS wrapper (require/module.exports) causes
-  bundlers like Vite to inject a `require` shim, which tricks environ's
-  runtime detection into believing it's running in Node.js, leading to
+  bundlers like Vite to inject a `require` shim, which can trick runtime
+  environment detection into believing it's running in Node.js, leading to
   fileExistsSync errors in the browser. ESM avoids this entirely."
   (:require [datahike.api.specification :refer [api-specification]]
             [datahike.codegen.naming :refer [assert-unique-js-names!
@@ -39,7 +39,7 @@
                 "// DO NOT EDIT - Generated from datahike.api.specification"
                 "//"
                 "// Using ESM avoids CJS require() shims that confuse runtime environment"
-                "// detection (e.g. environ checking for `require` to detect Node.js)."
+                "// detection based on the presence of `require`."
                 ""
                 "import './datahike.js';"
                 ""

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -3,7 +3,7 @@
             [clojure.walk :refer [postwalk]]
             [clojure.string :as str]
             [clojure.spec.alpha :as s]
-            [environ.core :refer [env]]
+            [datahike.env :refer [env]]
             [datahike.tools :as dt]
             [datahike.store :as ds]
             [datahike.index :as di]

--- a/src/datahike/db/search.cljc
+++ b/src/datahike/db/search.cljc
@@ -9,7 +9,7 @@
    [datahike.index :as di]
    [datahike.lru :refer [lru-datom-cache-factory]]
    [datahike.tools :refer [match-vector]]
-   [environ.core :refer [env]]
+   [datahike.env :refer [env]]
    [replikativ.logging :as log])
   #?(:cljs (:require-macros [datahike.db.search :refer [lookup-strategy]]))
   #?(:clj (:import [datahike.datom Datom])))
@@ -328,5 +328,4 @@
                          :avet
                          (di/-slice (:avet db) from to :avet)
                          (di/-slice (:temporal-avet db) from to :avet))))
-
 

--- a/src/datahike/env.cljc
+++ b/src/datahike/env.cljc
@@ -1,0 +1,86 @@
+(ns ^:no-doc datahike.env
+  "Runtime defaults read from the finite environment surface Datahike uses.
+
+   Environment variables override legacy Leiningen/Boot files, and JVM system
+   properties override environment variables. Unrelated process settings are
+   discarded before merging, so their values cannot collide or leak."
+  (:require [clojure.string :as str]
+            #?(:clj [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])
+            #?(:clj [clojure.java.io :as io])
+            #?(:cljs [goog.object :as obj])))
+
+#?(:cljs
+   (do
+     (def ^:private nodejs? (exists? js/require))
+     (def ^:private ^js fs (when nodejs? (js/require "fs")))
+     (def ^:private ^js process (when nodejs? (js/require "process")))))
+
+(def ^:private supported-keys
+  #{:schema-meta-cache-size
+    :schema-write-cache-size
+    :datahike-store-backend
+    :datahike-index
+    :datahike-initial-tx
+    :datahike-keep-history
+    :datahike-attribute-refs
+    :datahike-schema-flexibility
+    :datahike-search-cache-size
+    :datahike-store-cache-size
+    :datahike-index-config
+    :datahike-max-db-caches})
+
+(defn normalize-key
+  "Normalize an environment or system-property key to Datahike's historical
+   keyword shape."
+  [key]
+  (-> key name str/lower-case (str/replace "_" "-") (str/replace "." "-") keyword))
+
+(defn- normalize-source [source]
+  (into {}
+        (keep (fn [[key value]]
+                (let [key (normalize-key key)]
+                  (when (contains? supported-keys key)
+                    [key (if (string? value) value (str value))]))))
+        source))
+
+(defn merge-sources
+  "Merge configuration sources in precedence order after discarding settings
+   Datahike never reads."
+  [& sources]
+  (apply merge (map normalize-source sources)))
+
+(defn- slurp-file [file]
+  #?(:clj (when file
+            (let [file (io/file file)]
+              (when (.exists file)
+                (slurp file))))
+     :cljs (when (and nodejs? file (.existsSync ^js fs file))
+             (str (.readFileSync ^js fs file)))))
+
+(defn- read-env-file [file]
+  (some-> file slurp-file edn/read-string))
+
+(defn- system-environment []
+  #?(:clj (System/getenv)
+     :cljs (if nodejs?
+             (zipmap (obj/getKeys (.-env ^js process))
+                     (obj/getValues (.-env ^js process)))
+             {})))
+
+#?(:clj
+   (defn- system-properties []
+     (into {} (System/getProperties))))
+
+(defn read-env []
+  #?(:clj (merge-sources
+           (read-env-file ".lein-env")
+           (read-env-file (io/resource ".boot-env"))
+           (system-environment)
+           (system-properties))
+     :cljs (if nodejs?
+             (merge-sources (read-env-file ".lein-env")
+                            (system-environment))
+             {})))
+
+(defonce env (read-env))

--- a/test/datahike/test/env_test.cljc
+++ b/test/datahike/test/env_test.cljc
@@ -1,0 +1,28 @@
+(ns datahike.test.env-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.env :as env]))
+
+(deftest keys-retain-the-historical-normalization
+  (is (= :datahike-store-backend (env/normalize-key "DATAHIKE_STORE_BACKEND")))
+  (is (= :datahike-store-backend (env/normalize-key "datahike.store.backend")))
+  (is (= :schema-meta-cache-size (env/normalize-key :schema_meta_cache_size))))
+
+(deftest only-datahike-settings-enter-the-runtime-map
+  (is (= {:datahike-store-backend "file"
+          :datahike-keep-history "false"
+          :schema-meta-cache-size "42"}
+         (env/merge-sources
+          {:datahike-store-backend :memory
+           :unrelated-secret "must-not-enter-the-map"
+           :schema-meta-cache-size 42}
+          {"DATAHIKE_STORE_BACKEND" "file"
+           "DATAHIKE_KEEP_HISTORY" "false"
+           "JAVA_HOME" "/environment/jdk"}
+          {"java.home" "/property/jdk"}))))
+
+(deftest later-sources-win
+  (is (= {:datahike-store-backend "system-property"}
+         (env/merge-sources
+          {"datahike.store.backend" "file"}
+          {"DATAHIKE_STORE_BACKEND" "environment"}
+          {"datahike.store.backend" "system-property"}))))


### PR DESCRIPTION
## Summary

- replace the direct Environ dependency with a small cross-platform runtime-default reader
- retain the existing setting names and source precedence while filtering to the finite set Datahike actually consumes
- prevent unrelated environment variables, JVM properties, and secrets from entering the runtime map or overwrite warnings
- document the exact supported database-default variables and remove examples for unsupported `DATAHIKE_STORE_CONFIG`
- update the stale Environ-specific ESM comments

This removes the `JAVA_HOME` / `java.home` collision that produced raw startup output in the standalone server. It also addresses the broader problem behind weavejester/environ#98: Environ's overwrite warning can print arbitrary values, including secrets. The independent upstream hardening is proposed in weavejester/environ#100 for other users; Datahike does not need to retain a dependency that eagerly collects configuration it never reads.

## Compatibility

The Datahike settings currently read through Environ keep their historical normalized names and precedence:

`.lein-env` < `.boot-env` < process environment < JVM system properties < explicit Datahike configuration

Node.js retains `.lein-env` < `process.env`; browser builds retain an empty runtime-default map. Unrelated keys were never part of Datahike's documented configuration contract and are now discarded.

## Verification

- `clojure -M:format`
- `bb jcompile`
- `bb kaocha --focus datahike.test.env-test --focus datahike.test.config-test` (42 tests, 153 assertions)
- `bb node-cljs-test` (advanced Node build: 310 files, 0 warnings; test process successful)
- `bb reflection` (no reflective calls)
- requiring `datahike.config` with the current `JAVA_HOME` emits no Environ warning
- `clojure -Stree -A:test` contains no Environ dependency
