### PR TITLE
Optional :create-database policy for the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **`:create-database` policy for the server.** `create-database` took the
+  client's `:store` as given, so a client with `:create` could point the
+  server at any backend it has loaded, a JDBC URL, an S3 bucket or a file
+  path anywhere the process may write. The optional server option
+  `{:create-database {:backends #{…}}}` allows only those backends, and
+  `{:create-database {:store {:backend :file :path root}}}` makes the server
+  choose the store below its own root with the client's id, as the Kabel
+  listener does. Without the option behaviour is unchanged and the server
+  logs at start that creation is unrestricted.
 - **Query functions are allow-listed on the server.** A `:where` function or
   predicate, an aggregate, a `:db.attr/preds` or `:db.entity/preds` symbol
   resolved through `clojure.core/resolve` and reflection, so any client of the

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -360,7 +360,28 @@ your service — or give that client a `:self` writer.
 
 Checklist: a token or validator set · `:dev-mode` false · secrets in
 env/secret store · TLS at the edge · `release-all!` on shutdown · `delete`
-granted only to owners who may · `:query-functions` left at `:safe`.
+granted only to owners who may · `:query-functions` left at `:safe` ·
+`:create-database` set unless clients may choose any store.
+
+### What may be created
+
+`create-database` takes the client's configuration, `:store` included. Without
+a policy a client with `:create` may point the server at any backend it has
+loaded: a JDBC URL of its choosing, an S3 bucket, a file path anywhere the
+process may write. `:create-database` in the server config restricts that:
+
+```clojure
+{:create-database {:backends #{:memory :file}}}            ; only these backends
+{:create-database {:store {:backend :file                  ; the server chooses:
+                           :path "/var/lib/datahike/databases"}}} ; root/<id>
+```
+
+With `:store` the client's store is replaced: the server keeps the id the
+client chose, or picks one, and places the database below its own root, as
+the Kabel listener does with its `:store`. With `:backends` the client's
+store is kept but its backend must be in the set. A refused create is `403`
+with `{:type :datahike.http/store-refused}`. Both keys may be given; without
+the option the server logs at start that creation is unrestricted.
 
 ### Query functions
 
@@ -431,6 +452,7 @@ clojure -M:http-server --config config.edn
  :token    "securerandompassword"
  :dev-mode false
  :query-functions :safe     ; the default; :permissive only for trusted clients
