### PR TITLE
fix: refuse unauthenticated public server binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **The standalone server refuses accidental public exposure.** An
+  unauthenticated server may bind only to a host whose resolved addresses are
+  all loopback. Wildcard, missing, and non-loopback hosts require a nonblank
+  `:token` or a custom `:validator`; `:dev-mode true` and `:auth :upstream` do
+  not count because they do not authenticate requests in the standalone
+  process.
 - **The standalone HTTP server owns production logging.** Its artifact now
   configures Datahike and third-party SLF4J logs at one runtime level and sends
   them to stdout. `:log-format :json`, `DATAHIKE_LOG_FORMAT=json`, or

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -319,6 +319,7 @@ The edn configuration file looks like:
 
 ```clojure
 {:port     4444
+ :host     "127.0.0.1"
  :level    :debug
  :log-format :json
  :dev-mode true
@@ -330,6 +331,12 @@ and `log-format` selects human-readable `:text` or newline-delimited `:json`.
 `dev-mode` deactivates authentication during development and if `token` is
 provided then you need to send this token as the HTTP header "token" to
 authenticate.
+
+The standalone server refuses to bind a wildcard or non-loopback address
+without effective authentication. Configure a nonblank `:token` or a custom
+`:validator`, or use an explicit loopback host such as `:host "127.0.0.1"` for
+unauthenticated local development. `:dev-mode true` bypasses authentication and
+therefore never permits a public bind, even if a token is also present.
 
 The server exports a swagger interface on the port and can serialize requests in
 `transit-json`, `edn` and `JSON` with

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -292,6 +292,12 @@ Checklist: a token or validator set · `:dev-mode` false · secrets in
 env/secret store · TLS at the edge · `release-all!` on shutdown · `delete`
 granted only to owners who may.
 
+The standalone server enforces the first two items at bind time: without a
+nonblank token or a validator, every resolved bind address must be loopback.
+Missing and wildcard hosts count as public. `:auth :upstream` is valid only for
+an embedded handler behind authentication middleware and does not authorize a
+standalone public bind.
+
 ## Running the standalone server
 
 The server is the same routes with Swagger UI at `/`, `/swagger.json`, CORS

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -7,7 +7,8 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.tools.cli :refer [parse-opts]]))
+            [clojure.tools.cli :refer [parse-opts]])
+  (:import [java.net InetAddress]))
 
 (defn- parse-port [value]
   (let [port (parse-long value)]
@@ -60,7 +61,7 @@
 (def ^:private cli-options
   [["-f" "--config FILE" "Base EDN configuration file"]
    ["-p" "--port PORT" "HTTP port" :parse-fn parse-port]
-   ["-H" "--host HOST" "HTTP bind address" :parse-fn non-blank]
+   ["-H" "--host HOST" "HTTP bind address (unauthenticated must be loopback)" :parse-fn non-blank]
    [nil "--token TOKEN" "Shared authentication token" :parse-fn non-blank]
    [nil "--token-file FILE" "Read the shared token from FILE" :parse-fn non-blank]
    [nil "--dev-mode BOOLEAN" "Enable or disable development authentication" :parse-fn parse-bool]
@@ -139,6 +140,49 @@
           (assoc-in [:auth-db :store :backend] :file)
           (assoc-in [:auth-db :store :path] path)))
     config))
+
+(defn- loopback-addresses [host]
+  (when (and (string? host) (not (str/blank? host)))
+    (try
+      (let [addresses (seq (InetAddress/getAllByName host))]
+        (when (and addresses
+                   (every? #(.isLoopbackAddress ^InetAddress %) addresses))
+          addresses))
+      (catch Exception _
+        nil))))
+
+(defn loopback-host?
+  "True when every address `host` resolves to is a loopback address. A missing,
+   wildcard, unknown, or partly non-loopback host is not safe for an
+   unauthenticated standalone server."
+  [host]
+  (boolean (loopback-addresses host)))
+
+(defn- configured-authentication?
+  [{:keys [dev-mode auth token validator]}]
+  ;; Dev mode and upstream auth precede the token/validator chain and admit
+  ;; requests themselves, so credentials beside either bypass do not make the
+  ;; effective standalone config safe.
+  (and (not dev-mode)
+       (not= :upstream auth)
+       (or (and (string? token) (not (str/blank? token)))
+           (ifn? validator))))
+
+(defn assert-safe-bind!
+  "Refuse to expose the standalone server without effective authentication.
+   An unauthenticated loopback hostname is pinned to the numeric address that
+   was checked, so the HTTP adapter does not perform a second DNS resolution.
+   Returns the validated config."
+  [{:keys [host] :as config}]
+  (if (configured-authentication? config)
+    config
+    (if-let [addresses (loopback-addresses host)]
+      (assoc config :host (.getHostAddress ^InetAddress (first addresses)))
+      (throw (ex-info
+              (str "Refusing unauthenticated HTTP bind to " (pr-str host)
+                   "; configure a nonblank :token or :validator, or set :host to a loopback address")
+              {:type :datahike.http/unsafe-bind
+               :host host})))))
 
 (defn usage [summary]
   (str "Usage: java -jar datahike-http-server.jar [options] [config.edn]\n\n"

--- a/http-server/datahike/http/main.clj
+++ b/http-server/datahike/http/main.clj
@@ -21,7 +21,7 @@
         :version (println "Datahike HTTP Server" tools/datahike-version)
         :run (do
                (logging/configure! config)
-               (start! config))))
+               (start! (config/assert-safe-bind! config)))))
     (catch Exception e
       (log/error :datahike/http-server-start-failed
                  (ex-message e)

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -4,6 +4,7 @@
    eacl-backed permissions. Embedding hosts want `datahike.http.routes`."
   (:require
    [datahike.http.backends]
+   [datahike.http.config :as server-config]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
@@ -202,7 +203,8 @@
   "Start Jetty and acquire the standalone server's shared Konserve metric sink
    unless `:metrics` is false. `stop-server` releases both."
   [config]
-  (let [connections (atom {})
+  (let [config      (server-config/assert-safe-bind! config)
+        connections (atom {})
         app         (app config connections)
         config      (::config (meta app))
         metrics-lease (when-not (false? (:metrics config))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -13,6 +13,38 @@
   (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
   (is (= "DATAHIKE_AUTH_DB_PATH" (config/env-name :auth-db-path))))
 
+(deftest standalone-bind-safety
+  (testing "literal and named loopback hosts need no authentication"
+    (doseq [host ["127.0.0.1" "127.23.4.5" "::1" "localhost"]]
+      (is (config/loopback-host? host) host)
+      (let [validated (config/assert-safe-bind! {:host host :port 4444})]
+        (is (= 4444 (:port validated)) host)
+        (is (config/loopback-host? (:host validated)) host))))
+  (testing "wildcard and non-loopback binds require effective authentication"
+    (doseq [host [nil "0.0.0.0" "::" "192.0.2.1"]]
+      (let [error (try
+                    (config/assert-safe-bind! {:host host})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (= :datahike.http/unsafe-bind (:type (ex-data error))) (pr-str host))
+        (is (= host (:host (ex-data error))) (pr-str host)))))
+  (testing "a token or custom validator protects a remote bind"
+    (is (= "0.0.0.0"
+           (:host (config/assert-safe-bind! {:host "0.0.0.0" :token "secret"}))))
+    (is (= "0.0.0.0"
+           (:host (config/assert-safe-bind! {:host "0.0.0.0"
+                                             :validator (constantly {:sub "user"})})))))
+  (testing "authentication bypasses do not make a public bind safe"
+    (doseq [unsafe [{:host "0.0.0.0" :token "secret" :dev-mode true}
+                    {:host "0.0.0.0" :validator identity :dev-mode true}
+                    {:host "0.0.0.0" :auth :upstream}
+                    {:host "0.0.0.0" :auth :upstream :token "secret"}
+                    {:host "0.0.0.0" :auth :upstream :validator identity}
+                    {:host "0.0.0.0" :token ""}]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing unauthenticated HTTP bind"
+                            (config/assert-safe-bind! unsafe))
+          (pr-str unsafe)))))
+
 (deftest command-line-overrides-environment-overrides-file
   (let [file (temp-file (pr-str {:port 1001
                                  :host "file-host"

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -100,6 +100,16 @@
       (finally
         (stop-server server)))))
 
+(deftest unsafe-bind-is-refused-before-jetty
+  ;; The invalid port makes this safe even if the guard regresses: Jetty cannot
+  ;; leave a listening server behind. The asserted error type proves the bind
+  ;; guard, rather than Jetty's validation, ran first.
+  (let [error (try
+                (start-server {:host "0.0.0.0" :port -1 :join? false})
+                nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (= :datahike.http/unsafe-bind (:type (ex-data error))))))
+
 (deftest test-server
   (testing "Test transit binding."
     (let [port 23189]
@@ -167,13 +177,14 @@
   (testing "Dev-mode overrides password authentication."
     (let [port   23195
           server (start-server {:port     port
+                                :host     "127.0.0.1"
                                 :join?    false
                                 :dev-mode true
                                 :token    "securerandompassword"})
           cfg {:store {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000004"}
                :schema-flexibility :read
                :remote-peer        {:backend :datahike-server
-                                    :url    (str "http://localhost:" port)
+                                    :url    (str "http://127.0.0.1:" port)
                                     :token  "wrong"
                                     :format :edn}}]
       (try
@@ -187,11 +198,12 @@
   (testing "Direct JSON interaction"
     (let [port   23196
           server (start-server {:port     port
+                                :host     "127.0.0.1"
                                 :join?    false
                                 :dev-mode true
                                 :token    "securerandompassword"})
           remote {:backend :datahike-server
-                  :url     (str "http://localhost:" port)
+                  :url     (str "http://127.0.0.1:" port)
                   :token   "securerandompassword"
                   :format  :json}
           _ (try (api/request-json-raw :post "delete-database" remote


### PR DESCRIPTION
## Summary

- refuse wildcard, missing, unknown, and non-loopback standalone binds unless effective authentication is configured
- treat dev mode and upstream auth as authentication bypasses, even when a token or validator is also present
- resolve unauthenticated loopback hostnames once and pin Jetty to the checked numeric address
- apply the guard both in the CLI launcher and direct standalone server startup, with docs and regression coverage

## Verification

- `bb kaocha --focus datahike.test.http.config-test --focus datahike.test.http.server-test --focus datahike.test.http.health-test --focus datahike.test.http.metrics-test --focus datahike.test.http.writer-test` — 75 tests, 624 assertions
- `bb reflection` — no reflective calls in Datahike sources
- `bb http-server-uber`
- packaged JAR rejects unauthenticated `0.0.0.0` before Jetty starts
- packaged JAR pins `localhost` to `127.0.0.1` and serves `/health/live`