### PR TITLE
feat(server): publish dedicated server artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,23 @@ jobs:
             - .m2
             - .npm
             - replikativ
+  build-http-server:
+    executor: tools/clojurecli
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Build thin and standalone server jars
+          command: bb http-server-uber
+          no_output_timeout: 10m
+      - run:
+          name: Smoke-test packaged standalone server
+          command: bb http-server-smoke
+          no_output_timeout: 3m
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - replikativ/target-http-server
   deploy:
     executor: tools/clojurecli
     steps:
@@ -377,6 +394,9 @@ jobs:
       - run:
           name: Deploy to clojars
           command: bb clojars
+      - run:
+          name: Deploy dedicated HTTP server artifact to Clojars
+          command: bb http-server-clojars
   npm-publish:
     docker:
       - image: cimg/node:22.14
@@ -407,7 +427,9 @@ jobs:
           at: /home/circleci
       - run:
           name: Release jar on GitHub
-          command: bb release jar
+          command: |
+            bb release jar
+            bb release http-server
 
 workflows:
   build-test-and-deploy:
@@ -416,6 +438,10 @@ workflows:
           context: ghcr-read-package
           setup_cljs: true
       - build:
+          context: ghcr-read-package
+          requires:
+            - setup
+      - build-http-server:
           context: ghcr-read-package
           requires:
             - setup
@@ -512,6 +538,7 @@ workflows:
             - npm-test
             - java-examples-test
             - native-image
+            - build-http-server
       - release-jar:
           context:
             - ghcr-read-package

--- a/bb.edn
+++ b/bb.edn
@@ -12,6 +12,7 @@
                     [tools.clj-kondo :as clj-kondo-tools]
                     [tools.deploy :as deploy]
                     [tools.examples :as examples]
+                    [tools.http-server :as http-server]
                     [tools.npm :as npm]
                     [tools.python :as python]
                     [tools.reflection :as reflection]
@@ -164,23 +165,36 @@
                                :depends [http-server-clean jcompile]
                                :task    (build/compile-java (-> config :build :http-server-clj))}
 
