### PR TITLE
feat(server): add opt-in nREPL access

### DIFF
--- a/bb/src/tools/http_server.clj
+++ b/bb/src/tools/http_server.clj
@@ -90,6 +90,7 @@
                    :port port
                    :token token
                    :metrics true
+                   :nrepl {:port 0}
                    :system-db {:store {:backend :memory}}}))
     (let [process (p/process ["java" "-jar" jar config-file]
                              {:out :inherit :err :inherit})
@@ -116,7 +117,12 @@
                          (json/parse-string true))]
           (expect! "catalog contains the smoke database"
                    #(= ["smoke"] %)
-                   (mapv :name (:databases status))))
+                   (mapv :name (:databases status)))
+          (expect! "packaged nREPL starts on loopback"
+                   #(and (true? (:enabled %))
+                         (= ["!kw" "tcp"] (:transport %))
+                         (pos-int? (:port %)))
+                   (get-in status [:node :nrepl])))
         (let [version-body (:body (response :get (str base-url "/version")
                                              {:headers (assoc auth "accept" "application/json")}))]
           (doseq [backend ["memory" "file" "s3" "jdbc" "dynamodb" "redis"]]

--- a/deps.edn
+++ b/deps.edn
@@ -241,6 +241,7 @@
                                       metosin/reitit          {:mvn/version "0.10.1"}
                                       ring-cors/ring-cors     {:mvn/version "0.1.13"}
                                       nrepl/bencode           {:mvn/version "1.2.0"}
+                                      nrepl/nrepl             {:mvn/version "1.7.0"}
                                       org.clojure/tools.cli   {:mvn/version "1.4.256"}
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
 

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -321,11 +321,14 @@ CLI flags, then `DATAHIKE_*` environment variables, then the EDN file. The
 supported environment variables are `DATAHIKE_PORT`, `DATAHIKE_HOST`,
 `DATAHIKE_TOKEN`, `DATAHIKE_DEV_MODE`, `DATAHIKE_LEVEL`,
 `DATAHIKE_LOG_FORMAT`, `DATAHIKE_SHUTDOWN_TIMEOUT_MS`, and
-`DATAHIKE_SYSTEM_DB_PATH`. Log format is `text` by default and accepts `json`.
+`DATAHIKE_SYSTEM_DB_PATH`. Optional nREPL overrides are
+`DATAHIKE_NREPL_PORT`, `DATAHIKE_NREPL_BIND`, and `DATAHIKE_NREPL_SOCKET`.
+Log format is `text` by default and accepts `json`.
 `DATAHIKE_TOKEN_FILE` reads the token from a Docker or Kubernetes secret mount
 without putting it in the process environment. CLI uses the corresponding
 `--port`, `--host`, `--token`, `--dev-mode`, `--level`, `--log-format`,
 `--shutdown-timeout-ms`, `--system-db-path`, and `--token-file` options.
+The nREPL flags are `--nrepl-port`, `--nrepl-bind`, and `--nrepl-socket`.
 
 The edn configuration file looks like:
 
@@ -350,6 +353,41 @@ without effective authentication. Configure a nonblank `:token` or a custom
 `:validator`, or use an explicit loopback host such as `:host "127.0.0.1"` for
 unauthenticated local development. `:dev-mode true` bypasses authentication and
 therefore never permits a public bind, even if a token is also present.
+
+### Developer nREPL
+
+nREPL is bundled but disabled by default. It evaluates arbitrary code in the
+server JVM and does not inherit HTTP authentication. Enable either a TCP
+loopback endpoint:
+
+```clojure
+{:nrepl {:port 7888 :bind "127.0.0.1"}}
+```
+
+or, on JDK 17 and newer, an absolute Unix-domain socket:
+
+```clojure
+{:nrepl {:socket "/run/datahike-nrepl/nrepl.sock"}}
+```
+
+TCP binds are always restricted to addresses that resolve only to loopback;
+configuring an HTTP token does not relax this guard. The Unix socket's parent
+directory and filesystem permissions are deployment-owned. `:port` and
+`:socket` are mutually exclusive. A requested nREPL that cannot start aborts
+server startup, and its endpoint is stopped and its socket removed during the
+normal server shutdown lifecycle.
+
+For remote development, forward rather than expose nREPL. OpenSSH can map a
+local TCP port directly to the server's Unix socket:
+
+```bash
+ssh -N -L 7888:/run/datahike-nrepl/nrepl.sock datahike-host
+```
+
+The authenticated `GET /admin/status` response reports whether nREPL is
+enabled and its resolved transport endpoint. Inside an nREPL session,
+`datahike.http.repl/config`, `catalog`, `runtime`, and `loaded-connections`
+provide read-only conveniences for inspecting the owning server instance.
 
 On SIGTERM or normal JVM shutdown, the standalone launcher first stops
 accepting requests, waits up to `:shutdown-timeout-ms` (30 seconds by default)

--- a/http-server/datahike/http/admin.clj
+++ b/http-server/datahike/http/admin.clj
@@ -58,14 +58,15 @@
     (authorize {:op :admin :principal principal :db nil :payload nil})
     true))
 
