### PR TITLE
Fix/cache db view hash

### DIFF
--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -148,7 +148,7 @@
 
 (defn since [db time-point]
   (if (dbi/-temporal-index? db)
-    (SinceDB. db time-point)
+    (SinceDB. db time-point (volatile! nil))
     (log/raise "since is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 (defn as-of
@@ -177,10 +177,10 @@
   (if (dbi/-temporal-index? db)
     (if (int? time-point)
       (if (<= const/tx0 time-point)
-        (AsOfDB. db time-point)
+        (AsOfDB. db time-point (volatile! nil))
         (log/raise (str "Invalid transaction ID. Must be bigger than " const/tx0 ".")
                    {:time-point time-point}))
-      (AsOfDB. db time-point))
+      (AsOfDB. db time-point (volatile! nil)))
     (log/raise "as-of is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 (defn history [db]
@@ -191,7 +191,7 @@
     ;; legacy lookup path on cljs (the fused temporal path needs the origin's
     ;; :eavt to be a real PersistentSortedSet, which a nested wrapper isn't).
     (instance? HistoricalDB db) db
-    (dbi/-temporal-index? db) (HistoricalDB. db)
+    (dbi/-temporal-index? db) (HistoricalDB. db (volatile! nil))
     :else (log/raise "history is only allowed on temporal indexed databases." {:config (dbi/-config db)})))
 
 ;; `vt-meta-attrs`, `tx-covers-at?`, `find-eav-winner`, `mk-vt-pred`,

--- a/src/datahike/core.cljc
+++ b/src/datahike/core.cljc
@@ -120,8 +120,8 @@
      (let [^FilteredDB fdb db
            orig-pred (.-pred fdb)
            orig-db (.-unfiltered-db fdb)]
-       (FilteredDB. orig-db #(and (orig-pred %) (pred orig-db %))))
-     (FilteredDB. db #(pred db %)))
+       (FilteredDB. orig-db #(and (orig-pred %) (pred orig-db %)) (volatile! nil)))
+     (FilteredDB. db #(pred db %) (volatile! nil)))
    assoc :datahike/secondary-filter-provenance :opaque))
 
 ; Changing DB

--- a/src/datahike/db.cljc
+++ b/src/datahike/db.cljc
@@ -482,7 +482,7 @@
 
 ;; FilteredDB
 
-(defrecord-updatable FilteredDB [unfiltered-db pred]
+(defrecord-updatable FilteredDB [unfiltered-db pred hash-cache]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
@@ -507,11 +507,11 @@
       ;; `(= view db)` threw while `(= db view)` answered true —
       ;; asymmetric, which `equals` may never be.
       [Object
-       (hashCode [db] (db-view-hash db))
+       (hashCode [db] (db-view-hash db (.-hash-cache db)))
        (equals [db other] (equiv-db db other))
 
        clojure.lang.IHashEq
-       (hasheq [db] (db-view-hash db))
+       (hasheq [db] (db-view-hash db (.-hash-cache db)))
 
        IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
@@ -577,7 +577,7 @@
 
 ;; HistoricalDB
 
-(defrecord-updatable HistoricalDB [origin-db]
+(defrecord-updatable HistoricalDB [origin-db hash-cache]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
@@ -601,11 +601,11 @@
       ;; `(= view db)` threw while `(= db view)` answered true —
       ;; asymmetric, which `equals` may never be.
       [Object
-       (hashCode [db] (db-view-hash db))
+       (hashCode [db] (db-view-hash db (.-hash-cache db)))
        (equals [db other] (equiv-db db other))
 
        clojure.lang.IHashEq
-       (hasheq [db] (db-view-hash db))
+       (hasheq [db] (db-view-hash db (.-hash-cache db)))
 
        IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
@@ -668,7 +668,7 @@
 
 ;; AsOfDB
 
-(defrecord-updatable AsOfDB [origin-db time-point]
+(defrecord-updatable AsOfDB [origin-db time-point hash-cache]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
@@ -691,11 +691,11 @@
       ;; `(= view db)` threw while `(= db view)` answered true —
       ;; asymmetric, which `equals` may never be.
       [Object
-       (hashCode [db] (db-view-hash db))
+       (hashCode [db] (db-view-hash db (.-hash-cache db)))
        (equals [db other] (equiv-db db other))
 
        clojure.lang.IHashEq
-       (hasheq [db] (db-view-hash db))
+       (hasheq [db] (db-view-hash db (.-hash-cache db)))
 
        IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
@@ -754,7 +754,7 @@
   (-index-range [db attr start end context]
                 (deeper-index-range (.-origin-db db) db attr start end context)))
 
-(defrecord-updatable SinceDB [origin-db time-point]
+(defrecord-updatable SinceDB [origin-db time-point hash-cache]
   #?@(:cljs
       [IEquiv (-equiv [db other] (equiv-db db other))
        ISeqable (-seq [db] (dbi/datoms db :eavt []))
@@ -777,11 +777,11 @@
       ;; `(= view db)` threw while `(= db view)` answered true —
       ;; asymmetric, which `equals` may never be.
       [Object
-       (hashCode [db] (db-view-hash db))
+       (hashCode [db] (db-view-hash db (.-hash-cache db)))
        (equals [db other] (equiv-db db other))
 
        clojure.lang.IHashEq
-       (hasheq [db] (db-view-hash db))
+       (hasheq [db] (db-view-hash db (.-hash-cache db)))
 
        IPersistentCollection
        (count [db] (count (dbi/datoms db :eavt [])))
@@ -877,10 +877,23 @@
    Deliberately the SAME additive datom-sum DB maintains incrementally
    (see `:hash` in `new-db`), so a view and a DB holding the same datoms
    hash alike — `equiv-db` reports those equal, so their hashes must
-   agree. O(n) per call: there is no running sum to read off, the same
-   reason `count` on a view is O(n)."
-  [db]
-  (reduce #(+ %1 (hash %2)) 0 (dbi/datoms db :eavt [])))
+   agree.
+
+   The sum is O(n) to compute — there is no running sum to read off, the
+   same reason `count` on a view is O(n) — so it is memoized per instance
+   in the view's `hash-cache` volatile: the first hasheq/hashCode scans,
+   later calls read the cached value. Views are immutable once constructed
+   (only ever assoc'd with non-content keys), so the cache never goes stale.
+
+   `cache` (the view's `hash-cache` volatile) is read by each caller from its
+   own typed record and passed in, so this shared fn carries no polymorphic
+   field access — which ClojureScript would reject as an un-inferable target."
+  [db cache]
+  (if-let [h (and cache @cache)]
+    h
+    (let [h (reduce #(+ %1 (hash %2)) 0 (dbi/datoms db :eavt []))]
+      (some-> cache (vreset! h))
+      h)))
 
 #?(:cljs
    (do

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -1531,7 +1531,7 @@
       :db/retractEntity (retract-entity db report op-vec)
 
       :db/purge (if (dbi/-keep-history? db)
-                  (let [history (HistoricalDB. db)]
+                  (let [history (HistoricalDB. db (volatile! nil))]
                     (if-some [e (dbu/entid history e)]
                       (let [v (if (dbu/ref? history a) (dbu/entid-strict history v) v)
                             old-datoms (dbi/search history [e a v])]
@@ -1542,7 +1542,7 @@
                              {:error :transact/purge :operation op :tx-data op-vec}))
 
       :db.purge/attribute (if (dbi/-keep-history? db)
-                            (let [history (HistoricalDB. db)]
+                            (let [history (HistoricalDB. db (volatile! nil))]
                               (if-let [e (dbu/entid history e)]
                                 (let [datoms (vec (dbi/search history [e a]))]
                                   [(reduce transact-purge-datom report datoms)
@@ -1553,7 +1553,7 @@
                                        {:error :transact/purge :operation op :tx-data op-vec}))
 
       :db.purge/entity (if (dbi/-keep-history? db)
-                         (let [history (HistoricalDB. db)]
+                         (let [history (HistoricalDB. db (volatile! nil))]
                            (if-let [e (dbu/entid history e)]
                              (let [e-datoms (vec (dbi/search history [e]))
                                    v-datoms (vec (mapcat (fn [a] (dbi/search history [nil a e]))
@@ -1566,7 +1566,7 @@
                                     {:error :transact/purge :operation op :tx-data op-vec}))
 
       :db.history.purge/before (if (dbi/-keep-history? db)
-                                 (let [history (HistoricalDB. db)
+                                 (let [history (HistoricalDB. db (volatile! nil))
                                        into-sorted-set #(apply sorted-set-by dd/cmp-datoms-eavt-quick %)
                                        e-datoms (-> (clojure.set/difference
                                                      (into-sorted-set (dbs/search-temporal-indices db nil))

--- a/src/datahike/readers.cljc
+++ b/src/datahike/readers.cljc
@@ -30,13 +30,13 @@
     (init-db (map (fn [[e a v tx]] (datom e a v tx)) datoms) schema)))
 
 (defn history-from-reader [{:keys [origin]}]
-  (HistoricalDB. origin))
+  (HistoricalDB. origin (volatile! nil)))
 
 (defn since-from-reader [{:keys [origin time-point]}]
-  (SinceDB. origin time-point))
+  (SinceDB. origin time-point (volatile! nil)))
 
 (defn as-of-from-reader [{:keys [origin time-point]}]
-  (AsOfDB. origin time-point))
+  (AsOfDB. origin time-point (volatile! nil)))
 
 (defn connection-from-reader [conn-id]
   (:conn (@*connections* conn-id)))

--- a/test/datahike/test/db_hash_test.cljc
+++ b/test/datahike/test/db_hash_test.cljc
@@ -144,3 +144,41 @@
                                             [{:db/id 100 :tag :z}]
                                             [{:db/id 100 :name "a" :tag :x}]]))]
       (is (= order-a order-b)))))
+
+;; ---------------------------------------------------------------------------
+;; The DB views — FilteredDB / HistoricalDB / AsOfDB / SinceDB — carry no
+;; precomputed `:hash`. They hash by `db-view-hash`, deliberately the SAME
+;; additive [e a v] sum DB maintains as `:hash`, computed over their own datoms.
+;; Two properties that had no test: the sum IS the hash, and a FilteredDB that
+;; mirrors a DB hashes equal to it (equiv-db reports them equal, so it must).
+
+(deftest views-over-the-same-content-hash-equal
+  (testing "the view hash is a function of content, not instance identity: two
+            separately constructed views over the same database hash equal (as a
+            java.util.HashSet needs, and as a per-instance cache must preserve)."
+    (with-conn true
+      (fn [conn]
+        (d/transact conn [{:db/id -1 :name "a" :score 1}])
+        (d/transact conn [{:db/id [:name "a"] :score 2}])
+        (let [db @conn]
+          (doseq [[label mk] [["FilteredDB" #(d/filter db (fn [_ _] true))]
+                              ["HistoricalDB" #(d/history db)]
+                              ["AsOfDB" #(d/as-of db (:max-tx db))]
+                              ["SinceDB" #(d/since db 0)]]]
+            (is (= (hash (mk)) (hash (mk)))
+                (str label ": two views over the same content must hash equal"))))))))
+
+(deftest a-filtered-view-mirroring-a-db-hashes-equal-to-it
+  (testing "a FilteredDB with an always-true predicate has the same schema and
+            `:eavt` datoms as the DB, so `equiv-db` reports them equal — and
+            equal values must hash equal, otherwise they take two slots in a
+            java.util.HashSet. `:keep-history? false` so the DB's `:hash` is the
+            sum over the current index the FilteredDB sees."
+    (with-conn false
+      (fn [conn]
+        (d/transact conn [{:db/id -1 :name "a" :score 1}
+                          {:db/id -2 :name "b" :score 2}])
+        (let [db @conn
+              mirror (d/filter db (fn [_ _] true))]
+          (is (= db mirror) "a FilteredDB mirroring the DB must be equal to it")
+          (is (= (hash db) (hash mirror)) "and therefore must hash equal"))))))

--- a/test/datahike/test/db_hash_test.cljc
+++ b/test/datahike/test/db_hash_test.cljc
@@ -33,6 +33,7 @@
    unnoticed since 2020 (`e9d55972`)."
   (:require [clojure.test :refer [deftest testing is]]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.test.utils :as utils]))
 
 (def ^:private schema
@@ -182,3 +183,27 @@
               mirror (d/filter db (fn [_ _] true))]
           (is (= db mirror) "a FilteredDB mirroring the DB must be equal to it")
           (is (= (hash db) (hash mirror)) "and therefore must hash equal"))))))
+
+(deftest hashing-a-view-scans-its-datoms-once-then-serves-cached
+  (testing "a view keeps no running `:hash`, so `db-view-hash` scans its datoms
+            to compute the sum — an O(n) walk. Repeated hashes of the SAME view
+            instance must reuse that result rather than rescan, or every hash
+            (e.g. using a view as a map/set key) pays another full scan. Counts
+            datom scans via `datahike.db.interface/datoms`, which `db-view-hash`
+            calls, over five hashes of one instance."
+    (with-conn true
+      (fn [conn]
+        (d/transact conn [{:db/id -1 :name "a" :score 1}])
+        (d/transact conn [{:db/id [:name "a"] :score 2}])
+        (let [db @conn]
+          (doseq [[label view] [["FilteredDB" (d/filter db (fn [_ _] true))]
+                                ["HistoricalDB" (d/history db)]
+                                ["AsOfDB" (d/as-of db (:max-tx db))]
+                                ["SinceDB" (d/since db 0)]]]
+            (let [scans (atom 0)
+                  orig  dbi/datoms]
+              (with-redefs [dbi/datoms (fn [& args] (swap! scans inc) (apply orig args))]
+                (dotimes [_ 5] (hash view)))
+              (is (= 1 @scans)
+                  (str label ": expected one datom scan across five hashes, got "
+                       @scans)))))))))


### PR DESCRIPTION
#### SUMMARY

Fixes #1063.

The DB views (`FilteredDB` / `HistoricalDB` / `AsOfDB` / `SinceDB`) hash themselves by
content via `db-view-hash` — a full O(n) datom sum — on **every** `hasheq`/`hashCode`
call, with no memoization. A plain `DB` reads its precomputed `:hash` (O(1)); the views
don't. So using a view as a map/set key re-scans all of its datoms on every lookup, and
a batching/caching layer that keys on an `as-of` db can rescan a large history many
times per request.

The content hashing itself is correct and intentional — #939 added it so a view and an
equal `DB` hash consistently for `equiv-db`. This PR only makes it cheap: each view
record gets a `hash-cache` field (a `volatile!`); `db-view-hash` computes the sum on the
first call and reads the cache afterwards. The first `hasheq`/`hashCode` scans; later
calls are O(1). The hash **value is unchanged**, so the `equiv-db` consistency invariant
is preserved.

Design decisions:
- **Per-instance, not a global cache** — no shared mutable state, no leak, GC-natural,
  and it mirrors how `DB` already carries `:hash`. Views are immutable once constructed
  (only ever `assoc`'d with non-content keys like `:system`/`:history?`), so the cached
  value never goes stale.
- The field is threaded through **all** view constructors, including the EDN readers, so
  nothing can build a view without a cache cell.
- `db-view-hash` takes the cache as a **parameter**, read by each caller from its own
  typed record via `(.-hash-cache db)`. This keeps the shared fn free of a polymorphic
  field access ClojureScript can't type-infer (`FilteredDB` blocks keyword/`valAt`
  lookup, so interop is the only cross-platform accessor).

#### Checks
##### Bugfix
- [x] Related issues linked using `fixes #number`  <!-- fixes #1063 -->
- [x] Integration tests added  <!-- unit tests in test/datahike/test/db_hash_test.cljc; views had no hashing coverage before -->
- [ ] Architecture Decision Record added if design changes necessary  <!-- N/A: internal perf cache, no architecture change -->
- [x] Formatting checked  <!-- bb format: All source files formatted correctly -->

#### ADDITIONAL INFORMATION

Adds three commits: a consistency test (`FilteredDB` mirrors a `DB` → equal + hash-equal;
two views over the same content hash-equal), a caching guard (deterministic scan count,
red on `main`), and the fix (green).

Validation:
- **clj** — `bb test` (`:persistent-set` + `:hitchhiker-tree` tiers, plus
  `migrate`/`norm`/`specs`; `migrate` exercises the readers this PR touches): 2826 tests /
  30119 assertions, no new failures. The only reds are pre-existing
  `datahike.test.http.server-test` flakiness (fail identically on `main`).
- **cljs** — `bb node-cljs-test`: 289 tests / 1823 assertions, 0 failures, 0 warnings.
- **format** — `bb format`: clean.
- **native-image / back-compat** — not exercised locally: both fail on `main` too in this
  environment for unrelated reasons (native-image trips a pre-existing
  `clojure.core.async.timers` "started Thread in the image heap" on GraalVM 24; back-compat
  fails building the cloned old version's Java codegen under JDK 26). Left to CI.

Before / after — the caching guard counts datom scans over five hashes of one view instance.

Without the fix (`db-hash-test`):

```
FAIL in (hashing-a-view-scans-its-datoms-once-then-serves-cached) (db_hash_test.cljc)
  HistoricalDB: expected one datom scan across five hashes, got 5
  AsOfDB:       expected one datom scan across five hashes, got 5
  SinceDB:      expected one datom scan across five hashes, got 5
  FilteredDB:   expected one datom scan across five hashes, got 5
Ran 7 tests containing 25 assertions.
4 failures, 0 errors.
```

With the fix:

```
Ran 7 tests containing 25 assertions.
0 failures, 0 errors.
```

A view instance now costs one datom scan no matter how many times it is hashed.

This PR, together with a yet unimplemented fix for #1024, closes the regressions we've found in our test suites.