### PR TITLE
Bundle portable cloud backends in the server

### DIFF
--- a/bb/src/tools/http_server.clj
+++ b/bb/src/tools/http_server.clj
@@ -134,7 +134,8 @@
                    (get-in status [:node :nrepl])))
         (let [version-body (:body (response :get (str base-url "/version")
                                              {:headers (assoc auth "accept" "application/json")}))]
-          (doseq [backend ["memory" "file" "s3" "jdbc" "dynamodb" "redis"]]
+          (doseq [backend ["memory" "file" "s3" "jdbc" "dynamodb" "redis"
+                           "gcs" "azure-blob"]]
             (expect! (str "backend inventory contains " backend)
                      #(str/includes? % backend)
                      version-body)))

--- a/config.edn
+++ b/config.edn
@@ -45,7 +45,10 @@
                                   ;; CI treats this as a regression budget, not a
                                   ;; product promise. Raise it deliberately when a
                                   ;; new bundled backend justifies the increase.
-                                  :max-bytes   62914560}
+                                  ;; Audited GCS and Azure HTTP transports bring
+                                  ;; the current artifact to ~71.7 MiB. Keep a
+                                  ;; bounded 8.3 MiB allowance for SDK patch drift.
+                                  :max-bytes   83886080}
          ;; Used only on Windows, where native-image cannot take the classpath
          ;; on the command line (8191-char limit). Same shape as :native, but
          ;; carrying the CLI's own aliases rather than libdatahike's.

