### PR TITLE
Secure the bundled PostgreSQL listener

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -190,7 +190,7 @@
                                org.replikativ/konserve-azure-blob
                                {:mvn/version "0.1.5"}
                                org.postgresql/postgresql     {:mvn/version "42.7.13"}
-                               org.replikativ/pg-datahike    {:mvn/version "0.1.159"
+                               org.replikativ/pg-datahike    {:mvn/version "0.1.160"
                                                                :exclusions [org.replikativ/datahike]}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
@@ -270,7 +270,7 @@
                                       org.postgresql/postgresql
                                       {:mvn/version "42.7.13"}
                                       org.replikativ/pg-datahike
-                                      {:mvn/version "0.1.159"
+                                      {:mvn/version "0.1.160"
                                        :exclusions [org.replikativ/datahike]}}
                          :main-opts ["-m" "datahike.http.main"]}
 

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -447,6 +447,38 @@ run but remains visible in container metadata; production deployments should
 mount a secret readable by UID 10001 and set `DATAHIKE_TOKEN_FILE` to its
 in-container path.
 
+To expose the beta PostgreSQL listener, mount a complete server configuration
+and a PKCS#12 server keystore, then publish port 5432 as well:
+
+```clojure
+{:host "0.0.0.0"
+ :port 4444
+ :token "replace-with-a-long-random-token"
+ :system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
+ :pg-listener
+ {:host "0.0.0.0"
+  :port 5432
+  :users {"app" "replace-with-a-separate-postgresql-password"}
+  :tls {:keystore "/run/secrets/datahike-pg.p12"
+        :keystore-password "replace-with-the-keystore-password"}}}
+```
+
+```bash
+docker run --name datahike --detach \
+  --publish 4444:4444 --publish 5432:5432 \
+  --mount type=volume,source=datahike-data,target=/var/lib/datahike \
+  --mount type=bind,source="$PWD/server.edn",target=/run/secrets/server.edn,readonly \
+  --mount type=bind,source="$PWD/datahike-pg.p12",target=/run/secrets/datahike-pg.p12,readonly \
+  ghcr.io/replikativ/datahike-server:latest \
+  --config /run/secrets/server.edn
+```
+
+Keep the configuration readable only by the deployment identity because its
+`:users` map and keystore password are secrets. PostgreSQL authentication is
+separate from the HTTP token and currently grants node-wide access to all
+catalog databases exposed by the listener. Clients should use
+`sslmode=verify-full` with the issuing CA certificate.
+
 The image has a built-in health check against `/health/live`. Its Java process is
 PID 1 and receives SIGTERM directly. Docker's default ten-second stop timeout
 is shorter than Datahike's 30-second graceful drain, hence the explicit

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -184,8 +184,11 @@ store UUID when unnamed):
 ```clojure
 {:system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
  :pg-listener
- {:host "127.0.0.1"
+ {:host "0.0.0.0"
   :port 5432
+  :users {"app" "secret-from-deployment"}
+  :tls {:keystore "/run/secrets/datahike-pg.p12"
+        :keystore-password "keystore-secret-from-deployment"}
   :database-overrides
   {"accounts" {:store {:password "secret-from-deployment"}}}}}
 ```
@@ -205,17 +208,27 @@ connection; a failed delete restores it. pg-datahike's independent
 Catalog names exposed through PostgreSQL must be unique; the server rejects a
 conflicting HTTP create before it changes physical storage.
 
-This listener is beta and currently restricted to loopback because released
-pg-datahike versions do not authenticate the wire connection. Once password
-authentication is available, the server will accept an authenticated public
-bind. Use the HTTP API for provisioning and permission administration in the
-meantime.
+The default listener remains unauthenticated and restricted to loopback. A
+wildcard or non-loopback bind is accepted only when both password
+authentication and TLS are configured; TLS is then mandatory. `:users` is a
+small deployment-owned `{username password}` map. Embedded servers can use an
+`:authenticator` callback and a preconfigured `:ssl-context` instead. The TLS
+shorthand loads a PKCS#12 keystore. On loopback, set `:require-tls? true` when
+plaintext connections should also be rejected.
 
-The PostgreSQL listener is currently a trusted local data surface: PostgreSQL
-users are not mapped to Datahike EACL principals, so a client that can reach
-the listener can access every database it exposes. The loopback restriction is
-a security boundary, not merely a beta convenience. Do not publish or proxy
-this port to untrusted clients.
+PostgreSQL password authentication is a node-level access gate. PostgreSQL
+users are not yet mapped to Datahike EACL principals, so every authenticated
+user can access every database exposed by this listener. HTTP tokens and EACL
+permissions do not authenticate the PostgreSQL protocol. Use the HTTP API for
+provisioning and permission administration, and give PostgreSQL credentials
+only to principals trusted for the whole node.
+
+Clients use standard PostgreSQL TLS settings. For example:
+
+```bash
+PGPASSWORD="$DATAHIKE_PG_PASSWORD" psql \
+  "host=datahike.example port=5432 dbname=accounts user=app sslmode=verify-full sslrootcert=/path/to/ca.crt"
+```
 
 The graph (`datahike.http.permissions/schema`):
 

--- a/http-server/datahike/http/pg.clj
+++ b/http-server/datahike/http/pg.clj
@@ -7,7 +7,6 @@
   (:require
    [datahike.api :as d]
    [datahike.connections :as connections]
-   [datahike.http.config :as server-config]
    [datahike.http.system :as system]
    [datahike.pg.server :as pg]
    [datahike.store :as store]
@@ -89,12 +88,6 @@
       (throw (ex-info ":pg-listener requires :system-db"
                       {:type :datahike.http/missing-system-database})))
     (reject-independent-provisioning! listener-config)
