### PR TITLE
Bump pg-datahike to 0.1.167

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -192,7 +192,7 @@
                                org.replikativ/konserve-azure-blob
                                {:mvn/version "0.1.5"}
                                org.postgresql/postgresql     {:mvn/version "42.7.13"}
-                               org.replikativ/pg-datahike    {:mvn/version "0.1.160"
+                               org.replikativ/pg-datahike    {:mvn/version "0.1.167"
                                                                :exclusions [org.replikativ/datahike]}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
@@ -272,7 +272,7 @@
                                       org.postgresql/postgresql
                                       {:mvn/version "42.7.13"}
                                       org.replikativ/pg-datahike
-                                      {:mvn/version "0.1.160"
+                                      {:mvn/version "0.1.167"
                                        :exclusions [org.replikativ/datahike]}}
                          :main-opts ["-m" "datahike.http.main"]}
 


### PR DESCRIPTION
## Summary
- bump the test/runtime pg-datahike pin from 0.1.160 to 0.1.167
- bump the bundled Datahike Server listener pin from 0.1.160 to 0.1.167

This brings generation-fenced secondary-index timeout cancellation, asynchronous build-failure reporting, and the updated deployment guidance into the server bundle.

## Validation
- built `datahike-http-server-0.8.1864-standalone.jar` against released pg-datahike 0.1.167
- packaged standalone server smoke test passed (75,199,895 bytes)
- diff check passes