-(defn- status-response [config connections principal page-options]
+(defn- status-response [config connections nrepl-status principal page-options]
   (try
     (let [runtime (metrics/runtime-snapshot connections)
           ;; Do not let viewing the dashboard alter its query statistics.
           page    (binding [metrics/*query-metrics?* false]
                     (system/visible-entry-page config principal page-options))]
       {:status 200
-       :body {:node (when (server-admin? config principal) (:node runtime))
+       :body {:node (when (server-admin? config principal)
+                      (assoc (:node runtime) :nrepl @nrepl-status))
               :page (:page page)
               :databases
               (mapv (fn [{:keys [store-id] :as database}]
@@ -84,8 +85,9 @@
 (defn routes
   "Public shell and assets. Data is fetched from the normally authenticated
    `/version` and `/admin/status` APIs, so this introduces no authorization path."
-  [config connections]
-  (cond-> [["/"
+  ([config connections] (routes config connections (atom {:enabled false})))
+  ([config connections nrepl-status]
+   [["/"
     {:public? true
      :get {:no-doc true
            :metric-op :admin
@@ -113,15 +115,14 @@
    ["/admin/datahike-logo.svg"
     {:public? true
      :get {:no-doc true
-           :handler (fn [_] (asset-response :logo))}}]]
-    (get config system/conn-key)
-    (conj ["/admin/status"
-           {:get {:no-doc true
-                  :metric-op :read
-                  :parameters {:query [:map
-                                       [:q {:optional true} :string]
-                                       [:offset {:optional true :default 0} [:int {:min 0}]]
-                                       [:limit {:optional true :default 24} [:int {:min 1 :max 100}]]]}
-                  :handler (fn [{{query :query} :parameters
-                                 principal :datahike/principal}]
-                             (status-response config connections principal query))}}])))
+           :handler (fn [_] (asset-response :logo))}}]
+    ["/admin/status"
+     {:get {:no-doc true
+            :metric-op :read
+            :parameters {:query [:map
+                                 [:q {:optional true} :string]
+                                 [:offset {:optional true :default 0} [:int {:min 0}]]
+                                 [:limit {:optional true :default 24} [:int {:min 1 :max 100}]]]}
+            :handler (fn [{{query :query} :parameters
+                           principal :datahike/principal}]
+                       (status-response config connections nrepl-status principal query))}}]]))

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -55,6 +55,9 @@
    {:key :shutdown-timeout-ms :parse parse-nonnegative-long}
    {:key :level        :parse parse-level}
    {:key :log-format   :parse parse-log-format}
+   {:key :nrepl-port   :parse parse-port}
+   {:key :nrepl-bind   :parse non-blank}
+   {:key :nrepl-socket :parse non-blank}
    ;; A deployment-friendly shorthand for the full
    ;; {:system-db {:store {:backend :file :path ...}}} EDN shape.
    {:key :system-db-path :parse non-blank}])
@@ -75,6 +78,9 @@
    [nil "--shutdown-timeout-ms MILLIS" "Grace period for in-flight requests" :parse-fn parse-nonnegative-long]
    ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
    [nil "--log-format FORMAT" "Log format: text or json" :parse-fn parse-log-format]
+   [nil "--nrepl-port PORT" "Enable nREPL on a loopback TCP port" :parse-fn parse-port]
+   [nil "--nrepl-bind ADDRESS" "nREPL loopback bind address (default 127.0.0.1)" :parse-fn non-blank]
+   [nil "--nrepl-socket PATH" "Enable nREPL on an absolute Unix socket path" :parse-fn non-blank]
    [nil "--system-db-path PATH" "File-backed catalog and permissions database path" :parse-fn non-blank]
    ["-h" "--help" "Show this help"]
    [nil "--version" "Show the Datahike version"]])
@@ -140,7 +146,7 @@
                          :cause-class (.getName (class e))}
                         e))))))
 
-(defn- normalize-shorthands [config]
+(defn- normalize-system-db-path [config]
   (if (contains? config :system-db-path)
     (let [path (non-blank (:system-db-path config))]
       (-> config
@@ -148,6 +154,38 @@
           (assoc-in [:system-db :store :backend] :file)
           (assoc-in [:system-db :store :path] path)))
     config))
+
+(defn- normalize-nrepl-shorthands [config]
+  (let [nrepl-keys (select-keys config [:nrepl-port :nrepl-bind :nrepl-socket])]
+    (cond-> (apply dissoc config (keys nrepl-keys))
+      (seq nrepl-keys)
+      (assoc :nrepl (cond-> {}
+                      (contains? nrepl-keys :nrepl-port)
+                      (assoc :port (:nrepl-port nrepl-keys))
+                      (contains? nrepl-keys :nrepl-bind)
+                      (assoc :bind (:nrepl-bind nrepl-keys))
+                      (contains? nrepl-keys :nrepl-socket)
+                      (assoc :socket (:nrepl-socket nrepl-keys)))))))
+
+(defn- merge-nrepl [lower higher]
+  (cond
+    (not (contains? higher :nrepl)) (:nrepl lower)
+    (nil? (:nrepl higher)) nil
+    (not (map? (:nrepl higher))) (:nrepl higher)
+    :else
+    (let [override (:nrepl higher)
+          base (cond
+                 (contains? override :socket) (dissoc (:nrepl lower) :port :bind)
+                 (contains? override :port) (dissoc (:nrepl lower) :socket)
+                 :else (:nrepl lower))]
+      (merge base override))))
+
+(defn- merge-layers [lower higher]
+  (let [nrepl (merge-nrepl lower higher)
+        merged (merge lower higher)]
+    (if (or (contains? lower :nrepl) (contains? higher :nrepl))
+      (assoc merged :nrepl nrepl)
+      merged)))
 
 (defn- loopback-addresses [host]
   (when (and (string? host) (not (str/blank? host)))
@@ -165,6 +203,42 @@
    unauthenticated standalone server."
   [host]
   (boolean (loopback-addresses host)))
+
+(defn assert-safe-nrepl!
+  "Validate and normalize optional nREPL configuration. TCP nREPL is always
+   restricted to loopback because nREPL evaluates arbitrary JVM code and has
+   no authentication layer of its own."
+  [config]
+  (if-not (contains? config :nrepl)
+    config
+    (let [nrepl (:nrepl config)
+          fail (fn [message data]
+                 (throw (ex-info message
+                                 (assoc data :type :datahike.http/invalid-nrepl))))]
+      (cond
+        (nil? nrepl) (dissoc config :nrepl)
+        (not (map? nrepl)) (fail ":nrepl must be a map" {:nrepl nrepl})
+        (seq (remove #{:port :bind :socket} (keys nrepl)))
+        (fail ":nrepl contains unsupported keys" {:keys (keys nrepl)})
+        (= (contains? nrepl :port) (contains? nrepl :socket))
+        (fail ":nrepl must contain exactly one of :port or :socket" {})
+        (contains? nrepl :socket)
+        (cond
+          (contains? nrepl :bind)
+          (fail ":nrepl :bind cannot be used with :socket" {})
+          (or (not (string? (:socket nrepl))) (str/blank? (:socket nrepl)))
+          (fail ":nrepl :socket must be a nonblank string" {})
+          (not (.isAbsolute (io/file (:socket nrepl))))
+          (fail ":nrepl :socket must be an absolute path" {:socket (:socket nrepl)})
+          :else config)
+        :else
+        (let [port (:port nrepl)
+              bind (get nrepl :bind "127.0.0.1")]
+          (when-not (and (integer? port) (<= 0 port 65535))
+            (fail ":nrepl :port must be an integer from 0 through 65535" {:port port}))
+          (if-let [addresses (loopback-addresses bind)]
+            (assoc config :nrepl (assoc nrepl :bind (.getHostAddress ^InetAddress (first addresses))))
+            (fail ":nrepl :bind must resolve only to loopback addresses" {:bind bind})))))))
 
 (defn- configured-authentication?
   [{:keys [dev-mode auth token validator]}]
@@ -225,8 +299,9 @@
 
        :else
        (let [path   (or (:config options) positional-file)
-             config (-> (merge (file-config path)
-                               (env-config env)
-                               (cli-config options))
-                        normalize-shorthands)]
+             layers (map normalize-nrepl-shorthands
+                         [(file-config path) (env-config env) (cli-config options)])
+             config (-> (reduce merge-layers {} layers)
+                        normalize-system-db-path
+                        assert-safe-nrepl!)]
          {:action :run :config config})))))

--- a/http-server/datahike/http/nrepl.clj
+++ b/http-server/datahike/http/nrepl.clj
@@ -1,0 +1,47 @@
+(ns datahike.http.nrepl
+  "Lifecycle wrapper for the standalone server's opt-in nREPL endpoint."
+  (:require [datahike.http.repl :as repl]
+            [nrepl.server :as nrepl]
+            [replikativ.logging :as log])
+  (:import [java.nio.file Files Path]))
+
+(def disabled-status {:enabled false})
+
+(defn status-atom [] (atom disabled-status))
+
+(defn- handler [context]
+  (let [delegate (nrepl/default-handler)]
+    (fn [message]
+      (binding [repl/*context* context]
+        (delegate message)))))
+
+(defn start!
+  "Start configured nREPL and update `status`. Returns an owned resource map,
+   or nil when nREPL is disabled. Configuration must already be validated."
+  [configured-config public-config connections status]
+  (when-let [{:keys [port bind socket]} (:nrepl public-config)]
+    (let [context {:configured-config configured-config
+                   :config public-config
+                   :connections connections}
+          options (cond-> [:handler (handler context)]
+                    socket (into [:socket socket])
+                    (some? port) (into [:port port :bind bind]))
+          server (apply nrepl/start-server options)
+          endpoint (if socket
+                     {:enabled true :transport :unix :socket socket}
+                     {:enabled true :transport :tcp :bind bind :port (:port server)})]
+      (reset! status endpoint)
+      (log/info :datahike/nrepl-started endpoint)
+      {:server server :socket socket :status status})))
+
+(defn stop! [{:keys [server socket status]}]
+  (when server
+    (try
+      (nrepl/stop-server server)
+      (finally
+        ;; nREPL marks Unix sockets for deletion at JVM exit, but a server
+        ;; restart in the same process must not leave a stale socket behind.
+        (when socket
+          (Files/deleteIfExists (Path/of socket (make-array String 0))))
+        (when status (reset! status disabled-status)))))
+  nil)

--- a/http-server/datahike/http/repl.clj
+++ b/http-server/datahike/http/repl.clj
@@ -1,0 +1,40 @@
+(ns datahike.http.repl
+  "Convenience functions available inside the standalone server's nREPL.
+
+   nREPL remains an arbitrary-code interface; these functions make common
+   read-only inspection explicit without pretending to be a security boundary."
+  (:require [datahike.http.system :as system]
+            [datahike.metrics :as metrics]))
+
+(def ^:dynamic *context* nil)
+
+(defn- context []
+  (or *context*
+      (throw (ex-info "Not running inside a Datahike server nREPL"
+                      {:type :datahike.http/no-repl-context}))))
+
+(defn config
+  "The server's redacted startup configuration."
+  []
+  (:config (context)))
+
+(defn catalog
+  "All entries in the server system catalog, or an empty vector without one."
+  []
+  (if-let [conn (get (:configured-config (context)) system/conn-key)]
+    (system/entries conn)
+    []))
+
+(defn runtime
+  "Cheap process-local query, writer, and loaded-connection metrics."
+  []
+  (metrics/runtime-snapshot (:connections (context))))
+
+(defn loaded-connections
+  "Summaries of connections currently leased by HTTP clients."
+  []
+  (mapv (fn [[[store-id branch] {:keys [count]}]]
+          {:store-id (str store-id)
+           :branch (or branch :db)
+           :leases (or count 1)})
+        @(:connections (context))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -7,6 +7,7 @@
    [datahike.http.admin :as admin]
    [datahike.http.backends]
    [datahike.http.config :as server-config]
+   [datahike.http.nrepl :as server-nrepl]
    [datahike.metrics :as metrics]
    [datahike.http.permissions :as permissions]
    [datahike.http.pg :as pg]
@@ -156,33 +157,35 @@
    This handler exposes process metrics but does not install a global Konserve
    sink: an embedding host owns that lifecycle. `start-server` installs and
    reference-counts the standalone server's sink."
-  [config connections]
-  (let [server-config config
-        config  (system/configure config)
-        config  (if (get config system/conn-key)
-                  (permissions/configure config)
-                  config)
-        handler (routes/handler config
-                                {:connections     connections
-                                 :extra-routes    (concat [swagger-route]
-                                                          (admin/routes config connections)
-                                                          (health-routes config connections)
-                                                          [(version-route server-config)]
-                                                          (keep identity [(metrics-route config connections)])
-                                                          (system/routes config)
-                                                          (permissions/routes config))
-                                 :default-handler (ring/routes
-                                                   (swagger-ui/create-swagger-ui-handler
-                                                    {:path   "/swagger"
-                                                     :config {:validatorUrl     nil
-                                                              :operationsSorter "alpha"}})
-                                                   (ring/create-default-handler))})]
-    ;; CORS outermost, so the gate's own 401/413 carry the headers too.
-    (with-meta (wrap-cors handler
-                          :access-control-allow-origin (or (:access-control-allow-origin config)
-                                                           [#"http://localhost" #"http://localhost:8080"])
-                          :access-control-allow-methods [:get :put :post :delete])
-      (assoc (meta handler) ::config config))))
+  ([config connections]
+   (app config connections (server-nrepl/status-atom)))
+  ([config connections nrepl-status]
+   (let [server-config config
+         config  (system/configure config)
+         config  (if (get config system/conn-key)
+                   (permissions/configure config)
+                   config)
+         handler (routes/handler config
+                                 {:connections     connections
+                                  :extra-routes    (concat [swagger-route]
+                                                           (admin/routes config connections nrepl-status)
+                                                           (health-routes config connections)
+                                                           [(version-route server-config)]
+                                                           (keep identity [(metrics-route config connections)])
+                                                           (system/routes config)
+                                                           (permissions/routes config))
+                                  :default-handler (ring/routes
+                                                    (swagger-ui/create-swagger-ui-handler
+                                                     {:path   "/swagger"
+                                                      :config {:validatorUrl     nil
+                                                               :operationsSorter "alpha"}})
+                                                    (ring/create-default-handler))})]
+     ;; CORS outermost, so the gate's own 401/413 carry the headers too.
+     (with-meta (wrap-cors handler
+                           :access-control-allow-origin (or (:access-control-allow-origin config)
+                                                            [#"http://localhost" #"http://localhost:8080"])
+                           :access-control-allow-methods [:get :put :post :delete])
+       (assoc (meta handler) ::config config)))))
 
 (defonce ^:private owned
   ;; server -> what it opened, so `stop-server` can close it without a
@@ -230,46 +233,60 @@
            (when configurator
              (configurator server)))))
 
-(defn- cleanup-owned! [connections config pg-listener metrics-lease]
+(defn- cleanup-owned! [connections config nrepl-resource pg-listener metrics-lease]
   (try
-    (pg/stop! pg-listener)
+    (server-nrepl/stop! nrepl-resource)
     (finally
       (try
-        (routes/release-all! connections)
+        (pg/stop! pg-listener)
         (finally
           (try
-            (system/close! config)
+            (routes/release-all! connections)
             (finally
-              (release-metrics-sink! metrics-lease))))))))
+              (try
+                (system/close! config)
+                (finally
+                  (release-metrics-sink! metrics-lease))))))))))
 
 (defn start-server
   "Start Jetty and acquire the standalone server's shared Konserve metric sink
    unless `:metrics` is false. `stop-server` releases both."
   [config]
-  (let [config      (server-config/assert-safe-bind! config)
+  (let [requested-config (-> config
+                             server-config/assert-safe-nrepl!
+                             server-config/assert-safe-bind!)
+        config      requested-config
         timeout     (shutdown-timeout config)
         connections (atom {})
-        app         (app config connections)
+        nrepl-status (server-nrepl/status-atom)
+        app         (app config connections nrepl-status)
         config      (::config (meta app))
         jetty-config (with-graceful-shutdown config timeout)
         pg-listener (try
                       (pg/start! config connections)
                       (catch Throwable t
-                        (cleanup-owned! connections config nil nil)
+                        (cleanup-owned! connections config nil nil nil)
                         (throw t)))
         metrics-lease (try
                         (when-not (false? (:metrics config))
                           (acquire-metrics-sink!))
                         (catch Throwable t
-                          (cleanup-owned! connections config pg-listener nil)
+                          (cleanup-owned! connections config nil pg-listener nil)
                           (throw t)))
+        nrepl-resource (try
+                         (server-nrepl/start! config (routes/redact requested-config)
+                                              connections nrepl-status)
+                         (catch Throwable t
+                           (cleanup-owned! connections config nil pg-listener metrics-lease)
+                           (throw t)))
         server      (try (run-jetty app jetty-config)
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
-                           (cleanup-owned! connections config pg-listener metrics-lease)
+                           (cleanup-owned! connections config nrepl-resource pg-listener metrics-lease)
                            (throw t)))]
     (swap! owned assoc server {:connections connections
                                :config config
+                               :nrepl-resource nrepl-resource
                                :pg-listener pg-listener
                                :metrics-lease metrics-lease})
     server))
@@ -281,11 +298,11 @@
    twice."
   [^org.eclipse.jetty.server.Server server]
   (let [[before _] (swap-vals! owned dissoc server)
-        {:keys [connections config pg-listener metrics-lease]} (get before server)]
+        {:keys [connections config nrepl-resource pg-listener metrics-lease]} (get before server)]
     (try (.stop server)
          (finally
            (when connections
-             (cleanup-owned! connections config pg-listener metrics-lease))))))
+             (cleanup-owned! connections config nrepl-resource pg-listener metrics-lease))))))
 
 (defn- shutdown-hook [server config]
   (Thread.

--- a/test/datahike/test/http/admin_test.clj
+++ b/test/datahike/test/http/admin_test.clj
@@ -66,6 +66,7 @@
               body     (edn/read-string (slurp (:body response)))]
           (is (= 200 (:status response)))
           (is (map? (:node body)))
+          (is (= {:enabled false} (get-in body [:node :nrepl])))
           (is (= [] (:databases body)))))
       (finally
         (system/close! (:datahike.http.server/config (meta handler)))))))

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -12,7 +12,33 @@
   (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
   (is (= "DATAHIKE_SHUTDOWN_TIMEOUT_MS" (config/env-name :shutdown-timeout-ms)))
   (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
+  (is (= "DATAHIKE_NREPL_PORT" (config/env-name :nrepl-port)))
+  (is (= "DATAHIKE_NREPL_BIND" (config/env-name :nrepl-bind)))
+  (is (= "DATAHIKE_NREPL_SOCKET" (config/env-name :nrepl-socket)))
   (is (= "DATAHIKE_SYSTEM_DB_PATH" (config/env-name :system-db-path))))
+
+(deftest nrepl-configuration-is-opt-in-layered-and-local
+  (is (not (contains? (:config (config/resolve-config [] {})) :nrepl)))
+  (let [file (temp-file "{:nrepl {:socket \"/file/nrepl.sock\"}}")
+        resolved (:config (config/resolve-config
+                           ["--config" (.getPath file) "--nrepl-bind" "localhost"]
+                           {"DATAHIKE_NREPL_PORT" "7000"}))]
+    (is (= 7000 (get-in resolved [:nrepl :port])))
+    (is (config/loopback-host? (get-in resolved [:nrepl :bind])))
+    (is (nil? (get-in resolved [:nrepl :socket])))
+    (is (= "/run/datahike/nrepl.sock"
+           (get-in (config/resolve-config ["--nrepl-socket" "/run/datahike/nrepl.sock"] {})
+                   [:config :nrepl :socket]))))
+  (doseq [invalid [{:port 7888 :bind "0.0.0.0"}
+                   {:port 7888 :socket "/tmp/nrepl.sock"}
+                   {:socket "relative.sock"}
+                   {:bind "127.0.0.1"}
+                   {:port -1}]]
+    (let [error (try
+                  (config/assert-safe-nrepl! {:nrepl invalid})
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :datahike.http/invalid-nrepl (:type (ex-data error))) (pr-str invalid)))))
 
 (deftest standalone-bind-safety
   (testing "literal and named loopback hosts need no authentication"
@@ -54,7 +80,8 @@
                                  :shutdown-timeout-ms 10000
                                  :level :info
                                  :metrics false
-                                 :system-db {:store {:backend :memory}}}))
+                                 :system-db {:store {:backend :memory}
+                                             :keep-history? true}}))
         env  {"DATAHIKE_PORT" "2002"
               "DATAHIKE_HOST" "env-host"
               "DATAHIKE_TOKEN" "env-token"
@@ -82,7 +109,9 @@
     (is (= :json (:log-format resolved)))
     (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
     (is (= {:backend :file :path "/cli/system"}
-           (get-in resolved [:system-db :store])))))
+           (get-in resolved [:system-db :store])))
+    (is (true? (get-in resolved [:system-db :keep-history?]))
+        "the deployment path shorthand preserves other EDN system settings")))
 
 (deftest positional-config-remains-backward-compatible
   (let [file (temp-file "{:port 4444}")]

--- a/test/datahike/test/http/nrepl_test.clj
+++ b/test/datahike/test/http/nrepl_test.clj
@@ -1,0 +1,93 @@
+(ns datahike.test.http.nrepl-test
+  (:require [babashka.http-client :as http]
+            [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.http.nrepl :as server-nrepl]
+            [datahike.http.server :as server]
+            [nrepl.core :as nrepl])
+  (:import [java.nio.file Files Path]))
+
+(defn- eval-values [connection code]
+  (->> (nrepl/message (nrepl/client connection 3000)
+                      {:op "eval" :code code})
+       (keep :value)
+       vec))
+
+(defn- http-port [^org.eclipse.jetty.server.Server instance]
+  (.getLocalPort ^org.eclipse.jetty.server.ServerConnector
+   (first (.getConnectors instance))))
+
+(deftest tcp-nrepl-evaluates-with-server-context
+  (let [connections (atom {})
+        status (server-nrepl/status-atom)
+        config {:nrepl {:port 0 :bind "127.0.0.1"}}
+        resource (server-nrepl/start! config
+                                      {:nrepl (:nrepl config) :token "REDACTED"}
+                                      connections status)]
+    (try
+      (is (= :tcp (:transport @status)))
+      (is (pos? (:port @status)))
+      (with-open [connection (nrepl/connect :host (:bind @status)
+                                            :port (:port @status))]
+        (is (= ["3"] (eval-values connection "(+ 1 2)")))
+        (is (some #(str/includes? % "REDACTED")
+                  (eval-values connection "(datahike.http.repl/config)")))
+        (is (= ["[]"]
+               (eval-values connection "(datahike.http.repl/loaded-connections)"))))
+      (finally
+        (server-nrepl/stop! resource)))
+    (is (= server-nrepl/disabled-status @status))))
+
+(deftest unix-socket-is-usable-and-removed-on-stop
+  (let [directory (Files/createTempDirectory "datahike-nrepl-test-"
+                                             (make-array java.nio.file.attribute.FileAttribute 0))
+        socket (str (.resolve directory "nrepl.sock"))
+        status (server-nrepl/status-atom)
+        resource (server-nrepl/start! {:nrepl {:socket socket}}
+                                      {:nrepl {:socket socket}}
+                                      (atom {}) status)]
+    (try
+      (testing "the JDK Unix-domain transport accepts normal nREPL clients"
+        (is (= {:enabled true :transport :unix :socket socket} @status))
+        (is (Files/exists (Path/of socket (make-array String 0))
+                          (make-array java.nio.file.LinkOption 0)))
+        (with-open [connection (nrepl/connect :socket socket)]
+          (is (= ["42"] (eval-values connection "(* 6 7)")))))
+      (finally
+        (server-nrepl/stop! resource)))
+    (is (not (Files/exists (Path/of socket (make-array String 0))
+                           (make-array java.nio.file.LinkOption 0))))))
+
+(deftest standalone-server-owns-nrepl-and-reports-its-resolved-endpoint
+  (let [instance (server/start-server {:host "127.0.0.1"
+                                       :port 0
+                                       :join? false
+                                       :metrics false
+                                       :token "test-token"
+                                       :nrepl {:port 0}})
+        endpoint (try
+                   (let [response (http/request
+                                   {:method :get
+                                    :uri (str "http://127.0.0.1:" (http-port instance)
+                                              "/admin/status")
+                                    :headers {"authorization" "token test-token"
+                                              "accept" "application/edn"}
+                                    :as :stream})]
+                     (get-in (edn/read-string (slurp (:body response)))
+                             [:node :nrepl]))
+                   (catch Throwable t
+                     (server/stop-server instance)
+                     (throw t)))]
+    (try
+      (is (= :tcp (:transport endpoint)))
+      (with-open [connection (nrepl/connect :host (:bind endpoint) :port (:port endpoint))]
+        (is (= ["11"] (eval-values connection "(+ 5 6)"))))
+      (finally
+        (server/stop-server instance)))
+    (is (thrown? java.net.ConnectException
+                 (with-open [connection (nrepl/connect :host (:bind endpoint)
+                                                       :port (:port endpoint))]
+                   ;; connect constructs a lazy transport; sending proves the
+                   ;; server socket was actually closed by stop-server.
+                   (eval-values connection "(+ 1 1)"))))))

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -141,7 +141,7 @@
         configured-timeout (promise)
         instance      (atom nil)]
     (with-redefs [server/app
-                  (fn [config _connections]
+                  (fn [config _connections _nrepl-status]
                     (with-meta
                       (fn [request]
                         (if (= "/slow" (:uri request))


### PR DESCRIPTION
Adds lifecycle-owned nREPL access to the standalone server while keeping it disabled by default.

- supports loopback-only TCP and JDK Unix-domain sockets
- rejects public TCP binds and ambiguous endpoint configuration before startup
- resolves EDN, DATAHIKE_NREPL_*, and CLI configuration with normal precedence
- reports the resolved endpoint through authenticated /admin/status
- provides server-scoped read-only inspection helpers
- stops nREPL and removes Unix sockets with the HTTP server
- exercises TCP, Unix socket, real eval, ownership, config, admin status, and packaged JAR startup

Verification:
- 165 HTTP tests, 1569 assertions, 0 failures
- formatting clean
- changed-file clj-kondo: 0 errors, 0 warnings
- standalone packaged smoke passed
- standalone JAR: 86,126,751 bytes (about 0.96 MB larger)