-    (let [host (get listener-config :host "127.0.0.1")]
-      (when-not (server-config/loopback-host? host)
-        (throw (ex-info
-                "The beta pg-datahike listener is restricted to a loopback bind until wire authentication is available"
-                {:type :datahike.http/unsafe-pg-bind
-                 :host host}))))
     (log/warn :datahike/pg-listener-beta
               "The pg-datahike listener is beta and does not yet provide the full PostgreSQL surface")
     (let [opened   (atom {})

--- a/test/datahike/test/http/pg_test.clj
+++ b/test/datahike/test/http/pg_test.clj
@@ -8,7 +8,8 @@
    [datahike.pg.server :as pg])
   (:import
    [datahike.pg PgWireServer]
-   [java.sql DriverManager]))
+   [java.sql DriverManager SQLException]
+   [javax.net.ssl SSLContext]))
 
 (defn- memory-config [name]
   {:name name
@@ -153,24 +154,51 @@
            #"shared system catalog"
            (listener/start! config (atom {}))))
       (finally
-        (system/close! config))))
-  (let [config (system/configure
-                {:system-db {:store {:backend :memory}}
-                 :pg-listener {:host "0.0.0.0" :port 5432}})]
-    (try
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"restricted to a loopback bind"
-           (listener/start! config (atom {}))))
-      (finally
         (system/close! config)))))
+
+(deftest listener-delegates-wire-security-to-pg-datahike
+  (testing "an unsafe public listener is rejected by pg-datahike"
+    (let [config (system/configure
+                  {:system-db {:store {:backend :memory}}
+                   :pg-listener {:host "0.0.0.0" :port 0}})]
+      (try
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"require password authentication and TLS"
+             (listener/start! config (atom {}))))
+        (finally
+          (system/close! config)))))
+  (testing "authentication and TLS options reach pg-datahike unchanged"
+    (let [ssl-context (SSLContext/getDefault)
+          options-seen (atom nil)
+          config (system/configure
+                  {:system-db {:store {:backend :memory}}
+                   :pg-listener {:host "0.0.0.0"
+                                 :port 0
+                                 :users {"app" "secret"}
+                                 :ssl-context ssl-context}})]
+      (try
+        (with-redefs [pg/start-server (fn [_ options]
+                                        (reset! options-seen options)
+                                        ::server)
+                      pg/stop-server (constantly nil)]
+          (listener/stop! (listener/start! config (atom {}))))
+        (is (= {:host "0.0.0.0"
+                :port 0
+                :users {"app" "secret"}
+                :ssl-context ssl-context}
+               @options-seen))
+        (finally
+          (system/close! config))))))
 
 (deftest catalog-name-routes-a-real-postgresql-session
   (let [database      (memory-config "analytics")
         registry      (atom {})
         system-config (system/configure
                        {:system-db {:store {:backend :memory}}
-                        :pg-listener {:host "127.0.0.1" :port 0}})]
+                        :pg-listener {:host "127.0.0.1"
+                                      :port 0
+                                      :users {"datahike" "secret"}}})]
     (binding [connections/*connections* registry]
       (try
         (d/create-database database)
@@ -178,13 +206,20 @@
         (let [runtime (listener/start! system-config registry)
               wire    ^PgWireServer (:server (:server runtime))
               url     (str "jdbc:postgresql://127.0.0.1:" (.getPort wire)
-                           "/analytics?sslmode=disable")]
+                           "/analytics?sslmode=disable&user=datahike&password=secret")]
           (try
-            (with-open [sql-conn (DriverManager/getConnection url "datahike" "")
+            (with-open [sql-conn (DriverManager/getConnection url)
                         statement (.createStatement sql-conn)
                         result    (.executeQuery statement "SELECT current_database()")]
               (is (.next result))
               (is (= "analytics" (.getString result 1))))
+            (let [error (try
+                          (DriverManager/getConnection
+                           (str "jdbc:postgresql://127.0.0.1:" (.getPort wire)
+                                "/analytics?sslmode=disable&user=datahike&password=wrong"))
+                          nil
+                          (catch SQLException e e))]
+              (is (= "28P01" (.getSQLState ^SQLException error))))
             (finally
               (listener/stop! runtime))))
         (finally


### PR DESCRIPTION
## Summary

- update the batteries-included server to pg-datahike 0.1.160
- allow authenticated TLS PostgreSQL listeners to bind publicly while keeping pg-datahike as the single security authority
- exercise password acceptance/rejection through the shared system catalog
- document PKCS#12, psql verify-full, node-wide access semantics, and Docker deployment

## Security model

- loopback remains usable without authentication
- every non-loopback/wildcard bind requires both a password authenticator and TLS; TLS becomes mandatory
- PostgreSQL credentials are separate from HTTP authentication and currently gate the entire node, not individual EACL principals/databases

## Verification

- focused listener suite: 6 tests, 25 assertions, 0 failures/errors
- formatting check passes
- changed-file clj-kondo: 0 errors (existing unresolved generated API warnings only)
- `bb http-server-uber`
- `bb http-server-smoke`: packaged JAR passed (75,157,351 bytes)
- real psql 17.10: verify-full negotiated TLSv1.3 / TLS_AES_256_GCM_SHA384 and queried `current_database()`; wrong password rejected; plaintext rejected

Depends on replikativ/pg-datahike#139, released as v0.1.160.