### PR TITLE
feat(server): publish portable container image to GHCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,8 +428,11 @@ jobs:
       - run:
           name: Release jar on GitHub
           command: |
-            bb release jar
+            # The release event starts the GHCR workflow. Upload its required
+            # standalone JAR first; the workflow also retries while the asset
+            # becomes visible.
             bb release http-server
+            bb release jar
 
 workflows:
   build-test-and-deploy:

--- a/.github/workflows/server-container.yml
+++ b/.github/workflows/server-container.yml
@@ -1,0 +1,136 @@
+name: Publish server container
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: server-container-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/replikativ/datahike-server
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+jobs:
+  publish:
+    name: Test and publish multi-platform image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Check out the released source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      # CircleCI creates the release while uploading its assets. The release
+      # event can therefore arrive just before the standalone JAR is visible.
+      - name: Download the released standalone server
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p docker/server/release
+          for attempt in $(seq 1 30); do
+            if gh release download "$RELEASE_TAG" \
+                 --repo "$GITHUB_REPOSITORY" \
+                 --pattern 'datahike-http-server-*-standalone.jar' \
+                 --dir docker/server/release; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Standalone server JAR did not appear on release $RELEASE_TAG" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          mapfile -t jars < <(find docker/server/release -maxdepth 1 -type f \
+            -name 'datahike-http-server-*-standalone.jar')
+          test "${#jars[@]}" -eq 1
+          mv "${jars[0]}" docker/server/datahike-http-server.jar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Extract image tags and labels
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
+          tags: |
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+
+      - name: Build local image for smoke testing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: docker/server
+          load: true
+          tags: datahike-server:smoke
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}
+            REVISION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image as its non-root user
+        run: |
+          test "$(docker image inspect --format '{{.Config.User}}' datahike-server:smoke)" = "10001:10001"
+          docker run --detach --name datahike-server-smoke --publish 127.0.0.1::4444 \
+            --env DATAHIKE_TOKEN=container-smoke-token datahike-server:smoke
+          trap 'docker rm --force --volumes datahike-server-smoke >/dev/null 2>&1 || true' EXIT
+          for attempt in $(seq 1 120); do
+            status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{end}}' \
+              datahike-server-smoke)
+            if [ "$status" = healthy ]; then
+              break
+            fi
+            if [ "$status" = unhealthy ] || [ "$attempt" -eq 120 ]; then
+              docker logs datahike-server-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+          port=$(docker port datahike-server-smoke 4444/tcp | sed 's/.*://')
+          curl --fail --silent --show-error "http://127.0.0.1:${port}/" | grep -q 'Datahike server'
+          docker stop --time 40 datahike-server-smoke
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish linux/amd64 and linux/arm64
+        id: publish
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: docker/server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}
+            REVISION=${{ github.sha }}
+          cache-from: type=gha
+          provenance: mode=max
+          sbom: true
+
+      - name: Attest the published image index
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true

--- a/bb.edn
+++ b/bb.edn
@@ -165,10 +165,6 @@
                                :depends [http-server-clean jcompile]
                                :task    (build/compile-java (-> config :build :http-server-clj))}
 
-         http-server-ccompile {:doc  "Compile clojure namespaces for the standalone http-server"
-                               :depends [http-server-jar]
-                               :task (build/compile-clojure (-> config :build :http-server-clj))}
-
          http-server-pom {:doc  "Create pom file"
                           :task (build/pom config (-> config :build :http-server-clj))}
 
@@ -177,11 +173,19 @@
                            :task    (build/jar config (-> config :build :http-server-clj))}
 
          http-server-uber {:doc     "Build the executable standalone server jar"
-                           :depends [http-server-ccompile]
+                           :depends [http-server-jar]
                            :task    (build/uber config (-> config :build :http-server-standalone))}
 
          http-server-smoke {:doc "Smoke-test the packaged standalone server jar"
                             :task (http-server/smoke! config)}
