### PR TITLE
Bump kabel to 0.3.134; the listener's gates decide on a thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **kabel 0.3.134; the listener's gates decide on a thread.** Kabel asks the
+  `:authorize` gate from inside a go block, and Datahike's gate runs a
+  synchronous permission query, which held one of the dispatch pool's few
+  threads per decision. Kabel 0.3.134 lets a gate answer with a channel, so
+  `authorize-remote` and `authorize-sync` now decide on `async/thread`.
 - **kabel 0.3.133.** Two concurrent releases of a store subscription (a
   connection's shutdown and its owner's) could send two unsubscribe
   requests; the second drain then removed a subscription made meanwhile and

--- a/deps.edn
+++ b/deps.edn
@@ -177,7 +177,7 @@
                                ;; longer duplicated here: it is a main dep now,
                                ;; because declaring it twice is precisely how the
                                ;; tested and shipped versions came apart.
-                               org.replikativ/kabel          {:mvn/version "0.3.133"}
+                               org.replikativ/kabel          {:mvn/version "0.3.134"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
                                org.replikativ/geheimnis      {:mvn/version "0.2.33"
                                                               :exclusions [org.clojure/clojurescript]}
@@ -257,7 +257,7 @@
                                       nrepl/nrepl             {:mvn/version "1.7.0"}
                                       org.clojure/tools.cli   {:mvn/version "1.4.256"}
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
-                                      org.replikativ/kabel          {:mvn/version "0.3.133"}
+                                      org.replikativ/kabel          {:mvn/version "0.3.134"}
                                       org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
                                       org.replikativ/geheimnis      {:mvn/version "0.2.33"
                                                                      :exclusions [org.clojure/clojurescript]}

--- a/http-server/datahike/http/kabel.clj
+++ b/http-server/datahike/http/kabel.clj
@@ -9,7 +9,8 @@
    `create-database` a `:create`, `delete-database` a `:delete`, and a sync
    subscription to a store's topic a `:read`. Without a policy every
    authenticated caller may do everything, as over HTTP."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.core.async :as async]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [datahike.api :as d]
             [datahike.http.routes :as routes]
@@ -131,32 +132,39 @@
    to server admins only and a custom `:authorize` decides for everyone else."
   [config]
   (fn [{:keys [principal fn-name arg-map]}]
-    (let [sym (remote-name fn-name)]
-      (cond
-        (remote-op sym arg-map)
-        (allowed? config (remote-op sym arg-map) principal (remote-store-id sym arg-map) arg-map)
-
-        ;; Nothing else under Datahike's own namespace is served; refuse any
-        ;; spelling of it rather than asking the host about it.
-        (= "datahike.kabel" (some-> sym namespace))
-        false
-
-        :else
+    ;; Decided on a thread: the permission graph is a synchronous Datahike
+    ;; query, and kabel asks this gate from inside a go block, where a
+    ;; blocking call holds one of the dispatch pool's few threads. Since kabel
+    ;; 0.3.134 a gate may answer with a channel.
+    (async/thread
+      (let [sym (remote-name fn-name)]
         (boolean
-         (and principal
-              (if-let [policy (:authorize config)]
-                (policy {:op :invoke :fn-name sym :principal principal
-                         :db nil :payload arg-map})
-                true)))))))
+         (cond
+           (remote-op sym arg-map)
+           (allowed? config (remote-op sym arg-map) principal (remote-store-id sym arg-map) arg-map)
+
+           ;; Nothing else under Datahike's own namespace is served; refuse any
+           ;; spelling of it rather than asking the host about it.
+           (= "datahike.kabel" (some-> sym namespace))
+           false
+
+           :else
+           (and principal
+                (if-let [policy (:authorize config)]
+                  (policy {:op :invoke :fn-name sym :principal principal
+                           :db nil :payload arg-map})
+                  true))))))))
 
 (defn authorize-sync
   "The gate for the sync middleware: subscribing to a store's topic reads the
    store; nobody publishes into the server."
   [config]
   (fn [{:keys [op principal topic]}]
-    (case op
-      :subscribe (allowed? config :read principal (topic-store-id topic) nil)
-      false)))
+    (async/thread
+      (boolean
+       (case op
+         :subscribe (allowed? config :read principal (topic-store-id topic) nil)
+         false)))))
 
 (defn- reopen-databases!
   "Serve again the databases an earlier run of this listener created: every

--- a/test/datahike/test/http/kabel_test.clj
+++ b/test/datahike/test/http/kabel_test.clj
@@ -30,10 +30,16 @@
          (and (= (str store-a) (str (:store-id db)))
               (contains? #{:transact :read} op)))))
 
+(defn- decided
+  "The gate as a plain predicate: since kabel 0.3.134 the listener's gates
+   decide on a thread and answer with a channel."
+  [gate]
+  (fn [ctx] (<!! (gate ctx))))
+
 (deftest gates-map-remote-calls-and-topics-onto-the-policy
   (let [config {:authorize policy}
-        remote-gate (kabel/authorize-remote config)
-        sync-gate (kabel/authorize-sync config)
+        remote-gate (decided (kabel/authorize-remote config))
+        sync-gate (decided (kabel/authorize-sync config))
         alice {:sub "alice"} bob {:sub "bob"}]
     (testing "dispatch is a transact on the store the call names"
       (is (remote-gate {:principal alice :fn-name 'datahike.kabel/dispatch
@@ -76,7 +82,7 @@
       (is (not (sync-gate {:op :subscribe :principal bob :topic store-a})))
       (is (not (sync-gate {:op :publish :principal alice :topic store-a}))))
     (testing "without a policy every authenticated principal passes, nobody anonymous"
-      (let [open-gate (kabel/authorize-remote {})]
+      (let [open-gate (decided (kabel/authorize-remote {}))]
         (is (open-gate {:principal bob :fn-name 'datahike.kabel/dispatch :arg-map {:store-id store-b}}))
         (is (not (open-gate {:principal nil :fn-name 'datahike.kabel/dispatch :arg-map {:store-id store-b}})))))))
 
@@ -143,7 +149,7 @@
                               (if (= op :invoke)
                                 (and (= 'app/ping fn-name) (= "alice" (:sub principal)))
                                 (default)))})
-        gate (kabel/authorize-remote config)]
+        gate (decided (kabel/authorize-remote config))]
     (try
       (testing "the host rules on its own remote functions"
         (is (gate {:principal {:sub "alice"} :fn-name 'app/ping :arg-map {}}))


### PR DESCRIPTION
Follow-up to #1057 that had to wait for replikativ/kabel#34 (kabel 0.3.134): an `:authorize` gate may now answer with a channel.

Kabel asks the gate from inside a go block. Datahike's gate runs a synchronous permission query against the system database, so every decision held one of the dispatch pool's eight threads for the round trip, and enough concurrent decisions could deadlock the process. `authorize-remote` and `authorize-sync` now decide on `async/thread` and return the channel.

This is only correct from 0.3.134 on: on 0.3.132 and 0.3.133 a channel result is coerced truthy, which would allow everything. Hence pin and change in one commit.

CI is red until 0.3.134 is on Clojars; it is being released alongside this PR.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3