--- a/deps.edn
+++ b/deps.edn
@@ -185,6 +185,10 @@
                                {:mvn/version "0.1.33"
                                 :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
                                org.replikativ/konserve-redis {:mvn/version "0.1.29"}
+                               org.replikativ/konserve-gcs
+                               {:mvn/version "0.1.19"}
+                               org.replikativ/konserve-azure-blob
+                               {:mvn/version "0.1.5"}
                                org.postgresql/postgresql     {:mvn/version "42.7.13"}
                                org.replikativ/pg-datahike    {:mvn/version "0.1.159"
                                                                :exclusions [org.replikativ/datahike]}
@@ -246,10 +250,9 @@
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
 
                                       ;; Batteries included for the standalone server. File,
-                                      ;; memory and tiered ship with Konserve itself. GCS stays
-                                      ;; optional because its SDK graph is exceptionally large;
-                                      ;; RocksDB/LMDB stay optional because they add native and
-                                      ;; platform constraints to an otherwise portable jar.
+                                      ;; memory and tiered ship with Konserve itself. Cloud SDK
+                                      ;; backends remain portable JVM bytecode; RocksDB/LMDB stay
+                                      ;; separate because they add native and platform constraints.
                                       org.replikativ/konserve-s3
                                       {:mvn/version "0.1.42"
                                        :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
@@ -260,6 +263,10 @@
                                        :exclusions [com.amazonaws/aws-xray-recorder-sdk-aws-sdk-v2]}
                                       org.replikativ/konserve-redis
                                       {:mvn/version "0.1.29"}
+                                      org.replikativ/konserve-gcs
+                                      {:mvn/version "0.1.19"}
+                                      org.replikativ/konserve-azure-blob
+                                      {:mvn/version "0.1.5"}
                                       org.postgresql/postgresql
                                       {:mvn/version "42.7.13"}
                                       org.replikativ/pg-datahike

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -463,11 +463,11 @@ redacted configuration exposes deployment topology. Send an `Accept` header
 such as `application/json` or `application/edn` to choose the response format.
 
 The standalone server artifact registers the built-in file, memory, and tiered
-stores plus the official S3, JDBC, DynamoDB, and Redis backends. It includes the
-PostgreSQL JDBC driver. GCS remains an opt-in dependency because of its large
-SDK graph; RocksDB and LMDB remain opt-in because they impose native and
-platform-specific runtime requirements. Embedding applications can load any
-additional Konserve backend, and `/version` reports it automatically.
+stores plus the official S3, GCS, Azure Blob, JDBC, DynamoDB, and Redis backends.
+It includes the PostgreSQL JDBC driver. RocksDB and LMDB remain separate because
+they impose native and platform-specific runtime requirements. Embedding
+applications can load any additional Konserve backend, and `/version` reports
+it automatically.
 
 `datahike.http.server/start-server` and `stop-server` do the same from a
 REPL; `stop-server` releases every database the server opened, the auth

--- a/doc/storage-backends.md
+++ b/doc/storage-backends.md
@@ -8,11 +8,13 @@ Datahike provides pluggable storage through [konserve](https://github.com/replik
 |---------|----------|--------------|------------|------------------|
 | **File** | Unix tools, rsync, git-like workflows | Single machine | High | Good |
 | **LMDB** | High-performance single machine | Single filesystem | High | Excellent |
+| **RocksDB** | Embedded high-write workloads | Single machine | High | Excellent |
 | **Memory** | Testing, ephemeral data | Single process | None | Excellent |
 | **JDBC** | Existing SQL infrastructure | Multi-machine | High | Good |
 | **Redis** | High write throughput | Multi-machine | Medium | Excellent |
 | **S3** | Distributed scale-out, cost-effective | Multi-region | Very high | Good |
 | **GCS** | Google Cloud scale-out | Multi-region | Very high | Good |
+| **Azure Blob** | Azure-native object storage | Multi-region | Very high | Good |
 | **DynamoDB** | Low latency, AWS-native | Multi-region | Very high | Excellent (expensive) |
 | **IndexedDB** | Browser persistence | Browser | Medium | Good |
 
@@ -44,7 +46,7 @@ Datahike provides pluggable storage through [konserve](https://github.com/replik
 **Key advantage**: Lightning-fast memory-mapped database with ACID transactions, optimized for read-heavy workloads.
 
 ```clojure
-;; Requires: org.replikativ/datahike-lmdb
+;; Requires: org.replikativ/konserve-lmdb
 {:store {:backend :lmdb
          :path "/var/lib/myapp/db"}}
 ```
@@ -58,7 +60,29 @@ Datahike provides pluggable storage through [konserve](https://github.com/replik
 - Very low latency
 - Large file blob that cannot be as efficiently synched a the file store
 
-**Note**: The LMDB backend is available as a separate library: [datahike-lmdb](https://github.com/replikativ/datahike-lmdb), extending [konserve-lmdb](https://github.com/replikativ/konserve-lmdb).
+**Note**: The LMDB backend is available as the separate
+[konserve-lmdb](https://github.com/replikativ/konserve-lmdb) library. It is not
+part of the portable server artifact: it requires Java 22+, native access, and
+a platform `liblmdb` installation.
+
+### RocksDB Backend
+
+RocksDB is available through
+[konserve-rocksdb](https://github.com/replikativ/konserve-rocksdb). It remains a
+separate server deployment dependency: its `rocksdbjni` artifact is about 68
+MiB because it carries native libraries for several operating systems and CPU
+architectures. Bundling it would nearly double the portable server JAR.
+
+Native-store server variants therefore have different contracts from the
+portable artifact:
+
+- a RocksDB distribution must select and test its target platforms instead of
+  hiding a multi-platform JNI payload in the standard JAR;
+- an LMDB distribution must select Java 22+ and supply `liblmdb` plus native
+  access at launch.
+
+Until those distributions are published, use the thin server artifact from a
+Clojure project that adds and requires the corresponding Konserve backend.
 
 ### Memory Backend
 
@@ -88,7 +112,7 @@ All distributed backends support **Distributed Index Space (DIS)**: multiple rea
 **Key advantage**: Leverage existing SQL database skills, backup procedures, and monitoring tools.
 
 ```clojure
-;; Requires: org.replikativ/datahike-jdbc
+;; Requires: org.replikativ/konserve-jdbc
 {:store {:backend :jdbc
          :dbtype "postgresql"
          :host "db.example.com"
@@ -105,7 +129,9 @@ All distributed backends support **Distributed Index Space (DIS)**: multiple rea
 - Good for teams already operating PostgreSQL
 - Available for: PostgreSQL, MySQL, H2, and others
 
-**Note**: Available as separate library: [datahike-jdbc](https://github.com/replikativ/datahike-jdbc)
+**Note**: The standalone server includes
+[konserve-jdbc](https://github.com/replikativ/konserve-jdbc) and the PostgreSQL
+driver. Embedding applications add the driver for the SQL database they use.
 
 ### Redis Backend
 
@@ -169,6 +195,24 @@ All distributed backends support **Distributed Index Space (DIS)**: multiple rea
 - Native GCP integration
 - Good latency within GCP regions
 - Cost-effective for large datasets
+
+The standalone server carries the Google SDK's default HTTP/JSON client. GCS
+production endpoints are still HTTPS with the normal Google authentication and
+integrity checks; only the optional gRPC implementation is omitted.
+
+### Azure Blob Storage Backend
+
+**Use when**: You're on Azure and want distributed object storage.
+
+```clojure
+;; Requires: org.replikativ/konserve-azure-blob
+{:store {:backend :azure-blob
+         :container "datahike"
+         :account-name "my-storage-account"}}
+```
+
+The standalone server uses Azure's portable JDK HTTP provider. It does not
+bundle the alternative Netty provider or its platform-native TLS binaries.
 
 ### DynamoDB Backend
 

--- a/http-server/datahike/http/backends.clj
+++ b/http-server/datahike/http/backends.clj
@@ -5,7 +5,9 @@
    classpath is not enough: its namespace must be loaded. Keeping those
    requires in one namespace makes the artifact's supported surface explicit
    and leaves the Datahike library jar free of optional backend dependencies."
-  (:require [konserve-dynamodb.core]
+  (:require [konserve-azure-blob.core]
+            [konserve-dynamodb.core]
+            [konserve-gcs.core]
             [konserve-jdbc.core]
             [konserve-redis.core]
             [konserve-s3.core]))


### PR DESCRIPTION
## What

- bundle GCS and Azure Blob in the standalone server alongside the existing portable backends
- load both registration namespaces at startup and report them from `/version`
- raise the standalone regression budget from 60 to 80 MiB with the measured reason recorded beside it
- document the portable/native boundary and current Konserve coordinates

The Datahike library artifact remains unchanged; only the dedicated server pays for these dependencies.

## Dependency audit

- `konserve-gcs 0.1.19` uses Google Storage's default HTTP/JSON transport over HTTPS and excludes the optional gRPC/Netty/native-TLS graph upstream
- `konserve-azure-blob 0.1.5` uses Azure's JDK HTTP provider and excludes Netty/native-TLS upstream
- the resolved Datahike server graph contains neither transport stack

RocksDB stays separate because `rocksdbjni` alone is 70,837,810 bytes. LMDB stays separate because it requires Java 22+, native access, and a platform `liblmdb` installation.

## Size

| artifact | bytes | MiB |
|---|---:|---:|
| previous standalone server | 45,522,588 | 43.41 |
| GCS only, naïve SDK graph | 96,270,924 | 91.81 |
| GCS only, audited graph | 66,807,219 | 63.71 |
| final GCS + Azure server | 75,150,655 | 71.67 |
| final JAR wrapped in ZIP | 67,802,357 | 64.66 |

The GitHub Release should remain the directly executable JAR; another ZIP saves about 9.8% but adds an unpacking step. OCI layer compression gets the same benefit automatically.

## Verification

- `bb format`
- `bb http-server-uber`
- `bb http-server-smoke`
- smoke verifies `gcs` and `azure-blob` in `/version`
- final packaged server starts, serves its admin shell and authenticated APIs, then shuts down cleanly