+
+         http-server-image {:doc "Build the non-root Datahike server image with Docker or Podman"
+                            :depends [http-server-uber]
+                            :task (http-server/image! config)}
+
+         http-server-container-smoke {:doc "Smoke-test the local Datahike server container"
+                                      :depends [http-server-image]
+                                      :task (http-server/container-smoke! config)}
 
          http-server-install {:doc  "Install the thin server jar locally"
                               :depends [http-server-jar]

--- a/bb/src/tools/http_server.clj
+++ b/bb/src/tools/http_server.clj
@@ -5,7 +5,8 @@
    [babashka.process :as p]
    [cheshire.core :as json]
    [clojure.string :as str]
-   [tools.build :as build])
+   [tools.build :as build]
+   [tools.version :as version])
   (:import
    [java.net ServerSocket]
    [java.util UUID]
@@ -35,14 +36,15 @@
                       (catch Exception _ nil))]
       (cond
         (= 200 (:status result)) result
-        (< attempt 119) (do (Thread/sleep 250) (recur (inc attempt)))
-        :else (throw (ex-info "Standalone server did not become live within 30 seconds" {}))))))
+        (< attempt 479) (do (Thread/sleep 250) (recur (inc attempt)))
+        :else (throw (ex-info "Standalone server did not become live within 120 seconds" {}))))))
 
 (defn- assert-slim! [jar max-bytes]
   (let [bytes (fs/size jar)]
     (expect! (str "jar exceeds " max-bytes " bytes") #(<= % max-bytes) bytes)
     (with-open [zip (ZipFile. (str jar))]
       (let [names (mapv #(.getName %) (enumeration-seq (.entries zip)))
+            name-set (set names)
             compiler-content
             (filterv #(or (str/starts-with? % "com/google/javascript/jscomp/")
                           (str/starts-with? % "cljs/analyzer")
@@ -53,12 +55,19 @@
                      names)]
         (expect! "ClojureScript compiler content is absent"
                  empty?
-                 compiler-content)))))
+                 compiler-content)
+        (expect! "portable Java launcher is present"
+                 #(contains? % "datahike/http/Launcher.class")
+                 name-set)
+        (expect! "build-JVM-dependent superv.async AOT classes are absent"
+                 #(not (contains? % "superv/async__init.class"))
+                 name-set)))))
 
 (defn- assert-thin! [jar]
   (with-open [zip (ZipFile. (str jar))]
     (let [names (into #{} (map #(.getName %)) (enumeration-seq (.entries zip)))]
       (doseq [path ["datahike/http/main.clj"
+                    "datahike/http/Launcher.class"
                     "eacl/core.cljc"
                     "eacl/datahike/core.clj"
                     "META-INF/maven/org.replikativ/datahike-http-server/pom.xml"]]
@@ -138,3 +147,86 @@
         (finally
           (p/destroy-tree process)
           (fs/delete-tree temp-dir))))))
+
+(def ^:private local-image "datahike-server:dev")
+(def ^:private container-context "docker/server")
+
+(defn- container-engine []
+  (let [requested (System/getenv "DATAHIKE_CONTAINER_ENGINE")
+        candidates (if requested [requested] ["docker" "podman"])]
+    (or (some #(when (fs/which %) %) candidates)
+        (throw (ex-info
+                "No container engine found; install Docker or Podman, or set DATAHIKE_CONTAINER_ENGINE"
+                {:type :datahike.tools/no-container-engine
+                 :candidates candidates})))))
+
+(defn image!
+  "Build the local server image from the already-built standalone JAR."
+  [config]
+  (let [project (get-in config [:build :http-server-standalone])
+        jar (build/jar-path config project)
+        staged (str (fs/file container-context "datahike-http-server.jar"))
+        engine (container-engine)]
+    (expect! "standalone jar exists before container build" fs/exists? jar)
+    (fs/copy jar staged {:replace-existing true})
+    (try
+      (apply p/shell
+             (concat [engine "build"]
+                     ;; Podman's default OCI manifest omits Docker health
+                     ;; checks. Its Docker format preserves the same image
+                     ;; contract Buildx publishes in CI.
+                     (when (str/ends-with? engine "podman") ["--format" "docker"])
+                     ["--tag" local-image
+                      "--build-arg" (str "VERSION=" (version/string config))
+                      "--build-arg" (str "REVISION=" (version/current-commit))
+                      container-context]))
+      (println "Built local server image" local-image "with" engine)
+      (finally
+        (fs/delete-if-exists staged)))))
+
+(defn- wait-until-container-live! [base-url]
+  (loop [attempt 0]
+    (let [result (try (response :get (str base-url "/health/live") {})
+                      (catch Exception _ nil))]
+      (cond
+        (= 200 (:status result)) result
+        (< attempt 479) (do (Thread/sleep 250) (recur (inc attempt)))
+        :else (throw (ex-info "Container did not become live within 120 seconds" {}))))))
+
+(defn container-smoke!
+  "Run the local image as its non-root user and exercise its HTTP lifecycle."
+  [_config]
+  (let [engine (container-engine)
+        port (free-port)
+        name (str "datahike-server-smoke-" (UUID/randomUUID))
+        base-url (str "http://127.0.0.1:" port)
+        token "container-smoke-token"
+        image-user (-> (p/shell {:out :string}
+                                engine "image" "inspect" "--format" "{{.Config.User}}" local-image)
+                       :out str/trim)]
+    (expect! "container image runs as the stable non-root user"
+             #(= "10001:10001" %) image-user)
+    (p/shell engine "run" "--detach" "--name" name
+             "--publish" (str "127.0.0.1:" port ":4444")
+             "--env" (str "DATAHIKE_TOKEN=" token)
+             local-image)
+    (try
+      (wait-until-container-live! base-url)
+      (expect! "container landing page returns 200"
+               #(= 200 %)
+               (:status (response :get base-url {})))
+      (expect! "container operational API accepts its configured token"
+               #(= 200 %)
+               (:status (response :get (str base-url "/version")
+                                  {:headers {"authorization" (str "token " token)}})))
+      ;; Longer than the server's default 30-second graceful drain. A failed
+      ;; stop is a smoke failure; the finally block still force-cleans it.
+      (p/shell engine "stop" "--time" "40" name)
+      (println "Local server container smoke test passed:" local-image)
+      (catch Throwable t
+        (try (p/shell engine "logs" name)
+             (catch Exception _))
+        (throw t))
+      (finally
+        (try (p/shell engine "rm" "--force" "--volumes" name)
+             (catch Exception _))))))

--- a/config.edn
+++ b/config.edn
@@ -18,7 +18,7 @@
                :jar-pattern "{{repo.lib}}-{{version-str}}.jar"
                :lib org.replikativ/datahike}
          :http-server-clj {:src-dirs      ["src" "http-server" "resources"]
-                           :java-src-dirs ["java"]
+                           :java-src-dirs ["java" "http-server-java"]
                            :target-dir    "target-http-server"
                            :class-dir     "target-http-server/classes"
                            :deps-file     "deps.edn"
@@ -39,11 +39,13 @@
                                   :jar-pattern "{{repo.lib}}-http-server-{{version-str}}-standalone.jar"
                                   :aliases     [:http-server]
                                   :basis-exclusions [junit/junit org.hamcrest/hamcrest-core]
-                                  :main        datahike.http.main
+                                  ;; A tiny Java launcher avoids AOT-freezing
+                                  ;; build-JVM probes into the portable JAR.
+                                  :main        datahike.http.Launcher
                                   ;; CI treats this as a regression budget, not a
                                   ;; product promise. Raise it deliberately when a
                                   ;; new bundled backend justifies the increase.
-                                  :max-bytes   99614720}
+                                  :max-bytes   62914560}
          ;; Used only on Windows, where native-image cannot take the classpath
          ;; on the command line (8191-char limit). Same shape as :native, but
          ;; carrying the CLI's own aliases rather than libdatahike's.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -100,6 +100,14 @@ two variables `GITHUB_TOKEN` and `GITHUB_USER` need to be set in a context calle
 Each merge to `main` creates a draft release on GitHub and a git tag to point to the merge commit
 made when merging a branch into `main`. The jar is appended to the Github-release.
 
+The published release event also builds `ghcr.io/replikativ/datahike-server`
+from that release's standalone server JAR. GitHub Actions authenticates to GHCR
+with its repository-scoped `GITHUB_TOKEN`; no Docker Hub account or additional
+registry secret is required. The workflow requests `packages: write` itself.
+After the package is created for the first time, an organization owner should
+verify that it is linked to this repository and set its package visibility to
+public. Subsequent version, minor, and `latest` tags are automatic.
+
 ### The release process step by step
 - Set a new version in build.clj if you want to release a new minor or major version.
   For the ordinary patch release you can let the CI automatically increment the patch

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -313,7 +313,10 @@ backends through ordinary dependency configuration. To build both artifacts
 locally, clone this repository and run `bb http-server-uber`; the results are
 written to `target-http-server/`. `bb http-server-smoke` runs the packaged
 executable against its public shell, authenticated catalog, backend inventory,
-and Prometheus endpoint.
+and Prometheus endpoint. The executable uses a small Java launcher and loads
+its Clojure sources on the target JVM. This keeps it portable across ordinary
+OpenJDK and GraalVM builds instead of freezing build-JVM probes into AOT
+bytecode.
 
 The old positional `path/to/config.edn` form remains supported. Run with
 `--help` for all deployment overrides. Configuration precedence is explicit
@@ -388,6 +391,60 @@ The authenticated `GET /admin/status` response reports whether nREPL is
 enabled and its resolved transport endpoint. Inside an nREPL session,
 `datahike.http.repl/config`, `catalog`, `runtime`, and `loaded-connections`
 provide read-only conveniences for inspecting the owning server instance.
+
+### Docker and Podman
+
+Each GitHub release publishes the same standalone JAR as a non-root,
+multi-platform image for `linux/amd64` and `linux/arm64`:
+
+```bash
+docker pull ghcr.io/replikativ/datahike-server:latest
+docker volume create datahike-data
+docker run --name datahike --detach \
+  --publish 4444:4444 \
+  --stop-timeout 40 \
+  --mount type=volume,source=datahike-data,target=/var/lib/datahike \
+  --env DATAHIKE_TOKEN='replace-with-a-long-random-token' \
+  ghcr.io/replikativ/datahike-server:latest
+```
+
+Podman accepts the same image and equivalent arguments. For reproducible
+deployments, replace `latest` with the full Datahike version tag, for example
+`0.8.1856`. Stable minor tags such as `0.8` are also published. The container
+listens on port 4444, stores its system catalog under `/var/lib/datahike`, and
+runs as UID/GID `10001:10001`. A bind-mounted data directory must be writable
+by that identity. Database file paths should also live below a persistent
+mount; persisting the catalog does not implicitly persist arbitrary database
+paths from client configuration.
+
+The public container bind still requires effective authentication, so startup
+fails unless a token, token file, or custom configuration provides it. Mount a
+complete EDN file and append `--config /path/config.edn` to the image command
+when environment shorthands are insufficient. `JAVA_TOOL_OPTIONS` remains
+available for JVM sizing. The inline token above is concise for a first local
+run but remains visible in container metadata; production deployments should
+mount a secret readable by UID 10001 and set `DATAHIKE_TOKEN_FILE` to its
+in-container path.
+
+The image has a built-in health check against `/health/live`. Its Java process is
+PID 1 and receives SIGTERM directly. Docker's default ten-second stop timeout
+is shorter than Datahike's 30-second graceful drain, hence the explicit
+`--stop-timeout 40` above; use `stop_grace_period: 40s` in Compose or an
+equivalent Kubernetes termination grace period.
+
+TCP nREPL deliberately binds only inside the container's loopback namespace,
+so publishing that TCP port does not expose it. For remote development, enable
+the Unix socket, mount `/run/datahike-nrepl` into a host directory owned by
+UID/GID 10001, and forward that socket over SSH.
+
+To build and smoke-test the image locally after cloning the repository, run:
+
+```bash
+bb http-server-container-smoke
+```
+
+Docker is used when available, with Podman as a fallback. Set
+`DATAHIKE_CONTAINER_ENGINE=podman` (or `docker`) to choose explicitly.
 
 On SIGTERM or normal JVM shutdown, the standalone launcher first stops
 accepting requests, waits up to `:shutdown-timeout-ms` (30 seconds by default)

--- a/docker/server/.gitignore
+++ b/docker/server/.gitignore
@@ -1,0 +1,2 @@
+/datahike-http-server.jar
+/release/

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,0 +1,41 @@
+FROM docker.io/library/eclipse-temurin:21-jre-noble
+
+ARG VERSION=dev
+ARG REVISION=unknown
+
+LABEL org.opencontainers.image.title="Datahike server" \
+      org.opencontainers.image.description="Batteries-included Datahike HTTP server" \
+      org.opencontainers.image.url="https://datahike.io" \
+      org.opencontainers.image.source="https://github.com/replikativ/datahike" \
+      org.opencontainers.image.documentation="https://github.com/replikativ/datahike/blob/main/doc/distributed.md#http-server-setup" \
+      org.opencontainers.image.licenses="EPL-1.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 datahike \
+    && useradd --uid 10001 --gid 10001 --home-dir /opt/datahike \
+       --no-create-home --shell /usr/sbin/nologin datahike \
+    && mkdir --parents /opt/datahike /var/lib/datahike /run/datahike-nrepl \
+    && chown --recursive 10001:10001 /opt/datahike /var/lib/datahike /run/datahike-nrepl
+
+COPY --chown=10001:10001 datahike-http-server.jar /opt/datahike/datahike-http-server.jar
+
+USER 10001:10001
+WORKDIR /var/lib/datahike
+
+ENV DATAHIKE_HOST="0.0.0.0" \
+    DATAHIKE_PORT="4444" \
+    DATAHIKE_SYSTEM_DB_PATH="/var/lib/datahike/system"
+
+VOLUME ["/var/lib/datahike"]
+EXPOSE 4444
+STOPSIGNAL SIGTERM
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=60s --retries=6 \
+  CMD curl --fail --silent --show-error \
+      "http://127.0.0.1:${DATAHIKE_PORT:-4444}/health/live" >/dev/null || exit 1
+
+ENTRYPOINT ["java", "-jar", "/opt/datahike/datahike-http-server.jar"]

--- a/http-server-java/datahike/http/Launcher.java
+++ b/http-server-java/datahike/http/Launcher.java
@@ -1,0 +1,25 @@
+package datahike.http;
+
+import clojure.java.api.Clojure;
+import clojure.lang.IFn;
+import clojure.lang.RT;
+
+/**
+ * Minimal JVM launcher for the standalone server.
+ *
+ * Keeping this entry point in Java lets the release JAR load Clojure sources
+ * on its target JVM. AOT-compiling the full dependency graph on the build JVM
+ * can freeze build-runtime probes (notably GraalVM detection) into bytecode and
+ * make the same JAR fail or behave differently on an ordinary OpenJDK runtime.
+ */
+public final class Launcher {
+    private Launcher() {}
+
+    public static void main(String[] args) {
+        IFn require = Clojure.var("clojure.core", "require");
+        require.invoke(Clojure.read("datahike.http.main"));
+
+        IFn main = Clojure.var("datahike.http.main", "-main");
+        main.applyTo(RT.seq(args));
+    }
+}


### PR DESCRIPTION
## Summary

- publish a non-root multi-platform server image to `ghcr.io/replikativ/datahike-server` for each GitHub release
- build and smoke-test the same released standalone JAR, then publish amd64/arm64 tags with provenance, SBOM, and registry attestation
- add Docker/Podman build and lifecycle-smoke tasks plus deployment documentation
- replace whole-graph Clojure AOT with a small Java launcher so the standalone artifact runs on ordinary OpenJDK as well as GraalVM

The launcher change also reduces the standalone JAR from 86,126,751 bytes to 45,522,586 bytes. The previous AOT artifact froze a GraalVM `ImageInfo` probe from `superv.async` into bytecode and failed on Temurin with `ClassNotFoundException`.

Rebased directly onto the squash-merged #1049.

## Verification

- complete packaged standalone server smoke passed (45,522,586-byte JAR)
- Temurin 21 Podman image smoke passed as UID/GID 10001:10001
- landing page and authenticated `/version` passed
- graceful SIGTERM stop passed with a 40-second deadline
- changed Babashka tooling: clj-kondo 0 errors, 0 warnings
- formatting and `git diff --check` passed
- actionlint 1.7.12 passed
- workflow action revisions are pinned to exact commits