-         http-server-ccompile {:doc  "Compile clojure namespaces for http-server"
+         http-server-ccompile {:doc  "Compile clojure namespaces for the standalone http-server"
+                               :depends [http-server-jar]
                                :task (build/compile-clojure (-> config :build :http-server-clj))}
 
          http-server-pom {:doc  "Create pom file"
                           :task (build/pom config (-> config :build :http-server-clj))}
 
-         http-server-uber {:doc     "Build jar"
-                           :depends [http-server-jcompile http-server-pom http-server-ccompile version-resource]
-                           :task    (build/uber config (-> config :build :http-server-clj))}
+         http-server-jar {:doc     "Build the thin server jar"
+                           :depends [http-server-jcompile http-server-pom version-resource]
+                           :task    (build/jar config (-> config :build :http-server-clj))}
 
-         http-server-install {:doc  "Install uber jar locally"
+         http-server-uber {:doc     "Build the executable standalone server jar"
+                           :depends [http-server-ccompile]
+                           :task    (build/uber config (-> config :build :http-server-standalone))}
+
+         http-server-smoke {:doc "Smoke-test the packaged standalone server jar"
+                            :task (http-server/smoke! config)}
+
+         http-server-install {:doc  "Install the thin server jar locally"
+                              :depends [http-server-jar]
                               :task (deploy/local config (-> config :build :http-server-clj))}
 
-         http-server-release {:doc     "Build and release jar to GitHub"
+         http-server-clojars {:doc "Deploy the thin server jar to Clojars"
+                              :depends [http-server-jar]
+                              :task (deploy/remote config (-> config :build :http-server-clj))}
+
+         http-server-release {:doc     "Build and release the standalone jar to GitHub"
                               :depends [http-server-uber]
-                              :task    (let [jar (build/jar-path config (-> config :build :http-server-clj))]
-                                         (release/gh-release jar config))}
+                              :task    (let [jar (build/jar-path config (-> config :build :http-server-standalone))]
+                                         (release/gh-release config jar))}
 
          ;; native image
 

--- a/bb/src/tools/build.clj
+++ b/bb/src/tools/build.clj
@@ -18,6 +18,13 @@
   (b/create-basis (cond-> {:project deps-file}
                     aliases (assoc :aliases aliases))))
 
+(defn artifact-basis
+  "The resolved basis after removing dependencies deliberately omitted from a
+   published artifact. Compilation still uses the full basis."
+  [{:keys [basis-exclusions] :as project-config}]
+  (cond-> (basis project-config)
+    (seq basis-exclusions) (update :libs #(apply dissoc % basis-exclusions))))
+
 (defn write-version-resource
   "Writes version and commit resources for embedding in builds."
   [repo-config]
@@ -59,7 +66,7 @@
                 :class-dir class-dir
                 :lib lib
                 :version (version/string repo-config)
-                :basis (basis project-config)
+                :basis (artifact-basis project-config)
                 :scm (assoc scm :tag (version/sha))})
   (println "Done." "Saved to" (pom-path project-config)))
 
@@ -75,8 +82,18 @@
 
 (defn jar
   "Builds jar file"
-  [repo-config {:keys [class-dir target-dir src-dirs resource-dir] :as project-config}]
+  [repo-config {:keys [class-dir target-dir src-dirs resource-dir class-exclusions vendored-deps]
+                :as project-config}]
   (print (str "Packaging jar at '" target-dir "'..."))
+  (doseq [path class-exclusions]
+    (fs/delete-if-exists (fs/path class-dir path)))
+  (let [resolved (basis project-config)]
+    (doseq [coordinate vendored-deps
+            :let [paths (get-in resolved [:libs coordinate :paths])]]
+      (when-not (seq paths)
+        (throw (ex-info (str "Vendored dependency has no resolved paths: " coordinate)
+                        {:coordinate coordinate})))
+      (b/copy-dir {:src-dirs paths :target-dir class-dir})))
   (b/copy-dir {:src-dirs (filter identity (conj src-dirs resource-dir))
                :target-dir class-dir})
   (b/jar {:class-dir class-dir
@@ -91,7 +108,7 @@
                :target-dir class-dir})
   (b/uber {:class-dir class-dir
            :uber-file (jar-path repo-config project-config)
-           :basis (basis project-config)
+           :basis (artifact-basis project-config)
            :main main})
   (println "Done."))
 

--- a/bb/src/tools/http_server.clj
+++ b/bb/src/tools/http_server.clj
@@ -1,0 +1,134 @@
+(ns tools.http-server
+  (:require
+   [babashka.fs :as fs]
+   [babashka.http-client :as http]
+   [babashka.process :as p]
+   [cheshire.core :as json]
+   [clojure.string :as str]
+   [tools.build :as build])
+  (:import
+   [java.net ServerSocket]
+   [java.util UUID]
+   [java.util.zip ZipFile]))
+
+(defn- free-port []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+(defn- response [method url options]
+  (http/request (merge {:method method
+                        :uri url
+                        :throw false}
+                       options)))
+
+(defn- expect! [description predicate value]
+  (when-not (predicate value)
+    (throw (ex-info (str "Standalone server smoke check failed: " description)
+                    {:description description :actual value})))
+  value)
+
+(defn- wait-until-live! [process base-url]
+  (loop [attempt 0]
+    (when-not (p/alive? process)
+      (throw (ex-info "Standalone server exited during startup" {})))
+    (let [result (try (response :get (str base-url "/health/live") {})
+                      (catch Exception _ nil))]
+      (cond
+        (= 200 (:status result)) result
+        (< attempt 119) (do (Thread/sleep 250) (recur (inc attempt)))
+        :else (throw (ex-info "Standalone server did not become live within 30 seconds" {}))))))
+
+(defn- assert-slim! [jar max-bytes]
+  (let [bytes (fs/size jar)]
+    (expect! (str "jar exceeds " max-bytes " bytes") #(<= % max-bytes) bytes)
+    (with-open [zip (ZipFile. (str jar))]
+      (let [names (mapv #(.getName %) (enumeration-seq (.entries zip)))
+            compiler-content
+            (filterv #(or (str/starts-with? % "com/google/javascript/jscomp/")
+                          (str/starts-with? % "cljs/analyzer")
+                          (str/starts-with? % "cljs/compiler")
+                          (str/starts-with? % "cljs/closure")
+                          (str/starts-with? % "cljs/repl")
+                          (= % "goog/base.js"))
+                     names)]
+        (expect! "ClojureScript compiler content is absent"
+                 empty?
+                 compiler-content)))))
+
+(defn- assert-thin! [jar]
+  (with-open [zip (ZipFile. (str jar))]
+    (let [names (into #{} (map #(.getName %)) (enumeration-seq (.entries zip)))]
+      (doseq [path ["datahike/http/main.clj"
+                    "eacl/core.cljc"
+                    "eacl/datahike/core.clj"
+                    "META-INF/maven/org.replikativ/datahike-http-server/pom.xml"]]
+        (expect! (str "thin jar contains " path) #(contains? % path) names))
+      (doseq [path ["datahike/java/DatahikeGeneratedTest.class"
+                    "datahike/java/DatahikeTest.class"]]
+        (expect! (str "thin jar excludes " path) #(not (contains? % path)) names)))))
+
+(defn smoke!
+  "Run the built standalone jar and verify its public shell, authenticated
+   operational APIs, catalog, metrics, and bundled backend inventory."
+  [config]
+  (let [thin-project (get-in config [:build :http-server-clj])
+        thin-jar     (build/jar-path config thin-project)
+        project      (get-in config [:build :http-server-standalone])
+        jar          (build/jar-path config project)
+        port     (free-port)
+        token    "standalone-smoke-token"
+        base-url (str "http://127.0.0.1:" port)
+        temp-dir (fs/create-temp-dir {:prefix "datahike-http-server-smoke-"})
+        config-file (str (fs/file temp-dir "config.edn"))
+        database-id (UUID/randomUUID)]
+    (expect! "thin jar exists" fs/exists? thin-jar)
+    (assert-thin! thin-jar)
+    (expect! "standalone jar exists" fs/exists? jar)
+    (assert-slim! jar (:max-bytes project))
+    (spit config-file
+          (pr-str {:host "127.0.0.1"
+                   :port port
+                   :token token
+                   :metrics true
+                   :system-db {:store {:backend :memory}}}))
+    (let [process (p/process ["java" "-jar" jar config-file]
+                             {:out :inherit :err :inherit})
+          auth    {"authorization" (str "token " token)}]
+      (try
+        (wait-until-live! process base-url)
+        (let [landing (response :get base-url {})]
+          (expect! "landing page returns 200" #(= 200 %) (:status landing))
+          (expect! "landing page identifies Datahike" #(str/includes? % "Datahike server") (:body landing)))
+        (expect! "admin status is authenticated"
+                 #(= 401 %)
+                 (:status (response :get (str base-url "/admin/status") {})))
+        (let [created (response :post (str base-url "/create-database")
+                                {:headers (assoc auth
+                                                 "content-type" "application/edn"
+                                                 "accept" "application/edn")
+                                 :body (pr-str [{:name "smoke"
+                                                :store {:backend :memory :id database-id}
+                                                :schema-flexibility :write}])})]
+          (expect! "create-database succeeds" #(= 200 %) (:status created)))
+        (let [status (-> (response :get (str base-url "/admin/status")
+                                   {:headers (assoc auth "accept" "application/json")})
+                         :body
+                         (json/parse-string true))]
+          (expect! "catalog contains the smoke database"
+                   #(= ["smoke"] %)
+                   (mapv :name (:databases status))))
+        (let [version-body (:body (response :get (str base-url "/version")
+                                             {:headers (assoc auth "accept" "application/json")}))]
+          (doseq [backend ["memory" "file" "s3" "jdbc" "dynamodb" "redis"]]
+            (expect! (str "backend inventory contains " backend)
+                     #(str/includes? % backend)
+                     version-body)))
+        (let [metrics (:body (response :get (str base-url "/prometheus")
+                                       {:headers auth}))]
+          (expect! "Prometheus output contains JVM metrics"
+                   #(str/includes? % "jvm_memory_used_bytes")
+                   metrics))
+        (println "Standalone server smoke test passed:" jar (fs/size jar) "bytes")
+        (finally
+          (p/destroy-tree process)
+          (fs/delete-tree temp-dir))))))

--- a/bb/src/tools/release.clj
+++ b/bb/src/tools/release.clj
@@ -96,6 +96,8 @@
     (case cmd
       "jar" (->> (build/jar-path config (-> config :build :clj))
                  (gh-release config))
+      "http-server" (->> (build/jar-path config (-> config :build :http-server-standalone))
+                         (gh-release config))
       "native-image" (->> (zip-cli config :native-cli)
                           (gh-release config))
       "libdatahike" (->> (zip-lib config :libdatahike)

--- a/config.edn
+++ b/config.edn
@@ -24,8 +24,26 @@
                            :deps-file     "deps.edn"
                            :jar-pattern   "{{repo.lib}}-http-server-{{version-str}}.jar"
                            :aliases       [:http-server]
-                           :main          datahike.http.main
+                           :basis-exclusions [junit/junit org.hamcrest/hamcrest-core]
+                           ;; tools.build cannot put the pinned source-only eacl
+                           ;; git/local coordinates in a Maven POM. Package those
+                           ;; two source modules; their ordinary Maven deps are
+                           ;; declared directly in the :http-server alias.
+                           :vendored-deps [io.github.whilo/eacl cloudafrica/eacl]
+                           :class-exclusions ["datahike/java/DatahikeGeneratedTest.class"
+                                              "datahike/java/DatahikeTest.class"]
                            :lib           org.replikativ/datahike-http-server}
+         :http-server-standalone {:target-dir  "target-http-server"
+                                  :class-dir   "target-http-server/classes"
+                                  :deps-file   "deps.edn"
+                                  :jar-pattern "{{repo.lib}}-http-server-{{version-str}}-standalone.jar"
+                                  :aliases     [:http-server]
+                                  :basis-exclusions [junit/junit org.hamcrest/hamcrest-core]
+                                  :main        datahike.http.main
+                                  ;; CI treats this as a regression budget, not a
+                                  ;; product promise. Raise it deliberately when a
+                                  ;; new bundled backend justifies the increase.
+                                  :max-bytes   99614720}
          ;; Used only on Windows, where native-image cannot take the classpath
          ;; on the command line (8191-char limit). Same shape as :native, but
          ;; carrying the CLI's own aliases rather than libdatahike's.

--- a/deps.edn
+++ b/deps.edn
@@ -144,7 +144,7 @@
                                                                            io.replikativ/konserve]}
 
                                ;; http server
-                               io.github.whilo/eacl {:git/url "https://github.com/whilo/eacl.git"
+                                      io.github.whilo/eacl {:git/url "https://github.com/whilo/eacl.git"
                                                      :git/sha "c11c3f855a5f795a2b66a0293a64dde7fe82d898"
                                                      :deps/root "modules/eacl-datahike"
                                                      ;; The fork's source-only datahike backend, until
@@ -209,6 +209,18 @@
            :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.5"}}}
 
            :http-server {:extra-paths ["http-server"]
+                         ;; These libraries are cross-platform, but the standalone
+                         ;; server is JVM-only. Their ClojureScript compiler edges
+                         ;; are needed to build CLJS consumers, not to run the JVM
+                         ;; namespaces packaged below. Keep the exclusions scoped
+                         ;; to this artifact so Datahike's browser builds retain
+                         ;; their normal dependency graph.
+                         :override-deps {org.replikativ/konserve
+                                         {:mvn/version "0.9.391"
+                                          :exclusions [org.clojure/clojurescript]}
+                                         com.github.pkpkpk/cljs-cache
+                                         {:mvn/version "1.0.21"
+                                          :exclusions [org.clojure/clojurescript]}}
                          :extra-deps {io.github.whilo/eacl {:git/url "https://github.com/whilo/eacl.git"
                                                      :git/sha "c11c3f855a5f795a2b66a0293a64dde7fe82d898"
                                                      :deps/root "modules/eacl-datahike"
@@ -216,6 +228,14 @@
                                                      ;; upstream dev.eacl/eacl-datahike ships a jar that
                                                      ;; is not AOT-compiled for a newer JDK.
                                                      :exclusions [org.replikativ/datahike]}
+                                      ;; Direct declarations make the vendored
+                                      ;; source-only eacl modules' runtime graph
+                                      ;; representable in datahike-http-server's
+                                      ;; generated Maven POM.
+                                      com.rpl/specter          {:mvn/version "1.1.4"}
+                                      org.clojure/core.cache   {:mvn/version "1.1.234"}
+                                      instaparse/instaparse    {:mvn/version "1.5.0"}
+                                      org.clojure/tools.logging {:mvn/version "1.3.0"}
                                       ring/ring-core          {:mvn/version "1.15.5"}
                                       ring/ring-jetty-adapter {:mvn/version "1.15.5"}
                                       metosin/reitit          {:mvn/version "0.10.1"}

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -298,11 +298,22 @@ This pattern is common in production systems where internal services need high-p
 
 The HTTP server provides a **REST/RPC interface** for conventional integrations with any language or tool that speaks HTTP. Use this when you need request/response semantics rather than reactive updates (for reactive updates, see Kabel above).
 
-To build locally, clone the repository and run `bb http-server-uber` to create the jar. Run the server with:
+The batteries-included executable is attached to each GitHub release as
+`datahike-http-server-VERSION-standalone.jar`. It includes the portable
+Konserve backends (memory, file, tiered, S3, JDBC, DynamoDB, and Redis), the
+PostgreSQL driver, and the beta pg-datahike listener. Run it with:
 
 ```bash
-java -jar datahike-http-server-VERSION.jar --config path/to/config.edn
+java -jar datahike-http-server-VERSION-standalone.jar --config path/to/config.edn
 ```
+
+The thin `org.replikativ/datahike-http-server` artifact is also published to
+Clojars for JVM applications that want to embed the server or exclude/replace
+backends through ordinary dependency configuration. To build both artifacts
+locally, clone this repository and run `bb http-server-uber`; the results are
+written to `target-http-server/`. `bb http-server-smoke` runs the packaged
+executable against its public shell, authenticated catalog, backend inventory,
+and Prometheus endpoint.
 
 The old positional `path/to/config.edn` form remains supported. Run with
 `--help` for all deployment overrides. Configuration precedence is explicit


### PR DESCRIPTION
## Summary

- publish a batteries-included standalone HTTP server JAR on each GitHub release
- publish a thin datahike-http-server artifact to Clojars for JVM embedding and backend exclusions
- remove the ClojureScript compiler and test-only classes from the JVM server artifacts
- add a 95 MiB size regression budget and packaged HTTP smoke test in CI
- document GitHub Releases as the primary server installation path

## Artifact sizes

- standalone: 85,167,743 bytes (81.2 MiB), down from 110,969,513 bytes (105.8 MiB)
- thin: 893,980 bytes (873 KiB)

## Verification

- bb http-server-uber
- bb http-server-smoke
- isolated thin-artifact consumer required datahike.http.main and eacl.datahike.core successfully
- 153 focused HTTP-server tests, 1,485 assertions
- bb format check
- targeted clj-kondo: zero findings
- bb reflection
- CircleCI YAML parsed successfully