### PR TITLE
feat(server): add lightweight operator status

### DIFF
--- a/http-server/datahike/http/admin.clj
+++ b/http-server/datahike/http/admin.clj
@@ -1,6 +1,9 @@
 (ns datahike.http.admin
   "Static, dependency-free operator landing page for the standalone server."
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [datahike.http.routes :as routes]
+            [datahike.http.system :as system]
+            [datahike.metrics :as metrics]))
 
 (def ^:private security-headers
   {"content-security-policy" (str "default-src 'none'; "
@@ -50,11 +53,39 @@
      ;; Muuntaja deliberately leaves byte-array streams untouched.
      :body (java.io.ByteArrayInputStream. body)}))
 
+(defn- server-admin? [config principal]
+  (if-let [authorize (:authorize config)]
+    (authorize {:op :admin :principal principal :db nil :payload nil})
+    true))
+
+(defn- status-response [config connections principal page-options]
+  (try
+    (let [runtime (metrics/runtime-snapshot connections)
+          ;; Do not let viewing the dashboard alter its query statistics.
+          page    (binding [metrics/*query-metrics?* false]
+                    (system/visible-entry-page config principal page-options))]
+      {:status 200
+       :body {:node (when (server-admin? config principal) (:node runtime))
+              :page (:page page)
+              :databases
+              (mapv (fn [{:keys [store-id] :as database}]
+                      (assoc database :activity
+                             (get-in runtime [:databases store-id]
+                                     {:loaded? false
+                                      :leases 0
+                                      :transactions 0
+                                      :transacted-datoms 0
+                                      :commits 0
+                                      :head-conflicts 0})))
+                    (:databases page))}})
+    (catch Exception e
+      (routes/error-response e))))
+
 (defn routes
   "Public shell and assets. Data is fetched from the normally authenticated
-   `/version` and `/databases` APIs, so this introduces no authorization path."
-  []
-  [["/"
+   `/version` and `/admin/status` APIs, so this introduces no authorization path."
+  [config connections]
+  (cond-> [["/"
     {:public? true
      :get {:no-doc true
            :metric-op :admin
@@ -82,4 +113,15 @@
    ["/admin/datahike-logo.svg"
     {:public? true
      :get {:no-doc true
-           :handler (fn [_] (asset-response :logo))}}]])
+           :handler (fn [_] (asset-response :logo))}}]]
+    (get config system/conn-key)
+    (conj ["/admin/status"
+           {:get {:no-doc true
+                  :metric-op :read
+                  :parameters {:query [:map
+                                       [:q {:optional true} :string]
+                                       [:offset {:optional true :default 0} [:int {:min 0}]]
+                                       [:limit {:optional true :default 24} [:int {:min 1 :max 100}]]]}
+                  :handler (fn [{{query :query} :parameters
+                                 principal :datahike/principal}]
+                             (status-response config connections principal query))}}])))

--- a/http-server/datahike/http/admin/app.js
+++ b/http-server/datahike/http/admin/app.js
@@ -6,6 +6,10 @@ const authStatus = byId("auth-status");
 const catalogStatus = byId("catalog-status");
 const databaseGrid = byId("databases");
 const databaseCount = byId("database-count");
+const databaseQuery = byId("database-query");
+const pageSize = 24;
+let pageOffset = 0;
+let searchQuery = "";
 
 tokenInput.value = sessionStorage.getItem("datahike.admin.token") || "";
 
@@ -58,9 +62,34 @@ function field(label, value) {
   return row;
 }
 
-function renderDatabases(databases) {
+function number(value) {
+  return Number(value || 0).toLocaleString();
+}
+
+function milliseconds(value) {
+  return value == null ? null : `${Number(value).toFixed(value < 10 ? 2 : 1)} ms`;
+}
+
+function hitRate(dispositions) {
+  const hits = Number(dispositions?.hit || 0);
+  const misses = Number(dispositions?.miss || 0);
+  return hits + misses === 0 ? null : `${((100 * hits) / (hits + misses)).toFixed(1)}%`;
+}
+
+function renderNodeActivity(node) {
+  const section = byId("node-activity");
+  section.hidden = !node;
+  if (!node) return;
+  setText("sampled-queries", number(node["sampled-queries"]));
+  setText("average-query", milliseconds(node["average-query-ms"]));
+  setText("result-cache-hit-rate", hitRate(node["result-cache"]));
+  setText("plan-cache-hit-rate", hitRate(node["plan-cache"]));
+  setText("query-errors", number(node["query-errors"]));
+}
+
+function renderDatabases(databases, total = databases.length) {
   databaseGrid.replaceChildren();
-  databaseCount.textContent = String(databases.length);
+  databaseCount.textContent = String(total);
   if (databases.length === 0) {
     const empty = document.createElement("p");
     empty.className = "empty";
@@ -78,15 +107,32 @@ function renderDatabases(databases) {
     backend.className = "backend";
     backend.textContent = taggedValue(database.config?.store?.backend) || "unknown backend";
     const details = document.createElement("dl");
+    const activity = database.activity || {};
     details.append(
       field("Store ID", database["store-id"]),
       field("State", String(taggedValue(database.state) || "active").replace(/^:/, "")),
+      field("Runtime", activity["loaded?"] ? `loaded · ${number(activity.leases)} lease${activity.leases === 1 ? "" : "s"}` : "idle"),
+      field("Basis t", activity["basis-t"]),
+      field("Transactions", number(activity.transactions)),
+      field("Datoms written", number(activity["transacted-datoms"])),
+      field("Average commit", milliseconds(activity["average-commit-ms"])),
+      field("Conflicts", number(activity["head-conflicts"])),
       field("Created", displayDate(database["created-at"])),
       field("Principal", database["created-by"])
     );
     card.append(title, backend, details);
     databaseGrid.append(card);
   }
+}
+
+function renderPage(page) {
+  const total = Number(page?.total || 0);
+  const offset = Number(page?.offset || 0);
+  const limit = Number(page?.limit || pageSize);
+  const end = Math.min(offset + limit, total);
+  byId("page-status").textContent = total === 0 ? "No results" : `${offset + 1}–${end} of ${total}`;
+  byId("previous-page").disabled = offset === 0;
+  byId("next-page").disabled = !page?.["has-more?"];
 }
 
 async function refreshReadiness() {
@@ -125,11 +171,20 @@ async function refresh() {
   }
 
   try {
-    const databases = await request("/databases");
-    renderDatabases(databases);
-    catalogStatus.textContent = `${databases.length} active database${databases.length === 1 ? "" : "s"} visible to this principal.`;
+    const params = new URLSearchParams({ offset: String(pageOffset), limit: String(pageSize) });
+    if (searchQuery) params.set("q", searchQuery);
+    const status = await request(`/admin/status?${params}`);
+    const databases = status.databases || [];
+    renderNodeActivity(status.node);
+    renderDatabases(databases, status.page?.total);
+    renderPage(status.page);
+    catalogStatus.textContent = searchQuery
+      ? `${status.page?.total || 0} matching database${status.page?.total === 1 ? "" : "s"}.`
+      : `${status.page?.total || 0} active database${status.page?.total === 1 ? "" : "s"} visible to this principal.`;
   } catch (error) {
+    renderNodeActivity(null);
     renderDatabases([]);
+    renderPage(null);
     catalogStatus.className = "status error";
     catalogStatus.textContent = error.status === 404
       ? "The system catalog is not configured on this server."
@@ -142,6 +197,7 @@ byId("auth-form").addEventListener("submit", (event) => {
   const token = tokenInput.value.trim();
   if (token) sessionStorage.setItem("datahike.admin.token", token);
   else sessionStorage.removeItem("datahike.admin.token");
+  pageOffset = 0;
   refresh();
 });
 
@@ -152,4 +208,24 @@ byId("clear-token").addEventListener("click", () => {
 });
 
 byId("refresh").addEventListener("click", refresh);
+byId("database-search").addEventListener("submit", (event) => {
+  event.preventDefault();
+  searchQuery = databaseQuery.value.trim();
+  pageOffset = 0;
+  refresh();
+});
+byId("clear-search").addEventListener("click", () => {
+  databaseQuery.value = "";
+  searchQuery = "";
+  pageOffset = 0;
+  refresh();
+});
+byId("previous-page").addEventListener("click", () => {
+  pageOffset = Math.max(0, pageOffset - pageSize);
+  refresh();
+});
+byId("next-page").addEventListener("click", () => {
+  pageOffset += pageSize;
+  refresh();
+});
 refresh();

--- a/http-server/datahike/http/admin/index.html
+++ b/http-server/datahike/http/admin/index.html
@@ -51,6 +51,23 @@
         </form>
       </section>
 
+      <section id="node-activity" class="activity" aria-labelledby="activity-title" hidden>
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">Process activity</p>
+            <h2 id="activity-title">Query engine since startup</h2>
+          </div>
+          <p class="activity-note">Successful queries are sampled; errors are exact.</p>
+        </div>
+        <dl class="activity-grid">
+          <div><dt>Sampled queries</dt><dd id="sampled-queries">0</dd></div>
+          <div><dt>Average query</dt><dd id="average-query">—</dd></div>
+          <div><dt>Result cache hits</dt><dd id="result-cache-hit-rate">—</dd></div>
+          <div><dt>Plan cache hits</dt><dd id="plan-cache-hit-rate">—</dd></div>
+          <div><dt>Query errors</dt><dd id="query-errors">0</dd></div>
+        </dl>
+      </section>
+
       <section class="catalog" aria-labelledby="catalog-title">
         <div class="section-heading">
           <div>
@@ -60,6 +77,19 @@
           <button id="refresh" class="secondary" type="button">Refresh</button>
         </div>
         <p id="catalog-status" class="status" role="status">Authenticate to load the databases visible to you.</p>
+        <div class="catalog-tools">
+          <form id="database-search" class="search" role="search">
+            <label class="sr-only" for="database-query">Search databases</label>
+            <input id="database-query" name="q" type="search" autocomplete="off" placeholder="Search name or store ID">
+            <button type="submit">Search</button>
+            <button id="clear-search" class="secondary" type="button">Clear</button>
+          </form>
+          <div class="pagination" aria-label="Database pages">
+            <button id="previous-page" class="secondary" type="button">Previous</button>
+            <span id="page-status">—</span>
+            <button id="next-page" class="secondary" type="button">Next</button>
+          </div>
+        </div>
         <div id="databases" class="database-grid" aria-live="polite"></div>
       </section>
 

--- a/http-server/datahike/http/admin/style.css
+++ b/http-server/datahike/http/admin/style.css
@@ -65,11 +65,24 @@ input, button { min-height: 2.75rem; border: 1px solid var(--line); border-radiu
 input { flex: 1; min-width: 8rem; padding: .65rem .8rem; color: var(--ink); background: rgba(255, 255, 255, .72); }
 button { padding: .6rem 1rem; color: white; background: var(--green); border-color: var(--green); cursor: pointer; font-weight: 700; }
 button:hover { filter: brightness(.94); }
+button:disabled { cursor: not-allowed; opacity: .45; filter: none; }
 button.secondary { color: var(--ink); background: transparent; border-color: var(--line); }
 .status { min-height: 1.4em; color: var(--muted); }
 .status.error { color: var(--red); }
 
+.activity { margin: 0 0 4rem; }
+.activity-note { margin: 0; color: var(--muted); font-size: .78rem; text-align: right; }
+.activity-grid { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 1px; margin: 1.2rem 0 0; overflow: hidden; border: 1px solid var(--line); border-radius: .8rem; background: var(--line); }
+.activity-grid div { min-width: 0; padding: 1rem; background: var(--panel); }
+.activity-grid dt { margin-bottom: .45rem; color: var(--muted); font-size: .72rem; }
+.activity-grid dd { margin: 0; font: 700 1rem ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+
 .catalog { margin-bottom: 4rem; }
+.catalog-tools { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1rem; }
+.search, .pagination { display: flex; align-items: center; gap: .55rem; }
+.search input { width: min(22rem, 45vw); }
+.pagination span { min-width: 6rem; color: var(--muted); font: .78rem ui-monospace, SFMono-Regular, Menlo, monospace; text-align: center; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 .section-heading { display: flex; align-items: end; justify-content: space-between; gap: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--line); }
 .count { display: inline-grid; place-items: center; min-width: 1.8rem; height: 1.8rem; margin-left: .4rem; padding: 0 .45rem; border-radius: 999px; color: var(--green); background: var(--green-soft); font: 700 .8rem ui-monospace, monospace; vertical-align: .15rem; }
 .database-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(270px, 1fr)); gap: 1rem; margin-top: 1.2rem; }
@@ -98,6 +111,12 @@ footer { max-width: 1180px; margin: 0 auto; padding: 0 2rem 2.5rem; color: var(-
   .token-row { flex-wrap: wrap; }
   .token-row input { flex-basis: 100%; }
   .endpoint-grid { grid-template-columns: 1fr; }
+  .activity-grid { grid-template-columns: 1fr 1fr; }
+  .activity-note { text-align: left; }
+  .catalog-tools { align-items: stretch; flex-direction: column; }
+  .search { flex-wrap: wrap; }
+  .search input { flex-basis: 100%; width: 100%; }
+  .pagination { justify-content: space-between; }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -165,7 +165,7 @@
         handler (routes/handler config
                                 {:connections     connections
                                  :extra-routes    (concat [swagger-route]
-                                                          (admin/routes)
+                                                          (admin/routes config connections)
                                                           (health-routes config connections)
                                                           [(version-route server-config)]
                                                           (keep identity [(metrics-route config connections)])

--- a/http-server/datahike/http/system.clj
+++ b/http-server/datahike/http/system.clj
@@ -4,6 +4,7 @@
    Catalog configs are deliberately redacted before storage: credentials stay
    in deployment configuration, not in the database they protect."
   (:require
+   [clojure.string :as str]
    [clojure.edn :as edn]
    [datahike.api :as d]
    [datahike.http.routes :as routes]
@@ -223,24 +224,36 @@
     (edn/read-string value)
     (catch Exception _ nil)))
 
+(defn- entry-ref [{:keys [e store-id name state]}]
+  {:e e :store-id store-id :name name :state state})
+
+(defn- entry-refs [conn]
+  (->> (d/q '[:find ?e ?id ?name ?state
+              :where
+              [?e :datahike.system.database/id ?id]
+              [?e :datahike.system.database/name ?name]
+              [?e :datahike.system.database/state ?state]]
+            @conn)
+       (map (fn [[e store-id name state]]
+              (entry-ref {:e e :store-id store-id :name name :state state})))
+       (sort-by (juxt :name :store-id))
+       vec))
+
+(defn- pull-entry [conn {:keys [e]}]
+  (let [entry (d/pull @conn catalog-pull e)]
+    {:store-id   (:datahike.system.database/id entry)
+     :name       (:datahike.system.database/name entry)
+     :config     (parse-stored-config (:datahike.system.database/config entry))
+     :state      (:datahike.system.database/state entry)
+     :created-at (:datahike.system.database/created-at entry)
+     :created-by (:datahike.system.database/created-by entry)
+     :deleted-at (:datahike.system.database/deleted-at entry)
+     :deleted-by (:datahike.system.database/deleted-by entry)}))
+
 (defn entries
   "Catalog entries as API data, newest state included."
   [conn]
-  (->> (d/q '[:find [?e ...]
-              :where [?e :datahike.system.database/id]]
-            @conn)
-       (map #(d/pull @conn catalog-pull %))
-       (map (fn [entry]
-              {:store-id   (:datahike.system.database/id entry)
-               :name       (:datahike.system.database/name entry)
-               :config     (parse-stored-config (:datahike.system.database/config entry))
-               :state      (:datahike.system.database/state entry)
-               :created-at (:datahike.system.database/created-at entry)
-               :created-by (:datahike.system.database/created-by entry)
-               :deleted-at (:datahike.system.database/deleted-at entry)
-               :deleted-by (:datahike.system.database/deleted-by entry)}))
-       (sort-by (juxt :name :store-id))
-       vec))
+  (mapv #(pull-entry conn %) (entry-refs conn)))
 
 (defn- visible? [config principal {:keys [store-id]}]
   (if-let [authorize (:authorize config)]
@@ -249,6 +262,44 @@
                 :db {:store-id (parse-uuid store-id) :branch :db}
                 :payload nil})
     true))
+
+(defn visible-entries
+  "Active catalog entries the principal may read."
+  [{::keys [conn] :as config} principal]
+  (when conn
+    (->> (entry-refs conn)
+         (filter #(= :active (:state %)))
+         (filter #(visible? config principal %))
+         (map #(pull-entry conn %))
+         vec)))
+
+(defn visible-entry-page
+  "One bounded page of active catalog entries visible to `principal`.
+
+   Authorization and search happen on lightweight identity tuples before the
+   selected page's full configs are pulled. No cataloged database is opened."
+  [{::keys [conn] :as config} principal {:keys [q offset limit]
+                                         :or {offset 0 limit 24}}]
+  (when conn
+    (let [needle     (some-> q str/trim str/lower-case not-empty)
+          matches?   (fn [{:keys [name store-id]}]
+                       (or (nil? needle)
+                           (str/includes? (str/lower-case name) needle)
+                           (str/includes? (str/lower-case store-id) needle)))
+          authorized (->> (entry-refs conn)
+                          (filter #(= :active (:state %)))
+                          (filter matches?)
+                          (filter #(visible? config principal %))
+                          vec)
+          total      (count authorized)
+          offset     (min (max 0 offset) total)
+          limit      (min 100 (max 1 limit))
+          selected   (->> authorized (drop offset) (take limit))]
+      {:databases (mapv #(pull-entry conn %) selected)
+       :page {:offset offset
+              :limit limit
+              :total total
+              :has-more? (< (+ offset limit) total)}})))
 
 (defn routes
   "GET /databases for active entries the caller may read."
@@ -261,10 +312,7 @@
              (fn [{principal :datahike/principal}]
                (try
                  {:status 200
-                  :body (->> (entries conn)
-                             (filter #(= :active (:state %)))
-                             (filter #(visible? config principal %))
-                             vec)}
+                  :body (visible-entries config principal)}
                  (catch Exception e
                    (routes/error-response e))))}}]]))
 

--- a/src/datahike/metrics.cljc
+++ b/src/datahike/metrics.cljc
@@ -218,3 +218,95 @@
        :labels {:database (str store-id)
                 :branch   (keyword-label (or branch :db))}
        :value  (or count 1)})))
+
+#?(:clj
+   (do
+     (defn- sum-series [series]
+       (reduce + 0 (vals (or series {}))))
+
+     (defn- histogram-summary [series]
+       (reduce (fn [{:keys [count sum]} value]
+                 {:count (+ count (or (:count value) 0))
+                  :sum   (+ sum (or (:sum value) 0))})
+               {:count 0 :sum 0.0}
+               (vals (or series {}))))
+
+     (defn- disposition-counts [series label]
+       (reduce-kv (fn [counts labels value]
+                    (update counts (keyword (get labels label "unknown"))
+                            (fnil + 0) (or (:count value) 0)))
+                  {}
+                  (or series {})))
+
+     (defn- database-metric [snapshot metric value-fn]
+       (reduce-kv (fn [by-database labels value]
+                    (if-let [database (:database labels)]
+                      (update by-database database (fnil + 0) (value-fn value))
+                      by-database))
+                  {}
+                  (get-in snapshot [metric :series])))
+
+     (defn runtime-snapshot
+       "Cheap process-local status for the standalone operator page.
+
+        This reads only the metrics registry and raw state of connections the
+        process already owns. It never opens a database, refreshes a branch,
+        probes a store, or walks an index."
+       ([connections] (runtime-snapshot connections (metrics/snapshot)))
+       ([connections snapshot]
+        (let [query-series    (get-in snapshot [:datahike_query_seconds :series])
+              query-summary   (histogram-summary query-series)
+              planning-series (get-in snapshot [:datahike_query_planning_seconds :series])
+              planning-summary (histogram-summary planning-series)
+              transactions    (database-metric snapshot :datahike_transactions_total identity)
+              datoms          (database-metric snapshot :datahike_transacted_datoms_total identity)
+              commits         (database-metric snapshot :datahike_commit_seconds #(or (:count %) 0))
+              commit-seconds  (database-metric snapshot :datahike_commit_seconds #(or (:sum %) 0.0))
+              conflicts       (database-metric snapshot :datahike_head_conflicts_total identity)
+              live (reduce-kv
+                    (fn [by-database [store-id branch] {:keys [conn count]}]
+                      (if-not conn
+                        by-database
+                        (let [database (str store-id)
+                              state    @(get conn :wrapped-atom)
+                              basis-t  (when (map? state) (:max-tx state))]
+                          (-> by-database
+                              (update-in [database :leases] (fnil + 0) (or count 1))
+                              (update-in [database :branches] (fnil conj #{})
+                                         (keyword-label (or branch :db)))
+                              (cond-> basis-t
+                                (update-in [database :basis-t] #(max (or % basis-t) basis-t)))))))
+                    {}
+                    @connections)
+              database-ids (into (set (keys live))
+                                 (mapcat keys)
+                                 [transactions datoms commits commit-seconds conflicts])]
+          {:node
+           {:sampled-queries       (:count query-summary)
+            :average-query-ms      (when (pos? (:count query-summary))
+                                     (* 1000.0 (/ (:sum query-summary) (:count query-summary))))
+            :result-cache          (disposition-counts query-series :result_cache)
+            :query-errors          (sum-series (get-in snapshot [:datahike_query_errors_total :series]))
+            :sampled-plans         (:count planning-summary)
+            :average-planning-ms   (when (pos? (:count planning-summary))
+                                     (* 1000.0 (/ (:sum planning-summary) (:count planning-summary))))
+            :plan-cache            (disposition-counts planning-series :plan_cache)
+            :planning-errors       (sum-series (get-in snapshot [:datahike_query_planning_errors_total :series]))
+            :query-sample-every    (get-in snapshot [:datahike_query_sample_every :series {}])}
+           :databases
+           (into {}
+                 (for [database database-ids
+                       :let [commit-count (get commits database 0)
+                             seconds      (get commit-seconds database 0.0)
+                             connection   (get live database)]]
+                   [database
+                    {:loaded?           (boolean connection)
+                     :leases            (get connection :leases 0)
+                     :branches          (-> connection :branches sort vec)
+                     :basis-t           (:basis-t connection)
+                     :transactions      (get transactions database 0)
+                     :transacted-datoms (get datoms database 0)
+                     :commits           commit-count
+                     :average-commit-ms (when (pos? commit-count)
+                                          (* 1000.0 (/ seconds commit-count)))
+                     :head-conflicts     (get conflicts database 0)}]))})))))

--- a/test/datahike/test/http/admin_test.clj
+++ b/test/datahike/test/http/admin_test.clj
@@ -1,5 +1,6 @@
 (ns datahike.test.http.admin-test
   (:require
+   [clojure.edn :as edn]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [datahike.http.server :as server]
@@ -48,13 +49,23 @@
           (is (str/includes? body "sessionStorage"))
           (is (str/includes? body "Authorization"))
           (is (str/includes? body "taggedValue"))
-          (is (str/includes? body "request(\"/databases\")"))
+          (is (str/includes? body "request(`/admin/status?${params}`)"))
           (is (not (str/includes? body "innerHTML")))))
 
       (testing "static visibility does not bypass API authentication"
         (is (= 401 (:status (request handler "/version"))))
         (is (= 401 (:status (request handler "/databases"))))
+        (is (= 401 (:status (request handler "/admin/status"))))
         (is (= 200 (:status (request handler "/version"
                                      {"authorization" (str "token " token)})))))
+
+      (testing "status is authenticated and does not require opening a catalog database"
+        (let [response (request handler "/admin/status"
+                                {"authorization" (str "token " token)
+                                 "accept" "application/edn"})
+              body     (edn/read-string (slurp (:body response)))]
+          (is (= 200 (:status response)))
+          (is (map? (:node body)))
+          (is (= [] (:databases body)))))
       (finally
         (system/close! (:datahike.http.server/config (meta handler)))))))

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -49,14 +49,22 @@
         db-obj   {:type :database :id (str store-id)}
         grant!   (fn [t updates] (client/request-cbor :post "permissions/relationships!" (peer t) updates))
         list!    (fn [t] (client/request-cbor :get "databases" (peer t) (random-uuid)))
+        status!  (fn [t] (client/request-cbor :get "admin/status" (peer t) (random-uuid)))
         s        (atom (start!))]
     (try
       (testing "root creates; nobody else may touch the database"
         (client/create-database (assoc cfg :remote-peer (peer root-token)))
         (is (= [{:store-id (str store-id) :state :active}]
                (mapv #(select-keys % [:store-id :state]) (list! root-token))))
+        (is (map? (:node (status! root-token)))
+            "server admins see process-wide query activity")
         (is (empty? (list! "alice-token"))
             "the catalog does not reveal databases the caller cannot read")
+        (is (= {:node nil
+                :page {:offset 0 :limit 24 :total 0 :has-more? false}
+                :databases []}
+               (status! "alice-token"))
+            "status reveals neither node activity nor unauthorized databases")
         (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
 
       (testing "root grants alice writer and bob reader in one batch; alice may read and write, not delete or grant"
@@ -67,6 +75,9 @@
                                     :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
         (is (= #{(str store-id)} (set (map :store-id (list! "alice-token")))))
         (is (= #{(str store-id)} (set (map :store-id (list! "bob-token")))))
+        (let [status (status! "bob-token")]
+          (is (nil? (:node status)))
+          (is (= #{(str store-id)} (set (map :store-id (:databases status))))))
         (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
           (client/transact alice [{:name "Ada"}])
           (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))

--- a/test/datahike/test/http/system_test.clj
+++ b/test/datahike/test/http/system_test.clj
@@ -64,6 +64,37 @@
        #"replaced by :system-db"
        (system/configure {:auth-db {:store {:backend :memory}}}))))
 
+(deftest visible-catalog-pages-search-and-authorize-before-paging
+  (let [configured (system/configure {:system-db {:store {:backend :memory}}})
+        databases  (vec (for [n (range 30)]
+                          {:name (format "db-%02d" n)
+                           :store {:backend :memory :id (random-uuid)}}))]
+    (try
+      (doseq [database databases]
+        ((get configured system/register-key) database {:sub "root"}))
+      (let [page (system/visible-entry-page configured {:sub "root"}
+                                            {:offset 10 :limit 7})]
+        (is (= 30 (get-in page [:page :total])))
+        (is (= 7 (count (:databases page))))
+        (is (= "db-10" (get-in page [:databases 0 :name])))
+        (is (true? (get-in page [:page :has-more?]))))
+      (let [page (system/visible-entry-page configured {:sub "root"}
+                                            {:q "DB-2" :offset 0 :limit 24})]
+        (is (= 10 (get-in page [:page :total])))
+        (is (= (mapv #(format "db-%02d" %) (range 20 30))
+               (mapv :name (:databases page)))))
+      (let [allowed (set (map (comp str :id :store) (take 3 databases)))
+            restricted (assoc configured :authorize
+                              (fn [{:keys [db]}]
+                                (contains? allowed (str (:store-id db)))))
+            page (system/visible-entry-page restricted {:sub "reader"}
+                                            {:offset 0 :limit 2})]
+        (is (= 3 (get-in page [:page :total])))
+        (is (= 2 (count (:databases page))))
+        (is (true? (get-in page [:page :has-more?]))))
+      (finally
+        (system/close! configured)))))
+
 (deftest catalog-lifecycle-events-follow-durable-state
   (let [configured (system/configure
                     {:system-db {:store {:backend :memory}}})

--- a/test/datahike/test/metrics_test.cljc
+++ b/test/datahike/test/metrics_test.cljc
@@ -80,6 +80,53 @@
            (set samples)))))
 
 #?(:clj
+   (deftest runtime-snapshot-uses-only-live-state-and-the-metrics-snapshot
+     (let [connections (atom {[test-id :db]
+                              {:conn {:wrapped-atom (atom {:max-tx 42})}
+                               :count 2}})
+           snapshot {:datahike_query_sample_every
+                     {:series {{} 256}}
+                     :datahike_query_seconds
+                     {:series {{:outcome "success" :result_cache "hit"}
+                               {:count 3 :sum 0.03}
+                               {:outcome "success" :result_cache "miss"}
+                               {:count 1 :sum 0.02}}}
+                     :datahike_query_errors_total
+                     {:series {{:result_cache "miss"} 2}}
+                     :datahike_query_planning_seconds
+                     {:series {{:outcome "success" :plan_cache "hit"}
+                               {:count 2 :sum 0.004}}}
+                     :datahike_transactions_total
+                     {:series {labels 3}}
+                     :datahike_transacted_datoms_total
+                     {:series {labels 7}}
+                     :datahike_commit_seconds
+                     {:series {labels {:count 2 :sum 0.125}}}
+                     :datahike_head_conflicts_total
+                     {:series {(assoc labels :outcome "retried") 1}}}
+           status (dhm/runtime-snapshot connections snapshot)]
+       (is (= {:sampled-queries 4
+               :average-query-ms 12.5
+               :result-cache {:hit 3 :miss 1}
+               :query-errors 2
+               :sampled-plans 2
+               :average-planning-ms 2.0
+               :plan-cache {:hit 2}
+               :planning-errors 0
+               :query-sample-every 256}
+              (:node status)))
+       (is (= {:loaded? true
+               :leases 2
+               :branches ["db"]
+               :basis-t 42
+               :transactions 3
+               :transacted-datoms 7
+               :commits 2
+               :average-commit-ms 62.5
+               :head-conflicts 1}
+              (get-in status [:databases (str test-id)]))))))
+
+#?(:clj
    (deftest a-real-transaction-records-the-durable-result
      (let [config (assoc test-config :branch :db)]
        (when (d/database-exists? config)


### PR DESCRIPTION
## Summary

- add an authenticated `/admin/status` JSON endpoint that merges the permission-filtered system catalog with process-local activity
- show node-wide sampled query/cache health only to server administrators
- show loaded state, leases, basis transaction, durable writes, commit latency, and conflicts per visible database without opening or probing databases
- add server-side name/store-ID search and bounded pagination to the database view
- avoid recording the dashboard's own catalog query in query metrics

## Cost and security model

- reads the in-process metrics and live-connection registries
- reads lightweight identity tuples from the system catalog and pulls full configs only for the selected page
- never opens an idle database, refreshes a branch, probes a backend, calls `d/metrics`, or walks a user index
- filters authorization before pagination and omits node-wide activity for non-admin principals

## Verification

- `bb format`
- `node --check http-server/datahike/http/admin/app.js`
- `git diff --check`
- `bb reflection` — no reflective calls in Datahike sources
- changed-file clj-kondo — 0 errors (existing unresolved generated API warnings only)
- focused server suite — 87 tests, 849 assertions, 0 failures across specs, persistent-set, and hitchhiker-tree

Stacked on #1046; retarget to `main` after it is squash-merged.
