### PR TITLE
Fence secondary build cancellation by generation

### DIFF
--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -110,7 +110,7 @@
                        " :paths [\"test/datahike/backward_compatibility_test/src\"]}")
          "-X:test" "backward-secondary-test/verify-current-formats")
 
-    (println "VERIFYING REFUSED ROOTS REMAIN READABLE BY THE RELEASE")
+    (println "VERIFYING RELEASED ROOTS REMAIN READABLE BY THE RELEASE")
     (clj {:dir old-version-dir
           :extra-env secondary-env}
          "-Sdeps" (str "{:deps {io.replikativ/datahike {:local/root \".\"}}"

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -283,6 +283,33 @@ Secondary indices are managed through schema transactions:
 
 The `:db.secondary/type` and `:db.secondary/attrs` are immutable after creation. To change indexed attributes, create a new index with a different ident.
 
+A caller that gives up waiting for a build can cancel the exact generation it
+observed. Capture the build boundary with the status, then pass both to the
+writer operation:
+
+```clojure
+(require '[datahike.writer :as writer])
+
+(def boundary
+  (get-in (d/db conn)
+          [:schema :idx/my-index :db.secondary/building-since-tx]))
+
+@(writer/cancel-secondary-index-build!
+  conn :idx/my-index boundary)
+```
+
+Cancellation is serialized with transactions. It retracts that declaration and
+clears its in-memory delta journal in one commit. If the ident now names a
+different generation—or has already become ready—the operation fails with
+`:secondary-index-build-generation-mismatch` and changes nothing. The detached
+scan may finish, but it is fenced from publication and releases its resources.
+Datahike applies the same cancellation transition automatically when a
+background scan fails, so a failed adapter cannot strand a permanently
+`:building` declaration. The connection keeps a generation-keyed diagnostic at
+`[:secondary-index-build-failures index-ident]` until a successful replacement
+generation clears it or the connection is released. This diagnostic is runtime
+state for the waiting caller; it is deliberately not a durable index root.
+
 ## Branching and Versioning
 
 Secondary indices are first-class versioned state. A committed Datahike root

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -304,6 +304,12 @@
    :cljs
    (defn- instantiate-secondary [db _idx-ident _idx-schema] db))
 
+(defn- drop-secondary-build-failure [db idx-ident]
+  (let [remaining (dissoc (:secondary-index-build-failures db) idx-ident)]
+    (if (empty? remaining)
+      (dissoc db :secondary-index-build-failures)
+      (assoc db :secondary-index-build-failures remaining))))
+
 #?(:clj
    (defn finalize-secondary-indices
      "Reconcile the runtime secondary-index map with the post-tx schema, then
@@ -343,7 +349,8 @@
         (fn [d k]
           (if (get-in d [:secondary-indices k])
             d
-            (instantiate-secondary d k (get-in d [:schema k]))))
+            (-> (instantiate-secondary d k (get-in d [:schema k]))
+                (drop-secondary-build-failure k))))
         db declared)))
    :cljs
    (defn finalize-secondary-indices [db] db))

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -787,6 +787,8 @@
                            ;; a short serialized report-producing operation.
                            #?@(:clj ['build-secondary-index! w/build-secondary-index!
                                      'install-secondary-index! w/install-secondary-index!
+                                     'cancel-secondary-index-build!
+                                     w/cancel-secondary-index-build!
                                      ;; Recovery re-anchors the snapshot boundary
                                      ;; before rebuilding (see connector).
                                      'reset-secondary-index-build-boundary!
