### PR TITLE
feat: add production server logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **The standalone HTTP server owns production logging.** Its artifact now
+  configures Datahike and third-party SLF4J logs at one runtime level and sends
+  them to stdout. `:log-format :json`, `DATAHIKE_LOG_FORMAT=json`, or
+  `--log-format json` emits one structured JSON object per line; text remains
+  the default. Operators can explicitly take over appenders and destinations
+  with `-Dlogback.configurationFile=...`; the server never creates log files by
+  default.
 - **Runtime defaults no longer collect the entire process environment.**
   Datahike replaced Environ with a small reader for the database defaults it
   actually supports. Environment variables and JVM properties keep their

--- a/config.edn
+++ b/config.edn
@@ -24,7 +24,7 @@
                            :deps-file     "deps.edn"
                            :jar-pattern   "{{repo.lib}}-http-server-{{version-str}}.jar"
                            :aliases       [:http-server]
-                           :main          datahike.http.server
+                           :main          datahike.http.main
                            :lib           org.replikativ/datahike-http-server}
          ;; Used only on Windows, where native-image cannot take the classpath
          ;; on the command line (8191-char limit). Same shape as :native, but

--- a/deps.edn
+++ b/deps.edn
@@ -156,9 +156,11 @@
                                metosin/reitit                {:mvn/version "0.10.1"}
                                ring-cors/ring-cors           {:mvn/version "0.1.13"}
                                org.clojure/tools.cli         {:mvn/version "1.4.256"}
+                               ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
 
                                ;; secondary index integrations (for testing)
-                               org.replikativ/proximum       {:mvn/version "0.1.36"}
+                               org.replikativ/proximum       {:mvn/version "0.1.36"
+                                                               :exclusions [org.slf4j/slf4j-simple]}
                                org.replikativ/scriptum       {:mvn/version "0.1.30"}
                                org.replikativ/stratum        {:mvn/version "0.3.82"}
 
@@ -218,7 +220,7 @@
                                       ring-cors/ring-cors     {:mvn/version "0.1.13"}
                                       nrepl/bencode           {:mvn/version "1.2.0"}
                                       org.clojure/tools.cli   {:mvn/version "1.4.256"}
-                                      org.slf4j/slf4j-simple  {:mvn/version "2.0.18"}
+                                      ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
 
                                       ;; Batteries included for the standalone server. File,
                                       ;; memory and tiered ship with Konserve itself. GCS stays
@@ -237,7 +239,7 @@
                                       {:mvn/version "0.1.29"}
                                       org.postgresql/postgresql
                                       {:mvn/version "42.7.13"}}
-                         :main-opts ["-m" "datahike.http.server"]}
+                         :main-opts ["-m" "datahike.http.main"]}
 
            ;; konserve-s3 is here for the same reason it is in :native-cli, and it
            ;; is NOT optional: `datahike.cli` requires `konserve-s3.core`

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -308,22 +308,25 @@ The old positional `path/to/config.edn` form remains supported. Run with
 `--help` for all deployment overrides. Configuration precedence is explicit
 CLI flags, then `DATAHIKE_*` environment variables, then the EDN file. The
 supported environment variables are `DATAHIKE_PORT`, `DATAHIKE_HOST`,
-`DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`, and
-`DATAHIKE_AUTH_DB_PATH`. `DATAHIKE_TOKEN_FILE` reads the token from a Docker or
+`DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`,
+`DATAHIKE_LOG_FORMAT`, and `DATAHIKE_AUTH_DB_PATH`. Log format is `text` by
+default and accepts `json`. `DATAHIKE_TOKEN_FILE` reads the token from a Docker or
 Kubernetes secret mount without putting it in the process environment. CLI
 uses the corresponding `--port`, `--host`, `--token`, `--dev-mode`, `--level`,
-`--auth-db-path`, and `--token-file` options.
+`--log-format`, `--auth-db-path`, and `--token-file` options.
 
 The edn configuration file looks like:
 
 ```clojure
 {:port     4444
  :level    :debug
+ :log-format :json
  :dev-mode true
  :token    "securerandompassword"}
 ```
 
