### PR TITLE
listen for thin clients: a change stream over server-sent events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,25 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Thin-client change stream.** *Experimental.* Authenticated thin clients
+  can follow `GET /listen` as a server-sent-event stream. It sends an initial
+  resync when needed, compact transaction reports for subsequent commits,
+  coalesces slow consumers at the current head, and closes with a deletion
+  event. The standalone server shares one connection registry and report bus
+  between HTTP and Kabel: writes in either transport reach SSE, HTTP writes
+  reach the Kabel transaction-report topic, and every report is published
+  there exactly once. Database and branch deletion terminate affected streams.
+  Jetty uses virtual threads for blocking streams on JDK 21+, with
+  `:max-threads` available for older runtimes.
 - **Thin client for npm: `datahike/remote`.** *Experimental.* The Datahike
   API against a server with no engine in the bundle, about 76 KiB gzipped:
   `datahike.http.client` is now `cljc`, speaking CBOR over `fetch` on
   ClojureScript with a promise-channel per call, and `datahike.js.remote`
   is its JavaScript boundary, generated from the specification like the
   main entry. Connections, databases and entities are opaque handles. See
-  `doc/thin-client.md`.
+  `doc/thin-client.md`. Its ClojureScript and JavaScript APIs now provide
+  `listen` and `unlisten`, with automatic reconnect and resume from the last
+  commit.
 - **Reads by URL, and every read route answers POST.** A GET may carry its
   arguments base64url-encoded in the `args` query parameter (format in `f`),
   which is how a browser client gets a cacheable read; the read routes also

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -101,6 +101,80 @@ middleware, reitit's 405 or the `:default-handler`:
 A handler with no `:token`, no `:validator`, no `:dev-mode` and no
 `:auth :upstream` admits nobody; that is the secure default, not a bug.
 
+## Listening for changes
+
+Thin clients can keep a change stream open after connecting:
+
+```text
+GET /listen?store=<store UUID>&branch=<keyword>&since=<commit UUID>
+Accept: text/event-stream
+Authorization: token …
+```
+
+`branch` defaults to `db` and `since` is optional. The route passes through
+the same authentication gate as every API route, then asks `:authorize` for
+`:read` on `{:store-id … :branch …}`. The database must already be present in
+the handler's shared connection registry; in the standalone server this also
+includes databases created or reopened by its Kabel listener, without a prior
+HTTP `connect`. The stream does not retain a connection lease, so an open
+listener never prevents deletion.
+
+The response is `text/event-stream` with `Cache-Control: no-cache`. Each event
+has one JSON object on its `data:` line, encoded with Datahike's JSON mapper:
+
+- `resync` is the first event when `since` is absent or differs from the
+  current head. It carries `store-id`, `branch`, `commit-id`, `max-tx`, and
+  `max-eid`.
+- `report` describes a subsequent commit and adds `tempids` and `tx-data`.
+  Reports of at most 500 datoms include the datoms; larger reports omit them
+  and carry `truncated: true`.
+- `coalesced` means the consumer fell behind and must fetch current state. It
+  has the same shape and meaning as `resync`.
+- `deleted` is terminal. The server closes the stream after sending it.
+
+Each subscriber has a 16-event sliding buffer. A slow connection can therefore
+lose intermediate reports; its next event is `coalesced` at the current head,
+never a misleading partial suffix. When idle, the server writes an SSE comment
+heartbeat every 20 seconds. There are no acknowledgements and no replay.
+
+The response body is blocking. The standalone server uses Jetty virtual-thread
+dispatch on JDK 21 and newer, so open streams do not consume its bounded worker
+threads. `:max-threads` and `:min-threads` size Jetty's platform pool; they do
+not bound concurrent streams dispatched on virtual threads. On older JDKs
+streams share that platform pool. Embedded hosts must make the same choice
+themselves: use a virtual-thread-enabled Jetty thread pool on JDK 21+, or budget
+their adapter's worker pool for every concurrent stream.
+
+Browser `EventSource` cannot attach the `Authorization` header. Use `fetch`
+and consume its stream instead:
+
+```javascript
+const response = await fetch(
+  `${base}/listen?store=${storeId}&since=${commitId}`,
+  {headers: {Authorization: `Bearer ${token}`}}
+);
+if (!response.ok) throw new Error(`listen failed: ${response.status}`);
+
+const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
+let pending = "";
+for (;;) {
+  const {value, done} = await reader.read();
+  if (done) break;
+  pending += value;
+  const frames = pending.split("\n\n");
+  pending = frames.pop();
+  for (const frame of frames) {
+    if (frame.startsWith(":")) continue;
+    const event = frame.match(/^event: (.+)$/m)?.[1];
+    const data = JSON.parse(frame.match(/^data: (.+)$/m)?.[1]);
+    handleChange(event, data);
+  }
+}
+```
+
+Use the authorization scheme your validator expects; the built-in shared token
+uses `token <value>` rather than `Bearer <value>`.
+
 ## Authentication: who is calling
 
 The config describes a chain of validators, each

--- a/doc/thin-client.md
+++ b/doc/thin-client.md
@@ -69,11 +69,44 @@ as the handle is used.
 
 ## Change notification
 
-A thin client holds no replica, so it learns about other writers' changes
-only by asking. The server broadcasts every transaction report per store
-over Kabel; a page that wants to be told adds the `datahike/kabel` entry's
-peer and subscribes to the store's report topic. That is the replica's
-transport and adds its bundle; there is no lighter notification lane.
+A thin client can follow the connected database without carrying a replica.
+In JavaScript, `listen` returns a key immediately and calls back with plain
+JavaScript reports; pass that key to `unlisten`:
+
+```javascript
+const listener = d.listen(conn, report => {
+  if (report.error) {
+    console.error(`listen failed with HTTP ${report.status}`, report.error);
+    return;
+  }
+  if (report.deleted) return;
+  renderFrom(report['db-after']);
+});
+
+d.unlisten(conn, listener);
+```
+
+The ClojureScript API also accepts an explicit listener key:
+
+```clojure
+(def listener (client/listen conn ::ui refresh!))
+(client/unlisten conn listener)
+```
+
+The first callback is a resync report with `:resync true` and a `:db-after`
+handle. Later transaction reports contain `:db-after`, `:db-before nil`,
+`:tempids`, and `:commit-id`. Reports of at most 500 datoms also contain
+`:tx-data`; larger reports instead contain `:truncated true`. A slow consumer
+can receive another resync report after the server coalesces changes. Database
+deletion produces the terminal `:deleted true` report.
+
+The client reconnects after a stream error or clean disconnect, starting at
+500 ms and doubling the delay up to 30 seconds. It sends the last observed
+commit id when reconnecting; the server resyncs when that id is no longer the
+head. `unlisten` aborts the open request and cancels reconnects. Deletion does
+not reconnect. HTTP 401, 403, and 404 responses are terminal too: the callback
+receives `{:error <ex-info> :status <integer>}` in ClojureScript, or an object
+with `error` and `status` in JavaScript, and the listener stops.
 
 ## What is not there
 

--- a/http-server/datahike/http/kabel.clj
+++ b/http-server/datahike/http/kabel.clj
@@ -13,6 +13,7 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.connections :refer [*connections*]]
             [datahike.http.routes :as routes]
             [datahike.kabel.cbor-handlers :as cbor]
             [datahike.kabel.handlers :as handlers]
@@ -171,33 +172,38 @@
    UUID-named directory below the file store's path is opened and registered
    for dispatch and sync. Without this a restart leaves every existing
    database unreachable until it is deleted."