@@ -1041,31 +1043,78 @@
         (when (map? tx-report) ;; not error
           #?(:clj
              (doseq [idx-ident (detect-new-building-indices tx-report)]
-               (log/trace :datahike/dispatch-backfill {:idx-ident idx-ident})
-               (go
-                 (let [build-result (<! (dispatch! writer
-                                                   {:op 'build-secondary-index!
-                                                    :args [idx-ident]}))]
-                   (when-not (map? build-result)
-                     (log/warn :datahike/secondary-index-build-failed
-                               {:idx-ident idx-ident :error build-result}))
-                   (when (map? build-result)
-                     ;; Awaiting here does not block the writer. The install is
-                     ;; merely queued behind transactions that may have arrived
-                     ;; during the scan; it replays their journaled deltas.
-                     (let [install-result
-                           (<! (dispatch! writer
-                                          {:op 'install-secondary-index!
-                                           :args [build-result]}))]
-                       ;; If release shut the local queue between scan and
-                       ;; install, no commit report exists to release the guard.
-                       ;; The build ran in this JVM, so clean it up here.
-                       (when (and local-writer? (not (map? install-result)))
-                         (w/finish-secondary-index-build! build-result))))))))
+               (let [building-since-tx
+                     (get-in tx-report
+                             [:db-after :schema idx-ident
+                              :db.secondary/building-since-tx])]
+                 (log/trace :datahike/dispatch-backfill {:idx-ident idx-ident})
+                 (go
+                   (let [build-result (<! (dispatch! writer
+                                                     {:op 'build-secondary-index!
+                                                      :args [idx-ident]}))]
+                     (if-not (map? build-result)
+                       (do
+                         (log/warn :datahike/secondary-index-build-failed
+                                   {:idx-ident idx-ident :error build-result})
+                         ;; A failed scan is a failed declaration, not a
+                         ;; permanently :building one. The generation token
+                         ;; prevents this cleanup from touching a replacement.
+                         (let [cancel-result
+                               (<! (dispatch!
+                                    writer
+                                    {:op 'cancel-secondary-index-build!
+                                     :args
+                                     [idx-ident building-since-tx
+                                      {:type (or (some-> build-result ex-data :type)
+                                                 :secondary-index-build-failed)
+                                       :message (if (instance? Throwable build-result)
+                                                  (ex-message build-result)
+                                                  (str build-result))}]}))]
+                           (when-not (map? cancel-result)
+                             (log/warn
+                              :datahike/secondary-index-build-failure-cleanup-failed
+                              {:idx-ident idx-ident
+                               :building-since-tx building-since-tx
+                               :error cancel-result}))))
+                       ;; Awaiting here does not block the writer. The install is
+                       ;; merely queued behind transactions that may have arrived
+                       ;; during the scan; it replays their journaled deltas.
+                       (let [install-result
+                             (<! (dispatch! writer
+                                            {:op 'install-secondary-index!
+                                             :args [build-result]}))]
+                         ;; If release shut the local queue between scan and
+                         ;; install, no commit report exists to release the guard.
+                         ;; The build ran in this JVM, so clean it up here.
+                         (when (and local-writer? (not (map? install-result)))
+                           (w/finish-secondary-index-build! build-result)))))))))
           (doseq [[_ callback] (some-> (:listeners (meta connection)) (deref))]
             (callback tx-report)))
         (#?(:clj deliver :cljs put!) p tx-report)))
     p))
+
+#?(:clj
+   (defn cancel-secondary-index-build!
+     "Cancel one exact asynchronous secondary-index build generation.
+
+      Returns a throwable promise containing the committed transaction report.
+      A generation mismatch is delivered as an ExceptionInfo and leaves the
+      current declaration untouched."
+     [connection idx-ident building-since-tx]
+     (let [p (throwable-promise)
+           db @(:wrapped-atom connection)
+           writer (:writer db)]
+       (go
+         (let [tx-report
+               (<! (dispatch! writer
+                              {:op 'cancel-secondary-index-build!
+                               :args [idx-ident building-since-tx]}))]
+           (when (map? tx-report)
+             (doseq [[_ callback]
+                     (some-> (:listeners (meta connection)) deref)]
+               (callback tx-report)))
+           (deliver p tx-report)))
+       p)))
 
 (defn- dispatch-load!
   "`args` is the argument vector as the write-fn will receive it AFTER `old` —

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -1825,6 +1825,51 @@
          (assoc db :secondary-index-build-deltas remaining)))))
 
 #?(:clj