-Port sets the `port` to run the HTTP server under, `level` sets the log-level.
+Port sets the `port` to run the HTTP server under, `level` sets the log-level,
+and `log-format` selects human-readable `:text` or newline-delimited `:json`.
 `dev-mode` deactivates authentication during development and if `token` is
 provided then you need to send this token as the HTTP header "token" to
 authenticate.

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -298,7 +298,7 @@ The server is the same routes with Swagger UI at `/`, `/swagger.json`, CORS
 and Jetty around them:
 
 ```bash
-clojure -M:http-server -m datahike.http.server config.edn
+clojure -M:http-server --config config.edn
 ```
 
 ```clojure
@@ -307,7 +307,8 @@ clojure -M:http-server -m datahike.http.server config.edn
  :join?    false
  :token    "securerandompassword"
  :dev-mode false
- :level    :info}
+ :level    :info
+ :log-format :text}
 ```
 
 ### Prometheus metrics

--- a/doc/logging_and_error_handling.md
+++ b/doc/logging_and_error_handling.md
@@ -8,6 +8,37 @@ As a library, Datahike does not force any logging implementation on users. By de
 logs to stdout via its built-in console backend. Your application can replace this with any
 backend (Timbre, SLF4J, etc.) by calling `trove/set-log-fn!`.
 
+## Standalone HTTP server
+
+The standalone server artifact configures both Datahike and third-party logs. Its default is
+human-readable logs at `:info`, written only to stdout. Set `:level` in the server EDN file,
+`DATAHIKE_LEVEL`, or `--level`; normal server precedence applies. Set
+`DATAHIKE_LOG_FORMAT=json`, `:log-format :json`, or `--log-format json` for one JSON object per
+line. JSON Datahike events retain the event ID, source coordinates, message, structured data,
+and exception details.
+
+Container deployments should let the runtime collect stdout. The server never creates a log
+file by default. An operator who explicitly needs one can supply a Logback configuration with
+`-Dlogback.configurationFile=/etc/datahike/logback.xml`. An external configuration owns the
+appenders and layout; the resolved Datahike level still sets the root logger. Datahike events
+are routed through SLF4J in this mode so the custom appender receives the complete process log.
+For example:
+
+```xml
+<configuration>
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>/var/log/datahike/server.log</file>
+    <append>true</append>
+    <encoder>
+      <pattern>%date{ISO8601,UTC} %-5level [%thread] %logger %kvp - %msg%n%ex</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>
+```
+
 ## Structured Logging
 
 Every log call in Datahike uses a **namespaced keyword ID** as its first argument, following

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -29,6 +29,12 @@
       (throw (ex-info "must be trace, debug, info, warn, error, or fatal" {})))
     level))
 
+(defn- parse-log-format [value]
+  (case (str/lower-case value)
+    "text" :text
+    "json" :json
+    (throw (ex-info "must be text or json" {}))))
+
 (defn- non-blank [value]
   (when (str/blank? value)
     (throw (ex-info "must not be blank" {})))
@@ -40,6 +46,7 @@
    {:key :token        :parse non-blank}
    {:key :dev-mode     :parse parse-bool}
    {:key :level        :parse parse-level}
+   {:key :log-format   :parse parse-log-format}
    ;; A deployment-friendly shorthand for the full
    ;; {:auth-db {:store {:backend :file :path ...}}} EDN shape.
    {:key :auth-db-path :parse non-blank}])
@@ -58,6 +65,7 @@
    [nil "--token-file FILE" "Read the shared token from FILE" :parse-fn non-blank]
    [nil "--dev-mode BOOLEAN" "Enable or disable development authentication" :parse-fn parse-bool]
    ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
+   [nil "--log-format FORMAT" "Log format: text or json" :parse-fn parse-log-format]
    [nil "--auth-db-path PATH" "File-backed permissions database path" :parse-fn non-blank]
    ["-h" "--help" "Show this help"]
    [nil "--version" "Show the Datahike version"]])

