### PR TITLE
Integrate Kabel transport metrics

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -171,7 +171,7 @@
                                ;; longer duplicated here: it is a main dep now,
                                ;; because declaring it twice is precisely how the
                                ;; tested and shipped versions came apart.
-                               org.replikativ/kabel          {:mvn/version "0.3.108"}
+                               org.replikativ/kabel          {:mvn/version "0.3.109"}
                                is.simm/distributed-scope     {:mvn/version "0.1.9"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
 

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -357,6 +357,27 @@ without effective authentication. Configure a nonblank `:token` or a custom
 unauthenticated local development. `:dev-mode true` bypasses authentication and
 therefore never permits a public bind, even if a token is also present.
 
+### Kabel transport metrics
+
+Kabel can publish bounded transport metrics into the same
+`replikativ.metrics` registry used by Datahike. Put logical-message metrics
+inside Datahike's CBOR codec and wire-byte metrics outside it:
+
+```clojure
+(:require [kabel.metrics :as kabel-metrics])
+
+(peer/server-peer
+ S handler server-id
+ (comp application-middleware kabel-metrics/messages)
+ (comp datahike-cbor-middleware kabel-metrics/wire))
+```
+
+The counters cover message direction and type, application bytes, connection
+lifecycle, and pub/sub subscription lifecycle. Labels deliberately omit peer
+ids, URLs, and topics. When the peer shares a process with Datahike's HTTP
+routes, the counters appear automatically at `GET /prometheus`; another host
+can read the registry snapshot or choose its own exposition format.
+
 ### Developer nREPL
 
 nREPL is bundled but disabled by default. It evaluates arbitrary code in the


### PR DESCRIPTION
## What

- update to `org.replikativ/kabel 0.3.109`
- document how Datahike peers compose logical-message and encoded-wire metrics at the correct middleware boundaries
- explain how the counters join Datahike's shared registry and `/prometheus` exposition

Instrumentation remains opt-in per peer. A peer that does not compose the two middlewares pays no channel, allocation, or registry-update cost.

Labels are bounded: direction, message type, serialization, side, and lifecycle event. Peer ids, URLs, and pub/sub topics are deliberately excluded.

## Verification

- upstream Kabel JVM suite: 114 tests / 603 assertions
- upstream Kabel Node suite: 28 tests / 104 assertions
- Datahike Kabel suite against 0.3.109: 25 tests / 131 assertions
- `bb format`

Measured upstream on 100,000 direct counter operations:

- logical-message counter: ~2.18 µs/op
- wire-byte counter: ~1.71 µs/op
