### PR TITLE
listen and unlisten on the JVM thin client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **JVM thin-client change stream.** *Experimental.* `datahike.http.client`
+  now provides `listen` and `unlisten` for Clojure remote connections, with
+  the same SSE reports, automatic reconnect and resume, terminal deletion and
+  authentication-error behavior as the ClojureScript thin client.
 - **Persistent and in-memory caching for immutable snapshot reads.** The HTTP
   server marks referentially transparent URL reads against database values as
   `immutable`, and the TypeScript thin client deduplicates and retains up to

--- a/doc/thin-client.md
+++ b/doc/thin-client.md
@@ -82,8 +82,25 @@ job, not this client's.
 ## Change notification
 
 A thin client can follow the connected database without carrying a replica.
-In JavaScript, `listen` returns a key immediately and calls back with plain
-JavaScript reports; pass that key to `unlisten`:
+On the JVM and in ClojureScript, `listen` returns a key immediately and calls
+back with transaction-report maps; pass that key to `unlisten`:
+
+```clojure
+(require '[datahike.http.client :as client])
+
+(def listener
+  (client/listen conn ::ui
+    (fn [{:keys [db-after deleted error] :as report}]
+      (cond
+        error   (println "listen failed" error)
+        deleted (println "database deleted")
+        :else   (println (client/q '[:find ?e :where [?e]] db-after))))))
+
+(client/unlisten conn listener)
+```
+
+In JavaScript the callback receives the corresponding plain JavaScript
+object:
 
 ```javascript
 const listener = d.listen(conn, report => {
@@ -98,13 +115,6 @@ const listener = d.listen(conn, report => {
 d.unlisten(conn, listener);
 ```
 
-The ClojureScript API also accepts an explicit listener key:
-
-```clojure
-(def listener (client/listen conn ::ui refresh!))
-(client/unlisten conn listener)
-```
-
 The first callback is a resync report with `:resync true` and a `:db-after`
 handle. Later transaction reports contain `:db-after`, `:db-before nil`,
 `:tempids`, and `:commit-id`. Reports of at most 500 datoms also contain
@@ -117,8 +127,8 @@ The client reconnects after a stream error or clean disconnect, starting at
 commit id when reconnecting; the server resyncs when that id is no longer the
 head. `unlisten` aborts the open request and cancels reconnects. Deletion does
 not reconnect. HTTP 401, 403, and 404 responses are terminal too: the callback
-receives `{:error <ex-info> :status <integer>}` in ClojureScript, or an object
-with `error` and `status` in JavaScript, and the listener stops.
+receives `{:error <ex-info> :status <integer>}` in Clojure or ClojureScript,
+or an object with `error` and `status` in JavaScript, and the listener stops.
 
 ## What is not there
 

--- a/src/datahike/http/client.cljc
+++ b/src/datahike/http/client.cljc
@@ -10,7 +10,8 @@
    fit (`url-args-limit`), which is what lets an HTTP cache serve it; larger
    arguments go by POST."
   (:refer-clojure :exclude [filter])
-  (:require #?@(:clj [[babashka.http-client :as http]
+  (:require [clojure.string :as str]
+            #?@(:clj [[babashka.http-client :as http]
                       [cognitect.transit :as transit]
                       [jsonista.core :as j]
                       [hasch.core :refer [uuid]]
@@ -18,7 +19,6 @@
                       [datahike.datom :as dd]
                       [datahike.impl.entity :as de]]
                 :cljs [[clojure.core.async :as async]
-                       [clojure.string :as str]
                        [datahike.datom :as dd]])
             ;; The specification drives the JVM's generated functions at load
             ;; and ClojureScript's at macro time; a browser bundle carries
@@ -30,7 +30,8 @@
             ;; The logger and its printer stay out of the browser bundle; a
             ;; request is traced with the console there.
             #?(:clj [replikativ.logging :as log]))