--- a/http-server/datahike/http/logging.clj
+++ b/http-server/datahike/http/logging.clj
@@ -1,0 +1,208 @@
+(ns datahike.http.logging
+  "Process-wide logging for the standalone server artifact.
+
+   Datahike events arrive through Trove and dependency events through SLF4J.
+   Both are filtered at the configured level and written only to stdout."
+  (:require [clojure.string :as str]
+            [jsonista.core :as json]
+            [taoensso.trove :as trove]
+            [taoensso.trove.console :as trove-console])
+  (:import [ch.qos.logback.classic Level Logger LoggerContext PatternLayout]
+           [ch.qos.logback.classic.spi ILoggingEvent ThrowableProxyUtil]
+           [ch.qos.logback.core ConsoleAppender LayoutBase]
+           [ch.qos.logback.core.encoder LayoutWrappingEncoder]
+           [java.io PrintWriter StringWriter]
+           [java.time Instant]
+           [org.slf4j LoggerFactory]
+           [org.slf4j.event KeyValuePair]
+           [org.slf4j.spi LoggingEventBuilder]))
+
+(def ^:private level-rank
+  {:trace 10 :debug 20 :info 30 :warn 40 :error 50 :fatal 60 :report 70})
+
+(defn- enabled? [minimum level]
+  (>= (get level-rank level -1)
+      (get level-rank minimum (level-rank :info))))
+
+(defn- throwable-map [^Throwable error]
+  (let [writer (StringWriter.)]
+    (.printStackTrace error (PrintWriter. writer))
+    {:class (.getName (class error))
+     :message (.getMessage error)
+     :stack-trace (str writer)}))
+
+(declare json-safe)
+
+(defn- json-map [value]
+  (into {}
+        (map (fn [[key item]]
+               [(if (or (keyword? key) (string? key)) key (str key))
+                (json-safe item)]))
+        value))
+
+(defn- json-safe [value]
+  (cond
+    (nil? value) nil
+    (or (string? value) (number? value) (boolean? value)) value
+    (keyword? value) (subs (str value) 1)
+    (symbol? value) (str value)
+    (instance? Throwable value) (throwable-map value)
+    (map? value) (json-map value)
+    (set? value) (mapv json-safe value)
+    (sequential? value) (mapv json-safe value)
+    (and value (.isArray (class value))) (mapv json-safe (seq value))
+    :else (str value)))
+
+(defn- event-name [id]
+  (when id
+    (if (or (keyword? id) (symbol? id))
+      (subs (str id) 1)
+      (str id))))
+
+(defn trove-event-map
+  "Convert one forced Trove event to the standalone JSON schema. Public for
+   consumers that want to validate their log pipeline against the schema."
+  [namespace coords level id {:keys [msg data error]}]
+  (cond-> {:timestamp (str (Instant/now))
+           :level (name level)
+           :logger (str namespace)}
+    coords (assoc :source {:line (first coords) :column (second coords)})
+    id (assoc :event (event-name id))
+    msg (assoc :message msg)
+    (not-empty data) (assoc :data (json-safe data))
+    error (assoc :error (throwable-map error))))
+
+(def ^:private stdout-lock (Object.))
+
+(defn json-log-fn [minimum]
+  (fn [namespace coords level id lazy-event]
+    (when (enabled? minimum level)
+      (let [line (json/write-value-as-string
+                  (trove-event-map namespace coords level id (force lazy-event)))]
+        (locking stdout-lock
+          (println line)
+          (flush))))))
+
+(defn- slf4j-event-map [^ILoggingEvent event]
+  (let [throwable (.getThrowableProxy event)
+        key-values (not-empty
+                    (into {}
+                          (map (fn [^KeyValuePair pair]
+                                 [(.-key pair) (json-safe (.-value pair))]))
+                          (.getKeyValuePairs event)))]
+    (cond-> {:timestamp (str (.getInstant event))
+             :level (str/lower-case (str (.getLevel event)))
+             :logger (.getLoggerName event)
+             :thread (.getThreadName event)
+             :message (.getFormattedMessage event)}
+      (not-empty (.getMDCPropertyMap event))
+      (assoc :mdc (.getMDCPropertyMap event))
+
+      key-values
+      (assoc :data key-values)
+
+      throwable
+      (assoc :error {:class (.getClassName throwable)
+                     :message (.getMessage throwable)
+                     :stack-trace (ThrowableProxyUtil/asString throwable)}))))
+
+(defn- json-layout []
+  (proxy [LayoutBase] []
+    (doLayout [event]
+      (str (json/write-value-as-string (slf4j-event-map event)) "\n"))))
+
+(defn- text-layout []
+  (doto (PatternLayout.)
+    (.setPattern "%date{ISO8601,UTC} %-5level [%thread] %logger - %msg%n%ex")))
+
+(defn- logback-level [level]
+  (case level
+    :trace Level/TRACE
+    :debug Level/DEBUG
+    :info Level/INFO
+    :warn Level/WARN
+    :error Level/ERROR
+    :fatal Level/ERROR
+    :report Level/ERROR
+    Level/INFO))
+
+(defn- external-logback-config? []
+  (some? (System/getProperty "logback.configurationFile")))
+
+(defn- configure-logback! [level format]
+  (let [factory (LoggerFactory/getILoggerFactory)]
+    (when-not (instance? LoggerContext factory)
+      (throw (ex-info "The standalone server requires its bundled Logback provider"
+                      {:type :datahike.http/invalid-logging-provider
+                       :provider (.getName (class factory))})))
+    (let [^LoggerContext context factory
+          ^Logger root (.getLogger context Logger/ROOT_LOGGER_NAME)]
+      (if (external-logback-config?)
+        (.setLevel root (logback-level level))
+        (let [^LayoutBase layout (if (= :json format) (json-layout) (text-layout))
+              encoder (doto (LayoutWrappingEncoder.)
+                        (.setContext context)
+                        (.setLayout layout))
+              appender (doto (ConsoleAppender.)
+                         (.setContext context)
+                         (.setName "stdout")
+                         (.setTarget "System.out")
+                         (.setEncoder encoder))]
+          (.reset context)
+          (.setContext layout context)
+          (.start layout)
+          (.start encoder)
+          (.start appender)
+          (.setLevel root (logback-level level))
+          (.addAppender root appender))))))
+
+(defn- slf4j-log-fn [namespace coords level id lazy-event]
+  (let [logger (LoggerFactory/getLogger ^String (str namespace))
+        ^LoggingEventBuilder builder
+        (case level
+          :trace (when (.isTraceEnabled logger) (.atTrace logger))
+          :debug (when (.isDebugEnabled logger) (.atDebug logger))
+          :info (when (.isInfoEnabled logger) (.atInfo logger))
+          :warn (when (.isWarnEnabled logger) (.atWarn logger))
+          :error (when (.isErrorEnabled logger) (.atError logger))
+          :fatal (when (.isErrorEnabled logger) (.atError logger))
+          :report (.atInfo logger)
+          nil)]
+    (when builder
+      (let [{:keys [msg data error]} (force lazy-event)]
+        (when id (.addKeyValue builder "event" (event-name id)))
+        (when coords (.addKeyValue builder "source" (str coords)))
+        (doseq [[key value] data]
+          (.addKeyValue builder (if (keyword? key) (name key) (str key)) (str value)))
+        (when msg (.setMessage builder ^String (str msg)))
+        (when error (.setCause builder error))
+        (.log builder)))))
+
+(defn configure!
+  "Configure Datahike and dependency logging for the standalone process."
+  [{:keys [level log-format] :or {level :info log-format :text}}]
+  (when-not (contains? level-rank level)
+    (throw (ex-info "Log level must be trace, debug, info, warn, error, or fatal"
+                    {:type :datahike.http/invalid-log-level})))
+  (when-not (#{:text :json} log-format)
+    (throw (ex-info "Log format must be text or json"
+                    {:type :datahike.http/invalid-log-format})))
+  (trove/set-log-fn!
+   (cond
+     (external-logback-config?) slf4j-log-fn
+     (= :json log-format) (json-log-fn level)
+     :else (trove-console/get-log-fn {:min-level level})))
+  (configure-logback! level log-format)
+  {:level level :log-format log-format})
+
+(defn- bootstrap-config []
+  ;; Invalid values are reported later by config/resolve-config inside -main's
+  ;; error boundary. Bootstrap only prevents early dependency logs from going
+  ;; to stderr or using the wrong layout.
+  (let [env (System/getenv)
+        level (some-> (get env "DATAHIKE_LEVEL") str/lower-case keyword)
+        format (some-> (get env "DATAHIKE_LOG_FORMAT") str/lower-case keyword)]
+    {:level (if (contains? level-rank level) level :info)
+     :log-format (if (#{:text :json} format) format :text)}))
+
+(configure! (bootstrap-config))

--- a/http-server/datahike/http/main.clj
+++ b/http-server/datahike/http/main.clj
@@ -1,0 +1,29 @@
+(ns datahike.http.main
+  "Lightweight entry point for the standalone server artifact. Configuration
+  and logging are resolved before database backends or the HTTP adapter load."
+  (:gen-class)
+  (:require [datahike.http.config :as config]
+            [datahike.http.logging :as logging]
+            [datahike.tools :as tools]
+            [replikativ.logging :as log]))
+
+(defn- start! [server-config]
+  ;; Loading the implementation registers bundled Konserve backends and loads
+  ;; the HTTP adapter. Do it only after the chosen layout owns process logging.
+  (require 'datahike.http.server)
+  ((requiring-resolve 'datahike.http.server/start-main!) server-config))
+
+(defn -main [& args]
+  (try
+    (let [{:keys [action message config]} (config/resolve-config args)]
+      (case action
+        :help (println message)
+        :version (println "Datahike HTTP Server" tools/datahike-version)
+        :run (do
+               (logging/configure! config)
+               (start! config))))
+    (catch Exception e
+      (log/error :datahike/http-server-start-failed
+                 (ex-message e)
+                 {:error-class (.getName (class e))})
+      (System/exit 1))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -2,10 +2,8 @@
   "HTTP server implementation for Datahike: `datahike.http.routes/handler`
    behind Jetty, with swagger-ui at `/`, CORS, and — given an `:auth-db` —
    eacl-backed permissions. Embedding hosts want `datahike.http.routes`."
-  (:gen-class)
   (:require
    [datahike.http.backends]
-   [datahike.http.config :as server-config]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
@@ -238,19 +236,11 @@
                      (finally
                        (swap! owned dissoc server)))))))))))
 
-(defn -main [& args]
-  (try
-    (let [{:keys [action message config]} (server-config/resolve-config args)]
-      (case action
-        :help (println message)
-        :version (println "Datahike HTTP Server" tools/datahike-version)
-        :run (let [{:keys [level]} config]
-               (when (#{:trace :debug :info nil} level)
-                 (println "Datahike HTTP Server" tools/datahike-version "- https://datahike.io"))
-               (log/info :datahike/http-server-config {:config (routes/redact config)})
-               (start-server config)
-               (log/info :datahike/http-server-started "Server started"))))
-    (catch Exception e
-      (binding [*out* *err*]
-        (println "Datahike HTTP Server:" (ex-message e)))
-      (System/exit 1))))
+(defn start-main!
+  "Start the standalone server after its lightweight launcher has configured
+   process logging. Kept separate so config and logging load before backends."
+  [config]
+  (log/info :datahike/http-server-starting {:version tools/datahike-version})
+  (log/info :datahike/http-server-config {:config (routes/redact config)})
+  (start-server config)
+  (log/info :datahike/http-server-started "Server started"))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -10,6 +10,7 @@
 (deftest environment-names-are-mechanical
   (is (= "DATAHIKE_PORT" (config/env-name :port)))
   (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
+  (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
   (is (= "DATAHIKE_AUTH_DB_PATH" (config/env-name :auth-db-path))))
 
 (deftest command-line-overrides-environment-overrides-file
@@ -25,6 +26,7 @@
               "DATAHIKE_TOKEN" "env-token"
               "DATAHIKE_DEV_MODE" "true"
               "DATAHIKE_LEVEL" "warn"
+              "DATAHIKE_LOG_FORMAT" "text"
               "DATAHIKE_AUTH_DB_PATH" "/env/auth"}
         args ["--config" (.getPath file)
               "--port" "3003"
@@ -32,6 +34,7 @@
               "--token" "cli-token"
               "--dev-mode" "false"
               "--level" "error"
+              "--log-format" "json"
               "--auth-db-path" "/cli/auth"]
         resolved (:config (config/resolve-config args env))]
     (is (= 3003 (:port resolved)))
@@ -39,6 +42,7 @@
     (is (= "cli-token" (:token resolved)))
     (is (false? (:dev-mode resolved)))
     (is (= :error (:level resolved)))
+    (is (= :json (:log-format resolved)))
     (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
     (is (= {:backend :file :path "/cli/auth"}
            (get-in resolved [:auth-db :store])))))
@@ -72,7 +76,9 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_PORT"
                           (config/resolve-config [] {"DATAHIKE_PORT" "not-a-port"})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid command line"
-                          (config/resolve-config ["--dev-mode" "perhaps"] {}))))
+                          (config/resolve-config ["--dev-mode" "perhaps"] {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_LOG_FORMAT"
+                          (config/resolve-config [] {"DATAHIKE_LOG_FORMAT" "xml"}))))
   (testing "config parse errors never echo the possibly secret EDN value"
     (let [secret "must-not-appear"
           file   (temp-file (str "{:token \"" secret "\" :broken"))]

--- a/test/datahike/test/http/logging_test.clj
+++ b/test/datahike/test/http/logging_test.clj
@@ -1,0 +1,45 @@
+(ns datahike.test.http.logging-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.http.logging :as logging]
+            [jsonista.core :as json]))
+
+(deftest structured-events-have-a-stable-json-shape
+  (let [event (logging/trove-event-map
+               "datahike.http.server" [12 7] :warn
+               :datahike/test-event
+               {:msg "something happened"
+                :data {:backend :memory}
+                :error (ex-info "boom" {:secret "not-in-message"})})]
+    (is (string? (:timestamp event)))
+    (is (= "warn" (:level event)))
+    (is (= "datahike.http.server" (:logger event)))
+    (is (= {:line 12 :column 7} (:source event)))
+    (is (= "datahike/test-event" (:event event)))
+    (is (= "something happened" (:message event)))
+    (is (= {:backend "memory"} (:data event)))
+    (is (= "clojure.lang.ExceptionInfo" (get-in event [:error :class])))
+    (is (= "boom" (get-in event [:error :message])))
+    (is (string? (get-in event [:error :stack-trace])))))
+
+(deftest json-logger-filters-before-forcing-and-writes-one-line
+  (let [forced? (atom false)
+        logger (logging/json-log-fn :warn)]
+    (is (= "" (with-out-str
+                (logger "test" nil :info :datahike/hidden
+                        (delay (reset! forced? true))))))
+    (is (false? @forced?) "filtered events retain Trove's lazy fast path")
+    (let [output (with-out-str
+                   (logger "test" nil :warn :datahike/visible
+                           (delay {:data {:value 1}})))
+          decoded (json/read-value output)]
+      (is (= "warn" (get decoded "level")))
+      (is (= "datahike/visible" (get decoded "event")))
+      (is (= 1 (get-in decoded ["data" "value"])))
+      (is (= 1 (count (filter #{\newline} output)))))))
+
+(deftest logging-configuration-is-strict
+  (testing "bad file values fail even though env and CLI are parsed earlier"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Log level"
+                          (logging/configure! {:level :verbose})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Log format"
+                          (logging/configure! {:log-format :xml})))))


### PR DESCRIPTION
## Summary

- give the standalone server artifact one logging owner for both Datahike/Trove and third-party SLF4J events
- replace the server's `slf4j-simple` provider with Logback and route default output exclusively to stdout
- add runtime `text` (default) and newline-delimited `json` layouts through EDN, `DATAHIKE_LOG_FORMAT`, and `--log-format`
- apply the resolved `:level` consistently to Datahike and dependency logs
- honor `-Dlogback.configurationFile=...` for operators who explicitly need custom appenders or file output
- introduce a lightweight launcher so logging is configured before bundled backends and Jetty load
- turn startup failures into normal structured log events without attaching potentially secret parser causes

This is stacked on #1039, which removes Environ's raw startup warning. Once #1039 is squash-merged, its patch disappears from this PR's diff; the logging change itself is commit `a205317d`.

## Behavior

Default:

```edn
{:level :info
 :log-format :text}
```

Container JSON:

```bash
DATAHIKE_LEVEL=info DATAHIKE_LOG_FORMAT=json java -jar datahike-http-server.jar --config config.edn
```

Every JSON record includes timestamp, level, and logger. Datahike records retain event ID, coordinates, message, structured data, and exception details; dependency records retain thread, MDC/key-value data, and exceptions. Help and version remain plain command output.

## Verification

- formatting and diff checks pass
- focused config/logging tests: 8 tests, 41 assertions
- HTTP routes/server/permissions/config/logging suites: 57 tests, 873 assertions
- remote CBOR suite: 18 tests, 102 assertions
- `bb reflection`: clean for core sources
- explicit reflection compile of the new HTTP namespaces: clean
- `bb http-server-uber`: successful; manifest main class is `datahike.http.main`
- packaged-jar smoke: all startup lines were valid JSON, third-party c3p0 and Jetty output used the same layout, `/health/live` returned `live`
- invalid startup configuration produced one structured error and exit 1
- external Logback smoke routed the Datahike startup error through a custom file appender with event and structured error-class fields
- resolved `:http-server` dependency tree contains Logback as the sole SLF4J provider and no Environ dependency
