### PR TITLE
feat(server): add durable system database catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,12 @@ When something is added, it's typically marked *Experimental*. When the API cont
   (`(fn [request] → principal | nil)`, kabel's shape — JWT/JWKS via
   `kabel.auth.jwt`) and `:auth :upstream`; every request carries its
   principal, and `:authorize` (`(fn [{:keys [op principal db payload]}])`) is
-  asked for each database a call reaches. With `:auth-db` the server keeps an
-  eacl permission graph (users, server admins, database owners/writers/readers)
-  in a Datahike database of its own and manages it through
-  `/permissions/*`. Token auth no longer uses buddy; the header is
+  asked for each database a call reaches. With `:system-db` the server keeps
+  an eacl permission graph (users, server admins, database
+  owners/writers/readers) and a redacted database catalog in a Datahike
+  database of its own. It manages permissions through `/permissions/*` and
+  lists authorized catalog entries at `GET /databases`. Token auth no longer
+  uses buddy; the header is
   `authorization: token <token>` as before.
 
 - **Index warming is unified across the stack, and real on ClojureScript.**

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -310,11 +310,11 @@ CLI flags, then `DATAHIKE_*` environment variables, then the EDN file. The
 supported environment variables are `DATAHIKE_PORT`, `DATAHIKE_HOST`,
 `DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`,
 `DATAHIKE_LOG_FORMAT`, `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, and
-`DATAHIKE_AUTH_DB_PATH`. Log format is `text` by default and accepts `json`.
+`DATAHIKE_SYSTEM_DB_PATH`. Log format is `text` by default and accepts `json`.
 `DATAHIKE_TOKEN_FILE` reads the token from a Docker or Kubernetes secret mount
 without putting it in the process environment. CLI uses the corresponding
 `--port`, `--host`, `--token`, `--dev-mode`, `--level`, `--log-format`,
-`--shutdown-timeout-ms`, `--auth-db-path`, and `--token-file` options.
+`--shutdown-timeout-ms`, `--system-db-path`, and `--token-file` options.
 
 The edn configuration file looks like:
 

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -146,26 +146,33 @@ transaction function can be handed a connection or database value for
 another database, and that database is then part of the call. Without `:authorize`, every authenticated caller may do everything —
 today's behaviour.
 
-### Permissions in an auth database (eacl)
+### Catalog and permissions in the system database
 
 The server ships a policy so you need not write one: relationship-based
 authorization in the [SpiceDB](https://authzed.com/spicedb) model via
 [eacl](https://github.com/theronic/eacl), *situated* — the permission graph
-lives in a Datahike database of its own, `:auth-db`, and every check is a
-local read. Give the server one and it is on:
+and database catalog live in a Datahike database of their own, `:system-db`,
+and every permission check is a local read. Give the server one and both are
+on:
 
 ```clojure
 ;; config.edn
 {:port     4444
  :token    "…"                                   ; the break-glass identity
  :validator …                                    ; everyone else, by JWT
- :auth-db  {:store {:backend :file :path "/var/lib/datahike/auth"}}}
+ :system-db {:store {:backend :file :path "/var/lib/datahike/system"}}}
 ```
 
 A durable store without an `:id` gets one derived from its path, the same
 on every start; a memory store gets a fresh one per server, so two servers
-in one process never share an auth database by accident. Servers that do
-share one share its admins.
+in one process never share a system database by accident. Servers that do
+share one share its catalog and admins. New system databases retain history.
+
+Successful database creates and deletes update the catalog with the store id,
+optional `:name`, a credential-redacted config, timestamps, and the acting
+principal. `GET /databases` returns active entries filtered through the same
+`:read` permission as database calls; callers cannot discover databases they
+cannot read.
 
 The graph (`datahike.http.permissions/schema`):
 
@@ -368,16 +375,16 @@ orchestrators and load balancers:
 
 - `GET /health/live` returns 200 while the HTTP process can answer requests.
 - `GET /health/ready` returns 200 only when every database store currently held
-  by the server, plus its configured `:auth-db`, accepts a non-mutating Konserve
+  by the server, plus its configured `:system-db`, accepts a non-mutating Konserve
   read. It returns 503 otherwise.
 
 Both responses intentionally contain only `live`, `ready`, or `not ready`. The
 server log identifies a failed store and the exception class/type without
 copying exception messages or data that might contain credentials. Data
 databases are supplied dynamically by API clients today, so readiness covers
-the live connections the server knows about.
-Once the planned system database provides a durable database catalog, readiness
-can also cover its eagerly reconnected entries.
+the live connections the server knows about. A later listener/reconnection
+stage will open catalog entries at startup so readiness can cover those before
+the first API call too.
 
 `GET /version` returns build and runtime metadata: the Datahike version and Git
 SHA, Konserve version, registered Konserve backends, and the server

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -56,8 +56,8 @@
    {:key :level        :parse parse-level}
    {:key :log-format   :parse parse-log-format}
    ;; A deployment-friendly shorthand for the full
-   ;; {:auth-db {:store {:backend :file :path ...}}} EDN shape.
-   {:key :auth-db-path :parse non-blank}])
+   ;; {:system-db {:store {:backend :file :path ...}}} EDN shape.
+   {:key :system-db-path :parse non-blank}])
 
 (defn env-name
   "The mechanical DATAHIKE_* name for a supported top-level config key."
@@ -75,7 +75,7 @@
    [nil "--shutdown-timeout-ms MILLIS" "Grace period for in-flight requests" :parse-fn parse-nonnegative-long]
    ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
    [nil "--log-format FORMAT" "Log format: text or json" :parse-fn parse-log-format]
-   [nil "--auth-db-path PATH" "File-backed permissions database path" :parse-fn non-blank]
+   [nil "--system-db-path PATH" "File-backed catalog and permissions database path" :parse-fn non-blank]
    ["-h" "--help" "Show this help"]
    [nil "--version" "Show the Datahike version"]])
 
@@ -141,12 +141,12 @@
                         e))))))
 
 (defn- normalize-shorthands [config]
-  (if (contains? config :auth-db-path)
-    (let [path (non-blank (:auth-db-path config))]
+  (if (contains? config :system-db-path)
+    (let [path (non-blank (:system-db-path config))]
       (-> config
-          (dissoc :auth-db-path)
-          (assoc-in [:auth-db :store :backend] :file)
-          (assoc-in [:auth-db :store :path] path)))
+          (dissoc :system-db-path)
+          (assoc-in [:system-db :store :backend] :file)
+          (assoc-in [:system-db :store :path] path)))
     config))
 
 (defn- loopback-addresses [host]

--- a/http-server/datahike/http/permissions.clj
+++ b/http-server/datahike/http/permissions.clj
@@ -4,7 +4,7 @@
    Authentication says who a caller is (`datahike.http.middleware/validators`);
    this namespace says what they may do, with eacl — relationship-based
    authorization in the SpiceDB model, situated: the permission graph lives in
-   an `:auth-db` next to the server's data, and checks are local reads.
+   the server's `:system-db`, and checks are local reads.
 
    The graph has three kinds of object. `user`s are principals, by their
    `:sub`. The one `server` has `admin`s, who may do everything — create
@@ -23,15 +23,15 @@
 
    `configure` opens the database and returns the config with `:authorize`
    set; `routes` are the permission management routes, authorized by the same
-   graph. Servers that share one auth database share its admins: the `server`
-   object is one per auth database, not per server."
+   graph. Servers that share one system database share its admins: the `server`
+   object is one per system database, not per server."
   (:require
    [clojure.string :as str]
    [datahike.api :as d]
    [datahike.http.routes :as routes]
+   [datahike.http.system :as system]
    [eacl.core :as eacl]
-   [eacl.datahike.core :as ed]
-   [eacl.datahike.schema :as eschema]))
+   [eacl.datahike.core :as ed]))
 
 (def schema
   "The permission graph, in SpiceDB's schema language."
@@ -71,25 +71,6 @@ definition database {
   [conn objects]
   (d/transact conn (vec (for [{:keys [id]} objects] {:eacl/id id}))))
 
-(defn- open-auth-db!
-  "Connect to the auth database, creating it with eacl's attributes if it is new."
-  [auth-db]
-  (let [path (get-in auth-db [:store :path])
-        cfg  (-> (merge eschema/default-config auth-db)
-                 ;; A durable store without an id gets one from its path, the
-                 ;; same on every start; a store without a path (memory) gets
-                 ;; a fresh one, so two servers in one process do not share
-                 ;; an auth database by accident.
-                 (update-in [:store :id]
-                            #(or % (if path
-                                     (java.util.UUID/nameUUIDFromBytes (.getBytes (str "datahike-auth-db:" path)))
-                                     (random-uuid)))))]
-    (if (d/database-exists? cfg)
-      (d/connect cfg)
-      (do (d/create-database cfg)
-          (doto (d/connect cfg)
-            (d/transact (eschema/merge-schema)))))))
-
 (defn- admin? [acl principal]
   (eacl/can? acl (user principal) :administer server))
 
@@ -106,11 +87,15 @@ definition database {
                    (eacl/can? acl (user principal) op (database (:store-id db)))))))))
 
 (defn configure
-  "Open `(:auth-db config)` — a Datahike config, `:store` at least — write the
-   schema, seed the token principal as server admin, and return `config` with
-   `:authorize` set."
-  [{:keys [auth-db token-subject] :as config}]
-  (let [conn (open-auth-db! auth-db)
+  "Use the configured system database for EACL, seed the token principal as
+   server admin, and return `config` with `:authorize` set."
+  [{:keys [token-subject] :as input-config}]
+  (let [config (if (get input-config system/conn-key)
+                 input-config
+                 (system/configure input-config))
+        conn (or (get config system/conn-key)
+                 (throw (ex-info "Permissions require :system-db"
+                                 {:type :datahike.http/missing-system-database})))
         acl  (ed/make-client conn {})
         root (object :user (or token-subject "root"))]
     (eacl/write-schema! acl schema)
@@ -119,8 +104,7 @@ definition database {
     (assoc config :authorize (policy acl) ::acl acl ::conn conn)))
 
 (defn close! [config]
-  (when-let [conn (::conn config)]
-    (d/release conn)))
+  (system/close! config))
 
 ;; ---------------------------------------------------------------------------
 ;; Routes
@@ -151,7 +135,7 @@ definition database {
    :resource (<-object (:resource r))})
 
 (defn routes
-  "The permission routes for a `configure`d config; none without `:auth-db`.
+  "The permission routes for a `configure`d config; none without a system database.
    Bodies are maps; objects are `{:type :user|:database|:server :id \"…\"}`.
 
    - POST /permissions/check `{:subject :permission :resource}` → `{:allowed}`.

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -57,7 +57,9 @@
 
 (def ^:private secret-keys
   "Config keys whose values must never leave the server in an error body."
-  #{:token :secret :access-key :secret-key :password})
+  #{:token :secret :access-key :secret-key :password
+    :account-key :api-key :client-secret :connection-string
+    :credential :credentials :private-key :sas-token})
 
 (defn redact
   "`x` with secret-valued keys blanked, at any depth."
@@ -256,15 +258,20 @@
                   ret-body
                   (cond (= f #'api/create-database)
                         ;; remove remote-peer and re-add
-                        (assoc
-                         (apply f (local (first body)) (rest body))
-                         :remote-peer (:remote-peer (first body)))
+                        (let [created (apply f (local (first body)) (rest body))]
+                          (when-let [register! (:datahike.http.system/register! config)]
+                            (register! created (:datahike/principal request)))
+                          (assoc created :remote-peer (:remote-peer (first body))))
 
                         (= f #'api/delete-database)
                         (with-exclusive state
                           (fn []
                             (swap! (:leases state) dissoc (conn-id (first body)))
-                            (apply f (local (first body)) (rest body))))
+                            (let [local-config (local (first body))
+                                  result (apply f local-config (rest body))]
+                              (when-let [deleted! (:datahike.http.system/delete! config)]
+                                (deleted! local-config (:datahike/principal request)))
+                              result)))
 
                         (= f #'api/connect)
                         (granted! state (apply f (cons (local (first body)) (rest body))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -1,6 +1,6 @@
 (ns datahike.http.server
   "HTTP server implementation for Datahike: `datahike.http.routes/handler`
-   behind Jetty, with swagger-ui at `/`, CORS, and — given an `:auth-db` —
+   behind Jetty, with swagger-ui at `/`, CORS, and — given a `:system-db` —
    eacl-backed permissions. Embedding hosts want `datahike.http.routes`."
   (:require
    [datahike.http.backends]
@@ -8,6 +8,7 @@
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
+   [datahike.http.system :as system]
    [reitit.ring :as ring]
    [reitit.swagger :as swagger]
    [reitit.swagger-ui :as swagger-ui]
@@ -64,15 +65,15 @@
 
 (defn- ready?
   "Check every store the server currently owns: live API connections and the
-   configured auth database. Do not short-circuit, so one outage does not hide
+   configured system database. Do not short-circuit, so one outage does not hide
    another from the operator logs."
   [config connections]
   (let [targets (concat
                  (for [[[store-id _branch] {:keys [conn]}] @connections
                        :when conn]
                    [store-id conn])
-                 (when-let [conn (get config ::permissions/conn)]
-                   [[:auth-db conn]]))]
+                 (when-let [conn (get config system/conn-key)]
+                   [[:system-db conn]]))]
     (reduce (fn [ready target]
               (let [target-ready? (probe-connection! target)]
                 (and ready target-ready?)))
@@ -145,22 +146,26 @@
           :handler (swagger/create-swagger-handler)}}])
 
 (defn app
-  "The server's Ring handler over `connections`. With `:auth-db` in `config`
-   the permissions database is opened here; `(::config (meta app))` is the
-   configured config, for `stop-server`.
+  "The server's Ring handler over `connections`. With `:system-db` in `config`,
+   the catalog and permissions database is opened here; `(::config (meta app))`
+   is the configured config, for `stop-server`.
 
    This handler exposes process metrics but does not install a global Konserve
    sink: an embedding host owns that lifecycle. `start-server` installs and
    reference-counts the standalone server's sink."
   [config connections]
   (let [server-config config
-        config  (if (:auth-db config) (permissions/configure config) config)
+        config  (system/configure config)
+        config  (if (get config system/conn-key)
+                  (permissions/configure config)
+                  config)
         handler (routes/handler config
                                 {:connections     connections
                                  :extra-routes    (concat [swagger-route]
                                                           (health-routes config connections)
                                                           [(version-route server-config)]
                                                           (keep identity [(metrics-route config connections)])
+                                                          (system/routes config)
                                                           (permissions/routes config))
                                  :default-handler (ring/routes
                                                    (swagger-ui/create-swagger-ui-handler
@@ -237,7 +242,7 @@
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
                            (release-metrics-sink! metrics-lease)
-                           (permissions/close! config)
+                           (system/close! config)
                            (throw t)))]
     (swap! owned assoc server {:connections connections
                                :config config
@@ -261,7 +266,7 @@
                (routes/release-all! connections)
                (finally
                  (try
-                   (permissions/close! config)
+                   (system/close! config)
                    (finally
                      (release-metrics-sink! metrics-lease))))))))))
 

--- a/http-server/datahike/http/system.clj
+++ b/http-server/datahike/http/system.clj
@@ -1,0 +1,217 @@
+(ns datahike.http.system
+  "The standalone server's durable catalog and permission database.
+
+   Catalog configs are deliberately redacted before storage: credentials stay
+   in deployment configuration, not in the database they protect."
+  (:require
+   [clojure.edn :as edn]
+   [datahike.api :as d]
+   [datahike.http.routes :as routes]
+   [datahike.store :as store]
+   [eacl.datahike.schema :as eschema]))
+
+(def register-key ::register!)
+(def delete-key ::delete!)
+(def conn-key ::conn)
+
+(def catalog-schema
+  [{:db/ident       :datahike.system.database/id
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/identity}
+   {:db/ident       :datahike.system.database/name
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique      :db.unique/value}
+   {:db/ident       :datahike.system.database/config
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :datahike.system.database/state
+    :db/valueType   :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/index       true}
+   {:db/ident       :datahike.system.database/created-at
+    :db/valueType   :db.type/instant
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :datahike.system.database/created-by
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :datahike.system.database/deleted-at
+    :db/valueType   :db.type/instant
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :datahike.system.database/deleted-by
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident       :datahike.system/principal
+    :db/valueType   :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(def ^:private catalog-pull
+  [:datahike.system.database/id
+   :datahike.system.database/name
+   :datahike.system.database/config
+   :datahike.system.database/state
+   :datahike.system.database/created-at
+   :datahike.system.database/created-by
+   :datahike.system.database/deleted-at
+   :datahike.system.database/deleted-by])
+
+(defn- configured-system-db [config]
+  (when (contains? config :auth-db)
+    (throw (ex-info ":auth-db was replaced by :system-db; rename this configuration key"
+                    {:type :datahike.http/obsolete-auth-database})))
+  (:system-db config))
+
+(defn- deterministic-id [path]
+  (java.util.UUID/nameUUIDFromBytes
+   (.getBytes (str "datahike-system-db:" path))))
+
+(defn- system-config [configured]
+  (let [path (get-in configured [:store :path])]
+    (-> (merge eschema/default-config configured)
+        ;; The catalog is also the audit trail; allowing history to be disabled
+        ;; would make its public lifecycle contract configuration-dependent.
+        (assoc :keep-history? true)
+        (update-in [:store :id]
+                   #(or % (if path
+                            (deterministic-id path)
+                            (random-uuid)))))))
+
+(defn- install-missing-schema! [conn]
+  (let [installed (set (keys (d/schema @conn)))
+        missing   (remove #(contains? installed (:db/ident %)) catalog-schema)]
+    (when (seq missing)
+      (d/transact conn (vec missing)))))
+
+(defn- open! [configured]
+  (let [cfg (system-config configured)]
+    (if (d/database-exists? cfg)
+      (doto (d/connect cfg)
+        (install-missing-schema!))
+      (do
+        (d/create-database cfg)
+        (doto (d/connect cfg)
+          (d/transact (eschema/merge-schema catalog-schema)))))))
+
+(defn- store-id [config]
+  (some-> config :store store/store-identity str))
+
+(defn- principal-id [principal]
+  (or (:sub principal) "unknown"))
+
+(defn- stored-config [config]
+  (-> config
+      (dissoc :remote-peer :writer)
+      routes/redact
+      pr-str))
+
+(defn register!
+  "Upsert an active catalog entry after a database was created successfully."
+  [conn config principal]
+  (let [id (or (store-id config)
+               (throw (ex-info "A cataloged database needs a stable store id"
+                               {:type :datahike.http/missing-database-id})))
+        lookup [:datahike.system.database/id id]
+        exists? (some? (d/entity @conn lookup))
+        now (java.util.Date.)
+        who (principal-id principal)
+        entry (cond-> {:datahike.system.database/id     id
+                       :datahike.system.database/name   (or (:name config) id)
+                       :datahike.system.database/config (stored-config config)
+                       :datahike.system.database/state  :active}
+                (not exists?)
+                (assoc :datahike.system.database/created-at now
+                       :datahike.system.database/created-by who))
+        tx-data (cond-> [entry]
+                  exists? (conj [:db.fn/retractAttribute lookup
+                                 :datahike.system.database/deleted-at]
+                                [:db.fn/retractAttribute lookup
+                                 :datahike.system.database/deleted-by]))]
+    (d/transact conn {:tx-data tx-data
+                      :tx-meta {:datahike.system/principal who}})
+    config))
+
+(defn mark-deleted!
+  "Soft-delete a catalog entry after its physical database was deleted."
+  [conn config principal]
+  (let [id (store-id config)
+        lookup [:datahike.system.database/id id]
+        who (principal-id principal)]
+    (when id
+      ;; A database created before the catalog may not have an entry. Register
+      ;; enough identity/config to make its deletion visible before marking it.
+      (when-not (d/entity @conn lookup)
+        (register! conn config principal))
+      (d/transact conn
+                  {:tx-data [{:db/id lookup
+                              :datahike.system.database/state :deleted
+                              :datahike.system.database/deleted-at (java.util.Date.)
+                              :datahike.system.database/deleted-by who}]
+                   :tx-meta {:datahike.system/principal who}})))
+  nil)
+
+(defn- parse-stored-config [value]
+  (try
+    (edn/read-string value)
+    (catch Exception _ nil)))
+
+(defn entries
+  "Catalog entries as API data, newest state included."
+  [conn]
+  (->> (d/q '[:find [?e ...]
+              :where [?e :datahike.system.database/id]]
+            @conn)
+       (map #(d/pull @conn catalog-pull %))
+       (map (fn [entry]
+              {:store-id   (:datahike.system.database/id entry)
+               :name       (:datahike.system.database/name entry)
+               :config     (parse-stored-config (:datahike.system.database/config entry))
+               :state      (:datahike.system.database/state entry)
+               :created-at (:datahike.system.database/created-at entry)
+               :created-by (:datahike.system.database/created-by entry)
+               :deleted-at (:datahike.system.database/deleted-at entry)
+               :deleted-by (:datahike.system.database/deleted-by entry)}))
+       (sort-by (juxt :name :store-id))
+       vec))
+
+(defn- visible? [config principal {:keys [store-id]}]
+  (if-let [authorize (:authorize config)]
+    (authorize {:op :read
+                :principal principal
+                :db {:store-id (parse-uuid store-id) :branch :db}
+                :payload nil})
+    true))
+
+(defn routes
+  "GET /databases for active entries the caller may read."
+  [{::keys [conn] :as config}]
+  (when conn
+    [["/databases"
+      {:get {:summary "List databases visible to the caller."
+             :metric-op :read
+             :handler
+             (fn [{principal :datahike/principal}]
+               (try
+                 {:status 200
+                  :body (->> (entries conn)
+                             (filter #(= :active (:state %)))
+                             (filter #(visible? config principal %))
+                             vec)}
+                 (catch Exception e
+                   (routes/error-response e))))}}]]))
+
+(defn configure
+  "Open the configured system database and install catalog callbacks."
+  [config]
+  (if-let [configured (configured-system-db config)]
+    (let [conn (open! configured)]
+      (-> config
+          (assoc :system-db configured
+                 conn-key conn
+                 register-key (partial register! conn)
+                 delete-key (partial mark-deleted! conn))))
+    config))
+
+(defn close! [config]
+  (when-let [conn (get config conn-key)]
+    (d/release conn)))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -12,7 +12,7 @@
   (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
   (is (= "DATAHIKE_SHUTDOWN_TIMEOUT_MS" (config/env-name :shutdown-timeout-ms)))
   (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
-  (is (= "DATAHIKE_AUTH_DB_PATH" (config/env-name :auth-db-path))))
+  (is (= "DATAHIKE_SYSTEM_DB_PATH" (config/env-name :system-db-path))))
 
 (deftest standalone-bind-safety
   (testing "literal and named loopback hosts need no authentication"
@@ -54,7 +54,7 @@
                                  :shutdown-timeout-ms 10000
                                  :level :info
                                  :metrics false
-                                 :auth-db {:store {:backend :memory}}}))
+                                 :system-db {:store {:backend :memory}}}))
         env  {"DATAHIKE_PORT" "2002"
               "DATAHIKE_HOST" "env-host"
               "DATAHIKE_TOKEN" "env-token"
@@ -62,7 +62,7 @@
               "DATAHIKE_SHUTDOWN_TIMEOUT_MS" "20000"
               "DATAHIKE_LEVEL" "warn"
               "DATAHIKE_LOG_FORMAT" "text"
-              "DATAHIKE_AUTH_DB_PATH" "/env/auth"}
+              "DATAHIKE_SYSTEM_DB_PATH" "/env/system"}
         args ["--config" (.getPath file)
               "--port" "3003"
               "--host" "cli-host"
@@ -71,7 +71,7 @@
               "--shutdown-timeout-ms" "30000"
               "--level" "error"
               "--log-format" "json"
-              "--auth-db-path" "/cli/auth"]
+              "--system-db-path" "/cli/system"]
         resolved (:config (config/resolve-config args env))]
     (is (= 3003 (:port resolved)))
     (is (= "cli-host" (:host resolved)))
@@ -81,13 +81,18 @@
     (is (= :error (:level resolved)))
     (is (= :json (:log-format resolved)))
     (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
-    (is (= {:backend :file :path "/cli/auth"}
-           (get-in resolved [:auth-db :store])))))
+    (is (= {:backend :file :path "/cli/system"}
+           (get-in resolved [:system-db :store])))))
 
 (deftest positional-config-remains-backward-compatible
   (let [file (temp-file "{:port 4444}")]
     (is (= {:action :run :config {:port 4444}}
            (config/resolve-config [(.getPath file)] {})))))
