### PR TITLE
fix: gracefully stop the standalone server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **The standalone server drains work on shutdown.** SIGTERM stops new accepts,
+  waits up to 30 seconds for in-flight HTTP operations, then releases database
+  connections, permissions state, and metrics ownership exactly once. The
+  grace period is configurable with `:shutdown-timeout-ms`,
+  `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, or `--shutdown-timeout-ms`.
 - **The standalone server refuses accidental public exposure.** An
   unauthenticated server may bind only to a host whose resolved addresses are
   all loopback. Wildcard, missing, and non-loopback hosts require a nonblank

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -309,11 +309,12 @@ The old positional `path/to/config.edn` form remains supported. Run with
 CLI flags, then `DATAHIKE_*` environment variables, then the EDN file. The
 supported environment variables are `DATAHIKE_PORT`, `DATAHIKE_HOST`,
 `DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`,
-`DATAHIKE_LOG_FORMAT`, and `DATAHIKE_AUTH_DB_PATH`. Log format is `text` by
-default and accepts `json`. `DATAHIKE_TOKEN_FILE` reads the token from a Docker or
-Kubernetes secret mount without putting it in the process environment. CLI
-uses the corresponding `--port`, `--host`, `--token`, `--dev-mode`, `--level`,
-`--log-format`, `--auth-db-path`, and `--token-file` options.
+`DATAHIKE_LOG_FORMAT`, `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, and
+`DATAHIKE_AUTH_DB_PATH`. Log format is `text` by default and accepts `json`.
+`DATAHIKE_TOKEN_FILE` reads the token from a Docker or Kubernetes secret mount
+without putting it in the process environment. CLI uses the corresponding
+`--port`, `--host`, `--token`, `--dev-mode`, `--level`, `--log-format`,
+`--shutdown-timeout-ms`, `--auth-db-path`, and `--token-file` options.
 
 The edn configuration file looks like:
 
@@ -322,6 +323,7 @@ The edn configuration file looks like:
  :host     "127.0.0.1"
  :level    :debug
  :log-format :json
+ :shutdown-timeout-ms 30000
  :dev-mode true
  :token    "securerandompassword"}
 ```
@@ -337,6 +339,14 @@ without effective authentication. Configure a nonblank `:token` or a custom
 `:validator`, or use an explicit loopback host such as `:host "127.0.0.1"` for
 unauthenticated local development. `:dev-mode true` bypasses authentication and
 therefore never permits a public bind, even if a token is also present.
+
+On SIGTERM or normal JVM shutdown, the standalone launcher first stops
+accepting requests, waits up to `:shutdown-timeout-ms` (30 seconds by default)
+for active requests and transactions, and then releases its database
+connections, permissions database, and metrics lease. Set the timeout to zero
+only when an immediate stop is preferable to draining work. Container stop
+grace periods must be longer than this value so the JVM is not killed while it
+is still draining.
 
 The server exports a swagger interface on the port and can serialize requests in
 `transit-json`, `edn` and `JSON` with

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -346,6 +346,21 @@ exports Datahike, connection, and JVM metrics. An embedding host that wants
 Konserve metrics can register `replikativ.metrics.konserve/sink` with
 `konserve.metrics/add-sink!` under its own id and remove it during shutdown.
 
+### Graceful shutdown
+
+The standalone launcher installs a JVM shutdown hook. On SIGTERM it stops
+Jetty from accepting new requests, gives active handlers up to 30 seconds to
+finish, and only then releases Datahike connections, the permissions database,
+and the process metrics lease. Configure the grace period with
+`:shutdown-timeout-ms`, `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, or
+`--shutdown-timeout-ms`; zero requests an immediate stop. Set an orchestrator's
+termination grace period above the server timeout.
+
+Calling `stop-server` provides the same ordered drain for programmatic server
+instances and is idempotent with respect to Datahike-owned resources. An
+embedding host using `datahike.http.routes/handler` still owns its HTTP and JVM
+shutdown lifecycle and should call `release-all!` after its adapter drains.
+
 ### Health checks
 
 The server exposes two unauthenticated, plain-text health endpoints for

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -16,6 +16,12 @@
       (throw (ex-info "must be an integer from 0 through 65535" {})))
     port))
 