+   (defn- drop-build-failure [db idx-ident]
+     (let [remaining (dissoc (:secondary-index-build-failures db) idx-ident)]
+       (if (empty? remaining)
+         (dissoc db :secondary-index-build-failures)
+         (assoc db :secondary-index-build-failures remaining)))))
+
+#?(:clj
+   (defn cancel-secondary-index-build!
+     "Atomically remove the exact secondary build generation named by
+      `building-since-tx` and discard its buffered deltas.
+
+      The generation check is the cancellation fence: a delayed timeout or
+      operator request cannot remove a replacement build that reused the same
+      index ident. The detached background scan may finish, but install's
+      equivalent generation check prevents it from publishing into the new
+      root and releases its resources."
+     ([old idx-ident building-since-tx]
+      (cancel-secondary-index-build! old idx-ident building-since-tx nil))
+     ([old idx-ident building-since-tx failure]
+      (let [status (get-in old [:schema idx-ident :db.secondary/status])
+            current-boundary (get-in old [:schema idx-ident
+                                          :db.secondary/building-since-tx])]
+        (when-not (and (= :building status)
+                       (= building-since-tx current-boundary))
+          (log/raise "Secondary-index build generation is no longer current"
+                     {:type :secondary-index-build-generation-mismatch
+                      :idx-ident idx-ident
+                      :expected-building-since-tx building-since-tx
+                      :actual-building-since-tx current-boundary
+                      :status status}))
+        (let [entity-id (dbu/entid-strict old [:db/ident idx-ident])
+              tx-report
+              (binding [sec/*durable-secondary-write-context* :commit]
+                (core/with old [[:db/retractEntity entity-id]] nil))]
+          (-> tx-report
+              (update :db-after drop-build-deltas idx-ident)
+              (cond-> failure
+                (assoc-in [:db-after :secondary-index-build-failures idx-ident]
+                          (assoc failure :building-since-tx building-since-tx)))
+              (assoc :secondary-index-build-canceled
+                     {:idx-ident idx-ident
+                      :building-since-tx building-since-tx})
+              (as-> report (complete-db-update old report))))))))
+
+#?(:clj
    (defn install-secondary-index!
      "Replay changes accumulated during an asynchronous backfill and publish
      the resulting index. This operation is serialized by the writer, which
@@ -1864,7 +1909,8 @@
                               (assoc-in [:schema idx-ident :db.secondary/status] :ready)
                               (update-in [:schema idx-ident] dissoc
                                          :db.secondary/building-since-tx)
-                              (drop-build-deltas idx-ident))]
+                              (drop-build-deltas idx-ident)
+                              (drop-build-failure idx-ident))]
              (complete-db-update
               old {:db-before old
                    :db-after db-after

--- a/test/datahike/backward_compatibility_test/src/backward_secondary_test.clj
+++ b/test/datahike/backward_compatibility_test/src/backward_secondary_test.clj
@@ -6,9 +6,7 @@
             [datahike.index.secondary.scriptum]
             [datahike.index.secondary.stratum]
             [konserve.core :as konserve]
-            [taoensso.trove :as trove])
-  (:import [java.io File FileInputStream]
-           [java.security MessageDigest]))
+            [taoensso.trove :as trove]))
 
 (def ^:private primary-ids
   {:stratum #uuid "e31a77d5-ae9b-4743-a35a-cd2b7c05a54d"
@@ -129,7 +127,7 @@
              (d/q '[:find (count ?v) . :in $ ?a :where [_ ?a ?v]]
                   (d/db conn) attr))))
 
-(defn- verify-old-scriptum! []
+(defn- verify-released-scriptum! []
   (let [conn (d/connect (config :scriptum))]
     (try
       (verify-primary-count conn :doc/body 1)
@@ -140,14 +138,23 @@
       (finally
         (d/release conn)))))
 
+(defn- verify-released-proximum! []
+  (let [conn (d/connect (config :proximum))]
+    (try
+      (verify-primary-count conn :doc/embedding 1)
+      (let [matches (secondary/-search
+                     (secondary-index conn :idx/vector)
+                     {:vector (float-array [1.0 0.0 0.0 0.0]) :k 1} nil)]
+        (assert (= 1 (entity-set/entity-bitset-cardinality matches))))
+      (finally
+        (d/release conn)))))
+
 (defn verify-old [_]
-  ;; Run after current code deliberately refuses these roots. Successful old
-  ;; Scriptum open proves that refusal did not rewrite its Datahike head or
-  ;; native index. The released Proximum adapter itself cannot reopen a durable
-  ;; file store (its restore path calls create-store on the existing path), so
-  ;; current code checks its exact files before and after the refusal instead.
+  ;; The released Proximum adapter itself cannot reopen a durable file store
+  ;; (its restore path calls create-store on the existing path), so this final
+  ;; released-code check remains Scriptum-only. Current code verifies both.
   (trove/set-log-fn! (fn [& _]))
-  (verify-old-scriptum!))
+  (verify-released-scriptum!))
 
 (defn write-current [_]
   (trove/set-log-fn! (fn [& _]))
@@ -174,65 +181,6 @@
       (finally
         (d/release proximum-conn)
         (d/release scriptum-conn)))))
-
-(defn- throwable-data [failure]
-  (loop [pending [failure]
-         result []]
-    (if-let [current (peek pending)]
-      (let [data (ex-data current)
-            nested-error (when (map? data) (:error data))]
-        (recur (cond-> (pop pending)
-                 (.getCause ^Throwable current)
-                 (conj (.getCause ^Throwable current))
-                 (instance? Throwable nested-error)
-                 (conj nested-error))
-               (cond-> result data (conj data))))
-      result)))
-
-(defn- digest-file [^File file]
-  (let [digest (MessageDigest/getInstance "SHA-256")
-        buffer (byte-array 8192)]
-    (with-open [input (FileInputStream. file)]
-      (loop []
-        (let [n (.read input buffer)]
-          (when (pos? n)
-            (.update digest buffer 0 n)
-            (recur)))))
-    (vec (.digest digest))))
-
-(defn- file-fingerprint [root-path]
-  (let [root-file (File. root-path)
-        root-uri (.toURI root-file)]
-    (into (sorted-map)
-          (for [^File file (file-seq root-file)
-                :when (.isFile file)]
-            [(str (.relativize root-uri (.toURI file)))
-             [(.length file) (digest-file file)]]))))
-
-(defn- legacy-paths [kind]
-  (case kind
-    :scriptum [(path "primary-scriptum") (path "scriptum-index")]
-    :proximum [(path "primary-proximum")
-               (path "proximum-store")
-               (path "proximum-release-mmap")]))
-
-(defn- expect-legacy-refusal! [kind expected-type expected-reason]
-  (let [paths (legacy-paths kind)
-        before (mapv file-fingerprint paths)
-        failure (try
-                  (let [conn (d/connect (config kind))]
-                    (d/release conn)
-                    nil)
-                  (catch Throwable failure failure))
-        after (mapv file-fingerprint paths)]
-    (assert failure (str "Current Datahike unexpectedly opened legacy " kind " root."))
-    (assert (= before after)
-            (str "Refusing legacy " kind " changed persisted files."))
-    (let [data-chain (throwable-data failure)]
-      (assert (some #(and (= expected-type (:type %))
-                          (= expected-reason (:reason %)))
-                    data-chain)
-              (str "Unexpected failure chain: " (pr-str data-chain))))))
 
 (defn- current-stratum! []
   (let [cfg (config :stratum)
@@ -263,9 +211,8 @@
 (defn verify-current [_]
   (trove/set-log-fn! (fn [& _]))
   (current-stratum!)
-  (expect-legacy-refusal! :scriptum
-                          :secondary/invalid-scriptum-generation
-                          :legacy-scriptum-v1-generation)
-  (expect-legacy-refusal! :proximum
-                          :secondary/invalid-proximum-generation
-                          :legacy-proximum-commit-root))
+  ;; 0.8.1863 is the first release with the immutable generation envelopes.
+  ;; They are now the compatibility baseline, rather than the legacy roots
+  ;; that the transition test deliberately rejected before that release.
+  (verify-released-scriptum!)
+  (verify-released-proximum!))

--- a/test/datahike/test/secondary_dynamic_test.clj
+++ b/test/datahike/test/secondary_dynamic_test.clj
@@ -9,6 +9,7 @@
    [konserve.core :as k]
    [datahike.index.secondary :as sec]
    [datahike.migrate.fs :as fs]
+   [datahike.writer :as writer]
    [datahike.writing :as writing]
    [superv.async :refer [<?? S]]))
 
@@ -44,6 +45,23 @@
    :test/slow-immutable
    (fn [config _db]
      (->SlowImmutableIndex (set (:attrs config)) [] #{}))))
+
+(defrecord FailingBackfillIndex [attrs]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [_ _]
+    (throw (ex-info "deterministic backfill failure"
+                    {:type :test/backfill-failure}))))
+
+(defonce _register-failing-backfill
+  (sec/register-index-type!
+   :test/failing-backfill
+   (fn [config _db]
+     (->FailingBackfillIndex (set (:attrs config))))))
 
 (defrecord RecorderPreparation [index]
   sec/IPreparedSecondaryGeneration
@@ -233,6 +251,121 @@
         (finally
           (d/release conn)
           (d/delete-database cfg))))))
+
+(deftest secondary-build-cancellation-is-generation-bound
+  (testing "cancellation retracts only the named build and clears its journal"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :keep-history? false
+               :schema-flexibility :write}
+          entered (promise)
+          release (promise)
+          control {:entered entered :release release :blocked? (atom false)}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :person/cancel-name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:person/cancel-name "Alice"}])
+          (reset! slow-build-control control)
+          (d/transact conn [{:db/ident :idx/cancel-slow
+                             :db.secondary/type :test/slow-immutable
+                             :db.secondary/attrs [:person/cancel-name]}])
+          (is (= true (deref entered 5000 ::timeout)))
+          (d/transact conn [{:person/cancel-name "Bob"}])
+          (let [boundary (get-in (d/db conn)
+                                 [:schema :idx/cancel-slow
+                                  :db.secondary/building-since-tx])]
+            (is (integer? boundary))
+            (is (= :secondary-index-build-generation-mismatch
+                   (try
+                     @(writer/cancel-secondary-index-build!
+                       conn :idx/cancel-slow (dec boundary))
+                     nil
+                     (catch Exception e (throwable-type e)))))
+            (is (= :building
+                   (get-in (d/db conn)
+                           [:schema :idx/cancel-slow :db.secondary/status])))
+            (is (= 1 (count (get-in (d/db conn)
+                                    [:secondary-index-build-deltas
+                                     :idx/cancel-slow]))))
+            (let [report @(writer/cancel-secondary-index-build!
+                           conn :idx/cancel-slow boundary)]
+              (is (= {:idx-ident :idx/cancel-slow
+                      :building-since-tx boundary}
+                     (:secondary-index-build-canceled report))))
+            (is (nil? (get-in (d/db conn) [:schema :idx/cancel-slow])))
+            (is (nil? (get-in (d/db conn)
+                              [:secondary-indices :idx/cancel-slow])))
+            (is (nil? (:secondary-index-build-deltas (d/db conn))))
+            (deliver release true)
+            (let [deadline (+ (System/currentTimeMillis) 5000)]
+              (loop []
+                (when (and (guard/in-flight? (get-in cfg [:store :id]))
+                           (< (System/currentTimeMillis) deadline))
+                  (Thread/sleep 10)
+                  (recur))))
+            (is (not (guard/in-flight? (get-in cfg [:store :id]))))
+            (is (nil? (get-in (d/db conn) [:schema :idx/cancel-slow]))
+                "the detached worker cannot publish after cancellation"))
+          (finally
+            (deliver release true)
+            (reset! slow-build-control nil)
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(deftest failed-secondary-build-retracts-its-declaration
+  (testing "a scan failure cannot strand a declaration or delta journal"
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :keep-history? false
+               :schema-flexibility :write}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :person/failing-name
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:person/failing-name "Alice"}])
+          (d/transact conn [{:db/ident :idx/failing-build
+                             :db.secondary/type :test/failing-backfill
+                             :db.secondary/attrs [:person/failing-name]}])
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (get-in (d/db conn) [:schema :idx/failing-build])
+                         (< (System/currentTimeMillis) deadline))
+                (Thread/sleep 10)
+                (recur))))
+          (is (nil? (get-in (d/db conn) [:schema :idx/failing-build])))
+          (is (nil? (get-in (d/db conn)
+                            [:secondary-indices :idx/failing-build])))
+          (is (nil? (:secondary-index-build-deltas (d/db conn))))
+          (is (= {:type :test/backfill-failure
+                  :message "deterministic backfill failure"}
+                 (select-keys
+                  (get-in (d/db conn)
+                          [:secondary-index-build-failures :idx/failing-build])
+                  [:type :message])))
+          (is (integer?
+               (get-in (d/db conn)
+                       [:secondary-index-build-failures :idx/failing-build
+                        :building-since-tx])))
+          (d/transact conn [{:db/ident :person/empty-replacement
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:db/ident :idx/failing-build
+                             :db.secondary/type :test/failing-backfill
+                             :db.secondary/attrs [:person/empty-replacement]}])
+          (is (= :ready
+                 (get-in (d/db conn)
+                         [:schema :idx/failing-build :db.secondary/status])))
+          (is (nil? (get-in (d/db conn)
+                            [:secondary-index-build-failures
+                             :idx/failing-build])))
+          (finally
+            (d/release conn)
+            (d/delete-database cfg)))))))
 
 (deftest asynchronous-backfill-replays-concurrent-deltas
   (testing "the writer remains available and immutable index updates are not lost"


### PR DESCRIPTION
## Summary
- add a serialized cancellation writer operation keyed by the exact building-since transaction
- retract the canceled declaration and clear its delta journal atomically
- apply the same cleanup automatically when a background scan fails
- update the backward-compatibility probe now that immutable generations are the released baseline
- document the low-level cancellation operation

## Validation
- focused secondary lifecycle/index suites: 54 tests, 300 assertions, 0 failures
- backward-compatibility lane against released 0.8.1863: pass
- persistent-set tier: 1,242 tests, 13,899 assertions, 0 failures; 18 socket-binding errors are caused by the restricted local sandbox and are left to CI
- formatting and diff checks pass