+
+(deftest system-database-path-shorthand
+  (is (= {:backend :file :path "/catalog"}
+         (get-in (config/resolve-config [] {"DATAHIKE_SYSTEM_DB_PATH" "/catalog"})
+                 [:config :system-db :store]))))
 
 (deftest token-files-are-secret-mount-friendly-and-layered
   (let [env-token (temp-file "environment-secret\n")

--- a/test/datahike/test/http/health_test.clj
+++ b/test/datahike/test/http/health_test.clj
@@ -6,6 +6,7 @@
             [datahike.connector :as connector]
             [datahike.http.permissions :as permissions]
             [datahike.http.server :as server]
+            [datahike.http.system :as system]
             [konserve.core :as k]))
 
 (def token "health-test-token")
@@ -40,14 +41,15 @@
       (finally
         (server/stop-server instance)))))
 
-(deftest readiness-checks-live-and-auth-stores
+(deftest readiness-checks-live-and-system-stores
   (let [data-id   #uuid "7bea093b-af2e-49a2-a02e-7cf4be87a77b"
         data-conn (connector/conn-from-db {:store ::data-store})
         auth-conn (connector/conn-from-db {:store ::auth-store})
         connections (atom {[data-id :db] {:conn data-conn :count 1}})
         probed      (atom [])]
-    (with-redefs [permissions/configure
-                  #(assoc % ::permissions/conn auth-conn)
+    (with-redefs [system/configure
+                  #(assoc % system/conn-key auth-conn)
+                  permissions/configure identity
                   connector/deref-conn
                   (fn [_]
                     (throw (ex-info "readiness must not refresh a connection" {})))
@@ -55,7 +57,7 @@
                   (fn [store key not-found opts]
                     (swap! probed conj [store key not-found opts])
                     nil)]
-      (let [handler  (server/app {:token token :metrics false :auth-db {}} connections)
+      (let [handler  (server/app {:token token :metrics false :system-db {}} connections)
             response (request handler "/health/ready")]
         (is (= 200 (:status response)))
         (is (= #{::data-store ::auth-store} (set (map first @probed))))

--- a/test/datahike/test/http/metrics_test.clj
+++ b/test/datahike/test/http/metrics_test.clj
@@ -2,9 +2,9 @@
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [datahike.http.permissions :as permissions]
             [datahike.http.routes :as routes]
             [datahike.http.server :as server]
+            [datahike.http.system :as system]
             [datahike.metrics :as dhm]
             [konserve.metrics :as konserve-metrics]
             [replikativ.metrics :as metrics]))
@@ -103,13 +103,13 @@
         (when-let [instance @second-server] (server/stop-server instance))
         (when-let [instance @disabled] (server/stop-server instance))))))
 
-(deftest shutdown-releases-the-process-sink-when-permission-cleanup-fails
+(deftest shutdown-releases-the-process-sink-when-system-cleanup-fails
   (let [before   @konserve-metrics/sinks
         instance (server/start-server {:port 0 :join? false :token token})]
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"forced permission cleanup failure"
-                          (with-redefs [permissions/close!
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"forced system cleanup failure"
+                          (with-redefs [system/close!
                                         (fn [_]
-                                          (throw (ex-info "forced permission cleanup failure" {})))]
+                                          (throw (ex-info "forced system cleanup failure" {})))]
                             (server/stop-server instance))))
     (is (= before @konserve-metrics/sinks)
         "permission cleanup failure does not strand the process metrics sink")))

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -30,11 +30,11 @@
                  (.getCause e) (recur (.getCause e))
                  :else false)))))
 
