### PR TITLE
feat(server): share system catalog with pg-datahike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ When something is added, it's typically marked *Experimental*. When the API cont
   lists authorized catalog entries at `GET /databases`. Token auth no longer
   uses buddy; the header is
   `authorization: token <token>` as before.
+- **The standalone server can expose its system catalog through pg-datahike.**
+  *Experimental.* Add `:pg-listener` to start a PostgreSQL wire listener whose
+  database names and live connections follow the same create/delete lifecycle
+  as the HTTP API. The initial beta is loopback-only while pg-datahike wire
+  authentication lands and PostgreSQL identities have defined EACL semantics.
+  Credential-redacted catalog entries can be restored with deployment-side
+  `:database-overrides`.
 
 - **Index warming is unified across the stack, and real on ClojureScript.**
   The breadth-first walk moved to persistent-sorted-set (>= 0.5.142), where

--- a/deps.edn
+++ b/deps.edn
@@ -186,6 +186,8 @@
                                 :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
                                org.replikativ/konserve-redis {:mvn/version "0.1.29"}
                                org.postgresql/postgresql     {:mvn/version "42.7.13"}
+                               org.replikativ/pg-datahike    {:mvn/version "0.1.159"
+                                                               :exclusions [org.replikativ/datahike]}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
            ;; Datomic Pro peer API, for `datahike.migrate.datomic` and its
@@ -238,7 +240,10 @@
                                       org.replikativ/konserve-redis
                                       {:mvn/version "0.1.29"}
                                       org.postgresql/postgresql
-                                      {:mvn/version "42.7.13"}}
+                                      {:mvn/version "42.7.13"}
+                                      org.replikativ/pg-datahike
+                                      {:mvn/version "0.1.159"
+                                       :exclusions [org.replikativ/datahike]}}
                          :main-opts ["-m" "datahike.http.main"]}
 
            ;; konserve-s3 is here for the same reason it is in :native-cli, and it

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -174,6 +174,49 @@ principal. `GET /databases` returns active entries filtered through the same
 `:read` permission as database calls; callers cannot discover databases they
 cannot read.
 
