### PR TITLE
Bump kabel to 0.3.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **kabel 0.3.133.** Two concurrent releases of a store subscription (a
+  connection's shutdown and its owner's) could send two unsubscribe
+  requests; the second drain then removed a subscription made meanwhile and
+  its handshake failed, which surfaced as the fork-branch Kabel test timing
+  out in CI. Fixed in kabel; nothing changes in Datahike's own code.
 - **`:create-database` policy for the server.** `create-database` took the
   client's `:store` as given, so a client with `:create` could point the
   server at any backend it has loaded, a JDBC URL, an S3 bucket or a file

--- a/deps.edn
+++ b/deps.edn
@@ -177,7 +177,7 @@
                                ;; longer duplicated here: it is a main dep now,
                                ;; because declaring it twice is precisely how the
                                ;; tested and shipped versions came apart.
-                               org.replikativ/kabel          {:mvn/version "0.3.132"}
+                               org.replikativ/kabel          {:mvn/version "0.3.133"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
                                org.replikativ/geheimnis      {:mvn/version "0.2.33"
                                                               :exclusions [org.clojure/clojurescript]}
@@ -257,7 +257,7 @@
                                       nrepl/nrepl             {:mvn/version "1.7.0"}
                                       org.clojure/tools.cli   {:mvn/version "1.4.256"}
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
-                                      org.replikativ/kabel          {:mvn/version "0.3.132"}
+                                      org.replikativ/kabel          {:mvn/version "0.3.133"}
                                       org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
                                       org.replikativ/geheimnis      {:mvn/version "0.2.33"
                                                                      :exclusions [org.clojure/clojurescript]}


### PR DESCRIPTION
kabel 0.3.133 carries replikativ/kabel#35: two concurrent releases of a store subscription (a connection's shutdown and its owner's `await-topic-release!`) could each send an unsubscribe request; the second drain was routed into the lane of a subscription made meanwhile and removed it, so its handshake failed with "No strategy for snapshot batch". That was the fork-branch Kabel integration test timing out in CI on #1058.

Nothing changes in Datahike's own code. Kabel tier (25 tests) and the HTTP listener suites are green locally against 0.3.133.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3