-  [server {:keys [store] :as kabel}]
+  [config server {:keys [store] :as kabel} connections]
   (when (= :file (:backend store))
-    (let [config-fn (store-config-fn kabel)]
-      (doseq [dir (some->> (io/file (:path store)) .listFiles (filter #(.isDirectory ^java.io.File %)))
-              :let [store-id (parse-uuid (.getName ^java.io.File dir))]
-              :when store-id]
-        (try
+    (binding [*connections* connections]
+      (let [config-fn (store-config-fn kabel)]
+        (doseq [dir (some->> (io/file (:path store)) .listFiles (filter #(.isDirectory ^java.io.File %)))
+                :let [store-id (parse-uuid (.getName ^java.io.File dir))]
+                :when store-id]
+          (try
           ;; Reopen with the configuration the database was created with:
           ;; Datahike refuses a connect whose settings differ from the stored ones.
-          (let [store-config (config-fn store-id nil)
-                store (ks/connect-store store-config {:sync? true})
-                stored (try (k/get store :db nil {:sync? true})
-                            (finally (ks/release-store store-config store {:sync? true})))
-                config (-> (:config stored) (assoc :store store-config :writer {:backend :self}))
-                conn (d/connect config)]
-            (handlers/register-store-for-remote-access! store-id conn server)
-            (log/info :datahike/kabel-database-reopened {:store-id store-id}))
-          (catch Throwable t
-            (log/warn :datahike/kabel-database-reopen-failed
-                      {:store-id store-id :error (ex-message t)})))))))
+            (let [store-config (config-fn store-id nil)
+                  store (ks/connect-store store-config {:sync? true})
+                  stored (try (k/get store :db nil {:sync? true})
+                              (finally (ks/release-store store-config store {:sync? true})))
+                  db-config (-> (:config stored) (assoc :store store-config :writer {:backend :self}))
+                  conn (d/connect db-config)]
+              (when-let [state (get config routes/report-bus-key)]
+                (routes/register-report-listener! config state conn))
+              (handlers/register-store-for-remote-access! store-id conn server)
+              (log/info :datahike/kabel-database-reopened {:store-id store-id}))
+            (catch Throwable t
+              (log/warn :datahike/kabel-database-reopen-failed
+                        {:store-id store-id :error (ex-message t)}))))))))
 
 (defn start!
   "Start the configured Kabel listener. Returns an owned peer resource or nil."
   [config]
   (when-let [{:keys [host port peer-id jwt] :as kabel}
              (:kabel (validate-config config))]
-    (let [url     (str "ws://" host ":" port)
+    (let [connections (or (get config routes/connections-key) *connections*)
+          bus-state (get config routes/report-bus-key)
+          url     (str "ws://" host ":" port)
           handler (create-http-kit-handler! S url peer-id (atom {}) (atom {})
                                             {:server-opts {:ip host}})
           server  (peer/server-peer
@@ -209,19 +215,32 @@
           served  (remote/serve server {:authorize (authorize-remote config)})]
       (handlers/register-global-handlers!
        server {:store-config-fn (store-config-fn kabel)
+               :on-connect (when bus-state
+                             #(routes/register-report-listener! config bus-state %))
+               :on-report (when bus-state
+                            #(routes/publish-kabel-report! config bus-state %1 %2))
+               :on-delete (when bus-state #(routes/forget-database! config bus-state %))
                ;; a go block carries its bindings across parks and the local
                ;; writer onto its thread, so the request's resolver holds
                ;; through the whole dispatch
                :wrap-handler (let [run (routes/query-function-binding config)]
-                               (fn [handler] (fn [arg-map] (run #(handler arg-map)))))})
-      (reopen-databases! server kabel)
+                               (fn [handler]
+                                 (fn [arg-map]
+                                   (binding [*connections* connections]
+                                     (run #(handler arg-map))))))})
+      (reopen-databases! config server kabel connections)
       (<?? S (peer/start server))
+      (when-let [peer-ref (get config routes/kabel-peer-key)]
+        (reset! peer-ref server))
       (log/info :datahike/kabel-server-started {:url url :peer-id peer-id})
-      {:peer server :url url :peer-id peer-id :served served})))
+      {:peer server :url url :peer-id peer-id :served served
+       :route-peer-ref (get config routes/kabel-peer-key)})))
 
 (defn stop! [resource]
   (when-let [server (:peer resource)]
     (try
+      (when-let [peer-ref (:route-peer-ref resource)]
+        (reset! peer-ref nil))
       (when-let [stop! (get-in resource [:served :stop!])] (stop!))
       (<?? S (peer/stop server))
       (finally

--- a/http-server/datahike/http/middleware.clj
+++ b/http-server/datahike/http/middleware.clj
@@ -5,7 +5,8 @@
    [datahike.json :as json]
    [datahike.readers :refer [edn-readers]]
    [muuntaja.core :as m]
-   [replikativ.logging :as log])
+   [replikativ.logging :as log]
+   [ring.core.protocols :as protocols])
   (:import
    [clojure.lang ExceptionInfo]))
 
@@ -76,6 +77,8 @@
             body           (:body response)
             should-encode? (and encoder
                                 (not (instance? java.io.ByteArrayInputStream body))
+                                (not (and (some? body)
+                                          (satisfies? protocols/StreamableResponseBody body)))
                                 ;; Without a request content type only a scalar is
                                 ;; encoded here; a collection stays for muuntaja,
                                 ;; which also sets the response content type.

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -22,6 +22,7 @@
    [datahike.query.resolve :as qr]
    [clojure.string :as str]
    [clojure.core.async :as async]
+   [clojure.core.async.impl.protocols :as async-protocols]
    [datahike.connections :refer [*connections*]]
    [datahike.store]
    [reitit.core :as reitit]
@@ -34,6 +35,8 @@
    [datahike.remote.cbor :as rcbor]
    [datahike.http.cbor :as cbor]
    [datahike.json :as json]
+   [datahike.kabel.handlers :as kabel-handlers]
+   [datahike.kabel.tx-broadcast :as tx-broadcast]
    [datahike.api :refer :all :as api]
    [datahike.writing]
    [datahike.writer]
@@ -47,10 +50,13 @@
    [reitit.ring.middleware.multipart :as multipart]
    [reitit.ring.middleware.parameters :as parameters]
    [muuntaja.core :as m]
+   [jsonista.core :as j]
    [replikativ.metrics :as registry]
-   [replikativ.logging :as log])
+   [replikativ.logging :as log]
+   [ring.core.protocols :as protocols])
   (:import [datahike.datom Datom]
            [datahike.impl.entity Entity]
+           [java.io OutputStreamWriter]
            [java.util.concurrent.locks ReentrantReadWriteLock]))
 
 ;; ---------------------------------------------------------------------------
@@ -176,14 +182,126 @@
 (defn- conn-id [cfg]
   [(datahike.store/store-identity (:store cfg)) (:branch cfg :db)])
 
+(def kabel-peer-key
+  "The internal config key holding the standalone server's live Kabel peer."
+  ::kabel-peer)
+
+(def connections-key
+  "The internal config key holding the standalone server's connection registry."
+  ::connections-registry)
+
+(def report-bus-key
+  "The internal config key holding the routes' change-stream state."
+  ::report-bus)
+
+(def ^:private report-listener-key ::report-bus)
+(def ^:private subscriber-buffer-size 16)
+(def ^:private heartbeat-ms 20000)
+
+(deftype OverflowTrackingBuffer [delegate overflowed]
+  async-protocols/UnblockingBuffer
+  async-protocols/Buffer
+  (full? [_] false)
+  (remove! [_] (async-protocols/remove! delegate))
+  (add!* [this item]
+    ;; add!* runs under the channel mutex, so this observes the exact moment
+    ;; the sliding buffer evicts an event rather than racing a consumer take.
+    (when (>= (count delegate) subscriber-buffer-size)
+      (reset! overflowed true))
+    (async-protocols/add!* delegate item)
+    this)
+  (close-buf! [_] (async-protocols/close-buf! delegate))
+  clojure.lang.Counted
+  (count [_] (count delegate)))
+
+(defn- db-head [store-id branch db]
+  {:store-id store-id
+   :branch branch
+   :commit-id (get-in db [:meta :datahike/commit-id])
+   :max-tx (:max-tx db)
+   :max-eid (:max-eid db)})
+
+(defn- thin-report [store-id branch report]
+  (let [{:keys [db-after tempids tx-data]} report
+        head (db-head store-id branch db-after)
+        tx-data-count (count tx-data)]
+    (cond-> (assoc head :tempids tempids)
+      (<= tx-data-count 500) (assoc :tx-data tx-data)
+      (> tx-data-count 500) (assoc :truncated true))))
+
+(defn- enqueue!
+  "Offer one event without making a transaction callback wait."
+  [{:keys [channel] :as subscriber} event]
+  (locking subscriber
+    (async/offer! channel event)))
+
+(defn- publish-report!
+  [{:keys [subscribers heads]} config id report origin]
+  (let [[store-id branch] id
+        head (db-head store-id branch (:db-after report))]
+    (locking subscribers
+      ;; Head publication and subscriber registration use the same lock. A new
+      ;; subscriber therefore sees either the old head and this report, or the
+      ;; new head without this report, never both the new head and its report.
+      (swap! heads assoc id head)
+      (doseq [subscriber (get @subscribers id)]
+        (enqueue! subscriber {:event :report
+                              :data (thin-report store-id branch report)})))
+    ;; The Kabel handler already published its report with the request id.
+    (when (not= origin :kabel)
+      (when-let [peer (some-> (get config kabel-peer-key) deref)]
+        (tx-broadcast/publish-tx-report! peer store-id report nil)))))
+
+(defn publish-kabel-report!
+  "Publish one Kabel-originated report to SSE without broadcasting it again."
+  [config state store-id report]
+  (let [branch (get-in report [:db-after :config :branch] :db)]
+    (publish-report! state config [store-id branch] report :kabel)))
+
+(defn register-report-listener!
+  "Install the report listener owned by `conn`'s presence in the shared
+   registry. Repeated registration of the same connection is harmless."
+  [config {:keys [listener-keys] :as state} conn]
+  (let [id (conn-id (:config @conn))
+        listener-key [report-listener-key listener-keys]]
+    (locking listener-keys
+      (when-not (contains? @listener-keys conn)
+        (api/listen conn listener-key
+                    (fn [report]
+                      (try
+                        (publish-report! state config id report :connection)
+                        (catch Throwable error
+                          (log/error :datahike/http-report-publish-failed
+                                     (ex-message error)
+                                     {:store-id (first id)
+                                      :branch (second id)
+                                      :error-class (.getName (class error))})))))
+        (swap! listener-keys assoc conn {:id id :key listener-key})))
+    conn))
+
+(defn- detach-report-listeners!
+  [{:keys [listener-keys]} pred]
+  (let [removed (locking listener-keys
+                  (let [found (into {} (clojure.core/filter
+                                        (fn [[_ {:keys [id]}]] (pred id))
+                                        @listener-keys))]
+                    (swap! listener-keys #(apply dissoc % (keys found)))
+                    found))]
+    (doseq [[conn {:keys [key]}] removed]
+      (try (api/unlisten conn key) (catch Exception _)))))
+
 (defn- new-state
   "What the routes keep per handler: `leases`, per database — `:base`, whether
    the server holds its base lease, and `:api`, how many leases it has handed
-   out through `connect` — and a read-write lock that lets a delete wait for
-   the calls pinned on the database it removes."
-  []
+   out through `connect` — a report bus, and a read-write lock that lets a
+   delete wait for the calls pinned on the database it removes."
+  [connections]
   {:leases (atom {})
-   :lock   (ReentrantReadWriteLock.)})
+   :lock (ReentrantReadWriteLock.)
+   :connections connections
+   :subscribers (atom {})
+   :heads (atom {})
+   :listener-keys (atom {})})
 
 (defn- with-connection
   "Run `f` with a connection to `cfg`'s database, pinned for the duration.
@@ -196,15 +314,15 @@
    requests instead of being rebuilt for each; `release-all!` drops it on
    shutdown, a delete drops it. The call holds the read side of the lock, so
    a delete (`with-exclusive`) waits for it."
-  [cfg {:keys [leases ^ReentrantReadWriteLock lock]} f]
+  [cfg {:keys [leases ^ReentrantReadWriteLock lock] :as state} config f]
   (let [id (conn-id cfg)]
     (.lock (.readLock lock))
     (try
       (locking leases
         (when-not (and (get-in @leases [id :base]) (get-in @*connections* [id :conn]))
-          (api/connect cfg)
+          (register-report-listener! config state (api/connect cfg))
           (swap! leases assoc-in [id :base] true)))
-      (let [conn (api/connect cfg)]
+      (let [conn (register-report-listener! config state (api/connect cfg))]
         (try (f conn)
              (finally (api/release conn))))
       (finally (.unlock (.readLock lock))))))
@@ -218,7 +336,8 @@
 
 (defn- granted!
   "Count a lease handed out through `connect`."
-  [{:keys [leases]} conn]
+  [config {:keys [leases] :as state} conn]
+  (register-report-listener! config state conn)
   (swap! leases update-in [(conn-id (:config @conn)) :api] (fnil inc 0))
   conn)
 
@@ -242,11 +361,185 @@
    shared its atom, the host's own — for a process shutting down. Takes the
    connections atom or the handler `handler` returned."
   [handler-or-connections]
-  (let [connections (or (::connections (meta handler-or-connections)) handler-or-connections)]
+  (let [state (or (::state (meta handler-or-connections))
+                  (when (and (map? handler-or-connections)
+                             (:connections handler-or-connections))
+                    handler-or-connections))
+        connections (or (::connections (meta handler-or-connections))
+                        (:connections state)
+                        handler-or-connections)]
+    (when state
+      (detach-report-listeners! state (constantly true)))
     (binding [*connections* connections]
       (doseq [[_ {:keys [conn]}] @connections]
         (when conn
           (try (api/release conn true) (catch Exception _)))))))
+
+;; ---------------------------------------------------------------------------
+;; Change stream
+;; ---------------------------------------------------------------------------
+
+(defn- parse-listen-uuid [value parameter]
+  (try
+    (java.util.UUID/fromString value)
+    (catch Exception _
+      (throw (ex-info (str parameter " must be a UUID")
+                      {:type :datahike.http/invalid-listen-parameter
+                       :parameter parameter
+                       :value value})))))
+
+(defn- write-sse! [^OutputStreamWriter writer {:keys [event data]}]
+  (.write writer (str "event: " (name event) "\n"
+                      "data: " (j/write-value-as-string data json/mapper) "\n\n"))
+  (.flush writer))
+
+(defn- remove-subscriber!
+  [{:keys [subscribers]} id subscriber]
+  (locking subscribers
+    (swap! subscribers
+           (fn [subscriptions]
+             (let [remaining (disj (get subscriptions id #{}) subscriber)]
+               (if (seq remaining)
+                 (assoc subscriptions id remaining)
+                 (dissoc subscriptions id)))))
+    (async/close! (:channel subscriber))))
+
+(defn- coalesced-event!
+  "Replace queued reports with one current head after the sliding buffer drops."
+  [{:keys [heads]} id {:keys [channel overflowed] :as subscriber}]
+  (locking subscriber
+    (when @overflowed
+      (reset! overflowed false)
+      (loop []
+        (when (async/poll! channel)
+          (recur)))
+      {:event :coalesced :data (get @heads id)})))
+
+(defn- stream-body [state id subscriber]
+  (reify protocols/StreamableResponseBody
+    (write-body-to-stream [_ _ output-stream]
+      (let [writer (OutputStreamWriter. output-stream "UTF-8")]
+        (try
+          ;; Commit the response headers even when `since` is current and the
+          ;; first event is therefore still in the future.
+          (.flush writer)
+          (loop [heartbeat (async/timeout heartbeat-ms)]
+            (let [[event port] (async/alts!! [(:channel subscriber) heartbeat])]
+              (cond
+                (= port heartbeat)
+                (do (.write writer ": heartbeat\n\n")
+                    (.flush writer)
+                    (recur (async/timeout heartbeat-ms)))
+
+                (nil? event)
+                nil
+
+                :else
+                (let [event (or (coalesced-event! state id subscriber) event)]
+                  (write-sse! writer event)
+                  (when-not (= :deleted (:event event))
+                    ;; Keep the one outstanding heartbeat deadline. Busy
+                    ;; streams do not accumulate abandoned timeout channels.
+                    (recur heartbeat))))))
+          (catch java.io.IOException _)
+          (finally
+            (remove-subscriber! state id subscriber)
+            (try (.close writer) (catch java.io.IOException _))))))))
+
+(defn- listen-handler
+  [config {:keys [connections subscribers heads] :as state}]
+  (fn [request]
+    (try
+      (let [query (:query-params request)
+            store-id (some-> (get query "store") (parse-listen-uuid "store"))
+            branch (some-> (get query "branch") (str/replace-first #"^:" "") keyword)
+            branch (or branch :db)
+            since (some-> (get query "since") (parse-listen-uuid "since"))
+            id [store-id branch]
+            authorization-config {:store {:backend :listen :id store-id}
+                                  :branch branch}]
+        (when-not store-id
+          (throw (ex-info "store is required"
+                          {:type :datahike.http/invalid-listen-parameter
+                           :parameter "store"})))
+        (or (authorize config request :read [authorization-config])
+            (if-let [conn (get-in @connections [id :conn])]
+              (let [overflowed (atom false)
+                    buffer (OverflowTrackingBuffer.
+                            (async/sliding-buffer subscriber-buffer-size)
+                            overflowed)
+                    subscriber {:channel (async/chan buffer)
+                                :overflowed overflowed}]
+                (locking subscribers
+                  (register-report-listener! config state conn)
+                  (let [head (db-head store-id branch @conn)]
+                    (swap! heads assoc id head)
+                    (when (not= since (:commit-id head))
+                      (enqueue! subscriber {:event :resync :data head}))
+                    (swap! subscribers update id (fnil conj #{}) subscriber)))
+                {:status 200
+                 :headers {"Content-Type" "text/event-stream; charset=utf-8"
+                           "Cache-Control" "no-cache"}
+                 :body (stream-body state id subscriber)})
+              {:status 404
+               :body {:msg "Database is not connected"
+                      :ex-data {:type :datahike.http/not-connected
+                                :databases [{:store-id store-id :branch branch}]}}})))
+      (catch Exception e
+        (error-response e)))))
+
+(defn- delete-subscribers!
+  "Send the terminal deletion event and close streams selected by `pred`."
+  [{:keys [subscribers heads]} pred]
+  (let [removed (locking subscribers
+                  (let [selected (fn [entries]
+                                   (clojure.core/filter pred (keys entries)))
+                        found (select-keys @subscribers (selected @subscribers))]
+                    (swap! subscribers #(apply dissoc % (keys found)))
+                    (swap! heads #(apply dissoc % (selected %)))
+                    found))]
+    (doseq [[[store-id branch] subscriptions] removed
+            {:keys [channel overflowed] :as subscriber} subscriptions]
+      (locking subscriber
+        (reset! overflowed false)
+        (loop []
+          (when (async/poll! channel)
+            (recur)))
+        (async/offer! channel {:event :deleted
+                               :data {:store-id store-id :branch branch}})
+        (async/close! channel)))))
+
+(defn forget-database!
+  "Remove a store, or one branch, from every transport-owned registry.
+   The caller performs the physical database/branch deletion."
+  ([config state store-id]
+   (forget-database! config state store-id nil))
+  ([config {:keys [connections leases] :as state} store-id branch]
+   (with-exclusive
+     state
+     (fn []
+       (let [matches? (if branch
+                        #(= [store-id branch] %)
+                        #(= store-id (first %)))
+             conns (keep (fn [[id {:keys [conn]}]]
+                           (when (and conn (matches? id)) conn))
+                         @connections)
+             peer (some-> (get config kabel-peer-key) deref)]
+         (delete-subscribers! state matches?)
+         (swap! leases (fn [entries]
+                         (reduce (fn [result id]
+                                   (if (matches? id) (dissoc result id) result))
+                                 entries (keys entries))))
+         (detach-report-listeners! state matches?)
+         (if branch
+           (kabel-handlers/unregister-connection-for-store! store-id branch)
+           (if peer
+             (kabel-handlers/unregister-store-for-remote-access! store-id peer)
+             (kabel-handlers/unregister-connection-for-store! store-id)))
+         (binding [*connections* connections]
+           (doseq [conn conns]
+             (try (api/release conn true) (catch Exception _))))
+         nil)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The API routes
@@ -284,18 +577,14 @@
                         (with-exclusive state
                           (fn []
                             (let [id           (conn-id (first body))
-                                  lease-state  (get @(:leases state) id)
                                   local-config (local (first body))
                                   principal    (:datahike/principal request)]
                               (when-let [prepare! (:datahike.http.system/prepare-delete! config)]
                                 (prepare! local-config principal))
-                              (swap! (:leases state) dissoc id)
                               (let [result
                                     (try
                                       (apply f local-config (rest body))
                                       (catch Throwable e
-                                        (when lease-state
-                                          (swap! (:leases state) assoc id lease-state))
                                         (when-let [cancel! (:datahike.http.system/cancel-delete! config)]
                                           (try
                                             (cancel! local-config principal)
@@ -306,16 +595,29 @@
                                         (throw e)))]
                                 (when-let [deleted! (:datahike.http.system/delete! config)]
                                   (deleted! local-config principal))
+                                (forget-database! config state (first id))
                                 result))))
 
                         (= f #'api/connect)
-                        (granted! state (apply f (cons (local (first body)) (rest body))))
+                        (granted! config state (apply f (cons (local (first body)) (rest body))))
 
                         ;; One caller releases one lease of its own.
                         ;; `release-all?` would close a connection the host
                         ;; and other callers share.
                         (= f #'api/release)
                         (give-back! state (first body))
+
+                        (= f #'api/delete-branch!)
+                        (let [conn (first body)
+                              id [(first (conn-id (:config @conn))) (second body)]
+                              result (apply f body)]
+                          (forget-database! config state (first id) (second id))
+                          result)
+
+                        ;; The public bulk loader is asynchronous locally, but
+                        ;; an HTTP response must contain its completed report.
+                        (= f #'api/load-entities)
+                        @(apply f body)
 
                         :else
                         (apply f body))]
@@ -499,12 +801,12 @@
                                  (try
                                    (with-exclusive state
                                      (fn []
-                                       (swap! (:leases state) dissoc (conn-id cfg))
                                        (try
                                          (api/release (api/connect cfg) true)
                                          (catch Exception _))
-                                       {:status 200
-                                        :body   (async/<!! (apply datahike.writing/delete-database cfg (rest body)))}))
+                                       (let [result (async/<!! (apply datahike.writing/delete-database cfg (rest body)))]
+                                         (forget-database! config state (first (conn-id cfg)))
+                                         {:status 200 :body result})))
                                    (catch Exception e
                                      (error-response e))))))
             :operationId "delete-database"},
@@ -538,7 +840,7 @@
                              (or (authorize config request :transact (cons cfg (rest body)))
                                  (try
                                    {:status 200
-                                    :body   (with-connection cfg state
+                                    :body   (with-connection cfg state config
                                               (fn [conn] @(apply datahike.writer/transact! conn (rest body))))}
                                    (catch Exception e
                                      (error-response e))))))
@@ -558,6 +860,12 @@
 (defn- router
   [config {:keys [prefix extra-routes state]}]
   (let [routes (vec (concat extra-routes
+                            [["/listen"
+                              {:muuntaja nil
+                               :coercion nil
+                               :get {:metric-op :read
+                                     :summary "Listen for committed changes."
+                                     :handler (listen-handler config state)}}]]
                             (create-routes config state)
                             (internal-writer-routes config state)))]
     (ring/router (if-let [p (normalize-prefix prefix)] [p routes] routes)
@@ -702,8 +1010,9 @@
                {:policy :unrestricted
                 :note "clients with :create may name any store configuration; set :create-database to restrict"}))
    (let [connections (or connections (atom {}))
-         rtr         (router config (assoc opts :state (new-state)))
+         state       (new-state connections)
+         rtr         (router config (assoc opts :state state))
          h           (-> (wrap-api (ring/ring-handler rtr (or default-handler (ring/create-default-handler)))
                                    rtr config connections)
                          (wrap-query-functions config))]
-     (with-meta h {::connections connections}))))
+     (with-meta h {::connections connections ::state state}))))

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -27,7 +27,9 @@
    [replikativ.metrics.konserve :as metrics-konserve]
    [replikativ.metrics.prometheus :as prometheus]
    [replikativ.logging :as log]
-   [ring.adapter.jetty :refer [run-jetty]]))
+   [ring.adapter.jetty :refer [run-jetty]])
+  (:import
+   [org.eclipse.jetty.util.thread QueuedThreadPool]))
 
 (def ^:private prometheus-content-type
   "text/plain; version=0.0.4; charset=utf-8")
@@ -161,7 +163,8 @@
   ([config connections]
    (app config connections (server-nrepl/status-atom)))
   ([config connections nrepl-status]
-   (let [server-config config
+   (let [server-config (dissoc config routes/kabel-peer-key routes/connections-key
+                               routes/report-bus-key)
          config  (system/configure config)
          config  (if (get config system/conn-key)
                    (permissions/configure config)
@@ -234,8 +237,31 @@
            (when configurator
              (configurator server)))))
 
+(defn- virtual-threads-supported? []
+  (>= (.feature (Runtime/version)) 21))
+
+(defn- with-sse-thread-pool [config]
+  (cond
+    (:thread-pool config) config
+
+    (virtual-threads-supported?)
+    (let [pool (QueuedThreadPool. (int (get config :max-threads 50))
+                                  (int (get config :min-threads 8)))
+          executor (clojure.lang.Reflector/invokeStaticMethod
+                    java.util.concurrent.Executors
+                    "newVirtualThreadPerTaskExecutor" (object-array 0))]
+      (.setVirtualThreadsExecutor pool executor)
+      (assoc config :thread-pool pool ::virtual-executor executor))
+
+    :else
+    (do
+      (log/info :datahike/http-sse-platform-threads
+                {:max-threads (get config :max-threads 50)
+                 :note "SSE streams share Jetty's worker pool; JDK 21+ enables virtual threads"})
+      config)))
+
 (defn- cleanup-owned!
-  [connections config nrepl-resource pg-listener kabel-resource metrics-lease]
+  [connections config nrepl-resource pg-listener kabel-resource metrics-lease virtual-executor]
   (try
     (server-nrepl/stop! nrepl-resource)
     (finally
@@ -246,12 +272,16 @@
             (pg/stop! pg-listener)
             (finally
               (try
-                (routes/release-all! connections)
+                (routes/release-all! (or (get config routes/report-bus-key) connections))
                 (finally
                   (try
                     (system/close! config)
                     (finally
-                      (release-metrics-sink! metrics-lease))))))))))))
+                      (try
+                        (release-metrics-sink! metrics-lease)
+                        (finally
+                          (when virtual-executor
+                            (.close ^java.lang.AutoCloseable virtual-executor)))))))))))))))
 
 (defn start-server
   "Start Jetty and acquire the standalone server's shared Konserve metric sink
@@ -260,46 +290,55 @@
   (let [requested-config (-> config
                              server-config/assert-safe-nrepl!
                              server-config/assert-safe-bind!)
-        config      requested-config
-        timeout     (shutdown-timeout config)
+        kabel-peer  (atom nil)
         connections (atom {})
+        config      (assoc requested-config
+                           routes/kabel-peer-key kabel-peer
+                           routes/connections-key connections)
+        timeout     (shutdown-timeout config)
         nrepl-status (server-nrepl/status-atom)
         app         (app config connections nrepl-status)
-        config      (::config (meta app))
-        jetty-config (with-graceful-shutdown config timeout)
+        config      (assoc (::config (meta app))
+                           routes/report-bus-key (::routes/state (meta app)))
+        jetty-config (-> config
+                         (with-graceful-shutdown timeout)
+                         with-sse-thread-pool)
+        virtual-executor (::virtual-executor jetty-config)
         pg-listener (try
                       (pg/start! config connections)
                       (catch Throwable t
-                        (cleanup-owned! connections config nil nil nil nil)
+                        (cleanup-owned! connections config nil nil nil nil virtual-executor)
                         (throw t)))
         kabel-resource (try
                          (kabel-server/start! config)
                          (catch Throwable t
-                           (cleanup-owned! connections config nil pg-listener nil nil)
+                           (cleanup-owned! connections config nil pg-listener nil nil virtual-executor)
                            (throw t)))
         metrics-lease (try
                         (when-not (false? (:metrics config))
                           (acquire-metrics-sink!))
                         (catch Throwable t
-                          (cleanup-owned! connections config nil pg-listener kabel-resource nil)
+                          (cleanup-owned! connections config nil pg-listener kabel-resource nil virtual-executor)
                           (throw t)))
         nrepl-resource (try
                          (server-nrepl/start! config (routes/redact requested-config)
                                               connections nrepl-status)
                          (catch Throwable t
-                           (cleanup-owned! connections config nil pg-listener kabel-resource metrics-lease)
+                           (cleanup-owned! connections config nil pg-listener kabel-resource metrics-lease virtual-executor)
                            (throw t)))
-        server      (try (run-jetty app jetty-config)
+        server      (try (run-jetty app (dissoc jetty-config ::virtual-executor))
                          (catch Throwable t
                            ;; Nothing owns what `app` opened if Jetty never started.
-                           (cleanup-owned! connections config nrepl-resource pg-listener kabel-resource metrics-lease)
+                           (cleanup-owned! connections config nrepl-resource pg-listener kabel-resource metrics-lease
+                                           virtual-executor)
                            (throw t)))]
     (swap! owned assoc server {:connections connections
                                :config config
                                :nrepl-resource nrepl-resource
                                :pg-listener pg-listener
                                :kabel-resource kabel-resource
-                               :metrics-lease metrics-lease})
+                               :metrics-lease metrics-lease
+                               :virtual-executor virtual-executor})
     server))
 
 (defn stop-server
@@ -309,12 +348,14 @@
    twice."
   [^org.eclipse.jetty.server.Server server]
   (let [[before _] (swap-vals! owned dissoc server)
-        {:keys [connections config nrepl-resource pg-listener kabel-resource metrics-lease]}
+        {:keys [connections config nrepl-resource pg-listener kabel-resource metrics-lease
+                virtual-executor]}
         (get before server)]
     (try (.stop server)
          (finally
            (when connections
-             (cleanup-owned! connections config nrepl-resource pg-listener kabel-resource metrics-lease))))))
+             (cleanup-owned! connections config nrepl-resource pg-listener kabel-resource metrics-lease
+                             virtual-executor))))))
 
 (defn- shutdown-hook [server config]
   (Thread.

--- a/src-kabel/datahike/kabel/handlers.cljc
+++ b/src-kabel/datahike/kabel/handlers.cljc
@@ -21,6 +21,7 @@
    ;; Now clients can send transactions to this store via KabelWriter
    ```"
   (:require [datahike.api :as d]
+            #?(:cljs [datahike.db :refer [TxReport]])
             [datahike.writer :as writer]
             [datahike.writing :as w]
             [kabel.remote :as remote]
@@ -36,7 +37,8 @@
                :cljs [clojure.core.async :refer [put!] :include-macros true])
             #?(:clj [replikativ.logging :as log]
                :cljs [replikativ.logging :as log :include-macros true]))
-  #?(:cljs (:require-macros [clojure.core.async.macros :refer [go]])))
+  #?(:cljs (:require-macros [clojure.core.async.macros :refer [go]]))
+  #?(:clj (:import [datahike.db TxReport])))
 
 ;; =============================================================================
 ;; Connection Registry
@@ -100,23 +102,11 @@
 ;; Global Dispatch Handler
 ;; =============================================================================
 
-(defn global-dispatch-handler
-  "Global dispatch handler that routes transactions by store-id and branch.
-
-   The handler:
-   1. Extracts store-id and branch from the request
-   2. Looks up the exact branch connection
-   3. Forwards the operation to the connection's writer
-   4. Publishes tx-report to subscribers
-   5. Returns the tx-report
-
-   Request format:
-   Old clients that omit :branch address :db for wire compatibility.
-
-   Request format:
-   {:store-id UUID :branch :db :arg-map {:op 'transact! :args [...]}}"
+(defn- dispatch-handler
   [{:keys [store-id branch arg-map request-id]
-    :or {branch :db}}]
+    :or {branch :db}}
+   on-report]
+  #_{:clj-kondo/ignore [:unresolved-symbol]}
   (go-try S
           ;; The request id is echoed to every tx-report subscriber; a client
           ;; does not get to choose its shape. (Older callers omit it.)
@@ -127,22 +117,15 @@
                                                 :branch branch
                                                 :op (:op arg-map)})
           (if-let [conn (get-connection-for-store store-id branch)]
-            (let [;; Get writer from connection
-                  writer (:writer @(:wrapped-atom conn))
-            ;; Dispatch to local writer
+            (let [writer (:writer @(:wrapped-atom conn))
                   tx-report (<? S (writer/dispatch! writer arg-map))]
-
-        ;; Publish tx-report to subscribers (if peer registered)
               (when-let [peer (get-peer-for-store store-id branch)]
                 (tx-broadcast/publish-tx-report! peer store-id tx-report request-id))
-
-        ;; Return the op's result unchanged. Stripping the live DBs out of a
-        ;; TxReport is the CODEC's job, done by the tag-27 write handler
-        ;; `datahike.cbor` registers for the TxReport class — so it happens for
-        ;; a TxReport and only for a TxReport. Projecting here instead meant
-        ;; projecting every op's result, and `gc-storage!` returns a set.
+              (when (and on-report (instance? TxReport tx-report))
+                (on-report store-id tx-report))
+              ;; Return the op's result unchanged. The codec projects live DBs
+              ;; only when this value really is a TxReport.
               tx-report)
-
             (throw (ex-info "Store branch is not registered for remote writes"
                             {:store-id store-id
                              :branch branch
@@ -152,6 +135,12 @@
                                           (when (= store-id registered-store-id)
                                             registered-branch)))
                                   set)})))))
+
+(defn global-dispatch-handler
+  "Route a writer operation by store and branch. Old clients that omit branch
+   address `:db`; the optional report callback is installed at registration."
+  [arg-map]
+  (dispatch-handler arg-map nil))
 
 ;; =============================================================================
 ;; Global Create/Delete Database Handlers
@@ -189,7 +178,7 @@
 
    The client sends logical config (schema-flexibility, keep-history?, etc.)
    and the store-id. The server uses store-config-fn to determine the actual store backend."
-  [peer store-config-fn]
+  [peer store-config-fn on-connect]
   (fn [{:keys [config]}]
     (go-try S
             (let [store-id (-> config :store :id)  ;; Extract UUID from store config
@@ -214,6 +203,7 @@
             ;; connect there holds one of the dispatch pool's few threads.
                   conn (<? S (d/connect server-config {:sync? false}))
                   _ (log/trace "Connected" {:store-id store-id})
+                  _ (when on-connect (on-connect conn))
 
             ;; Register connection in store registry (use UUID directly)
                   _ (register-connection-for-store! store-id conn peer)
@@ -247,7 +237,7 @@
 
    The client sends store-id. The server uses store-config-fn to determine
    which store to delete."
-  [_peer store-config-fn]  ;; peer looked up from store-registry
+  [_peer store-config-fn on-delete]  ;; peer looked up from store-registry
   (fn [{:keys [config]}]
     (go-try S
             (let [store-id (-> config :store :id)  ;; Extract UUID from store config
@@ -262,21 +252,24 @@
                   store-config (store-config-fn store-id config)
                   server-config {:store store-config}]
 
-              (when (seq registrations)
+              (if on-delete
+                #?(:clj  (<? S (async/thread (on-delete store-id)))
+                   :cljs (on-delete store-id))
+                (when (seq registrations)
           ;; Unregister from sync (use UUID directly)
-                (when peer
-                  (sync/unregister-store! peer store-id)
-                  (tx-broadcast/unregister-tx-report-topic! peer store-id))
+                  (when peer
+                    (sync/unregister-store! peer store-id)
+                    (tx-broadcast/unregister-tx-report-topic! peer store-id))
 
           ;; Remove from registry (use UUID directly)
-                (unregister-connection-for-store! store-id)
+                  (unregister-connection-for-store! store-id)
 
           ;; Release every branch connection registered for this store.
           ;; Releasing closes stores and index writers, blocking work that must
           ;; not run on a go dispatch thread: on the JVM it runs on its own.
-                #?(:clj  (<? S (async/thread (doseq [conn conns] (d/release conn)) true))
-                   :cljs (doseq [conn conns] (d/release conn)))
-                (log/trace "Connection released" {:store-id store-id}))
+                  #?(:clj  (<? S (async/thread (doseq [conn conns] (d/release conn)) true))
+                     :cljs (doseq [conn conns] (d/release conn)))
+                  (log/trace "Connection released" {:store-id store-id})))
 
         ;; Delete database using server-side config
               (<? S (w/delete-database server-config))
@@ -305,6 +298,11 @@
      - :wrap-handler - (fn [handler] -> handler) applied to each handler as it
        is registered; the server wraps them in the dynamic bindings a client
        request runs under (e.g. the query function resolver).
+     - :on-report - (fn [store-id tx-report]) called after a TxReport is
+       published to the Kabel topic.
+     - :on-connect - (fn [conn]) called before a new connection is registered.
+     - :on-delete - (fn [store-id]) tears down a database's registrations
+       before its storage is deleted.
      - :store-config-fn - (fn [store-id client-config] -> store-config)
        Function that returns the server-side store config for a given store-id.
        Default: `default-store-config-fn` which uses the client's store config
@@ -321,11 +319,17 @@
   ([peer] (register-global-handlers! peer {}))
   ([peer opts]
    (let [store-config-fn (or (:store-config-fn opts) default-store-config-fn)
-         wrap            (or (:wrap-handler opts) identity)]
+         wrap            (or (:wrap-handler opts) identity)
+         on-report       (:on-report opts)
+         on-connect      (:on-connect opts)
+         on-delete       (:on-delete opts)]
      (log/trace "Registering global datahike.kabel handlers" {:peer-id (some-> @peer :id)})
-     (remote/register! 'datahike.kabel/dispatch (wrap global-dispatch-handler))
-     (remote/register! 'datahike.kabel/create-database (wrap (make-create-database-handler peer store-config-fn)))
-     (remote/register! 'datahike.kabel/delete-database (wrap (make-delete-database-handler peer store-config-fn)))
+     (remote/register! 'datahike.kabel/dispatch
+                       (wrap #(dispatch-handler % on-report)))
+     (remote/register! 'datahike.kabel/create-database
+                       (wrap (make-create-database-handler peer store-config-fn on-connect)))
+     (remote/register! 'datahike.kabel/delete-database
+                       (wrap (make-delete-database-handler peer store-config-fn on-delete)))
      (log/info "Registered global datahike.kabel handlers" {:peer-id (some-> @peer :id)}))))
 
 ;; =============================================================================

--- a/src/datahike/codegen/esm.clj
+++ b/src/datahike/codegen/esm.clj
@@ -94,7 +94,8 @@
   []
   (let [clj-exports (remote-js-exports api-specification)
         _ (assert-unique-js-names! clj-exports)
-        all-exports (concat (map clj-name->js-name clj-exports) ["isPromise" "uuid" "randomUuid"])
+        all-exports (concat (map clj-name->js-name clj-exports)
+                            ["listen" "unlisten" "isPromise" "uuid" "randomUuid"])
         lines (concat
                ["// Auto-generated ESM wrapper for the thin HTTP client (datahike/remote)."
                 "// DO NOT EDIT - Generated from datahike.api.specification"

--- a/src/datahike/codegen/typescript.clj
+++ b/src/datahike/codegen/typescript.clj
@@ -518,6 +518,22 @@ export function setLogLevel(level: LogLevel): LogLevel;
      (if remote-only?
        (str header types "\n// API Functions (the thin HTTP client; every call reaches the server)\n\n" functions "
 
+export interface RemoteReport {
+  'db-after'?: Database;
+  'db-before'?: null;
+  'tx-data'?: Datom[];
+  tempids?: { [key: string]: number };
+  'commit-id'?: UuidValue;
+  resync?: boolean;
+  deleted?: boolean;
+  truncated?: boolean;
+  error?: any;
+  status?: number;
+}
+
+export function listen(conn: Connection, callback: (report: RemoteReport) => void): string;
+export function unlisten(conn: Connection, key: string): void;
+
 // JavaScript-specific value helpers.
 export function isPromise(value: any): value is Promise<unknown>;
 export function uuid(value: string): DatahikeUuid;

--- a/src/datahike/http/client.cljc
+++ b/src/datahike/http/client.cljc
@@ -17,7 +17,9 @@
                       [clojure.edn :as edn]
                       [datahike.datom :as dd]
                       [datahike.impl.entity :as de]]
-                :cljs [[clojure.core.async :as async]])
+                :cljs [[clojure.core.async :as async]
+                       [clojure.string :as str]
+                       [datahike.datom :as dd]])
             ;; The specification drives the JVM's generated functions at load
             ;; and ClojureScript's at macro time; a browser bundle carries
             ;; none of it.
@@ -399,13 +401,244 @@
            out)
          result))))
 
+#?(:cljs
+   (do
+     (defonce ^:private listeners (atom {}))
+
+     (def ^:private listen-event-keys
+       #{"store-id" "branch" "commit-id" "max-tx" "max-eid"
+         "tempids" "tx-data" "truncated"})
+
+     (defn ^:no-doc decode-listen-json
+       "Decode the tagged values present in change events into client values."
+       [value]
+       (cond
+         (array? value)
+         (let [items (mapv decode-listen-json (array-seq value))]
+           (if (and (= 2 (count items)) (string? (first items)))
+             (case (first items)
+               "!kw" (keyword (second items))
+               "!sym" (symbol (second items))
+               "!set" (set (second items))
+               "!uuid" (uuid (second items))
+               "!date" (js/Date. (js/Number (second items)))
+               "!datahike/Datom" (apply dd/datom (second items))
+               items)
+             items))
+
+         (and (some? value) (object? value))
+         (into {}
+               (map (fn [key]
+                      [key
+                       (decode-listen-json (aget value key))]))
+               (js-keys value))
+
+         :else value))
+
+     (defn- decode-listen-event [value]
+       (let [decoded (decode-listen-json value)]
+         (into {}
+               (map (fn [[key value]]
+                      [(if (contains? listen-event-keys key) (keyword key) key)
+                       value]))
+               decoded)))
+
+     (defn- listener-id [conn key]
+       [(get-in conn [:remote-peer :url]) (:store-id conn) key])
+
+     (defn- active-listener? [{:keys [id stopped?] :as listener}]
+       (and (not @stopped?) (identical? listener (get @listeners id))))
+
+     (defn- stop-listener! [{:keys [id stopped? controller timer] :as listener}]
+       (reset! stopped? true)
+       (when-let [timeout @timer]
+         (js/clearTimeout timeout)
+         (reset! timer nil))
+       (when-let [abort @controller]
+         (.abort abort)
+         (reset! controller nil))
+       (swap! listeners #(if (identical? listener (get % id)) (dissoc % id) %)))
+
+     (defn- remote-db-from-head [conn head]
+       (binding [remote/*remote-peer* (:remote-peer conn)]
+         (remote/remote-db
+          (assoc (select-keys head [:max-tx :max-eid :commit-id])
+                 :store-id (if (sequential? (:store-id head))
+                             (:store-id head)
+                             [(:store-id head) (:branch head :db)])))))
+
+     (defn- invoke-listener-callback! [{:keys [callback]} report]
+       (try
+         (callback report)
+         (catch :default error
+           (trace :datahike/http-listen-callback-error
+                  {:message (or (.-message error) (str error))}))))
+
+     (defn- deliver-listen-event!
+       [{:keys [conn last-commit] :as listener} event data]
+       (when (active-listener? listener)
+         (case event
+           "report"
+           (do
+             (reset! last-commit (:commit-id data))
+             (invoke-listener-callback!
+              listener
+              (cond-> {:db-after (remote-db-from-head conn data)
+                       :db-before nil
+                       :tempids (:tempids data)
+                       :commit-id (:commit-id data)}
+                (contains? data :tx-data) (assoc :tx-data (:tx-data data))
+                (:truncated data) (assoc :truncated true))))
+
+           ("resync" "coalesced")
+           (do
+             (reset! last-commit (:commit-id data))
+             (invoke-listener-callback!
+              listener {:resync true :db-after (remote-db-from-head conn data)}))
+
+           "deleted"
+           (do
+             (invoke-listener-callback! listener {:deleted true})
+             (stop-listener! listener))
+
+           nil)))
+
+     (defn- parse-sse-frame! [listener frame]
+       (let [{:keys [event data]}
+             (reduce (fn [parsed line]
+                       (cond
+                         (or (empty? line) (str/starts-with? line ":")) parsed
+                         (str/starts-with? line "event:")
+                         (assoc parsed :event (str/trim (subs line 6)))
+                         (str/starts-with? line "data:")
+                         (update parsed :data conj (str/triml (subs line 5)))
+                         :else parsed))
+                     {:data []}
+                     (str/split-lines frame))]
+         (when (and event (seq data))
+           (deliver-listen-event! listener event
+                                  (decode-listen-event
+                                   (js/JSON.parse (str/join "\n" data)))))))
+
+     (defn ^:no-doc split-listen-chunk
+       "Split complete SSE frames while retaining an unfinished trailing CR."
+       [pending chunk]
+       (let [raw (str pending chunk)
+             trailing-cr? (str/ends-with? raw "\r")
+             complete (if trailing-cr? (subs raw 0 (dec (count raw))) raw)
+             normalized (str/replace complete #"\r\n?" "\n")
+             frames (.split normalized "\n\n")
+             pending (str (.pop frames) (when trailing-cr? "\r"))]
+         [(vec (array-seq frames)) pending]))
+
+     (defn- read-listen-stream! [listener reader decoder pending]
+       (-> (.read reader)
+           (.then
+            (fn [result]
+              (if (.-done result)
+                nil
+                (let [chunk (.decode decoder (.-value result) #js {:stream true})
+                      [frames pending] (split-listen-chunk pending chunk)]
+                  (doseq [frame frames]
+                    (when (seq frame)
+                      (parse-sse-frame! listener frame)))
+                  (if (active-listener? listener)
+                    (read-listen-stream! listener reader decoder pending)
+                    (.cancel reader))))))))
+
+     (declare connect-listener! unlisten)
+
+     (defn- reconnect-listener! [{:keys [backoff timer] :as listener}]
+       (when (active-listener? listener)
+         (let [delay @backoff]
+           (reset! backoff (min 30000 (* 2 delay)))
+           (reset! timer
+                   (js/setTimeout
+                    (fn []
+                      (reset! timer nil)
+                      (connect-listener! listener))
+                    delay)))))
+
+     (defn- listen-url [{:keys [conn last-commit]}]
+       (let [{:keys [url]} (:remote-peer conn)
+             [store-id branch] (if (sequential? (:store-id conn))
+                                 (:store-id conn)
+                                 [(:store-id conn) :db])
+             since @last-commit]
+         (str url "/listen?store=" (js/encodeURIComponent (str store-id))
+              "&branch=" (js/encodeURIComponent (name branch))
+              (when since (str "&since=" (js/encodeURIComponent (str since)))))))
+
+     (defn- connect-listener!
+       [{:keys [conn controller] :as listener}]
+       (when (active-listener? listener)
+         (let [{:keys [token]} (:remote-peer conn)
+               abort (js/AbortController.)
+               target (listen-url listener)
+               headers (cond-> {"accept" "text/event-stream"}
+                         token (assoc "authorization" (str "token " token)))]
+           (reset! controller abort)
+           (trace :datahike/http-listen {:url target})
+           (-> (js/fetch target
+                         #js {:method "GET"
+                              :headers (clj->js headers)
+                              :signal (.-signal abort)})
+               (.then (fn [response]
+                        (let [status (.-status response)]
+                          (if-not (.-ok response)
+                            (if (contains? #{401 403 404} status)
+                              (let [error (ex-info (str "HTTP " status " from " target)
+                                                   {:status status :url target})]
+                                (invoke-listener-callback!
+                                 listener {:error error :status status})
+                                (stop-listener! listener)
+                                nil)
+                              (throw (js/Error. (str "HTTP " status " from " target))))
+                            (do
+                              (reset! (:backoff listener) 500)
+                              (if-let [body (.-body response)]
+                                (read-listen-stream! listener (.getReader body) (js/TextDecoder.) "")
+                                (throw (js/Error. (str "No response body from " target)))))))))
+               (.then (fn [_] (reconnect-listener! listener)))
+               (.catch (fn [error]
+                         (when (active-listener? listener)
+                           (trace :datahike/http-listen-error {:url target
+                                                               :message (or (.-message error) (str error))})
+                           (reconnect-listener! listener))))))))
+
+     (defn listen
+       "Listen for remote changes so a thin client can refresh without polling."
+       ([conn callback]
+        (listen conn (str (random-uuid)) callback))
+       ([conn key callback]
+        (unlisten conn key)
+        (let [listener {:id (listener-id conn key)
+                        :conn conn
+                        :callback callback
+                        :last-commit (atom nil)
+                        :backoff (atom 500)
+                        :controller (atom nil)
+                        :timer (atom nil)
+                        :stopped? (atom false)}]
+          (swap! listeners assoc (:id listener) listener)
+          (connect-listener! listener)
+          key)))
+
+     (defn unlisten
+       "Stop a remote change listener so its request and reconnect loop release resources."
+       [conn key]
+       (when-let [listener (get @listeners (listener-id conn key))]
+         (stop-listener! listener))
+       nil)))
+
 #?(:clj
    (defmacro emit-remote-api
      "Define the API functions for ClojureScript, one per specification entry:
       the remote-capable ones call the server, the rest throw as on the JVM."
      []
      `(do
-        ~@(for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api/api-specification]
+        ~@(for [[n {:keys [args doc supports-remote? referentially-transparent?]}] api/api-specification
+                :when (not (#{'listen 'unlisten} n))]
             `(defn ~(with-meta n {:arglists (list 'quote (api/malli-schema->argslist args)) :doc doc})
                [& ~'args]
                ~(if supports-remote?

--- a/src/datahike/js/remote.cljs
+++ b/src/datahike/js/remote.cljs
@@ -24,6 +24,19 @@
 
 (emit-js-remote-api)
 
+(defn ^:export listen
+  "Listen for remote changes and pass JavaScript reports to the callback."
+  [conn callback]
+  (datahike.http.client/listen
+   conn
+   (fn [report]
+     (callback (datahike.js.convert/clj->js-recursive report)))))
+
+(defn ^:export unlisten
+  "Stop a remote change listener by its key."
+  [conn key]
+  (datahike.http.client/unlisten conn key))
+
 (defn ^:export isPromise
   "Check if a value is a Promise."
   [x]

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -2,6 +2,7 @@
   (:require [superv.async :refer [S thread-try <?- go-try]]
             [replikativ.logging :as log]
             [datahike.core]
+            #?(:cljs [datahike.db :refer [TxReport]])
             [datahike.config :as dc]
             [datahike.metrics :as metrics]
             [datahike.writing :as w]
@@ -12,7 +13,8 @@
             [clojure.string :as str]
             [clojure.core.async :refer [chan close! promise-chan put! go go-loop <! >! poll! buffer timeout]]
             #?(:cljs [cljs.core.async.impl.channels :refer [ManyToManyChannel]]))
-  #?(:clj (:import [clojure.core.async.impl.channels ManyToManyChannel])))
+  #?(:clj (:import [clojure.core.async.impl.channels ManyToManyChannel]
+                   [datahike.db TxReport])))
 
 (defn chan? [x]
   (instance? ManyToManyChannel x))
@@ -1133,6 +1135,9 @@
         writer (:writer @(:wrapped-atom connection))]
     (go
       (let [tx-report (<! (dispatch! writer {:op op :args args}))]
+        (when (instance? TxReport tx-report)
+          (doseq [[_ callback] (some-> (:listeners (meta connection)) deref)]
+            (callback tx-report)))
         (#?(:clj deliver :cljs put!) p tx-report)))
     p))
 

--- a/test/datahike/test/http/kabel_test.clj
+++ b/test/datahike/test/http/kabel_test.clj
@@ -2,19 +2,28 @@
   "The Kabel listener's authorization: remote calls and sync subscriptions ask
    the same `:authorize` policy the HTTP routes do."
   (:require
-   [clojure.core.async :refer [<!! timeout alts!!]]
+   [babashka.http-client :as http]
+   [clojure.core.async :refer [<!! timeout alts!! chan put!]]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [datahike.http.kabel :as kabel]
+   [datahike.http.client :as http-client]
    [datahike.http.permissions :as permissions]
+   [datahike.http.server :as http-server]
    [datahike.api :as d]
    [datahike.kabel.handlers :as handlers]
+   [datahike.kabel.tx-broadcast :as tx-broadcast]
+   [datahike.json :as json]
    [datahike.migrate.fs :as fs]
    [datahike.kabel.cbor-handlers :as cbor]
    [kabel.auth.jwt :as jwt]
    [kabel.auth.websocket :as auth]
    [kabel.peer :as peer]
    [kabel.remote :as remote]
-   [superv.async :refer [S <??]]))
+   [konserve-sync.core :as sync]
+   [jsonista.core :as j]
+   [superv.async :refer [S <??]])
+  (:import [java.io BufferedReader InputStreamReader]))
 
 (def ^:private secret "kabel-listener-test-secret")
 (def ^:private store-a #uuid "aaaaaaaa-1111-1111-1111-111111111111")
@@ -104,6 +113,168 @@
   [ch]
   (let [[v _] (alts!! [ch (timeout 2000)])]
     (if (instance? Throwable v) (:type (ex-data v)) v)))
+
+(defn- local-port [^org.eclipse.jetty.server.Server instance]
+  (.getLocalPort ^org.eclipse.jetty.server.ServerConnector
+   (first (.getConnectors instance))))
+
+(defn- next-report
+  ([events] (next-report events 5000))
+  ([events timeout-ms]
+   (let [[value port] (alts!! [events (timeout timeout-ms)])]
+     (when (= port events) value))))
+
+(defn- open-stream [url store-id]
+  (let [response (http/get (str url "/listen?store=" store-id)
+                           {:headers {"authorization" "token http-kabel-token"}
+                            :as :stream})]
+    (is (= 200 (:status response))
+        "a Kabel-reopened store can be listened to before an HTTP connect")
+    (assoc response :reader
+           (BufferedReader. (InputStreamReader. (:body response) "UTF-8")))))
+
+(defn- read-stream-event [stream]
+  (let [result (future
+                 (loop [event nil data nil]
+                   (let [line (.readLine ^BufferedReader (:reader stream))]
+                     (cond
+                       (nil? line) {:event :eof}
+                       (str/starts-with? line "event: ")
+                       (recur (keyword (subs line 7)) data)
+                       (str/starts-with? line "data: ")
+                       (recur event (j/read-value (subs line 6) json/mapper))
+                       (and (str/blank? line) event) {:event event :data data}
+                       :else (recur event data)))))]
+    (if (= ::timeout (deref result 5000 ::timeout))
+      (do (future-cancel result) ::timeout)
+      @result)))
+
+(deftest standalone-broadcasts-http-and-kabel-writes-once
+  (let [http-port (free-port)
+        kabel-port (free-port)
+        server-id (random-uuid)
+        client-id (random-uuid)
+        store-id (random-uuid)
+        root (str (fs/temp-dir! "dh-http-kabel-broadcast-") "/databases")
+        store-config {:store {:backend :file
+                              :path (str root "/" store-id)
+                              :id store-id}
+                      :schema-flexibility :read
+                      :keep-history? false}
+        _ (d/create-database store-config)
+        server (http-server/start-server
+                {:host "127.0.0.1"
+                 :port http-port
+                 :join? false
+                 :metrics false
+                 :token "http-kabel-token"
+                 :kabel {:host "127.0.0.1"
+                         :port kabel-port
+                         :peer-id server-id
+                         :jwt {:alg :HS256 :secret secret}
+                         :store {:backend :file :path root}}})
+        peer (peer/client-peer
+              S client-id
+              (comp (sync/client-middleware)
+                    remote/middleware
+                    (auth/auth-middleware
+                     {:authenticate {:token (token-for "alice")}
+                      :permissive true}))
+              cbor/datahike-cbor-middleware)
+        reports (chan 8)]
+    (try
+      (remote/serve peer)
+      (<?? S (remote/connect S peer (str "ws://127.0.0.1:" kabel-port)))
+      (<?? S (tx-broadcast/subscribe-tx-reports! peer store-id
+                                                 #(put! reports %)))
+      (let [http-peer {:backend :datahike-server
+                       :url (str "http://127.0.0.1:" (local-port server))
+                       :token "http-kabel-token"
+                       :format :cbor}
+            stream (open-stream (:url http-peer) store-id)
+            _ (is (= :resync (:event (read-stream-event stream))))
+            host-conn (handlers/get-connection-for-store store-id)
+            host-report (d/transact host-conn [{:source "host-before-http-connect"}])
+            host-topic-event (next-report reports)
+            host-sse-event (read-stream-event stream)
+            _ (is (= (get-in host-report [:db-after :meta :datahike/commit-id])
+                     (get-in host-topic-event [:tx-report :db-after :meta :datahike/commit-id])
+                     (get-in host-sse-event [:data :commit-id]))
+                  "a host write on a Kabel-reopened store reaches both transports before HTTP connects")
+            http-conn (http-client/connect (assoc store-config :remote-peer http-peer))]
+        (try
+          (let [http-result (http-client/transact http-conn [{:source "http"}])
+                event (next-report reports)
+                sse-event (read-stream-event stream)]
+            (is (= (get-in http-result [:db-after :commit-id])
+                   (get-in event [:tx-report :db-after :meta :datahike/commit-id])))
+            (is (= (get-in http-result [:db-after :commit-id])
+                   (get-in sse-event [:data :commit-id]))
+                "an HTTP write reaches SSE as well as Kabel")
+            (is (nil? (next-report reports 750)) "the HTTP commit is published once"))
+          (let [result (<?? S (remote/invoke
+                               peer server-id 'datahike.kabel/dispatch
+                               {:store-id store-id
+                                :branch :db
+                                :request-id (random-uuid)
+                                :arg-map {:op 'transact!
+                                          :args [[{:source "kabel"}]]}}))
+                event (next-report reports)
+                sse-event (read-stream-event stream)]
+            (is (= (get-in result [:db-after :meta :datahike/commit-id])
+                   (get-in event [:tx-report :db-after :meta :datahike/commit-id])))
+            (is (= (get-in result [:db-after :meta :datahike/commit-id])
+                   (get-in sse-event [:data :commit-id]))
+                "a Kabel write reaches SSE")
+            (is (nil? (next-report reports 750)) "the Kabel commit is published once"))
+          (finally
+            (try (http-client/release http-conn)
+                 (catch Throwable _))))
+        (let [host-report (d/transact host-conn [{:source "host-after-http-release"}])
+              topic-event (next-report reports)
+              sse-event (read-stream-event stream)]
+          (is (= (get-in host-report [:db-after :meta :datahike/commit-id])
+                 (get-in topic-event [:tx-report :db-after :meta :datahike/commit-id])
+                 (get-in sse-event [:data :commit-id]))
+              "the registry listener survives the last HTTP release"))
+        (let [late-conn (http-client/connect (assoc store-config :remote-peer http-peer))]
+          (<?? S (remote/invoke peer server-id 'datahike.kabel/delete-database
+                                {:config {:store {:id store-id}}}))
+          (<?? S (remote/invoke peer server-id 'datahike.kabel/create-database
+                                {:config {:store {:id store-id}
+                                          :schema-flexibility :read}}))
+          (http-client/release late-conn)
+          (let [result (<?? S (remote/invoke
+                               peer server-id 'datahike.kabel/dispatch
+                               {:store-id store-id
+                                :branch :db
+                                :request-id (random-uuid)
+                                :arg-map {:op 'transact!
+                                          :args [[{:source "after-late-release"}]]}}))]
+            (is (map? result)
+                "a late HTTP release from before Kabel deletion does not release the recreated connection"))
+          (http-client/delete-database (assoc store-config :remote-peer http-peer))
+          (let [error (next-report
+                       (remote/invoke peer server-id 'datahike.kabel/dispatch
+                                      {:store-id store-id
+                                       :branch :db
+                                       :request-id (random-uuid)
+                                       :arg-map {:op 'transact!
+                                                 :args [[{:source "after-http-delete"}]]}}))]
+            (is (instance? Throwable error))
+            (is (str/includes? (ex-message error) "not registered")
+                "HTTP deletion removes the Kabel dispatch registration")))
+        (is (= :deleted (:event (read-stream-event stream))))
+        (is (= :eof (:event (read-stream-event stream)))
+            "Kabel deletion terminates the SSE stream")
+        (.close ^BufferedReader (:reader stream)))
+      (finally
+        (try (<?? S (tx-broadcast/unsubscribe-tx-reports! peer store-id))
+             (catch Throwable _))
+        (<?? S (peer/stop peer))
+        (http-server/stop-server server)
+        (when (d/database-exists? store-config)
+          (d/delete-database store-config))))))
 
 (deftest listener-refuses-through-the-policy
   (let [port (free-port)

--- a/test/datahike/test/http/listen_test.clj
+++ b/test/datahike/test/http/listen_test.clj
@@ -1,0 +1,217 @@
+(ns datahike.test.http.listen-test
+  "The authenticated SSE change stream for thin HTTP clients."
+  (:require
+   [babashka.http-client :as http]
+   [clojure.core.async :as async]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.connections :refer [*connections*]]
+   [datahike.http.client :as client]
+   [datahike.http.routes :as routes]
+   [datahike.json :as json]
+   [jsonista.core :as j]
+   [ring.adapter.jetty :refer [run-jetty]]
+   [ring.core.protocols :as protocols])
+  (:import
+   [java.io BufferedReader ByteArrayOutputStream InputStreamReader OutputStream]
+   [java.net ServerSocket URLEncoder]))
+
+(def ^:private token "listen-test-token")
+
+(defn- free-port []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+(defn- encode [x]
+  (URLEncoder/encode (str x) "UTF-8"))
+
+(defn- listen-url [url store-id & [{:keys [branch since]}]]
+  (str url "/listen?store=" store-id
+       (when branch (str "&branch=" (encode branch)))
+       (when since (str "&since=" since))))
+
+(defn- open-stream [url store-id opts]
+  (let [response (http/get (listen-url url store-id opts)
+                           {:headers {"authorization" (str "token " token)}
+                            :as :stream})]
+    (is (= 200 (:status response)))
+    (is (str/starts-with? (get-in response [:headers "content-type"] "")
+                          "text/event-stream"))
+    (assoc response :reader (BufferedReader. (InputStreamReader. (:body response) "UTF-8")))))
+
+(defn- read-event
+  ([stream] (read-event stream 5000))
+  ([stream timeout-ms]
+   (let [result (future
+                  (loop [event nil data nil]
+                    (let [line (.readLine ^BufferedReader (:reader stream))]
+                      (cond
+                        (nil? line) {:event :eof}
+                        (str/starts-with? line "event: ")
+                        (recur (keyword (subs line 7)) data)
+                        (str/starts-with? line "data: ")
+                        (recur event (j/read-value (subs line 6) json/mapper))
+                        (and (str/blank? line) event)
+                        {:event event :data data}
+                        :else (recur event data)))))]
+     (if (= ::timeout (deref result timeout-ms ::timeout))
+       (do (future-cancel result) ::timeout)
+       @result))))
+
+(defn- close-stream! [stream]
+  (.close ^BufferedReader (:reader stream)))
+
+(deftest authentication-and-authorization-run-before-listening
+  (let [port (free-port)
+        store-id (random-uuid)
+        app (routes/handler {:token token
+                             :authorize (constantly false)})
+        server (run-jetty app {:host "127.0.0.1" :port port :join? false})
+        url (str "http://127.0.0.1:" port)]
+    (try
+      (is (= 401 (:status (http/get (listen-url url store-id nil)
+                                    {:throw false}))))
+      (let [response (http/get (listen-url url store-id nil)
+                               {:throw false
+                                :headers {"authorization" (str "token " token)}})]
+        (is (= 403 (:status response)))
+        (is (= :datahike.http/forbidden
+               (get-in (j/read-value (:body response) json/mapper) [:ex-data :type]))))
+      (finally
+        (.stop server)
+        (routes/release-all! app)))))
+
+(deftest listeners-see-resync-reports-and-deletion
+  (let [port (free-port)
+        store-id (random-uuid)
+        cfg {:store {:backend :memory :id store-id} :schema-flexibility :read}
+        connections (atom {})
+        app (routes/handler {:token token} {:connections connections})
+        server (run-jetty app {:host "127.0.0.1" :port port :join? false})
+        url (str "http://127.0.0.1:" port)
+        remote-peer {:backend :datahike-server :url url :token token :format :cbor}]
+    (binding [*connections* connections]
+      (d/create-database cfg))
+    (let [conn (client/connect (assoc cfg :remote-peer remote-peer))
+          current (:commit-id @conn)
+          current-stream (open-stream url store-id {:since current})
+          stale-stream (open-stream url store-id nil)]
+      (try
+        (testing "an absent since resyncs, while an equal since waits for a report"
+          (is (= :resync (:event (read-event stale-stream)))))
+        (testing "one HTTP transaction reaches both listeners once with datoms"
+          (let [report (client/transact conn [{:name "Ada"}])
+                first-current (read-event current-stream)
+                first-stale (read-event stale-stream)]
+            (doseq [event [first-current first-stale]]
+              (is (= :report (:event event)))
+              (is (= (:commit-id (:db-after report)) (get-in event [:data :commit-id])))
+              (is (seq (get-in event [:data :tx-data]))))
+            (let [second-report (client/transact conn [{:name "Grace"}])]
+              (doseq [stream [current-stream stale-stream]]
+                (let [event (read-event stream)]
+                  (is (= :report (:event event)))
+                  (is (= (:commit-id (:db-after second-report))
+                         (get-in event [:data :commit-id]))))))))
+        (testing "HTTP load-entities reaches the report bus"
+          (let [report (client/load-entities conn [[100 :loaded true 536870913 true]])]
+            (doseq [stream [current-stream stale-stream]]
+              (let [event (read-event stream)]
+                (is (= :report (:event event)))
+                (is (= (:commit-id (:db-after report))
+                       (get-in event [:data :commit-id])))))))
+        (testing "deletion is terminal"
+          (try (client/release conn)
+               (catch Throwable _))
+          (client/delete-database (assoc cfg :remote-peer remote-peer))
+          (doseq [stream [current-stream stale-stream]]
+            (is (= :deleted (:event (read-event stream))))
+            (is (= :eof (:event (read-event stream))))))
+        (finally
+          (close-stream! current-stream)
+          (close-stream! stale-stream)
+          (.stop server)
+          (routes/release-all! app))))))
+
+(deftest deleting-a-branch-terminates-its-stream
+  (let [port (free-port)
+        store-id (random-uuid)
+        cfg {:store {:backend :memory :id store-id} :schema-flexibility :read}
+        connections (atom {})
+        app (routes/handler {:token token} {:connections connections})
+        server (run-jetty app {:host "127.0.0.1" :port port :join? false})
+        url (str "http://127.0.0.1:" port)
+        remote-peer {:backend :datahike-server :url url :token token :format :cbor}]
+    (binding [*connections* connections]
+      (d/create-database cfg))
+    (let [main (client/connect (assoc cfg :remote-peer remote-peer))]
+      (try
+        (client/branch! main :db :feature)
+        (let [branch (client/connect (assoc cfg :branch :feature :remote-peer remote-peer))
+              stream (open-stream url store-id {:branch :feature
+                                                :since (:commit-id @branch)})]
+          (try
+            (client/delete-branch! main :feature)
+            (is (= :deleted (:event (read-event stream))))
+            (is (= :eof (:event (read-event stream))))
+            (finally
+              (close-stream! stream)
+              (try (client/release branch) (catch Throwable _)))))
+        (finally
+          (try (client/release main) (catch Throwable _))
+          (try (client/delete-database (assoc cfg :remote-peer remote-peer))
+               (catch Throwable _))
+          (.stop server)
+          (routes/release-all! app))))))
+
+(deftest a-slow-writer-is-coalesced
+  (let [store-id (random-uuid)
+        cfg {:store {:backend :memory :id store-id} :schema-flexibility :read}
+        connections (atom {})
+        app (routes/handler {:token token} {:connections connections})
+        conn (binding [*connections* connections]
+               (d/create-database cfg)
+               (d/connect cfg))
+        head (d/commit-id @conn)
+        response (app {:request-method :get
+                       :uri "/listen"
+                       :query-string (str "store=" store-id "&since=" head)
+                       :headers {"authorization" (str "token " token)}})
+        entered (promise)
+        proceed (promise)
+        bytes (ByteArrayOutputStream.)
+        blocked-output
+        (proxy [OutputStream] []
+          (write
+            ([b]
+             (deliver entered true)
+             @proceed
+             (.write bytes (int b)))
+            ([b off len]
+             (deliver entered true)
+             @proceed
+             (.write bytes b off len))))
+        writing (future
+                  (protocols/write-body-to-stream (:body response) response blocked-output))]
+    (try
+      (d/transact conn [{:n 0}])
+      (is (= true (deref entered 5000 ::timeout)))
+      (doseq [n (range 1 25)]
+        (d/transact conn [{:n n}]))
+      (deliver proceed true)
+      (loop [attempts 100]
+        (when (and (pos? attempts)
+                   (not (str/includes? (.toString bytes "UTF-8") "event: coalesced")))
+          (Thread/sleep 10)
+          (recur (dec attempts))))
+      (is (str/includes? (.toString bytes "UTF-8") "event: coalesced"))
+      (finally
+        (doseq [subscriber (mapcat val @(-> app meta ::routes/state :subscribers))]
+          (async/close! (:channel subscriber)))
+        (deliver proceed true)
+        (deref writing 5000 nil)
+        (binding [*connections* connections]
+          (d/release conn)
+          (d/delete-database cfg))
+        (routes/release-all! app)))))

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -134,6 +134,26 @@
                 (catch clojure.lang.ExceptionInfo e e))]
     (is (= :datahike.http/invalid-shutdown-timeout (:type (ex-data error))))))
 
+(deftest standalone-uses-virtual-threads-for-streaming-on-jdk-21
+  (when (>= (.feature (Runtime/version)) 21)
+    (let [instance (start-server {:host "127.0.0.1"
+                                  :port 0
+                                  :join? false
+                                  :metrics false
+                                  :max-threads 17})
+          pool (.getThreadPool ^org.eclipse.jetty.server.Server instance)
+          executor (.getVirtualThreadsExecutor
+                    ^org.eclipse.jetty.util.thread.QueuedThreadPool pool)]
+      (try
+        (is (instance? org.eclipse.jetty.util.thread.QueuedThreadPool pool))
+        (is (= 17 (.getMaxThreads
+                   ^org.eclipse.jetty.util.thread.QueuedThreadPool pool)))
+        (is (some? executor))
+        (finally
+          (stop-server instance)))
+      (is (.isShutdown ^java.util.concurrent.ExecutorService executor)
+          "the owned virtual-thread executor is closed with the server"))))
+
 (deftest graceful-stop-drains-active-requests-and-cleans-up-once
   (let [entered       (promise)
         finish        (promise)

--- a/test/datahike/test/remote_test.cljs
+++ b/test/datahike/test/remote_test.cljs
@@ -4,12 +4,11 @@
    (`datahike.js.remote`). `bb node-remote-test` starts the server and
    points DATAHIKE_REMOTE_URL / DATAHIKE_REMOTE_TOKEN at it; without them the
    suite reports itself skipped."
-  (:require [cljs.test :refer [deftest is testing async] :as t]
+  (:require [cljs.test :refer [deftest is async] :as t]
             [datahike.http.client :as client]
             [datahike.remote :as remote]
             [datahike.js.remote :as js-remote]
-            [cljs.core.async :refer [<! go]]
-            [cljs.nodejs :as nodejs]))
+            [cljs.core.async :refer [<! go] :as core-async]))
 
 (def ^:private url (some-> js/process .-env .-DATAHIKE_REMOTE_URL))
 (def ^:private token (some-> js/process .-env .-DATAHIKE_REMOTE_TOKEN))
@@ -21,10 +20,39 @@
   (go (let [v (<! ch)]
         (if (instance? js/Error v) (throw v) v))))
 
+(defn- <event
+  "Take one listener event or fail so a broken stream cannot hang the suite."
+  [events]
+  (let [out (core-async/promise-chan)
+        pending? (atom true)
+        timeout (js/setTimeout
+                 #(when (compare-and-set! pending? true false)
+                    (core-async/put! out (js/Error. "Timed out waiting for a change event")))
+                 5000)]
+    (core-async/take! events
+                      (fn [value]
+                        (when (compare-and-set! pending? true false)
+                          (js/clearTimeout timeout)
+                          (core-async/put! out value))))
+    out))
+
 (defn- config []
   {:store {:backend :memory :id (random-uuid)}
    :schema-flexibility :read
    :remote-peer peer})
+
+(deftest listen-json-and-crlf-chunks
+  (let [decoded (client/decode-listen-json
+                 #js ["!set" #js [#js ["!kw" "one"]
+                                  #js ["!sym" "two"]]])
+        [frames pending] (client/split-listen-chunk
+                          "" "event: report\r\ndata: {\"max-tx\":1}\r")
+        [frames-2 pending-2] (client/split-listen-chunk pending "\n\r\n")]
+    (is (= #{:one 'two} decoded) "all collection element tags are decoded")
+    (is (empty? frames) "a trailing CR is retained rather than becoming a frame end")
+    (is (= ["event: report\ndata: {\"max-tx\":1}"] frames-2)
+        "a CR/LF split across chunks produces exactly one frame")
+    (is (empty? pending-2))))
 
 (deftest cljs-api-against-the-server
   (async done
@@ -55,6 +83,56 @@
                (is false (str "unexpected: " (ex-message e) " " (pr-str (ex-data e))))))
            (done))))
 
+(deftest cljs-change-listener
+  (async done
+         (go
+           (try
+             (let [cfg (<! (<ok (client/create-database (config))))
+                   conn (<! (<ok (client/connect cfg)))
+                   events (core-async/chan 8)
+                   key (client/listen conn :remote-test #(core-async/put! events %))
+                   resync (<! (<ok (<event events)))
+                   _ (is (= :remote-test key) "an explicit listener key is returned")
+                   _ (is (:resync resync) "a listener without since starts with a resync")
+                   _ (is (instance? remote/RemoteDB (:db-after resync)))
+                   _ (<! (<ok (client/transact conn [{:db/id "Serg"
+                                                      :listener/value :received
+                                                      :listener/symbol 'tagged}])))
+                   report (<! (<ok (<event events)))
+                   _ (is (not (:resync report)) "the next event is a transaction report")
+                   _ (is (= [:received] (mapv :v (filter #(= :listener/value (:a %))
+                                                         (:tx-data report))))
+                         "tagged JSON datoms and keywords are decoded")
+                   _ (is (number? (get (:tempids report) "Serg"))
+                         "string tempid keys remain strings")
+                   _ (is (= ['tagged]
+                            (mapv :v (filter #(= :listener/symbol (:a %))
+                                             (:tx-data report))))
+                         "tagged JSON symbols are decoded")
+                   db (<! (<ok (client/db conn)))
+                   _ (is (= (:commit-id report) (:commit-id (:db-after report)) (:commit-id db))
+                         "the event handle is the new head")
+                   _ (client/unlisten conn key)
+                   _ (<! (<ok (client/transact conn [{:listener/value :after-unlisten}])))
+                   [_ port] (core-async/alts! [events (core-async/timeout 300)])
+                   _ (is (not= port events) "unlisten stops delivery")
+                   failures (core-async/chan 2)
+                   bad-conn (assoc conn :remote-peer (assoc peer :token "wrong"))
+                   _ (client/listen bad-conn :permanent-failure #(core-async/put! failures %))
+                   failure (<! (<ok (<event failures)))
+                   _ (is (= 401 (:status failure)))
+                   _ (is (instance? ExceptionInfo (:error failure))
+                         "a permanent HTTP status reaches the application as ex-info")
+                   [_ retry-port] (core-async/alts! [failures (core-async/timeout 800)])
+                   _ (is (not= retry-port failures)
+                         "a permanent HTTP status stops instead of reconnecting")
+                   _ (<! (client/release conn))
+                   _ (<! (<ok (client/delete-database cfg)))]
+               (is true))
+             (catch :default e
+               (is false (str "unexpected: " (ex-message e) " " (pr-str (ex-data e))))))
+           (done))))
+
 (deftest javascript-boundary-against-the-server
   (async done
     ;; As in the JavaScript docs: the configuration object holding the uuid()
@@ -75,7 +153,41 @@
                                      (.then (fn [db] (js-remote/q "[:find ?n :where [?e :name ?n]]" db)))
                                      (.then (fn [result]
                                               (is (= [["Linus"]] (js->clj result)) "results are JavaScript values")
-                                              (js-remote/release conn)))
+                                              (let [phase (atom :resync)
+                                                    key (atom nil)
+                                                    report-promise
+                                                    (js/Promise.
+                                                     (fn [resolve reject]
+                                                       (let [timeout (js/setTimeout
+                                                                      #(do
+                                                                         (when @key
+                                                                           (js-remote/unlisten conn @key))
+                                                                         (reject (js/Error. "Timed out waiting for a JavaScript change event")))
+                                                                      5000)]
+                                                         (reset! key
+                                                                 (js-remote/listen
+                                                                  conn
+                                                                  (fn [report]
+                                                                    (case @phase
+                                                                      :resync
+                                                                      (do
+                                                                        (is (object? report) "a listener receives a JavaScript object")
+                                                                        (is (true? (aget report "resync")))
+                                                                        (reset! phase :report)
+                                                                        (-> (js-remote/transact
+                                                                             conn #js [#js {:name "Listener"}])
+                                                                            (.catch reject)))
+
+                                                                      :report
+                                                                      (do
+                                                                        (js/clearTimeout timeout)
+                                                                        (resolve report)))))))))]
+                                                (.then report-promise
+                                                       (fn [report]
+                                                         (is (some? (aget report "db-after"))
+                                                             "a JavaScript change report carries a handle")
+                                                         (js-remote/unlisten conn @key)
+                                                         (js-remote/release conn))))))
                                      (.then (fn [_] (js-remote/deleteDatabase cfg))))))))
                (.catch (fn [e] (is false (str "unexpected: " e))))
                (.finally done)))))


### PR DESCRIPTION
Builds on #1062 (thin client). Merge that first.

## Why

A thin client holds no replica, so it learned about other writers' commits only by asking. This adds the push side: one server-sent-events route, and `listen` / `unlisten` on the thin client.

Server-sent events rather than Kabel, deliberately. A Kabel subscriber has to speak the subscribe, handshake, ack, publish and unsubscribe frames plus the auth handshake and reconnection, which is a protocol state machine we would have to reimplement in every non-Clojure client and keep in step forever. A thin listener has no state to synchronise: it only needs to hear that a commit happened. So the transport is a plain HTTP stream that browsers, Node and a future TypeScript client implement for us, and Kabel stays the replica's lane, unchanged.

## Server

`GET /listen?store=<uuid>&branch=<kw>&since=<commit-id>`, inside the handler, so the same gate authenticates it and the same `:authorize` policy is asked for `:read` on that store. Events: `resync` (first, when `since` is absent or stale), `report` per commit, `coalesced` when a slow subscriber's buffer dropped events, `deleted` when the database goes away. A `report` carries the head (store id, branch, commit id, `max-tx`, `max-eid`), the tempids and the datoms, or `truncated` above 500 datoms. Sliding buffer of 16 per subscriber, heartbeat every 20 seconds, no acks and no replay: after a gap the client is told to resync and re-queries, which is what it would do anyway.

Three things this fixes beyond the feature itself:

- **One connection registry.** The HTTP routes bound their own connection registry while the Kabel listener connected outside it, so one store had two connection objects and neither side saw the other's writes. They now share one registry, which is also why a database created over Kabel is listenable over HTTP.
- **One broadcast source.** A report published on the Kabel topic came only from Kabel-dispatched writes, so a replica missed everything written through the HTTP API. Reports now flow through one bus, published exactly once per origin: the tests prove both directions and both "once" properties.
- **One deletion path.** Both transports now call one function that ends the streams, drops the routes' leases and heads, detaches the report listener and unregisters the store from Kabel. Before the shared registry this was two half-truths; with it, deleting through one transport would have left the other serving a released connection, and a stale lease could release a freshly recreated database of the same id. Both directions are tested.

Streams block the thread that writes them, so on JDK 21 and later the standalone server runs Jetty's handlers on virtual threads; below that it logs that streams share the worker pool. Embedded hosts get the same note in the docs.

## Client

`listen` and `unlisten` on the ClojureScript thin client and its JavaScript entry. A small frame parser, a decoder for the tagged values the events carry, `AbortController` per listener, and a callback that receives a report shaped like the local one: `db-after` is a remote handle, `tx-data` are datoms, absent with `truncated` above 500 datoms. Reconnection sends the last commit id and backs off; a status that will not fix itself, 401, 403 or 404, stops the listener and hands the application `{error, status}` instead of retrying forever. Cost in the bundle: 757 bytes gzipped (68,645 to 69,402), since the machinery is `fetch` and `JSON.parse`.

```javascript
const key = d.listen(conn, (report) => {
  if (report.deleted) return;
  refresh(report['db-after']);      // a handle: query it, or fetch a fresh db
});
d.unlisten(conn, key);
```

Three review rounds went into this; the reviewer reproduced the stale-lease defect rather than only reasoning about it, and the client's decoder, its stream framing across chunk boundaries and its retry policy were all wrong in ways tests now cover.

## Tests

`datahike.test.http.listen-test`: 401 without a token, 403 without read, two listeners seeing one write once, `since` current yielding no resync, a slow consumer getting `coalesced`, delete ending the streams. `kabel-test`: HTTP write seen by a Kabel subscriber and by an SSE listener, Kabel write likewise, each exactly once, and a Kabel delete ending an SSE stream. Node: a ClojureScript and a JavaScript listener against a live server.

## Not in this PR

A client-side result cache on immutable handles, live queries (the report says what changed; the application decides whether to re-query), and `listen` on the JVM thin client, which still throws as before.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3
