### PR TITLE
Bump pg-datahike to 0.1.189

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -197,7 +197,7 @@
                                org.replikativ/konserve-azure-blob
                                {:mvn/version "0.1.5"}
                                org.postgresql/postgresql     {:mvn/version "42.7.13"}
-                               org.replikativ/pg-datahike    {:mvn/version "0.1.167"
+                               org.replikativ/pg-datahike    {:mvn/version "0.1.189"
                                                                :exclusions [org.replikativ/datahike]}
                                http-kit/http-kit             {:mvn/version "2.8.1"}}}
 
@@ -284,7 +284,7 @@
                                       org.postgresql/postgresql
                                       {:mvn/version "42.7.13"}
                                       org.replikativ/pg-datahike
-                                      {:mvn/version "0.1.167"
+                                      {:mvn/version "0.1.189"
                                        :exclusions [org.replikativ/datahike]}}
                          :main-opts ["-m" "datahike.http.main"]}
 


### PR DESCRIPTION
## Summary

Pin both the Datahike Server test and runtime aliases to pg-datahike 0.1.189. This includes the completed beta compatibility campaign through per-session temporary-table isolation.

## Verification

Built the standalone server from this branch after downloading 0.1.189 from Clojars.

- standalone JAR soak: restart, file persistence, TLS verify-full, password authentication, and repeated abrupt client drops
- non-root Podman image soak: UID/GID 10001:10001 plus the same lifecycle checks across a named-volume stop/start
- both packaged JARs report Datahike 0.8.1869 and pg-datahike 0.1.189