+### Optional PostgreSQL listener (beta)
+
+The batteries-included server bundles
+[pg-datahike](https://github.com/replikativ/pg-datahike). Add a
+`:pg-listener` map to serve every active catalog entry under its `:name` (or
+store UUID when unnamed):
+
+```clojure
+{:system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
+ :pg-listener
+ {:host "127.0.0.1"
+  :port 5432
+  :database-overrides
+  {"accounts" {:store {:password "secret-from-deployment"}}}}}
+```
+
+Set `:pg-listener {:enabled? false}` to keep a deployment-supplied listener
+configuration present without opening the port.
+
+Catalog configs never retain passwords or cloud credentials. Generate or
+mount the deployment config securely. If a redacted value is still unresolved
+after applying the matching name or store-id override, the listener refuses to
+start and reports only the missing config paths.
+
+HTTP creates are added to the PostgreSQL registry immediately. Before an HTTP
+delete touches storage, the listener unregisters the database and releases its
+connection; a failed delete restores it. pg-datahike's independent
+`CREATE/DROP DATABASE` hooks are rejected so there is no second catalog.
+Catalog names exposed through PostgreSQL must be unique; the server rejects a
+conflicting HTTP create before it changes physical storage.
+
+This listener is beta and currently restricted to loopback because released
+pg-datahike versions do not authenticate the wire connection. Once password
+authentication is available, the server will accept an authenticated public
+bind. Use the HTTP API for provisioning and permission administration in the
+meantime.
+
+The PostgreSQL listener is currently a trusted local data surface: PostgreSQL
+users are not mapped to Datahike EACL principals, so a client that can reach
+the listener can access every database it exposes. The loopback restriction is
+a security boundary, not merely a beta convenience. Do not publish or proxy
+this port to untrusted clients.
+
 The graph (`datahike.http.permissions/schema`):
 
 ```

--- a/http-server/datahike/http/pg.clj
+++ b/http-server/datahike/http/pg.clj
@@ -1,0 +1,214 @@
+(ns datahike.http.pg
+  "Optional pg-datahike listener over the standalone server's catalog.
+
+   The HTTP server owns database connections and their lifecycle. pg-datahike
+   receives the same connections under catalog names and remains responsible
+   only for the PostgreSQL protocol surface."
+  (:require
+   [datahike.api :as d]
+   [datahike.connections :as connections]
+   [datahike.http.config :as server-config]
+   [datahike.http.system :as system]
+   [datahike.pg.server :as pg]
+   [datahike.store :as store]
+   [replikativ.logging :as log]))
+
+(defn- deep-merge [left right]
+  (merge-with (fn [a b]
+                (if (and (map? a) (map? b))
+                  (deep-merge a b)
+                  b))
+              left right))
+
+(defn- redacted-paths
+  ([value] (redacted-paths [] value))
+  ([path value]
+   (cond
+     (map? value)
+     (mapcat (fn [[key child]] (redacted-paths (conj path key) child)) value)
+
+     (coll? value)
+     (mapcat (fn [[index child]] (redacted-paths (conj path index) child))
+             (map-indexed vector value))
+
+     (= "REDACTED" value) [path]
+     :else [])))
+
+(defn- store-id [config]
+  (some-> config :store store/store-identity str))
+
+(defn- effective-config [{:keys [database-overrides]} entry]
+  (let [base     (:config entry)
+        override (or (get database-overrides (:name entry))
+                     (get database-overrides (:store-id entry))
+                     (when-let [name (:name entry)]
+                       (get database-overrides (keyword name)))
+                     {})
+        config   (deep-merge base override)
+        unresolved (vec (redacted-paths config))]
+    (when (seq unresolved)
+      (throw (ex-info
+              (str "Database " (pr-str (:name entry))
+                   " needs deployment-side secret overrides before pg-datahike can connect")
+              {:type :datahike.http/unresolved-database-secrets
+               :database (:name entry)
+               :store-id (:store-id entry)
+               :paths unresolved})))
+    config))
+
+(defn- connect! [connections config]
+  (binding [connections/*connections* connections]
+    (d/connect config)))
+
+(defn- release! [connections conn]
+  (binding [connections/*connections* connections]
+    (d/release conn)))
+
+(defn- active-entries [config]
+  (filter #(= :active (:state %))
+          (system/entries (get config system/conn-key))))
+
+(defn- reject-independent-provisioning! [listener-config]
+  (when-let [keys (seq (filter #(contains? listener-config %)
+                               [:database-template
+                                :on-create-database
+                                :on-delete-database]))]
+    (throw (ex-info
+            "pg-datahike database provisioning must use the shared system catalog"
+            {:type :datahike.http/independent-pg-provisioning
+             :keys (vec keys)}))))
+
+(defn start!
+  "Start the configured pg-datahike listener, or return nil when absent."
+  [config connections]
+  (when-let [listener-config (let [listener-config (:pg-listener config)]
+                               (when (and listener-config
+                                          (not (false? (:enabled? listener-config))))
+                                 listener-config))]
+    (when-not (get config system/conn-key)
+      (throw (ex-info ":pg-listener requires :system-db"
+                      {:type :datahike.http/missing-system-database})))
+    (reject-independent-provisioning! listener-config)
+    (let [host (get listener-config :host "127.0.0.1")]
+      (when-not (server-config/loopback-host? host)
+        (throw (ex-info
+                "The beta pg-datahike listener is restricted to a loopback bind until wire authentication is available"
+                {:type :datahike.http/unsafe-pg-bind
+                 :host host}))))
+    (log/warn :datahike/pg-listener-beta
+              "The pg-datahike listener is beta and does not yet provide the full PostgreSQL surface")
+    (let [opened   (atom {})
+          runtime  (atom nil)
+          validate-name!
+          (fn [{:keys [name store-id]}]
+            (when-let [existing (get @opened name)]
+              (when-not (= store-id (:store-id existing))
+                (throw
+                 (ex-info
+                  (str "PostgreSQL database name " (pr-str name)
+                       " identifies more than one catalog store")
+                  {:type :datahike.http/duplicate-pg-database-name
+                   :database name
+                   :store-ids [(:store-id existing) store-id]})))))
+          add!     (fn [entry]
+                     (let [name (:name entry)
+                           id   (:store-id entry)]
+                       (locking opened
+                         (validate-name! entry)
+                         (if-let [existing (get @opened name)]
+                           (:conn existing)
+                           (let [config (effective-config listener-config entry)
+                                 conn   (connect! connections config)]
+                             (try
+                               (when-let [server @runtime]
+                                 (pg/add-database! server name conn))
+                               (swap! opened assoc name {:conn conn
+                                                         :config config
+                                                         :store-id id})
+                               conn
+                               (catch Throwable e
+                                 (release! connections conn)
+                                 (throw e))))))))
+          remove!  (fn [config]
+                     (locking opened
+                       (let [id (store-id config)
+                             [name {:keys [conn]}]
+                             (some (fn [[name entry]]
+                                     (when (= id (:store-id entry))
+                                       [name entry]))
+                                   @opened)]
+                         (when name
+                           (when-let [server @runtime]
+                             (pg/remove-database! server name))
+                           (swap! opened dissoc name)
+                           (release! connections conn)))))
+          add-event! (fn [entry event]
+                       (try
+                         (add! entry)
+                         (catch Throwable e
+                           ;; The physical database and durable catalog already
+                           ;; exist. Do not turn that success into a misleading
+                           ;; failed HTTP create/rollback; expose the degraded
+                           ;; listener loudly and retry on the next server start.
+                           (log/error :datahike/pg-catalog-add-failed
+                                      (ex-message e)
+                                      {:event event
+                                       :database (:name entry)
+                                       :store-id (:store-id entry)
+                                       :error-class (.getName (class e))}))))
+          listener (fn [{:keys [event config]}]
+                     (case event
+                       :creating
+                       (locking opened
+                         (validate-name!
+                          {:name (or (:name config) (store-id config))
+                           :store-id (store-id config)}))
+
+                       :created
+                       (add-event! {:name (or (:name config) (store-id config))
+                                    :store-id (store-id config)
+                                    :config config}
+                                   event)
+
+                       :deleting (remove! config)
+
+                       :delete-cancelled
+                       (add-event! {:name (or (:name config) (store-id config))
+                                    :store-id (store-id config)
+                                    :config config}
+                                   event)
+
+                       nil))]
+      (try
+        (doseq [entry (active-entries config)]
+          (add! entry))
+        (let [registry (into {} (map (fn [[name {:keys [conn]}]] [name conn]) @opened))
+              options  (dissoc listener-config :database-overrides :enabled?)
+              server   (pg/start-server registry options)
+              _        (reset! runtime server)
+              subscription (system/subscribe! config listener)]
+          {:server server
+           :subscription subscription
+           :opened opened
+           :config config
+           :connections connections})
+        (catch Throwable e
+          (when-let [server @runtime]
+            (try
+              (pg/stop-server server)
+              (catch Throwable _)))
+          (doseq [[_ {:keys [conn]}] @opened]
+            (release! connections conn))
+          (throw e))))))
+
+(defn stop! [{:keys [server subscription config opened connections]}]
+  (when subscription
+    (system/unsubscribe! config subscription))
+  (try
+    (when server
+      (pg/stop-server server))
+    (finally
+      (when opened
+        (doseq [[_ {:keys [conn]}] @opened]
+          (release! connections conn)))))
+  nil)

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -257,21 +257,46 @@
             (let [local    (fn [cfg] (dissoc cfg :remote-peer :writer))
                   ret-body
                   (cond (= f #'api/create-database)
-                        ;; remove remote-peer and re-add
-                        (let [created (apply f (local (first body)) (rest body))]
-                          (when-let [register! (:datahike.http.system/register! config)]
-                            (register! created (:datahike/principal request)))
-                          (assoc created :remote-peer (:remote-peer (first body))))
+                        (with-exclusive state
+                          (fn []
+                            ;; Remove remote-peer while this server creates the
+                            ;; physical store, then restore it in the response.
+                            (let [requested (local (first body))
+                                  principal (:datahike/principal request)]
+                              (when-let [prepare! (:datahike.http.system/prepare-register! config)]
+                                (prepare! requested principal))
+                              (let [created (apply f requested (rest body))]
+                                (when-let [register! (:datahike.http.system/register! config)]
+                                  (register! created principal))
+                                (assoc created :remote-peer (:remote-peer (first body)))))))
 
                         (= f #'api/delete-database)
                         (with-exclusive state
                           (fn []
-                            (swap! (:leases state) dissoc (conn-id (first body)))
-                            (let [local-config (local (first body))
-                                  result (apply f local-config (rest body))]
-                              (when-let [deleted! (:datahike.http.system/delete! config)]
-                                (deleted! local-config (:datahike/principal request)))
-                              result)))
+                            (let [id           (conn-id (first body))
+                                  lease-state  (get @(:leases state) id)
+                                  local-config (local (first body))
+                                  principal    (:datahike/principal request)]
+                              (when-let [prepare! (:datahike.http.system/prepare-delete! config)]
+                                (prepare! local-config principal))
+                              (swap! (:leases state) dissoc id)
+                              (let [result
+                                    (try
+                                      (apply f local-config (rest body))
+                                      (catch Throwable e
+                                        (when lease-state
+                                          (swap! (:leases state) assoc id lease-state))
+                                        (when-let [cancel! (:datahike.http.system/cancel-delete! config)]
+                                          (try
+                                            (cancel! local-config principal)
+                                            (catch Throwable cleanup-error
+                                              (log/error :datahike/catalog-delete-rollback-failed
+                                                         (ex-message cleanup-error)
+                                                         {:error-class (.getName (class cleanup-error))}))))
+                                        (throw e)))]
+                                (when-let [deleted! (:datahike.http.system/delete! config)]
+                                  (deleted! local-config principal))
+                                result))))
 
                         (= f #'api/connect)
                         (granted! state (apply f (cons (local (first body)) (rest body))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -7,6 +7,7 @@
    [datahike.http.config :as server-config]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
+   [datahike.http.pg :as pg]
    [datahike.http.routes :as routes]
    [datahike.http.system :as system]
    [reitit.ring :as ring]
@@ -226,6 +227,18 @@
            (when configurator
              (configurator server)))))
 
+(defn- cleanup-owned! [connections config pg-listener metrics-lease]
+  (try
+    (pg/stop! pg-listener)
+    (finally
+      (try
+        (routes/release-all! connections)
+        (finally
+          (try
+            (system/close! config)
+            (finally
+              (release-metrics-sink! metrics-lease))))))))
+
 (defn start-server
   "Start Jetty and acquire the standalone server's shared Konserve metric sink
    unless `:metrics` is false. `stop-server` releases both."
@@ -236,16 +249,25 @@
         app         (app config connections)
         config      (::config (meta app))
         jetty-config (with-graceful-shutdown config timeout)
-        metrics-lease (when-not (false? (:metrics config))
-                        (acquire-metrics-sink!))
+        pg-listener (try
+                      (pg/start! config connections)
+                      (catch Throwable t
+                        (cleanup-owned! connections config nil nil)
+                        (throw t)))
+        metrics-lease (try
+                        (when-not (false? (:metrics config))
+                          (acquire-metrics-sink!))
+                        (catch Throwable t
+                          (cleanup-owned! connections config pg-listener nil)
+                          (throw t)))
         server      (try (run-jetty app jetty-config)
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
-                           (release-metrics-sink! metrics-lease)
-                           (system/close! config)
+                           (cleanup-owned! connections config pg-listener metrics-lease)
                            (throw t)))]
     (swap! owned assoc server {:connections connections
                                :config config
+                               :pg-listener pg-listener
                                :metrics-lease metrics-lease})
     server))
 
@@ -256,19 +278,11 @@
    twice."
   [^org.eclipse.jetty.server.Server server]
   (let [[before _] (swap-vals! owned dissoc server)
-        {:keys [connections config metrics-lease]} (get before server)]
+        {:keys [connections config pg-listener metrics-lease]} (get before server)]
     (try (.stop server)
          (finally
            (when connections
-             ;; Each cleanup owns an inner `finally`, so one failure cannot skip
-             ;; the remaining process-global cleanup.
-             (try
-               (routes/release-all! connections)
-               (finally
-                 (try
-                   (system/close! config)
-                   (finally
-                     (release-metrics-sink! metrics-lease))))))))))
+             (cleanup-owned! connections config pg-listener metrics-lease))))))
 
 (defn- shutdown-hook [server config]
   (Thread.

--- a/http-server/datahike/http/system.clj
+++ b/http-server/datahike/http/system.clj
@@ -11,8 +11,34 @@
    [eacl.datahike.schema :as eschema]))
 
 (def register-key ::register!)
+(def prepare-register-key ::prepare-register!)
+(def prepare-delete-key ::prepare-delete!)
 (def delete-key ::delete!)
+(def cancel-delete-key ::cancel-delete!)
 (def conn-key ::conn)
+(def listeners-key ::listeners)
+
+(defn subscribe!
+  "Subscribe to catalog lifecycle events. Returns an opaque subscription id."
+  [config listener]
+  (let [subscription (random-uuid)]
+    (swap! (get config listeners-key) assoc subscription listener)
+    subscription))
+
+(defn unsubscribe! [config subscription]
+  (when-let [listeners (get config listeners-key)]
+    (swap! listeners dissoc subscription))
+  nil)
+
+(defn- notify! [listeners event config principal]
+  (doseq [listener (vals @listeners)]
+    (listener {:event event :config config :principal principal})))
+
+(defn prepare-register!
+  "Let catalog consumers reject a create before physical storage is changed."
+  [listeners config principal]
+  (notify! listeners :creating config principal)
+  config)
 
 (def catalog-schema
   [{:db/ident       :datahike.system.database/id
@@ -107,7 +133,7 @@
 
 (defn register!
   "Upsert an active catalog entry after a database was created successfully."
-  [conn config principal]
+  [conn listeners config principal]
   (let [id (or (store-id config)
                (throw (ex-info "A cataloged database needs a stable store id"
                                {:type :datahike.http/missing-database-id})))
@@ -129,11 +155,38 @@
                                  :datahike.system.database/deleted-by]))]
     (d/transact conn {:tx-data tx-data
                       :tx-meta {:datahike.system/principal who}})
+    (notify! listeners :created config principal)
     config))
+
+(defn prepare-delete!
+  "Mark a database as deleting and let listeners release live resources."
+  [conn listeners config principal]
+  (let [id (store-id config)
+        lookup [:datahike.system.database/id id]
+        who (principal-id principal)]
+    (when id
+      (when-not (d/entity @conn lookup)
+        (register! conn listeners config principal))
+      (d/transact conn
+                  {:tx-data [{:db/id lookup
+                              :datahike.system.database/state :deleting}]
+                   :tx-meta {:datahike.system/principal who}})
+      (try
+        (notify! listeners :deleting config principal)
+        (catch Throwable e
+          (d/transact conn
+                      {:tx-data [{:db/id lookup
+                                  :datahike.system.database/state :active}]
+                       :tx-meta {:datahike.system/principal who}})
+          (try
+            (notify! listeners :delete-cancelled config principal)
+            (catch Throwable _))
+          (throw e)))))
+  config)
 
 (defn mark-deleted!
   "Soft-delete a catalog entry after its physical database was deleted."
-  [conn config principal]
+  [conn listeners config principal]
   (let [id (store-id config)
         lookup [:datahike.system.database/id id]
         who (principal-id principal)]
@@ -141,13 +194,28 @@
       ;; A database created before the catalog may not have an entry. Register
       ;; enough identity/config to make its deletion visible before marking it.
       (when-not (d/entity @conn lookup)
-        (register! conn config principal))
+        (register! conn listeners config principal))
       (d/transact conn
                   {:tx-data [{:db/id lookup
                               :datahike.system.database/state :deleted
                               :datahike.system.database/deleted-at (java.util.Date.)
                               :datahike.system.database/deleted-by who}]
                    :tx-meta {:datahike.system/principal who}})))
+  (when (store-id config)
+    (notify! listeners :deleted config principal))
+  nil)
+
+(defn cancel-delete!
+  "Restore an active entry and its listeners when physical deletion failed."
+  [conn listeners config principal]
+  (let [id (store-id config)
+        who (principal-id principal)]
+    (when id
+      (d/transact conn
+                  {:tx-data [{:db/id [:datahike.system.database/id id]
+                              :datahike.system.database/state :active}]
+                   :tx-meta {:datahike.system/principal who}})
+      (notify! listeners :delete-cancelled config principal)))
   nil)
 
 (defn- parse-stored-config [value]
@@ -204,12 +272,17 @@
   "Open the configured system database and install catalog callbacks."
   [config]
   (if-let [configured (configured-system-db config)]
-    (let [conn (open! configured)]
+    (let [conn (open! configured)
+          listeners (atom {})]
       (-> config
           (assoc :system-db configured
                  conn-key conn
-                 register-key (partial register! conn)
-                 delete-key (partial mark-deleted! conn))))
+                 listeners-key listeners
+                 prepare-register-key (partial prepare-register! listeners)
+                 register-key (partial register! conn listeners)
+                 prepare-delete-key (partial prepare-delete! conn listeners)
+                 delete-key (partial mark-deleted! conn listeners)
+                 cancel-delete-key (partial cancel-delete! conn listeners))))
     config))
 
 (defn close! [config]

--- a/test/datahike/test/http/pg_test.clj
+++ b/test/datahike/test/http/pg_test.clj
@@ -1,0 +1,193 @@
+(ns datahike.test.http.pg-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.connections :as connections]
+   [datahike.http.pg :as listener]
+   [datahike.http.system :as system]
+   [datahike.pg.server :as pg])
+  (:import
+   [datahike.pg PgWireServer]
+   [java.sql DriverManager]))
+
+(defn- memory-config [name]
+  {:name name
+   :store {:backend :memory :id (random-uuid)}})
+
+(deftest listener-shares-catalog-connections-and-lifecycle
+  (let [system-config (system/configure
+                       {:system-db {:store {:backend :memory}}
+                        :pg-listener {:host "127.0.0.1" :port 0}})
+        registry      (atom {})
+        stopped       (atom 0)
+        first-config  (memory-config "first")
+        second-config (memory-config "second")
+        conflict-config (memory-config "first")]
+    (binding [connections/*connections* registry]
+      (try
+        (d/create-database first-config)
+        ((get system-config system/register-key) first-config {:sub "root"})
+        (with-redefs [pg/start-server
+                      (fn [initial _options]
+                        {:registry-atom (atom initial)})
+                      pg/stop-server (fn [_] (swap! stopped inc))]
+          (let [runtime (listener/start! system-config registry)
+                pg-registry (:registry-atom (:server runtime))]
+            (is (= #{"first"} (set (keys @pg-registry))))
+            (is (= 1 (count (filter (comp :conn val) @registry))))
+
+            (testing "duplicate PostgreSQL names are rejected before storage changes"
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"identifies more than one catalog store"
+                   ((get system-config system/prepare-register-key)
+                    conflict-config
+                    {:sub "root"})))
+              (is (false? (d/database-exists? conflict-config)))
+              (is (= #{"first"} (set (keys @pg-registry)))))
+
+            (testing "HTTP-created databases become available to new pg sessions"
+              (d/create-database second-config)
+              ((get system-config system/register-key) second-config {:sub "root"})
+              (is (= #{"first" "second"} (set (keys @pg-registry)))))
+
+            (testing "delete preparation releases pg ownership before physical deletion"
+              ((get system-config system/prepare-delete-key) second-config {:sub "root"})
+              (is (= #{"first"} (set (keys @pg-registry))))
+              (d/delete-database second-config)
+              ((get system-config system/delete-key) second-config {:sub "root"})
+              (is (= #{"first"} (set (keys @pg-registry)))))
+
+            (testing "a failed physical delete restores listener availability"
+              ((get system-config system/prepare-delete-key) first-config {:sub "root"})
+              (is (empty? @pg-registry))
+              ((get system-config system/cancel-delete-key) first-config {:sub "root"})
+              (is (= #{"first"} (set (keys @pg-registry)))))
+
+            (listener/stop! runtime)
+            (is (= 1 @stopped))
+            (is (empty? (filter (comp :conn val) @registry)))))
+        (finally
+          (when (d/database-exists? first-config)
+            (d/delete-database first-config))
+          (when (d/database-exists? second-config)
+            (d/delete-database second-config))
+          (system/close! system-config))))))
+
+(deftest listener-requires-resolved-deployment-secrets
+  (let [system-config (system/configure
+                       {:system-db {:store {:backend :memory}}})
+        fake-config   {:name "accounts"
+                       :store {:backend :jdbc
+                               :id (random-uuid)
+                               :password "catalog-secret"}}
+        registry      (atom {})]
+    (try
+      ((get system-config system/register-key) fake-config {:sub "root"})
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"deployment-side secret overrides"
+           (listener/start! (assoc system-config :pg-listener {:port 0}) registry)))
+      (let [connected (atom nil)
+            released  (atom 0)]
+        (with-redefs [d/connect (fn [config]
+                                  (reset! connected config)
+                                  ::connection)
+                      d/release (fn [_] (swap! released inc))
+                      pg/start-server (fn [initial _]
+                                        {:registry-atom (atom initial)})
+                      pg/stop-server (constantly nil)]
+          (let [runtime
+                (listener/start!
+                 (assoc system-config
+                        :pg-listener
+                        {:port 0
+                         :database-overrides
+                         {"accounts" {:store {:password "deployment-secret"}}}})
+                 registry)]
+            (is (= "deployment-secret" (get-in @connected [:store :password])))
+            (listener/stop! runtime)
+            (is (= 1 @released)))))
+      (finally
+        (system/close! system-config)))))
+
+(deftest failed-dynamic-listener-add-does-not-rewrite-a-successful-create
+  (let [system-config (system/configure
+                       {:system-db {:store {:backend :memory}}
+                        :pg-listener {:host "127.0.0.1" :port 0}})
+        database     (memory-config "temporarily-unavailable")
+        registry     (atom {})]
+    (try
+      (with-redefs [pg/start-server (fn [initial _]
+                                      {:registry-atom (atom initial)})
+                    pg/stop-server (constantly nil)]
+        (let [runtime (listener/start! system-config registry)]
+          (try
+            (with-redefs [d/connect (fn [_]
+                                      (throw (ex-info "backend unavailable" {})))]
+              (is (= database
+                     ((get system-config system/register-key)
+                      database
+                      {:sub "root"})))
+              (is (= :active
+                     (:state (first (system/entries
+                                     (get system-config system/conn-key)))))))
+            (finally
+              (listener/stop! runtime)))))
+      (finally
+        (system/close! system-config)))))
+
+(deftest listener-refuses-an-independent-database-registry
+  (is (nil? (listener/start! {:pg-listener {:enabled? false}}
+                             (atom {}))))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"requires :system-db"
+       (listener/start! {:pg-listener {:port 0}} (atom {}))))
+  (let [config (system/configure
+                {:system-db {:store {:backend :memory}}
+                 :pg-listener {:database-template {:store {:backend :memory}}}})]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"shared system catalog"
+           (listener/start! config (atom {}))))
+      (finally
+        (system/close! config))))
+  (let [config (system/configure
+                {:system-db {:store {:backend :memory}}
+                 :pg-listener {:host "0.0.0.0" :port 5432}})]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"restricted to a loopback bind"
+           (listener/start! config (atom {}))))
+      (finally
+        (system/close! config)))))
+
+(deftest catalog-name-routes-a-real-postgresql-session
+  (let [database      (memory-config "analytics")
+        registry      (atom {})
+        system-config (system/configure
+                       {:system-db {:store {:backend :memory}}
+                        :pg-listener {:host "127.0.0.1" :port 0}})]
+    (binding [connections/*connections* registry]
+      (try
+        (d/create-database database)
+        ((get system-config system/register-key) database {:sub "root"})
+        (let [runtime (listener/start! system-config registry)
+              wire    ^PgWireServer (:server (:server runtime))
+              url     (str "jdbc:postgresql://127.0.0.1:" (.getPort wire)
+                           "/analytics?sslmode=disable")]
+          (try
+            (with-open [sql-conn (DriverManager/getConnection url "datahike" "")
+                        statement (.createStatement sql-conn)
+                        result    (.executeQuery statement "SELECT current_database()")]
+              (is (.next result))
+              (is (= "analytics" (.getString result 1))))
+            (finally
+              (listener/stop! runtime))))
+        (finally
+          (when (d/database-exists? database)
+            (d/delete-database database))
+          (system/close! system-config))))))

--- a/test/datahike/test/http/system_test.clj
+++ b/test/datahike/test/http/system_test.clj
@@ -63,3 +63,53 @@
        clojure.lang.ExceptionInfo
        #"replaced by :system-db"
        (system/configure {:auth-db {:store {:backend :memory}}}))))
+
+(deftest catalog-lifecycle-events-follow-durable-state
+  (let [configured (system/configure
+                    {:system-db {:store {:backend :memory}}})
+        events     (atom [])
+        database   {:name "events"
+                    :store {:backend :memory :id (random-uuid)}}
+        subscription (system/subscribe!
+                      configured
+                      #(swap! events conj (select-keys % [:event :config :principal])))]
+    (try
+      ((get configured system/prepare-register-key) database {:sub "alice"})
+      ((get configured system/register-key) database {:sub "alice"})
+      ((get configured system/prepare-delete-key) database {:sub "bob"})
+      ((get configured system/cancel-delete-key) database {:sub "bob"})
+      ((get configured system/prepare-delete-key) database {:sub "carol"})
+      ((get configured system/delete-key) database {:sub "carol"})
+      (is (= [:creating :created :deleting :delete-cancelled :deleting :deleted]
+             (mapv :event @events)))
+      (is (= ["alice" "alice" "bob" "bob" "carol" "carol"]
+             (mapv (comp :sub :principal) @events)))
+      (system/unsubscribe! configured subscription)
+      ((get configured system/register-key) database {:sub "nobody"})
+      (is (= 6 (count @events)))
+      (finally
+        (system/close! configured)))))
+
+(deftest failed-delete-preparation-restores-state-and-listeners
+  (let [configured (system/configure
+                    {:system-db {:store {:backend :memory}}})
+        events     (atom [])
+        database   {:name "rollback"
+                    :store {:backend :memory :id (random-uuid)}}]
+    (try
+      ((get configured system/register-key) database {:sub "root"})
+      (system/subscribe!
+       configured
+       (fn [{:keys [event]}]
+         (swap! events conj event)
+         (when (= :deleting event)
+           (throw (ex-info "listener could not release" {})))))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"could not release"
+           ((get configured system/prepare-delete-key) database {:sub "root"})))
+      (is (= [:deleting :delete-cancelled] @events))
+      (is (= :active (:state (first (system/entries
+                                     (get configured system/conn-key))))))
+      (finally
+        (system/close! configured)))))


### PR DESCRIPTION
## Summary

- bundle pg-datahike in the standalone server and optionally expose the durable system catalog over PostgreSQL wire
- share the server's exact Datahike connection registry and follow catalog create/delete/rollback lifecycle events
- restore credential-redacted catalog configs from deployment-side overrides without logging secret values
- reject independent SQL provisioning, ambiguous PostgreSQL names, and non-loopback binds while wire authentication/EACL identity semantics are still pending
- make startup and shutdown ownership explicit so listener failures cannot leak database, system-catalog, or metrics resources

This is stacked on #1044; review the comparison against `feat/system-database-catalog` for the focused change.

## Security model

The beta listener is a trusted local data surface. Released pg-datahike does not authenticate the wire connection, and PostgreSQL users are not mapped to Datahike EACL principals. The server therefore enforces a loopback-only bind and documents that the port must not be published or proxied to untrusted clients.

## Lifecycle guarantees

- active catalog entries are connected eagerly at listener startup
- HTTP creates preflight name uniqueness before physical storage changes, then enter the live PostgreSQL registry
- delete preparation unregisters and releases the PostgreSQL lease before physical deletion
- a failed physical delete restores both catalog state and PostgreSQL availability
- a dynamic listener connection failure is logged as degraded state without falsely reporting that an already-created physical database failed to create
- SQL `CREATE/DROP DATABASE` hooks are refused so the system database remains the only catalog

## Verification

- `clojure -M:test -m kaocha.runner --focus datahike.test.http.pg-test --focus datahike.test.http.system-test --focus datahike.test.http.routes-test --focus datahike.test.http.server-test`
  - 63 tests, 849 assertions, 0 failures
- final focused rerun after configuration polish
  - 27 tests, 138 assertions, 0 failures
- real PostgreSQL JDBC session routes by catalog database name
- `bb reflection`
  - no reflective calls in Datahike sources
- changed-file clj-kondo
  - 0 errors (existing generated API unresolved-var warnings only)
- `bb format`
- `git diff --check`
- `bb http-server-uber`
  - packaged successfully; 110,873,199-byte batteries-included jar before the dedicated slimming pass
- built-jar smoke test
  - Jetty liveness returned `live`
  - native `psql` reached the PostgreSQL listener and received the expected unknown-catalog error
  - Ctrl-C stopped Jetty and pg-datahike cleanly