+ :create-database {:store {:backend :file :path "/var/lib/datahike/databases"}}
  :level    :info
  :log-format :text}
 ```

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -18,6 +18,7 @@
    speaks) comes along."
   (:refer-clojure :exclude [read-string filter])
   (:require
+   [datahike.http.stores :as stores]
    [datahike.query.resolve :as qr]
    [clojure.string :as str]
    [clojure.core.async :as async]
@@ -75,6 +76,13 @@
    straight to the caller."
   [e]
   {:status 500
+   :body   {:msg (ex-message e) :ex-data (redact (ex-data e))}})
+
+(defn- store-refused
+  "403 for a store the server's `:create-database` policy does not allow."
+  [e]
+  (metrics/http-rejected! :forbidden)
+  {:status 403
    :body   {:msg (ex-message e) :ex-data (redact (ex-data e))}})
 
 (defn forbidden
@@ -262,7 +270,7 @@
                           (fn []
                             ;; Remove remote-peer while this server creates the
                             ;; physical store, then restore it in the response.
-                            (let [requested (local (first body))
+                            (let [requested (stores/assign (:create-database config) (local (first body)))
                                   principal (:datahike/principal request)]
                               (when-let [prepare! (:datahike.http.system/prepare-register! config)]
                                 (prepare! requested principal))
@@ -321,7 +329,9 @@
                  {:headers {"Cache-Control" (str (when (:dev-mode config) "public, ")
                                                  "max-age=" (get-in config [:cache :get :max-age]))}})))))
       (catch Exception e
-        (error-response e)))))
+        (if (= :datahike.http/store-refused (:type (ex-data e)))
+          (store-refused e)
+          (error-response e))))))
 
 (declare create-routes)
 
@@ -475,10 +485,12 @@
                                  (try
                                    {:status 200
                                     :body   (async/<!! (apply datahike.writing/create-database
-                                                              cfg
+                                                              (stores/assign (:create-database config) cfg)
                                                               (rest body)))}
                                    (catch Exception e
-                                     (error-response e))))))
+                                     (if (= :datahike.http/store-refused (:type (ex-data e)))
+                                       (store-refused e)
+                                       (error-response e)))))))
             :operationId "create-database"},
      :swagger {:tags ["Internal"]}}]
    ["/transact!-writer"
@@ -635,6 +647,11 @@
    - `:default-handler` — what answers a request the router does not match;
      reitit's default 404 unless given (the server puts swagger-ui here).
 
+   `:create-database` restricts what a client may create (see
+   `datahike.http.stores`): `{:backends #{…}}` allows only those backends,
+   `{:store {:backend :file :path root}}` makes the server choose the store
+   below its own root. Without it any store configuration is accepted.
+
    Every request runs under the query function resolver `config` asks for
    (`:query-functions`, `:safe` by default; see `query-function-binding`),
    so what a client sends never resolves symbols the host did not allow,
@@ -644,6 +661,11 @@
    releases what the routes opened when the host shuts down."
   ([config] (handler config {}))
   ([config {:keys [connections default-handler] :as opts}]
+   (if (stores/validate-policy (:create-database config))
+     (log/info :datahike/create-database-policy (select-keys (:create-database config) [:backends :store]))
+     (log/info :datahike/create-database-policy
+               {:policy :unrestricted
+                :note "clients with :create may name any store configuration; set :create-database to restrict"}))
    (let [connections (or connections (atom {}))
          rtr         (router config (assoc opts :state (new-state)))
          h           (-> (wrap-api (ring/ring-handler rtr (or default-handler (ring/create-default-handler)))

--- a/http-server/datahike/http/stores.clj
+++ b/http-server/datahike/http/stores.clj
@@ -1,0 +1,70 @@
+(ns datahike.http.stores
+  "What a client may ask the server to create.
+
+   `create-database` takes the client's configuration, `:store` included, so
+   without a policy a client with `:create` may point the server at any
+   backend it has loaded (a JDBC URL of its choosing, an S3 bucket, a file
+   path anywhere the process may write). The server's `:create-database`
+   option restricts that, optionally:
+
+     {:create-database {:backends #{:memory :file}}}          ; only these backends
+     {:create-database {:store {:backend :file
+                                :path \"/var/lib/datahike/databases\"}}}  ; the server chooses
+
+   With `:store`, the client's store is replaced: the server keeps the id
+   the client chose (or picks one) and places the database under its own
+   root, as the Kabel listener does. With `:backends`, the client's store is
+   kept but its backend must be one of the set. Both may be given."
+  (:require [clojure.java.io :as io]))
+
+(defn validate-policy
+  "The policy as given, or an exception for a shape the server cannot act on."
+  [policy]
+  (when (some? policy)
+    (when-not (map? policy)
+      (throw (ex-info ":create-database must be a map with :backends and/or :store"
+                      {:type :datahike.http/invalid-config :create-database policy})))
+    (let [{:keys [backends store]} policy]
+      (when (and (some? backends)
+                 (not (and (set? backends) (seq backends) (every? keyword? backends))))
+        (throw (ex-info ":create-database :backends must be a nonempty set of backend keywords"
+                        {:type :datahike.http/invalid-config :backends backends})))
+      (when (some? store)
+        (case (:backend store)
+          :memory nil
+          :file (when-not (and (string? (:path store)) (seq (:path store)))
+                  (throw (ex-info ":create-database :store with :backend :file needs a nonblank :path"
+                                  {:type :datahike.http/invalid-config :store store})))
+          (throw (ex-info ":create-database :store must have :backend :memory or :file"
+                          {:type :datahike.http/invalid-config :store store}))))
+      policy)))
+
+(defn- refuse [msg data]
+  (throw (ex-info msg (assoc data :type :datahike.http/store-refused))))
+
+(defn assign
+  "The configuration a create proceeds with: the client's, with its `:store`
+   checked against and, with a `:store` template, replaced by `policy`.
+   Throws `:datahike.http/store-refused` for a store the policy does not
+   allow. Without a policy the configuration is returned as is."
+  [policy config]
+  (if (nil? policy)
+    config
+    (let [{:keys [backends store]} policy
+          requested (:store config)
+          id (:id requested)]
+      (when (and backends (not (contains? backends (:backend requested))))
+        (refuse (str "This server creates databases only on " (pr-str backends)
+                     ", not " (pr-str (:backend requested)))
+                {:backend (:backend requested) :allowed backends}))
+      (when (and (some? id) (not (uuid? id)))
+        (refuse "A database id must be a uuid" {:id id}))
+      (if store
+        (let [id (or id (random-uuid))]
+          (assoc config :store
+                 (case (:backend store)
+                   :memory {:backend :memory :id id}
+                   :file   {:backend :file
+                            :path (.getPath (io/file (:path store) (str id)))
+                            :id id})))
+        config))))

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -339,3 +339,40 @@
     (is (thrown-with-msg? Exception #"safe or :permissive"
                           (start-server {:port 23198 :host "127.0.0.1" :join? false :dev-mode false
                                          :token "securerandompassword" :query-functions :anything})))))
+
+(deftest test-create-database-policy
+  (let [remote (fn [port] {:backend :datahike-server :url (str "http://localhost:" port)
+                           :token "securerandompassword" :format :transit})
+        create (fn [port store] (api/create-database {:store store :schema-flexibility :read
+                                                      :remote-peer (remote port)}))]
+    (testing "an allow-list of backends"
+      (let [port 23199
+            server (start-server {:port port :host "127.0.0.1" :join? false :dev-mode false
+                                  :token "securerandompassword"
+                                  :create-database {:backends #{:memory}}})]
+        (try
+          (is (map? (create port {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000011"})))
+          (is (thrown-with-msg? Exception #"403"
+                                (create port {:backend :file :path "/tmp/anywhere" :id #uuid "de110000-0000-0000-0000-000000000012"}))
+              "a backend outside the set is refused before anything is created")
+          (finally (stop-server server)))))
+    (testing "the server chooses the store below its root"
+      (let [port 23200
+            root (str (System/getProperty "java.io.tmpdir") "/dh-policy-" (random-uuid))
+            server (start-server {:port port :host "127.0.0.1" :join? false :dev-mode false
+                                  :token "securerandompassword"
+                                  :create-database {:store {:backend :file :path root}}})]
+        (try
+          (let [id  #uuid "de110000-0000-0000-0000-000000000013"
+                cfg (create port {:backend :memory :id id})]
+            (is (= :file (get-in cfg [:store :backend])) "the client's backend is not what gets created")
+            (is (= id (get-in cfg [:store :id])) "the client's id is kept")
+            (is (.startsWith ^String (get-in cfg [:store :path]) root) "the path is the server's"))
+          (let [cfg (create port {:backend :file :path "/etc" :id #uuid "de110000-0000-0000-0000-000000000014"})]
+            (is (.startsWith ^String (get-in cfg [:store :path]) root) "a client path is ignored"))
+          (finally (stop-server server)))))
+    (testing "a policy the server cannot act on is refused at start"
+      (is (thrown-with-msg? Exception #":create-database"
+                            (start-server {:port 23201 :host "127.0.0.1" :join? false :dev-mode false
+                                           :token "securerandompassword"
+                                           :create-database {:store {:backend :s3}}}))))))


### PR DESCRIPTION
## Why

The security review behind #1058 rated this medium: `create-database` (both `/create-database` and the writer's `/create-database-writer`) takes the client's configuration, `:store` included, so a client holding `:create` can point the server at any backend it has loaded. A JDBC URL of the client's choosing, an S3 bucket, a file path anywhere the process may write.

## What

New `datahike.http.stores` and a server option, off by default:

```clojure
{:create-database {:backends #{:memory :file}}}                          ; only these backends
{:create-database {:store {:backend :file :path "/var/lib/datahike/databases"}}}  ; the server chooses root/<id>
```

With `:store` the client's store is replaced: the server keeps the id the client chose (or picks one) and places the database below its root, the same rule the Kabel listener already applies. With `:backends` the client's store is kept but its backend must be in the set. Both may be combined. A refused create is `403 {:type :datahike.http/store-refused}`; an invalid policy is refused when the handler is built. Without the option behaviour is unchanged and the server logs at start that creation is unrestricted.

## Tests

`datahike.test.http.server-test/test-create-database-policy`: allow-list refuses a file store and admits memory; the template ignores the client's backend and path, keeps its id and places the store under the root; an unknown template backend is refused at start. HTTP suites green.

Follow-up candidates, not in this PR: the Kabel listener could share `datahike.http.stores` instead of its own `store-config-fn`; a default of `:backends #{:memory :file}` for the standalone server once the option has been out for a release.

https://claude.ai/code/session_01J9RUNkHFidHP8EvQVCSqf3