+(defn- parse-nonnegative-long [value]
+  (let [number (parse-long value)]
+    (when-not (and number (<= 0 number))
+      (throw (ex-info "must be a nonnegative integer" {})))
+    number))
+
 (defn- parse-bool [value]
   (case (str/lower-case value)
     "true" true
@@ -46,6 +52,7 @@
    {:key :host         :parse non-blank}
    {:key :token        :parse non-blank}
    {:key :dev-mode     :parse parse-bool}
+   {:key :shutdown-timeout-ms :parse parse-nonnegative-long}
    {:key :level        :parse parse-level}
    {:key :log-format   :parse parse-log-format}
    ;; A deployment-friendly shorthand for the full
@@ -65,6 +72,7 @@
    [nil "--token TOKEN" "Shared authentication token" :parse-fn non-blank]
    [nil "--token-file FILE" "Read the shared token from FILE" :parse-fn non-blank]
    [nil "--dev-mode BOOLEAN" "Enable or disable development authentication" :parse-fn parse-bool]
+   [nil "--shutdown-timeout-ms MILLIS" "Grace period for in-flight requests" :parse-fn parse-nonnegative-long]
    ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
    [nil "--log-format FORMAT" "Log format: text or json" :parse-fn parse-log-format]
    [nil "--auth-db-path PATH" "File-backed permissions database path" :parse-fn non-blank]

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -31,6 +31,8 @@
 
 (def ^:private readiness-probe-key ::readiness-probe)
 
+(def ^:private default-shutdown-timeout-ms 30000)
+
 (defn- text-response [status body]
   {:status  status
    :headers {"content-type" plain-text-content-type}
@@ -199,17 +201,39 @@
         (konserve-metrics/remove-sink! metrics-sink-id))))
   nil)
 
+(defn- shutdown-timeout
+  [{:keys [shutdown-timeout-ms]}]
+  (let [timeout (or shutdown-timeout-ms default-shutdown-timeout-ms)]
+    (when-not (and (integer? timeout) (<= 0 timeout Long/MAX_VALUE))
+      (throw (ex-info ":shutdown-timeout-ms must be a nonnegative 64-bit integer"
+                      {:type :datahike.http/invalid-shutdown-timeout
+                       :shutdown-timeout-ms timeout})))
+    timeout))
+
+(defn- with-graceful-shutdown
+  [{:keys [configurator] :as config} timeout]
+  (assoc config :configurator
+         (fn [^org.eclipse.jetty.server.Server server]
+           ;; A positive Jetty stop timeout first closes the connectors to
+           ;; new work, then waits for active handlers before stopping the
+           ;; thread pool. Zero deliberately requests an immediate stop.
+           (.setStopTimeout server (long timeout))
+           (when configurator
+             (configurator server)))))
+
 (defn start-server
   "Start Jetty and acquire the standalone server's shared Konserve metric sink
    unless `:metrics` is false. `stop-server` releases both."
   [config]
   (let [config      (server-config/assert-safe-bind! config)
+        timeout     (shutdown-timeout config)
         connections (atom {})
         app         (app config connections)
         config      (::config (meta app))
+        jetty-config (with-graceful-shutdown config timeout)
         metrics-lease (when-not (false? (:metrics config))
                         (acquire-metrics-sink!))
-        server      (try (run-jetty app config)
+        server      (try (run-jetty app jetty-config)
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
                            (release-metrics-sink! metrics-lease)
@@ -220,29 +244,64 @@
                                :metrics-lease metrics-lease})
     server))
 
-(defn stop-server [^org.eclipse.jetty.server.Server server]
-  (try (.stop server)
-       (finally
-         (when-let [{:keys [connections config metrics-lease]} (get @owned server)]
-           ;; Each cleanup owns an inner `finally`, so one failure cannot skip
-           ;; the remaining process-global cleanup. Forget ownership last: a
-           ;; failing permissions close must not strand the metrics lease.
-           (try
-             (routes/release-all! connections)
-             (finally
-               (try
-                 (permissions/close! config)
-                 (finally
-                   (try
-                     (release-metrics-sink! metrics-lease)
-                     (finally
-                       (swap! owned dissoc server)))))))))))
+(defn stop-server
+  "Gracefully stop `server`, then release everything the standalone server
+   opened. Resource ownership is claimed atomically so concurrent or repeated
+   calls cannot release a connection, permission database, or metric lease
+   twice."
+  [^org.eclipse.jetty.server.Server server]
+  (let [[before _] (swap-vals! owned dissoc server)
+        {:keys [connections config metrics-lease]} (get before server)]
+    (try (.stop server)
+         (finally
+           (when connections
+             ;; Each cleanup owns an inner `finally`, so one failure cannot skip
+             ;; the remaining process-global cleanup.
+             (try
+               (routes/release-all! connections)
+               (finally
+                 (try
+                   (permissions/close! config)
+                   (finally
+                     (release-metrics-sink! metrics-lease))))))))))
+
+(defn- shutdown-hook [server config]
+  (Thread.
+   ^Runnable
+   (fn []
+     (log/info :datahike/http-server-stopping
+               {:reason :jvm-shutdown
+                :timeout-ms (get config :shutdown-timeout-ms default-shutdown-timeout-ms)})
+     (try
+       (stop-server server)
+       (log/info :datahike/http-server-stopped "Server stopped")
+       (catch Throwable t
+         (log/error :datahike/http-server-stop-failed
+                    (ex-message t)
+                    {:error-class (.getName (class t))}))))
+   "datahike-http-server-shutdown"))
 
 (defn start-main!
   "Start the standalone server after its lightweight launcher has configured
-   process logging. Kept separate so config and logging load before backends."
+   process logging, and own its JVM shutdown lifecycle. Kept separate so
+   config and logging load before backends."
   [config]
   (log/info :datahike/http-server-starting {:version tools/datahike-version})
   (log/info :datahike/http-server-config {:config (routes/redact config)})
-  (start-server config)
-  (log/info :datahike/http-server-started "Server started"))
+  (let [server  (start-server (assoc config :join? false))
+        runtime (Runtime/getRuntime)
+        hook    (shutdown-hook server config)
+        hooked? (atom false)]
+    (try
+      (.addShutdownHook runtime hook)
+      (reset! hooked? true)
+      (log/info :datahike/http-server-started "Server started")
+      (.join ^org.eclipse.jetty.server.Server server)
+      (finally
+        ;; During JVM shutdown hooks may not be removed. The hook is already
+        ;; stopping this server in that case; stop-server's ownership claim
+        ;; keeps the cleanup exactly once.
+        (when @hooked?
+          (try (.removeShutdownHook runtime hook)
+               (catch IllegalStateException _)))
+        (stop-server server)))))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -10,6 +10,7 @@
 (deftest environment-names-are-mechanical
   (is (= "DATAHIKE_PORT" (config/env-name :port)))
   (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
+  (is (= "DATAHIKE_SHUTDOWN_TIMEOUT_MS" (config/env-name :shutdown-timeout-ms)))
   (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
   (is (= "DATAHIKE_AUTH_DB_PATH" (config/env-name :auth-db-path))))
 
@@ -50,6 +51,7 @@
                                  :host "file-host"
                                  :token "file-token"
                                  :dev-mode false
+                                 :shutdown-timeout-ms 10000
                                  :level :info
                                  :metrics false
                                  :auth-db {:store {:backend :memory}}}))