-(deftest permissions-in-the-auth-db
+(deftest permissions-in-the-system-db
   (let [port     23210
         url      (str "http://localhost:" port)
         config   {:token root-token :validator validator
-                  :auth-db {:store {:backend :file :path (str (fs/temp-dir! "dh-auth-") "/auth")}}}
+                  :system-db {:store {:backend :file :path (str (fs/temp-dir! "dh-system-") "/system")}}}
         start!   (fn []
                    (let [conns (atom {}) app (server/app config conns)]
                      {:server (run-jetty app {:port port :join? false}) :app app :conns conns}))
@@ -48,10 +48,15 @@
                   :schema-flexibility :read}
         db-obj   {:type :database :id (str store-id)}
         grant!   (fn [t updates] (client/request-cbor :post "permissions/relationships!" (peer t) updates))
+        list!    (fn [t] (client/request-cbor :get "databases" (peer t) (random-uuid)))
         s        (atom (start!))]
     (try
       (testing "root creates; nobody else may touch the database"
         (client/create-database (assoc cfg :remote-peer (peer root-token)))
+        (is (= [{:store-id (str store-id) :state :active}]
+               (mapv #(select-keys % [:store-id :state]) (list! root-token))))
+        (is (empty? (list! "alice-token"))
+            "the catalog does not reveal databases the caller cannot read")
         (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
 
       (testing "root grants alice writer and bob reader in one batch; alice may read and write, not delete or grant"
@@ -60,6 +65,8 @@
                                     :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}
                                    {:operation :touch
                                     :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
+        (is (= #{(str store-id)} (set (map :store-id (list! "alice-token")))))
+        (is (= #{(str store-id)} (set (map :store-id (list! "bob-token")))))
         (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
           (client/transact alice [{:name "Ada"}])
           (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
@@ -116,16 +123,17 @@
             "a batch with a bad relationship is refused whole")
         (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
             "…and its good half did not land")
-        (client/delete-database (assoc cfg :remote-peer (peer root-token))))
+        (client/delete-database (assoc cfg :remote-peer (peer root-token)))
+        (is (empty? (list! root-token))
+            "soft-deleted catalog entries are absent from the public list"))
       (finally
         (stop! @s)))))
 
-(deftest memory-auth-dbs-do-not-collide
-  (let [a (permissions/configure {:token "a" :auth-db {:store {:backend :memory}}})
-        b (permissions/configure {:token "b" :auth-db {:store {:backend :memory}}})]
+(deftest memory-system-dbs-do-not-collide
+  (let [a (permissions/configure {:token "a" :system-db {:store {:backend :memory}}})
+        b (permissions/configure {:token "b" :system-db {:store {:backend :memory}}})]
     (try
       (is (not (identical? (::permissions/conn a) (::permissions/conn b))))
       (is (true? ((:authorize a) {:op :create :principal {:sub "root"} :db nil})))
       (is (true? ((:authorize b) {:op :create :principal {:sub "root"} :db nil})))
       (finally (permissions/close! a) (permissions/close! b)))))
-

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -4,9 +4,9 @@
    [clojure.string :as str]
    [clojure.test :as t :refer [is deftest testing]]
    [datahike.http.client :as api]
-   [datahike.http.permissions :as permissions]
    [datahike.http.routes :as routes]
-   [datahike.http.server :as server :refer [start-server stop-server]]))
+   [datahike.http.server :as server :refer [start-server stop-server]]
+   [datahike.http.system :as system]))
 
 (defn- local-port [^org.eclipse.jetty.server.Server instance]
   (.getLocalPort ^org.eclipse.jetty.server.ServerConnector
@@ -137,7 +137,7 @@
   (let [entered       (promise)
         finish        (promise)
         releases      (atom 0)
-        permission-closes (atom 0)
+        system-closes (atom 0)
         configured-timeout (promise)
         instance      (atom nil)]
     (with-redefs [server/app
@@ -151,7 +151,7 @@
                           {:status 200 :body "unexpected"}))
                       {::server/config config}))
                   routes/release-all! (fn [_] (swap! releases inc))
-                  permissions/close! (fn [_] (swap! permission-closes inc))]
+                  system/close! (fn [_] (swap! system-closes inc))]
       (try
         (reset! instance
                 (start-server {:host "127.0.0.1"
@@ -181,7 +181,7 @@
             (is (nil? (deref stopping 2000 ::timeout)))
             (stop-server @instance)
             (is (= 1 @releases))
-            (is (= 1 @permission-closes))))
+            (is (= 1 @system-closes))))
         (finally
           (deliver finish true)
           (when @instance (stop-server @instance)))))))

--- a/test/datahike/test/http/system_test.clj
+++ b/test/datahike/test/http/system_test.clj
@@ -1,0 +1,65 @@
+(ns datahike.test.http.system-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.http.system :as system]))
+
+(deftest catalog-lifecycle-is-durable-redacted-and-auditable
+  (let [configured (system/configure
+                    {:system-db {:store {:backend :memory}}})
+        conn       (get configured system/conn-key)
+        store-id   (random-uuid)
+        database   {:name "accounts"
+                    :store {:backend :jdbc
+                            :id store-id
+                            :password "database-password"
+                            :client-secret "cloud-secret"}
+                    :remote-peer {:token "remote-token"}
+                    :writer {:token "writer-token"}}]
+    (try
+      (is (true? (get-in @conn [:config :keep-history?])))
+      ((get configured system/register-key) database {:sub "alice"})
+      (let [[entry] (system/entries conn)]
+        (is (= {:store-id (str store-id)
+                :name "accounts"
+                :state :active
+                :created-by "alice"}
+               (select-keys entry [:store-id :name :state :created-by])))
+        (is (inst? (:created-at entry)))
+        (is (= "REDACTED" (get-in entry [:config :store :password])))
+        (is (= "REDACTED" (get-in entry [:config :store :client-secret])))
+        (is (not (contains? (:config entry) :remote-peer)))
+        (is (not (contains? (:config entry) :writer))))
+
+      ((get configured system/delete-key) database {:sub "bob"})
+      (let [[entry] (system/entries conn)]
+        (is (= :deleted (:state entry)))
+        (is (= "bob" (:deleted-by entry)))
+        (is (inst? (:deleted-at entry)))
+        (is (= #{["bob"]}
+               (set
+                (d/q
+                 '[:find ?principal
+                   :where
+                   [_ :datahike.system.database/state :deleted ?tx true]
+                   [?tx :datahike.system/principal ?principal]]
+                 (d/history @conn))))
+            "the acting principal is attached to the lifecycle transaction"))
+
+      (testing "recreating the same store reactivates its one catalog identity"
+        ((get configured system/register-key) database {:sub "carol"})
+        (let [[entry :as entries] (system/entries conn)]
+          (is (= 1 (count entries)))
+          (is (= :active (:state entry)))
+          (is (= "alice" (:created-by entry))
+              "reactivation preserves the original creator")
+          (is (nil? (:deleted-at entry)))
+          (is (nil? (:deleted-by entry)))))
+      (finally
+        (system/close! configured)))))
+
+(deftest obsolete-auth-database-key-is-rejected
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"replaced by :system-db"
+       (system/configure {:auth-db {:store {:backend :memory}}}))))