-  #?(:clj (:import [java.io ByteArrayOutputStream])
+  #?(:clj (:import [java.io BufferedReader ByteArrayOutputStream InputStreamReader]
+                   [java.lang Thread])
      :cljs (:require-macros [datahike.http.client :refer [emit-remote-api]])))
 
 (def MEGABYTE (* 1024 1024))
@@ -356,7 +357,218 @@
 #?(:clj (declare db))
 
 #?(:clj
-   (doseq [[n {:keys [args doc supports-remote? referentially-transparent?]}] api/api-specification]
+   (do
+     (defonce ^:private listeners (atom {}))
+
+     (defn- listener-id [conn key]
+       [(get-in conn [:remote-peer :url]) (:store-id conn) key])
+
+     (defn- active-listener? [{:keys [id stopped?] :as listener}]
+       (and (not @stopped?) (identical? listener (get @listeners id))))
+
+     (defn- close-listen-stream! [{:keys [stream]}]
+       (when-let [body @stream]
+         (reset! stream nil)
+         (try
+           (.close ^java.io.Closeable body)
+           (catch Exception _))))
+
+     (defn- stop-listener! [{:keys [id stopped? thread] :as listener}]
+       (reset! stopped? true)
+       (close-listen-stream! listener)
+       (when-let [worker @thread]
+         (when-not (identical? worker (Thread/currentThread))
+           (.interrupt ^Thread worker)))
+       (swap! listeners #(if (identical? listener (get % id)) (dissoc % id) %)))
+
+     (defn- remote-db-from-head [conn head]
+       (binding [remote/*remote-peer* (:remote-peer conn)]
+         (remote/remote-db
+          (assoc (select-keys head [:max-tx :max-eid :commit-id])
+                 :store-id (if (sequential? (:store-id head))
+                             (:store-id head)
+                             [(:store-id head) (:branch head :db)])))))
+
+     (defn- invoke-listener-callback! [{:keys [callback]} report]
+       (try
+         (callback report)
+         (catch Throwable error
+           (log/error :datahike/http-listen-callback-error
+                      {:message (ex-message error)
+                       :error-class (.getName (class error))}))))
+
+     (defn- deliver-listen-event!
+       [{:keys [conn last-commit] :as listener} event data]
+       (when (active-listener? listener)
+         (case event
+           "report"
+           (do
+             (reset! last-commit (:commit-id data))
+             (invoke-listener-callback!
+              listener
+              (cond-> {:db-after (remote-db-from-head conn data)
+                       :db-before nil
+                       :tempids (:tempids data)
+                       :commit-id (:commit-id data)}
+                (contains? data :tx-data) (assoc :tx-data (:tx-data data))
+                (:truncated data) (assoc :truncated true))))
+
+           ("resync" "coalesced")
+           (do
+             (reset! last-commit (:commit-id data))
+             (invoke-listener-callback!
+              listener {:resync true :db-after (remote-db-from-head conn data)}))
+
+           "deleted"
+           (do
+             (invoke-listener-callback! listener {:deleted true})
+             (stop-listener! listener))
+
+           nil)))
+
+     (defn- sse-field-value [line prefix]
+       (let [value (subs line (count prefix))]
+         (if (str/starts-with? value " ") (subs value 1) value)))
+
+     (defn- read-listen-stream! [listener body]
+       (with-open [reader (BufferedReader. (InputStreamReader. body "UTF-8"))]
+         (loop [event nil data []]
+           (when (active-listener? listener)
+             (if-let [line (.readLine reader)]
+               (cond
+                 (empty? line)
+                 (do
+                   (when (and event (seq data))
+                     (deliver-listen-event!
+                      listener event
+                      (j/read-value (str/join "\n" data) remote/json-mapper)))
+                   (recur nil []))
+
+                 (str/starts-with? line ":")
+                 (recur event data)
+
+                 (str/starts-with? line "event:")
+                 (recur (sse-field-value line "event:") data)
+
+                 (str/starts-with? line "data:")
+                 (recur event (conj data (sse-field-value line "data:")))
+
+                 :else
+                 (recur event data))
+               nil)))))
+
+     (defn- listen-target [{:keys [conn last-commit]}]
+       (let [{:keys [url]} (:remote-peer conn)
+             [store-id branch] (if (sequential? (:store-id conn))
+                                 (:store-id conn)
+                                 [(:store-id conn) :db])]
+         {:url (str url "/listen")
+          :query-params (cond-> {"store" (str store-id)
+                                 "branch" (name branch)}
+                          @last-commit (assoc "since" (str @last-commit)))}))
+
+     (defn- wait-to-reconnect [listener delay]
+       (try
+         (Thread/sleep delay)
+         (active-listener? listener)
+         (catch InterruptedException _ false)))
+
+     (defn- listen-once! [{:keys [conn stream] :as listener}]
+       (let [{:keys [url query-params]} (listen-target listener)
+             {:keys [token]} (:remote-peer conn)
+             response (http/get url
+                                {:query-params query-params
+                                 :headers (cond-> {"accept" "text/event-stream"}
+                                            token (assoc "authorization" (str "token " token)))
+                                 :as :stream
+                                 :throw false})
+             status (:status response)
+             body (:body response)]
+         (cond
+           (contains? #{401 403 404} status)
+           (do
+             (when body
+               (try (.close ^java.io.Closeable body) (catch Exception _)))
+             (invoke-listener-callback!
+              listener {:error (ex-info (str "HTTP " status " from " url)
+                                        {:status status :url url})
+                        :status status})
+             (stop-listener! listener)
+             :terminal)
+
+           (= 200 status)
+           (do
+             (reset! stream body)
+             (try
+               (when (active-listener? listener)
+                 (read-listen-stream! listener body))
+               (catch Throwable error
+                 (when (active-listener? listener)
+                   (log/error :datahike/http-listen-error
+                              {:message (ex-message error)
+                               :error-class (.getName (class error))})))
+               (finally
+                 (close-listen-stream! listener)))
+             :success)
+
+           :else
+           (do
+             (when body
+               (try (.close ^java.io.Closeable body) (catch Exception _)))
+             (throw (ex-info (str "HTTP " status " from " url)
+                             {:status status :url url}))))))
+
+     (defn- run-listener! [listener]
+       (loop [backoff 500]
+         (when (active-listener? listener)
+           (let [outcome (try
+                           (listen-once! listener)
+                           (catch Throwable error
+                             (when (active-listener? listener)
+                               (log/error :datahike/http-listen-error
+                                          {:message (ex-message error)
+                                           :error-class (.getName (class error))}))
+                             :failure))]
+             (case outcome
+               :success (when (wait-to-reconnect listener 500)
+                          (recur 1000))
+               :failure (when (wait-to-reconnect listener backoff)
+                          (recur (min 30000 (* 2 backoff))))
+               nil)))))
+
+     (declare unlisten)
+
+     (defn listen
+       "Listen for remote changes so a thin client can refresh without polling."
+       ([conn callback]
+        (listen conn (str (random-uuid)) callback))
+       ([conn key callback]
+        (unlisten conn key)
+        (let [listener {:id (listener-id conn key)
+                        :conn conn
+                        :callback callback
+                        :last-commit (atom nil)
+                        :stream (atom nil)
+                        :thread (atom nil)
+                        :stopped? (atom false)}
+              worker (doto (Thread. #(run-listener! listener)
+                                    (str "datahike-http-listen-" key))
+                       (.setDaemon true))]
+          (reset! (:thread listener) worker)
+          (swap! listeners assoc (:id listener) listener)
+          (.start worker)
+          key)))
+
+     (defn unlisten
+       "Stop a remote change listener so its request and reconnect loop release resources."
+       [conn key]
+       (when-let [listener (get @listeners (listener-id conn key))]
+         (stop-listener! listener))
+       nil)))
+
+#?(:clj
+   (doseq [[n {:keys [args doc supports-remote? referentially-transparent?]}] api/api-specification
+           :when (not (#{'listen 'unlisten} n))]
      (eval
       `(def
          ~(with-meta n

--- a/src/datahike/http/client.cljc
+++ b/src/datahike/http/client.cljc
@@ -430,7 +430,7 @@
        (let [value (subs line (count prefix))]
          (if (str/starts-with? value " ") (subs value 1) value)))
 
-     (defn- read-listen-stream! [listener body]
+     (defn- read-listen-stream! [listener ^java.io.InputStream body]
        (with-open [reader (BufferedReader. (InputStreamReader. body "UTF-8"))]
          (loop [event nil data []]
            (when (active-listener? listener)
@@ -467,7 +467,7 @@
                                  "branch" (name branch)}
                           @last-commit (assoc "since" (str @last-commit)))}))
 
-     (defn- wait-to-reconnect [listener delay]
+     (defn- wait-to-reconnect [listener ^long delay]
        (try
          (Thread/sleep delay)
          (active-listener? listener)

--- a/test/datahike/test/http/client_listen_test.clj
+++ b/test/datahike/test/http/client_listen_test.clj
@@ -1,0 +1,119 @@
+(ns datahike.test.http.client-listen-test
+  "The JVM thin client's SSE change listener."
+  (:require
+   [clojure.core.async :as async]
+   [clojure.test :refer [deftest is testing]]
+   [datahike.api :as d]
+   [datahike.connections :refer [*connections*]]
+   [datahike.datom :as datom]
+   [datahike.http.client :as client]
+   [datahike.http.routes :as routes]
+   [ring.adapter.jetty :refer [run-jetty]])
+  (:import
+   [datahike.remote RemoteDB]
+   [java.net ServerSocket]))
+
+(def ^:private token "client-listen-test-token")
+
+(defn- free-port []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+(defn- take-with-timeout [ch timeout-ms]
+  (let [timeout (async/timeout timeout-ms)
+        [value port] (async/alts!! [ch timeout])]
+    (if (= port timeout) ::timeout value)))
+
+(defn- test-system []
+  (let [port (free-port)
+        store-id (random-uuid)
+        cfg {:store {:backend :memory :id store-id} :schema-flexibility :read}
+        connections (atom {})
+        handler (routes/handler {:token token} {:connections connections})
+        attempts (atom 0)
+        app (fn [request]
+              (when (= "/listen" (:uri request))
+                (swap! attempts inc))
+              (handler request))
+        server (run-jetty app {:host "127.0.0.1" :port port :join? false})
+        peer {:backend :datahike-server
+              :url (str "http://127.0.0.1:" port)
+              :token token
+              :format :cbor}]
+    (binding [*connections* connections]
+      (d/create-database cfg))
+    {:attempts attempts
+     :cfg cfg
+     :connections connections
+     :handler handler
+     :peer peer
+     :server server}))
+
+(defn- stop-system! [{:keys [cfg connections handler peer server]}]
+  (try
+    (client/delete-database (assoc cfg :remote-peer peer))
+    (catch Throwable _))
+  (.stop server)
+  (routes/release-all! handler)
+  (binding [*connections* connections]
+    (try
+      (d/delete-database cfg)
+      (catch Throwable _))))
+
+(deftest jvm-client-listens-unlistens-and-sees-deletion
+  (let [{:keys [cfg peer] :as system} (test-system)
+        conn (client/connect (assoc cfg :remote-peer peer))
+        events (async/chan 10)]
+    (try
+      (let [key (client/listen conn #(async/put! events %))]
+        (testing "the first callback is a resync with a usable remote DB"
+          (let [resync (take-with-timeout events 5000)]
+            (is (not= ::timeout resync))
+            (is (= true (:resync resync)))
+            (is (instance? RemoteDB (:db-after resync)))))
+
+        (testing "a client transaction delivers datoms and a queryable db-after"
+          (client/transact conn [{:name "Ada"}])
+          (let [report (take-with-timeout events 5000)]
+            (is (not= ::timeout report))
+            (is (seq (:tx-data report)))
+            (is (every? datom/datom? (:tx-data report)))
+            (is (= #{["Ada"]}
+                   (client/q '[:find ?name :where [?e :name ?name]]
+                             (:db-after report))))))
+
+        (testing "unlisten stops delivery"
+          (client/unlisten conn key)
+          (client/transact conn [{:name "Grace"}])
+          (is (= ::timeout (take-with-timeout events 500)))))
+
+      (testing "database deletion is terminal"
+        (client/listen conn ::deletion #(async/put! events %))
+        (is (= true (:resync (take-with-timeout events 5000))))
+        (client/release conn)
+        (client/delete-database (assoc cfg :remote-peer peer))
+        (is (= {:deleted true} (take-with-timeout events 5000))))
+      (finally
+        (client/unlisten conn ::deletion)
+        (try (client/release conn) (catch Throwable _))
+        (stop-system! system)))))
+
+(deftest authentication-failure-is-terminal
+  (let [{:keys [attempts cfg peer] :as system} (test-system)
+        bad-peer (assoc peer :token "wrong")
+        conn (client/connect (assoc cfg :remote-peer peer))
+        events (async/chan 10)]
+    (try
+      (client/listen (assoc conn :remote-peer bad-peer) ::bad-token
+                     #(async/put! events %))
+      (let [failure (take-with-timeout events 5000)
+            attempts-after-error @attempts]
+        (is (instance? clojure.lang.ExceptionInfo (:error failure)))
+        (is (= 401 (:status failure)))
+        (is (= ::timeout (take-with-timeout events 750)))
+        (is (= attempts-after-error @attempts)
+            "a terminal authentication failure is not retried"))
+      (finally
+        (client/unlisten (assoc conn :remote-peer bad-peer) ::bad-token)
+        (try (client/release conn) (catch Throwable _))
+        (stop-system! system)))))


### PR DESCRIPTION
Builds on #1068, which builds on #1066. Merge those first.

## Why

`GET /listen` gave the change stream to the JavaScript client. A Clojure program using the thin client, `:remote-peer {:backend :datahike-server}`, could not subscribe: the generated `listen` and `unlisten` threw "not supported for remote connections". Now they work, with the semantics the ClojureScript side already has, so the same code reads the same way on both platforms.

```clojure
(def key (client/listen conn (fn [report]
                               (cond (:deleted report) (stop!)
                                     (:error report)   (log/warn (:error report))
                                     :else             (refresh! (:db-after report))))))
(client/unlisten conn key)
```

## What

A streaming request on a dedicated thread, so a blocking read never occupies the async dispatch pool, feeding a frame parser and the server's JSON decoding. The callback receives the report shape the ClojureScript client produces: `db-after` as a remote handle you can query, `tx-data` as datoms, `tempids`, `truncated` for a large transaction, `{:resync true}` after a gap and `{:deleted true}` when the database goes away. Reconnection carries the last commit id and backs off from 500 ms to 30 s, resetting on a successful connection; 401, 403 and 404 are terminal and deliver `{:error … :status …}` rather than retrying forever. `unlisten` interrupts the reader and closes the stream. A callback that throws is caught and does not kill the loop.

`listen` and `unlisten` are excluded from the generated JVM API definitions so the hand-written ones stand.

## Tests

`datahike.test.http.client-listen-test` against a real server: resync then a report whose datoms are datoms and whose `db-after` can be queried through the client, `unlisten` stopping delivery, a delete delivering `{:deleted true}`, and a bad token delivering a 401 error without retrying. Run on both index tiers, since the earlier flake in this area was a timing race that only one tier lost, plus the Kabel tier and the full JVM tier.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3