@@ -57,6 +59,7 @@
               "DATAHIKE_HOST" "env-host"
               "DATAHIKE_TOKEN" "env-token"
               "DATAHIKE_DEV_MODE" "true"
+              "DATAHIKE_SHUTDOWN_TIMEOUT_MS" "20000"
               "DATAHIKE_LEVEL" "warn"
               "DATAHIKE_LOG_FORMAT" "text"
               "DATAHIKE_AUTH_DB_PATH" "/env/auth"}
@@ -65,6 +68,7 @@
               "--host" "cli-host"
               "--token" "cli-token"
               "--dev-mode" "false"
+              "--shutdown-timeout-ms" "30000"
               "--level" "error"
               "--log-format" "json"
               "--auth-db-path" "/cli/auth"]
@@ -73,6 +77,7 @@
     (is (= "cli-host" (:host resolved)))
     (is (= "cli-token" (:token resolved)))
     (is (false? (:dev-mode resolved)))
+    (is (= 30000 (:shutdown-timeout-ms resolved)))
     (is (= :error (:level resolved)))
     (is (= :json (:log-format resolved)))
     (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
@@ -109,6 +114,8 @@
                           (config/resolve-config [] {"DATAHIKE_PORT" "not-a-port"})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid command line"
                           (config/resolve-config ["--dev-mode" "perhaps"] {})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_SHUTDOWN_TIMEOUT_MS"
+                          (config/resolve-config [] {"DATAHIKE_SHUTDOWN_TIMEOUT_MS" "-1"})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_LOG_FORMAT"
                           (config/resolve-config [] {"DATAHIKE_LOG_FORMAT" "xml"}))))
   (testing "config parse errors never echo the possibly secret EDN value"

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -3,8 +3,21 @@
    [babashka.http-client :as http]
    [clojure.string :as str]
    [clojure.test :as t :refer [is deftest testing]]
-   [datahike.http.server :refer [start-server stop-server]]
-   [datahike.http.client :as api]))
+   [datahike.http.client :as api]
+   [datahike.http.permissions :as permissions]
+   [datahike.http.routes :as routes]
+   [datahike.http.server :as server :refer [start-server stop-server]]))
+
+(defn- local-port [^org.eclipse.jetty.server.Server instance]
+  (.getLocalPort ^org.eclipse.jetty.server.ServerConnector
+   (first (.getConnectors instance))))
+
+(defn- wait-until [pred]
+  (loop [attempts 200]
+    (cond
+      (pred) true
+      (zero? attempts) false
+      :else (do (Thread/sleep 10) (recur (dec attempts))))))
 
 (defn run-server-tests [server-config client-config]
   (let [{:keys [format]} client-config
@@ -109,6 +122,69 @@
                 nil
                 (catch clojure.lang.ExceptionInfo e e))]
     (is (= :datahike.http/unsafe-bind (:type (ex-data error))))))