--- a/test/datahike/test/http/version_test.clj
+++ b/test/datahike/test/http/version_test.clj
@@ -21,7 +21,9 @@
                                     :user     "datahike"
                                     :password "database-secret"}}
                  :nested {:access-key "access-secret"
-                          :secret-key "secret-secret"}}
+                          :secret-key "secret-secret"
+                          :client-secret "oauth-secret"
+                          :connection-string "jdbc-secret"}}
         handler (with-redefs [tools/datahike-version "1.2.3"
                               tools/datahike-git-sha "0123456789abcdef0123456789abcdef01234567"
                               tools/konserve-version "9.8.7"]
@@ -47,4 +49,6 @@
           (is (= "REDACTED" (get-in info [:config :token])))
           (is (= "REDACTED" (get-in info [:config :database :store :password])))
           (is (= "REDACTED" (get-in info [:config :nested :access-key])))
-          (is (= "REDACTED" (get-in info [:config :nested :secret-key]))))))))
+          (is (= "REDACTED" (get-in info [:config :nested :secret-key])))
+          (is (= "REDACTED" (get-in info [:config :nested :client-secret])))
+          (is (= "REDACTED" (get-in info [:config :nested :connection-string]))))))))


### PR DESCRIPTION
Adds the canonical system database for the standalone server and removes the short-lived auth-db name.

- stores redacted database configs and audited create/delete lifecycle metadata
- exposes authenticated GET /databases, filtered through the existing read authorization policy
- shares one history-enabled database with EACL permissions
- adds SYSTEM_DB_PATH environment and CLI configuration
- probes the system database in readiness and closes it with server lifecycle
- expands backend credential redaction and updates operator documentation

Verification:
- focused HTTP suites: 34 tests, 392 assertions
- catalog/config suites: 9 tests, 72 assertions
- prior three-index focused run before the canonical rename: 51 tests, 408 assertions
- bb reflection: no reflective calls
- clj-kondo on changed source and tests: no errors

The repository-wide lint task still reports its existing broad unresolved-var/error baseline; changed files have no lint errors.