### PR TITLE
Smaller browser bundle: the API schema registration is JVM-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Smaller browser bundle: malli stays on the JVM.** `datahike.api`
+  registered malli schemas for every API function at load so that a JVM user
+  running malli's instrumenter gets Datahike's API checked; on ClojureScript
+  that only pulled malli, cljs.spec and the specification data into every
+  bundle. The registration is JVM-only now. Browser bundle 461 -> 420 KiB
+  gzipped; JVM behaviour unchanged.
 - **kabel 0.3.133.** Two concurrent releases of a store subscription (a
   connection's shutdown and its owner's) could send two unsubscribe
   requests; the second drain then removed a subscription made meanwhile and

--- a/src/datahike/api.cljc
+++ b/src/datahike/api.cljc
@@ -4,10 +4,10 @@
   #?(:cljs (:require-macros [datahike.api :refer [emit-api]]))
   (:require [datahike.connector :as dc]
             [datahike.config :as config]
-            [datahike.api.specification :refer [api-specification malli-schema->argslist]]
-            [datahike.api.types :as types]
-            [malli.core :as m]
-            [malli.util :as mu]
+            #?(:clj [datahike.api.specification :refer [api-specification malli-schema->argslist]])
+            #?(:clj [datahike.api.types :as types])
+            #?(:clj [malli.core :as m])
+            #?(:clj [malli.util :as mu])
             [datahike.api.impl]
             [datahike.writer :as dw]
             #?(:clj [datahike.http.writer])
@@ -44,9 +44,10 @@
         ()
         (into (sorted-map) api-specification))))
 
-(defn ^:no-doc register-api-schemas!
-  "Publish this namespace's malli function schemas so `malli.instrument/instrument!`
-   can find them. Idempotent; called once at load.
+#?(:clj
+   (defn ^:no-doc register-api-schemas!
+     "Publish this namespace's malli function schemas so `malli.instrument/instrument!`
+   can find them. Idempotent; called once at JVM load.
 
    REGISTRATION IS NOT INSTRUMENTATION. This only records `[:=> …]` forms in
    malli's function-schema registry — no var is wrapped, nothing is validated,
@@ -61,9 +62,9 @@
 
    The schemas reference datahike's own type registry (`:datahike/SDB` and
    friends), so they are compiled against it here rather than the default one."
-  []
-  (let [opts {:registry (merge (m/default-schemas) (mu/schemas) types/registry)}]
-    (doseq [[n {:keys [args]}] api-specification]
+     []
+     (let [opts {:registry (merge (m/default-schemas) (mu/schemas) types/registry)}]
+       (doseq [[n {:keys [args]}] api-specification]
       ;; EVERY operation, with no exclusion list. NOT wrapped in a try either: a
       ;; schema that fails to compile is a schema that silently checks nothing,
       ;; which is how seven of them stayed wrong — so a new one must break the
@@ -77,11 +78,11 @@
       ;; that carries `Util.normalizeCollections`. Do not reintroduce the list —
       ;; an operation that cannot be registered is a schema bug or a codegen
       ;; gap, and both are fixable.
-      (m/-register-function-schema! 'datahike.api n (m/schema args opts) {}))
-    (count api-specification)))
+         (m/-register-function-schema! 'datahike.api n (m/schema args opts) {}))
+       (count api-specification))))
 
 (emit-api)
-(register-api-schemas!)
+#?(:clj (register-api-schemas!))
 
 ;; The read-only functions a query may call under every resolver, the
 ;; server's safe one included: a subquery, a pull, an index walk.

--- a/src/datahike/js/api.cljs
+++ b/src/datahike/js/api.cljs
@@ -1,8 +1,7 @@
 (ns datahike.js.api
   "JavaScript API for Datahike with Promise conversion and data transformation"
   (:refer-clojure :exclude [filter uuid])
-  (:require [datahike.api.specification :refer [api-specification]]
-            [datahike.api.impl]
+  (:require [datahike.api.impl]
             [datahike.connector]
             [datahike.optimistic :as optimistic]
             [datahike.store] ;; Register :mem backend


### PR DESCRIPTION
`datahike.api` registered malli schemas for every API function at load time so that a JVM user running malli's instrumenter gets Datahike's API checked. On ClojureScript that pulled malli, cljs.spec and the specification data into every bundle for nothing: no browser application instruments at load. The registration and its requires are now JVM-only.

| | before | after |
|---|---|---|
| `browser/datahike.js` raw | 1,967,537 | 1,787,005 |
| gzipped | 461 KiB | 420 KiB |

Verified: `datahike.test.malli-instrumentation-test` and `api-test` on the JVM, the node ClojureScript suite (289 tests), the Kabel browser build. No behaviour change on the JVM.

Found with a build report while sizing the thin client (#1062); the remaining weight is the two query engines, the index, konserve and cljs.core, which need structural work rather than a cut.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3