+
+(deftest invalid-shutdown-timeout-is-refused-before-jetty
+  (let [error (try
+                (start-server {:host "127.0.0.1"
+                               :port -1
+                               :join? false
+                               :shutdown-timeout-ms -1})
+                nil
+                (catch clojure.lang.ExceptionInfo e e))]
+    (is (= :datahike.http/invalid-shutdown-timeout (:type (ex-data error))))))
+
+(deftest graceful-stop-drains-active-requests-and-cleans-up-once
+  (let [entered       (promise)
+        finish        (promise)
+        releases      (atom 0)
+        permission-closes (atom 0)
+        configured-timeout (promise)
+        instance      (atom nil)]
+    (with-redefs [server/app
+                  (fn [config _connections]
+                    (with-meta
+                      (fn [request]
+                        (if (= "/slow" (:uri request))
+                          (do (deliver entered true)
+                              @finish
+                              {:status 200 :body "done"})
+                          {:status 200 :body "unexpected"}))
+                      {::server/config config}))
+                  routes/release-all! (fn [_] (swap! releases inc))
+                  permissions/close! (fn [_] (swap! permission-closes inc))]
+      (try
+        (reset! instance
+                (start-server {:host "127.0.0.1"
+                               :port 0
+                               :join? false
+                               :metrics false
+                               :shutdown-timeout-ms 5000
+                               :configurator #(deliver configured-timeout
+                                                       (.getStopTimeout
+                                                        ^org.eclipse.jetty.server.Server %))}))
+        (is (= 5000 (deref configured-timeout 1000 ::timeout))
+            "the graceful timeout is installed before a custom configurator runs")
+        (let [connector (first (.getConnectors ^org.eclipse.jetty.server.Server @instance))
+              request   (future
+                          (http/request {:method :get
+                                         :uri (str "http://127.0.0.1:"
+                                                   (local-port @instance)
+                                                   "/slow")}))]
+          (is (= true (deref entered 2000 ::timeout)))
+          (let [stopping (future (stop-server @instance))]
+            (is (wait-until #(.isShutdown ^org.eclipse.jetty.server.AbstractConnector connector))
+                "the connector stops accepting before the active request finishes")
+            (is (not (realized? stopping))
+                "server stop waits for the active request")
+            (deliver finish true)
+            (is (= 200 (:status (deref request 2000 {:status ::timeout}))))
+            (is (nil? (deref stopping 2000 ::timeout)))
+            (stop-server @instance)
+            (is (= 1 @releases))
+            (is (= 1 @permission-closes))))
+        (finally
+          (deliver finish true)
+          (when @instance (stop-server @instance)))))))
 
 (deftest test-server
   (testing "Test transit binding."


### PR DESCRIPTION
## Summary

- install a JVM shutdown hook for the standalone launcher and explicitly join the server lifecycle
- configure Jetty to stop accepting new requests and drain active handlers for 30 seconds by default
- expose the grace period through EDN, `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, and `--shutdown-timeout-ms`
- release connections, permissions state, and the shared metrics lease only after Jetty drains, with an atomic ownership claim that makes cleanup idempotent
- preserve and compose custom Jetty configurators without exposing the internal adapter configurator through `/version`

## Verification

- focused lifecycle/config tests across all profiles: 36 tests, 498 assertions
- HTTP routes, permissions, health, version, metrics, writer, server/config, and remote CBOR across all profiles: 126 tests, 1,245 assertions
- `bb format` and `git diff --check`
- `bb reflection` — no reflective calls in Datahike sources
- explicit reflection compile of the changed HTTP namespaces — no new warnings in Datahike sources
- `bb http-server-uber`
- packaged-JAR SIGTERM smoke: shutdown hook ran, used the configured timeout, stopped Jetty, and logged completion before normal signal exit