### PR TITLE
Expose sampled query, planner, and cache metrics

### DIFF
--- a/benchmark/src/benchmark/query_metrics.clj
+++ b/benchmark/src/benchmark/query_metrics.clj
@@ -1,0 +1,84 @@
+(ns benchmark.query-metrics
+  "Measure query-observability overhead on warmed point-query paths.
+
+   Run with:
+
+     clojure -M:dev -m benchmark.query-metrics
+
+   The comparison binds `datahike.metrics/*query-metrics?*` around the same
+   process, database, query form, caches, and warmed JVM. It reports both the
+   cheapest result-cache-hit path and an uncached-result/warm-plan execution.
+   The enabled path uses the production sampling rate."
+  (:require
+   [benchmark.join-strategy :as bench]
+   [datahike.api :as d]
+   [datahike.metrics :as dhm]
+   [datahike.query :as query]
+   [replikativ.metrics :as metrics]))
+
+(set! *warn-on-reflection* true)
+
+(def point-query
+  '[:find ?name .
+    :in $ ?e
+    :where
+    [?e :name ?name]])
+
+(defn- measure-case [label run]
+  ;; Keep the registry shape stable before timing so this measures steady-state
+  ;; recording rather than first-use series creation.
+  (metrics/reset!)
+  (dhm/describe!)
+  (binding [dhm/*query-metrics?* true] (run))
+  (let [measure-mode (fn [enabled?]
+                       (bench/measure #(binding [dhm/*query-metrics?* enabled?] (run))))
+        ;; Alternate order so neither mode systematically inherits the hotter
+        ;; JIT state. Seven paired rounds also make one GC/noise event harmless.
+        pairs (mapv (fn [round]
+                      (if (even? round)
+                        {:disabled (measure-mode false)
+                         :enabled  (measure-mode true)}
+                        {:enabled  (measure-mode true)
+                         :disabled (measure-mode false)}))
+                    (range 7))
+        median-result (fn [k]
+                        (nth (vec (sort-by :ms (map k pairs)))
+                             (quot (count pairs) 2)))
+        disabled (median-result :disabled)
+        enabled (median-result :enabled)]
+    {:case label
+     :disabled disabled
+     :enabled enabled
+     :time-ratio (/ (:ms enabled) (:ms disabled))
+     :allocation-delta-kb (* 1024.0
+                             (- (:allocated-mb enabled)
+                                (:allocated-mb disabled)))}))
+
+(defn- print-result [{:keys [case disabled enabled time-ratio allocation-delta-kb]}]
+  (println
+   (format "%-28s off=%8.4fms on=%8.4fms ratio=%5.2fx allocation-delta=%7.2fKiB"
+           (name case) (:ms disabled) (:ms enabled) time-ratio allocation-delta-kb)))
+
+(defn -main [& _]
+  (let [config {:store {:backend :memory :id (random-uuid)}
+                :schema-flexibility :read
+                :value-caps :default}]
+    (d/create-database config)
+    (let [conn (d/connect config)]
+      (try
+        (d/transact conn (mapv (fn [i] {:db/id i :name (str "person-" i)})
+                               (range 1 1001)))
+        (let [db @conn
+              run-hit #(d/q point-query db 500)
+              run-exec #(binding [query/*query-result-cache?* false]
+                          (d/q point-query db 500))]
+          ;; Warm form analysis, plan, compiled program, and the result entry.
+          (run-exec)
+          (run-hit)
+          (println "query metric sample-every:" dhm/*query-metrics-sample-every*)
+          (doseq [result [(measure-case :result-cache-hit run-hit)
+                          (measure-case :warm-plan-execution run-exec)]]
+            (print-result result)))
+        (finally
+          (d/release conn)
+          (d/delete-database config))))))

--- a/src/datahike/metrics.cljc
+++ b/src/datahike/metrics.cljc
@@ -35,7 +35,47 @@
 
    :datahike_connections
    {:type :gauge
-    :help "Connection leases held in this process, by database and branch."}})
+    :help "Connection leases held in this process, by database and branch."}
+
+   :datahike_query_seconds
+   {:type :histogram
+    :help "Sampled caller-visible query latency, by outcome and result-cache disposition; see datahike_query_errors_total for exact failures."}
+
+   :datahike_query_planning_seconds
+   {:type :histogram
+    :help "Sampled time to obtain a query plan, by outcome and plan-cache disposition; see datahike_query_planning_errors_total for exact failures."}
+
+   :datahike_query_engine_total
+   {:type :counter
+    :help "Sampled uncached query executions, by engine and execution path."}
+
+   :datahike_query_errors_total
+   {:type :counter
+    :help "Caller-visible query failures; unlike latency observations, every error is counted."}
+
+   :datahike_query_planning_errors_total
+   {:type :counter
+    :help "Query planning failures; unlike latency observations, every error is counted."}
+
+   :datahike_query_sample_every
+   {:type :gauge
+    :help "Successful queries represented by each sampled query observation."}})
+
+(def ^:dynamic *query-metrics?*
+  "Whether query, planner, and query-engine metrics are recorded.
+
+   Enabled by default. The binding exists primarily for measuring the cost of
+   instrumentation against the identical warmed query path; hosts with an
+   exceptionally latency-sensitive embedded workload may also disable it."
+  true)
+
+(def ^:dynamic *query-metrics-sample-every*
+  "Record one in this many successful queries. Errors are always recorded."
+  256)
+
+(def ^:dynamic *record-query-metrics?*
+  "Internal scope shared by one query and its planner/engine work."
+  false)
 
 (defn describe!
   "Install Datahike's metric descriptions into the process registry.
@@ -46,6 +86,7 @@
   []
   (doseq [[metric description] descriptions]
     (metrics/describe! metric description))
+  (metrics/gauge! :datahike_query_sample_every {} *query-metrics-sample-every*)
   nil)
 
 ;; Namespace loading installs descriptions; repeated loads are safe because
@@ -104,6 +145,62 @@
    `reason` is `:unauthorized`, `:forbidden`, or `:too-large`."
   [reason]
   (metrics/inc! :datahike_http_rejected_total {:reason (name reason)})
+  nil)
+
+(defn query-timer
+  "Start a query/planner timer when query metrics are enabled, otherwise nil."
+  ([] (query-timer *record-query-metrics?*))
+  ([sampled?]
+   (when (and *query-metrics?* sampled?)
+     (metrics/timer))))
+
+(defn sample-query?
+  "Whether one successful query should record its query/planner/engine trace."
+  []
+  (let [sample-every (max 1 *query-metrics-sample-every*)]
+    (and *query-metrics?*
+         (or (= 1 sample-every)
+             #?(:clj (zero? (.nextInt (java.util.concurrent.ThreadLocalRandom/current)
+                                      (int sample-every)))
+                :cljs (zero? (rand-int sample-every)))))))
+
+(defn query!
+  "Record one caller-visible query.
+
+   `result-cache` is `:hit`, `:miss`, or `:bypass`; `outcome` is `:success`
+  or `:error`. `started` comes from `query-timer`."
+  [started result-cache outcome sampled?]
+  (when (and *query-metrics?* (= :error outcome))
+    (metrics/inc! :datahike_query_errors_total
+                  {:result_cache (name result-cache)}))
+  (when (and started sampled?)
+    (metrics/observe-since! :datahike_query_seconds
+                            {:outcome      (name outcome)
+                             :result_cache (name result-cache)}
+                            started))
+  nil)
+
+(defn query-planning!
+  "Record one attempt to obtain a plan.
+
+   `plan-cache` is `:hit` or `:miss`; `outcome` is `:success` or `:error`."
+  [started plan-cache outcome]
+  (when (and *query-metrics?* (= :error outcome))
+    (metrics/inc! :datahike_query_planning_errors_total
+                  {:plan_cache (name plan-cache)}))
+  (when (and started *record-query-metrics?*)
+    (metrics/observe-since! :datahike_query_planning_seconds
+                            {:outcome    (name outcome)
+                             :plan_cache (name plan-cache)}
+                            started))
+  nil)
+
+(defn query-engine!
+  "Count an uncached engine execution on a bounded engine/path pair."
+  [engine path]
+  (when (and *query-metrics?* *record-query-metrics?*)
+    (metrics/inc! :datahike_query_engine_total
+                  {:engine (name engine) :path (name path)}))
   nil)
 
 (defn connection-samples

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -12,6 +12,7 @@
    [datahike.array :refer [a= wrap-comparable]]
    [datahike.impl.entity :as de]
    [datahike.lru]
+   [datahike.metrics :as dhm]
    [datahike.pull-api :as dpa]
    [datahike.query-stats :as dqs]
    [datahike.tools :as dt]
@@ -3893,7 +3894,8 @@
    so the key is run through `scale-sensitive-key` to keep BigDecimals of
    different scale distinct (Clojure `=`/`hash` would otherwise collapse them)."
   [db clauses bound-vars rules in-cards]
-  (let [schema-hash (hash (dbi/-schema db))
+  (let [started (dhm/query-timer)
+        schema-hash (hash (dbi/-schema db))
         ;; `in-cards` is part of the key: it is value-independent (shape-only),
         ;; but it distinguishes bindings the bound-var SET cannot — e.g. a tuple
         ;; [?a ?b] (#{?a ?b}, card 1) from a relation [[?a ?b]] (#{?a ?b}, many)
@@ -3909,8 +3911,11 @@
                             (conj key-prefix schema-hash)
                             (scale-sensitive-key (conj key-prefix schema-hash))))]
     (if-some [cached (get @plan-cache cache-key nil)]
-      cached
-      (let [plan (-> (create-plan-via-ir db clauses bound-vars rules in-cards)
+      (do
+        (dhm/query-planning! started :hit :success)
+        cached)
+      (try
+        (let [plan (-> (create-plan-via-ir db clauses bound-vars rules in-cards)
                      ;; per-plan compiled-program slot: the direct executor
                      ;; caches its per-[find-vars consts-keys] compilation here
                      ;; (see execute/direct-program), so repeated executions of
@@ -3922,10 +3927,14 @@
                      ;; bit-identical (an atom in meta is not serializable);
                      ;; a plan cached while OFF simply compiles uncached if
                      ;; the flag flips later.
-                     (cond-> (prepared-execution?)
-                       (vary-meta assoc :datahike.query.execute/program-cache (atom {}))))]
-        (vswap! plan-cache assoc cache-key plan)
-        plan))))
+                       (cond-> (prepared-execution?)
+                         (vary-meta assoc :datahike.query.execute/program-cache (atom {}))))]
+          (vswap! plan-cache assoc cache-key plan)
+          (dhm/query-planning! started :miss :success)
+          plan)
+        (catch #?(:clj Exception :cljs :default) e
+          (dhm/query-planning! started :miss :error)
+          (throw e))))))
 
 (def ^:dynamic *profile?* false)
 
@@ -5194,7 +5203,9 @@
                                                         wide->find)))
                                            filtered)]
                        (apply-result-transforms projected order-spec offset limit qreturnmaps)))))]
-        split-result
+        (do
+          (dhm/query-engine! :planner :cartesian)
+          split-result)
 
         (if (and use-planner?
                ;; Nested temporal wrappers (e.g. (d/history (d/as-of ...))) → legacy
@@ -5222,6 +5233,7 @@
                                       plan db qfind find-elements context-in query stats? qreturnmaps
                                       result-demand))]
               (let [result (apply-result-transforms direct-result order-spec offset limit qreturnmaps)]
+                (dhm/query-engine! :planner :direct)
                 #?(:clj
                    (when *profile?*
                      (let [t3 (System/nanoTime)]
@@ -5257,6 +5269,7 @@
                 (if columnar-result
                   (let [result (-post-process qfind columnar-result)
                         result (apply-result-transforms result order-spec offset limit qreturnmaps)]
+                    (dhm/query-engine! :planner :aggregate)
                     #?(:clj
                        (when *profile?*
                          (let [t3 (System/nanoTime)]
@@ -5271,6 +5284,7 @@
                                 plan db qfind find-elements context-in query all-vars
                                 result-arity lookup-ref-reverse-map order-spec offset limit
                                 stats? qreturnmaps)]
+                    (dhm/query-engine! :planner :relation)
                     #?(:clj
                        (when *profile?*
                          (let [t3 (System/nanoTime)]
@@ -5282,6 +5296,7 @@
         ;; Legacy engine
           (let [result (execute-legacy context-in query qfind find-elements all-vars result-arity
                                        order-spec offset limit stats? qreturnmaps)]
+            (dhm/query-engine! :base :relation)
             #?(:clj
                (when *profile?*
                  (let [t3 (System/nanoTime)]
@@ -5324,23 +5339,35 @@
                      (when (and (empty? (:rels context-in))
                                 (seq (:ops plan)))
                        (when-let [result (try-secondary-index-aggregate db plan find-elements)]
+                         (dhm/query-engine! :secondary-index :aggregate)
                          (-post-process qfind result)))))))))))))
 
 (defn raw-q [{:keys [query args stats? count-fns? offset limit order-by] :as query-map}]
-  (let [uncached (fn []
-                   #?(:clj (or (try-secondary-index-aggregate-fast query-map)
-                               (raw-q* query-map))
-                      :cljs (raw-q* query-map)))]
+  (let [sampled? (dhm/sample-query?)
+        started (dhm/query-timer sampled?)
+        recorded (fn [result-cache f]
+                   (try
+                     (let [result (f)]
+                       (dhm/query! started result-cache :success sampled?)
+                       result)
+                     (catch #?(:clj Exception :cljs :default) e
+                       (dhm/query! started result-cache :error sampled?)
+                       (throw e))))
+        uncached (fn []
+                   (binding [dhm/*record-query-metrics?* sampled?]
+                     #?(:clj (or (try-secondary-index-aggregate-fast query-map)
+                                 (raw-q* query-map))
+                        :cljs (raw-q* query-map))))]
     (if (or (not *query-result-cache?*)
             stats?
             count-fns?                         ;; counting needs re-execution; a cache hit wouldn't re-run the fn
             #?(:clj *profile?* :cljs false))
-      (uncached)
+      (recorded :bypass uncached)
       ;; Try result cache
       (let [db (first args)
             cacheable? (and (dbu/db? db) (instance? DB db))]
         (if-not cacheable?
-          (uncached)
+          (recorded :bypass uncached)
           (let [non-db-args (vec (rest args))
                 ;; scale-sensitive-key: BigDecimal args/consts of equal value but
                 ;; different scale (1.50M vs 1.500M) are `=` with equal hash in
@@ -5357,14 +5384,17 @@
                                      [query non-db-args offset limit order-by *disable-planner*])))
                 entry (result-cache-get db cache-key)]
             (if entry
-              (:result entry)
-              (let [result (uncached)
-                    where-deps (extract-query-attr-deps (:where query))
-                    find-deps  (extract-find-pull-attr-deps
-                                (:qfind (memoized-parse-query query)))
-                    attr-deps  (merge-attr-deps where-deps find-deps)]
-                (result-cache-put! db cache-key result attr-deps)
-                result))))))))
+              (recorded :hit (fn [] (:result entry)))
+              (recorded
+               :miss
+               (fn []
+                 (let [result (uncached)
+                       where-deps (extract-query-attr-deps (:where query))
+                       find-deps  (extract-find-pull-attr-deps
+                                   (:qfind (memoized-parse-query query)))
+                       attr-deps  (merge-attr-deps where-deps find-deps)]
+                   (result-cache-put! db cache-key result attr-deps)
+                   result))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Register legacy functions for CLJS execute.cljc (breaks circular dep)

--- a/test/datahike/test/http/metrics_test.clj
+++ b/test/datahike/test/http/metrics_test.clj
@@ -62,6 +62,7 @@
       (is (= "text/plain; version=0.0.4; charset=utf-8"
              (get-in response [:headers "content-type"])))
       (is (str/includes? body "datahike_http_request_seconds_bucket"))
+      (is (str/includes? body "datahike_query_sample_every 256"))
       (is (str/includes? body "jvm_memory_used_bytes"))
       (is (str/includes? body
                          (str "datahike_connections{branch=\"db\",database=\"" store-id "\"} 3")))

--- a/test/datahike/test/metrics_test.cljc
+++ b/test/datahike/test/metrics_test.cljc
@@ -2,6 +2,8 @@
   (:require #?(:clj [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer [deftest is testing]])
             [datahike.metrics :as dhm]
+            [datahike.query :as query]
+            [datahike.lru :as lru]
             [replikativ.metrics :as metrics]
             #?(:clj [datahike.api :as d])))
 
@@ -29,10 +31,16 @@
     (is (= :counter (get-in snapshot [:datahike_transactions_total :type])))
     (is (= :counter (get-in snapshot [:datahike_transacted_datoms_total :type])))
     (is (= :counter (get-in snapshot [:datahike_head_conflicts_total :type])))
+    (is (= :histogram (get-in snapshot [:datahike_query_seconds :type])))
+    (is (= :histogram (get-in snapshot [:datahike_query_planning_seconds :type])))
+    (is (= :counter (get-in snapshot [:datahike_query_engine_total :type])))
+    (is (= :counter (get-in snapshot [:datahike_query_errors_total :type])))
+    (is (= :counter (get-in snapshot [:datahike_query_planning_errors_total :type])))
+    (is (= 256 (get-in snapshot [:datahike_query_sample_every :series {}])))
     (is (every? seq (map :help (vals snapshot)))
         "every exported Datahike metric explains what it measures")
-    (is (every? empty? (map :series (vals snapshot)))
-        "describing instruments does not manufacture samples")))
+    (is (every? empty? (map :series (vals (dissoc snapshot :datahike_query_sample_every))))
+        "only the sampling configuration gauge has a startup sample")))
 
 (deftest one-durable-batch-counts-every-transaction
   (fresh-registry!)
@@ -93,3 +101,69 @@
            (finally
              (d/release conn)
              (d/delete-database config)))))))
+
+#?(:clj
+   (deftest queries-report-result-and-plan-cache-dispositions
+     (let [config (-> test-config
+                      (assoc :branch :db)
+                      (assoc-in [:store :id] (random-uuid)))]
+       (when (d/database-exists? config)
+         (d/delete-database config))
+       (d/create-database config)
+       (let [conn (d/connect config)
+             qform '[:find ?name :where [?e :name ?name]]]
+         (try
+           (d/transact conn [{:name "Ada"}])
+           (query/clear-query-cache!)
+           (vreset! @#'query/plan-cache (lru/lru query/lru-cache-size))
+           (fresh-registry!)
+
+           (binding [dhm/*query-metrics-sample-every* 1]
+             (is (= #{["Ada"]} (d/q qform @conn)))
+             (is (= #{["Ada"]} (d/q qform @conn)))
+
+             ;; Force another execution of the same form without throwing away
+             ;; its plan, so both plan-cache dispositions are observable.
+             (query/clear-query-cache!)
+             (is (= #{["Ada"]} (d/q qform @conn))))
+
+           (let [snapshot (metrics/snapshot)
+                 query-series (get-in snapshot [:datahike_query_seconds :series])
+                 planning-series (get-in snapshot [:datahike_query_planning_seconds :series])
+                 engine-series (get-in snapshot [:datahike_query_engine_total :series])]
+             (is (= 2 (get-in query-series [{:outcome "success" :result_cache "miss"} :count])))
+             (is (= 1 (get-in query-series [{:outcome "success" :result_cache "hit"} :count])))
+             (is (= 1 (get-in planning-series [{:outcome "success" :plan_cache "miss"} :count])))
+             (is (= 1 (get-in planning-series [{:outcome "success" :plan_cache "hit"} :count])))
+             (is (= 2 (reduce + 0 (vals engine-series)))
+                 "a result-cache hit does not execute an engine"))
+
+           (finally
+             (d/release conn)
+             (d/delete-database config)))))))
+
+(deftest query-metrics-can-be-disabled-for-overhead-measurement
+  (fresh-registry!)
+  (binding [dhm/*query-metrics?* false]
+    (let [started (dhm/query-timer)]
+      (is (nil? started))
+      (dhm/query! started :bypass :success false)
+      (dhm/query-planning! started :hit :success)
+      (dhm/query-engine! :planner :direct)))
+  (let [snapshot (metrics/snapshot)]
+    (is (empty? (get-in snapshot [:datahike_query_seconds :series])))
+    (is (empty? (get-in snapshot [:datahike_query_planning_seconds :series])))
+    (is (empty? (get-in snapshot [:datahike_query_engine_total :series])))))
+
+(deftest unsampled-query-errors-are-still-counted
+  (fresh-registry!)
+  (dhm/query! nil :miss :error false)
+  (binding [dhm/*record-query-metrics?* false]
+    (dhm/query-planning! nil :miss :error))
+  (let [snapshot (metrics/snapshot)]
+    (is (= 1 (get-in snapshot [:datahike_query_errors_total
+                               :series {:result_cache "miss"}])))
+    (is (= 1 (get-in snapshot [:datahike_query_planning_errors_total
+                               :series {:plan_cache "miss"}])))
+    (is (empty? (get-in snapshot [:datahike_query_seconds :series])))
+    (is (empty? (get-in snapshot [:datahike_query_planning_seconds :series])))))

--- a/test/datahike/test/metrics_test.cljc
+++ b/test/datahike/test/metrics_test.cljc
@@ -118,7 +118,11 @@
            (vreset! @#'query/plan-cache (lru/lru query/lru-cache-size))
            (fresh-registry!)
 
-           (binding [dhm/*query-metrics-sample-every* 1]
+           ;; This assertion is specifically about the planner cache. CI also
+           ;; runs the whole suite with the planner disabled globally to cover
+           ;; the base engine, so pin the subject of this test explicitly.
+           (binding [query/*disable-planner* false
+                     dhm/*query-metrics-sample-every* 1]
              (is (= #{["Ada"]} (d/q qform @conn)))
              (is (= #{["Ada"]} (d/q qform @conn)))
 


### PR DESCRIPTION
## Summary

- expose caller-visible query latency by result-cache hit/miss/bypass
- expose planning latency and plan-cache hit/miss behavior
- count sampled executor paths and every query/planning error
- keep labels bounded and publish the 1/256 sampling rate as a gauge
- add a paired, alternating-order overhead benchmark

Successful query traces are sampled coherently: when a query is selected, its query, planner, and engine events are all recorded. Errors have separate exact counters. No labels contain query forms, hashes, attributes, database ids, or user input.

## Benchmark

Run with: clojure -M:dev -m benchmark.query-metrics

Two isolated runs after selecting the 1/256 production rate:

- result-cache hit: 0.92x and 0.99x enabled/disabled
- warm-plan execution: 0.90x and 1.00x enabled/disabled
- allocation deltas remained within about 0.1 KiB

The initial exact-recording implementation was rejected after measuring roughly 40-49% overhead on these microquery paths.

## Verification

- bb format
- bb reflection
- metrics tests: 9 tests, 39 assertions
- focused cache/planner/engine/cartesian/aggregate tests: 59 tests, 301 assertions
- HTTP metrics tests: 5 tests, 25 assertions
- bb node-cljs-test: 310 files compiled, zero warnings, suite passed
