### PR TITLE
A result cache for snapshot reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Persistent and in-memory caching for immutable snapshot reads.** The HTTP
+  server marks referentially transparent URL reads against database values as
+  `immutable`, and the TypeScript thin client deduplicates and retains up to
+  128 such results per client instance with configurable LRU eviction.
 - **Bounded query execution.** Queries accept `:timeout` in milliseconds and
   fail with `:datahike/query-timeout` when the engine reaches the deadline,
   including planner, relational, rule and nested-query execution. The dynamic

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -443,11 +443,15 @@ A read (every function the specification marks referentially transparent)
 is a GET. Its arguments travel either in the body, as the JVM client sends
 them, or in the URL as `?args=<base64url of the encoded argument vector>&f=cbor`
 (`f` is `cbor`, `transit`, `edn` or `json`), which is what a browser client
-sends since a browser cannot GET with a body. Either way the response
-carries the cache headers `:cache {:get {:max-age …}}` asks for, and the URL
-form is what an HTTP cache keys on. Every read route answers POST as well,
-for arguments too large for a URL; that path is never cached. Writes are
-POST only.
+sends since a browser cannot GET with a body. The URL response carries the
+cache headers `:cache {:get {:max-age …}}` asks for, and the URL form is what
+an HTTP cache keys on. When every Datahike handle in a referentially
+transparent call is an immutable database value (including historical, since,
+and as-of views), and at least one is present, the URL response instead carries
+`max-age=31536000, immutable`; a connection handle never does. This is what
+makes a browser's own HTTP cache a correct persistent cache for snapshot reads.
+Every read route answers POST as well, for arguments too large for a URL; that
+path is never cached. Writes are POST only.
 
 ### What may be created
 

--- a/doc/thin-client.md
+++ b/doc/thin-client.md
@@ -72,6 +72,13 @@ POST with a JSON body, which is never cached. A write is always a POST. A
 database handle carries the snapshot's commit id, so a read against one is
 the same result for as long as the handle is used.
 
+The TypeScript client keeps up to 128 snapshot-read results per client instance
+in an in-memory least-recently-used cache. `configureCache({maxEntries})`
+changes that bound (zero disables it), and `clearCache()` empties it. The cache
+dies with the page and uses neither localStorage nor IndexedDB. Persistence
+across sessions is the browser's HTTP cache; offline reads are the replica's
+job, not this client's.
+
 ## Change notification
 
 A thin client can follow the connected database without carrying a replica.
@@ -118,9 +125,6 @@ with `error` and `status` in JavaScript, and the listener stops.
 - No offline operation: every call needs the server.
 - No streaming results: a query result arrives whole. Use `:limit` and
   `:offset`, or narrow the query.
-- No client-side result cache yet. A read against a database handle is
-  immutable for that snapshot, so one is possible; the HTTP cache covers the
-  GET path meanwhile.
 
 ## Reference
 

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -25,6 +25,8 @@
    [clojure.core.async :as async]
    [clojure.core.async.impl.protocols :as async-protocols]
    [datahike.connections :refer [*connections*]]
+   [datahike.connector :as connector]
+   [datahike.db.utils :as dbu]
    [datahike.store]
    [reitit.core :as reitit]
    [datahike.api.specification :refer [api-specification ->url]]
@@ -166,6 +168,16 @@
        (keep database-of)
        distinct
        vec))
+
+(defn- immutable-database-arguments?
+  "True when `args` contains a database value and no connection or other
+   database-bearing handle."
+  [args]
+  (let [values (mapcat #(tree-seq descend? seq %) args)]
+    (and (some dbu/db? values)
+         (not-any? #(or (connector/connection? %)
+                        (instance? Entity %))
+                   values))))
 
 (defn authorize
   "The 403 for `op` with `args` under `config`'s `:authorize`, or nil when the
@@ -562,7 +574,7 @@
 ;; The API routes
 ;; ---------------------------------------------------------------------------
 
-(defn- generic-handler [config state op f]
+(defn- generic-handler [config state op referentially-transparent? f]
   (fn [request]
     (try
       (let [{{body :body} :parameters
@@ -646,8 +658,13 @@
                (when (and (= method :get)
                           (or (get params "args-id") (get params "args"))
                           (get-in config [:cache :get :max-age]))
-                 {:headers {"Cache-Control" (str (when (:dev-mode config) "public, ")
-                                                 "max-age=" (get-in config [:cache :get :max-age]))}})))))
+                 {:headers
+                  {"Cache-Control"
+                   (str (when (:dev-mode config) "public, ")
+                        (if (and referentially-transparent?
+                                 (immutable-database-arguments? body))
+                          "max-age=31536000, immutable"
+                          (str "max-age=" (get-in config [:cache :get :max-age]))))}})))))
       (catch Exception e
         (throwable-response e)))))
 
@@ -788,7 +805,7 @@
                      :summary     (extract-first-sentence doc)
                      :description doc
                      :parameters  {:body (extract-input-schema args)}
-                     :handler     `(generic-handler ~'config ~'state ~(route-op n referentially-transparent?) ~(resolve n))}]
+                     :handler     `(generic-handler ~'config ~'state ~(route-op n referentially-transparent?) ~referentially-transparent? ~(resolve n))}]
           `[~(str "/" (->url n))
             ;; A read is a GET, cached by its URL: the arguments travel in the
             ;; `args` parameter (`url-args-middleware`) or, for a client that

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -333,9 +333,14 @@
 
 (deftest a-read-by-url-or-by-post
   (testing "a GET carries its arguments in the URL and is cached; a POST carries them in the body and is not"
-    (let [port      23202
-          server    (run-jetty (routes/handler {:token token :dev-mode false :cache {:get {:max-age 60}}})
-                               {:port port :join? false})
+    (let [port        23202
+          connections (atom {})
+          server      (run-jetty (routes/handler {:token token :dev-mode false :cache {:get {:max-age 60}}}
+                                                 {:connections connections})
+                                 {:port port :join? false})
+          uncached-server (run-jetty (routes/handler {:token token :dev-mode false}
+                                                     {:connections connections})
+                                     {:port 23203 :join? false})
           url       (str "http://localhost:" port)
           peer      {:backend :datahike-server :url url :token token :format :cbor}
           registry  (rcbor/client-registry)
@@ -354,17 +359,28 @@
               by-get  (http/get (str url "/q?args=" (base64url (encode q-args)) "&f=cbor")
                                 {:headers headers :as :bytes})
               by-post (http/post (str url "/q") {:headers (assoc headers "content-type" "application/cbor")
-                                                 :body (encode q-args) :as :bytes})]
+                                                 :body (encode q-args) :as :bytes})
+              by-connection (http/post (str url "/db")
+                                       {:headers (assoc headers "content-type" "application/cbor")
+                                        :body (encode [conn]) :as :bytes})
+              cache-unset (http/get (str "http://localhost:23203/q?args="
+                                         (base64url (encode q-args)) "&f=cbor")
+                                    {:headers headers :as :bytes})]
           (is (= #{["Ada"]} (decode (:body by-get))))
           (is (= #{["Ada"]} (decode (:body by-post))))
-          (is (re-find #"max-age=60" (get-in by-get [:headers "cache-control"] ""))
-              "a read by URL is cacheable")
+          (is (= "max-age=31536000, immutable" (get-in by-get [:headers "cache-control"]))
+              "a snapshot read by URL is immutable")
           (is (nil? (get-in by-post [:headers "cache-control"]))
               "a read by POST is not")
+          (is (nil? (get-in by-connection [:headers "cache-control"]))
+              "a call carrying a connection is not immutable")
+          (is (nil? (get-in cache-unset [:headers "cache-control"]))
+              "without cache configuration no header is added")
           (is (= 500 (:status (http/get (str url "/q?args=" (base64url (encode q-args)) "&f=nope")
                                         {:headers headers :throw false})))
               "an unknown args format is refused"))
         (finally
+          (.stop uncached-server)
           (.stop server))))))
 
 (deftest query-timeout-is-a-clean-http-error

--- a/ts-client/build.mjs
+++ b/ts-client/build.mjs
@@ -13,7 +13,7 @@ const generated = fs.readFileSync(path.join(compiled, "api.generated.js"), "utf8
 const names = [...generated.matchAll(/^export function ([A-Za-z0-9_$]+)/gm)]
   .map((match) => match[1])
   .filter((name, index, all) => all.indexOf(name) === index);
-const helpers = ["isPromise", "listen", "randomUuid", "unlisten", "uuid"];
+const helpers = ["clearCache", "configureCache", "isPromise", "listen", "randomUuid", "unlisten", "uuid"];
 const esm = `${core}\n${generated}\nexport { ${helpers.join(", ")} };\n` +
   `export default { ${[...names, ...helpers].join(", ")} };\n`;
 

--- a/ts-client/src/core.ts
+++ b/ts-client/src/core.ts
@@ -3,6 +3,9 @@ const rawSymbol: unique symbol = Symbol("datahike.raw");
 const peerSymbol: unique symbol = Symbol("datahike.peer");
 const uuidSymbol: unique symbol = Symbol("datahike.uuid");
 
+const resultCache = new Map<string, Promise<any>>();
+let maxCacheEntries = 128;
+
 export type Keyword = `:${string}`;
 export type Attribute = Keyword;
 export type UuidValue = string;
@@ -245,6 +248,35 @@ function encodeValue(value: unknown): unknown {
   return value;
 }
 
+function cacheableArguments(value: unknown): boolean {
+  let database = false;
+  let connection = false;
+  const visit = (item: unknown): void => {
+    if (!Array.isArray(item)) {
+      if (item !== null && typeof item === "object") Object.values(item).forEach(visit);
+      return;
+    }
+    if (item[0] === "!datahike/Connection") connection = true;
+    if (["!datahike/DB", "!datahike/HistoricalDB", "!datahike/SinceDB", "!datahike/AsOfDB"].includes(item[0])) {
+      database = true;
+    } else {
+      item.forEach(visit);
+    }
+  };
+  visit(value);
+  return database && !connection;
+}
+
+export function configureCache({ maxEntries }: { maxEntries: number }): void {
+  if (!Number.isInteger(maxEntries) || maxEntries < 0) throw new RangeError("maxEntries must be a non-negative integer.");
+  maxCacheEntries = maxEntries;
+  while (resultCache.size > maxEntries) resultCache.delete(resultCache.keys().next().value!);
+}
+
+export function clearCache(): void {
+  resultCache.clear();
+}
+
 function peerFromArgs(args: unknown[]): RemotePeer {
   const peers = new Set<RemotePeer>();
   const first = args[0];
@@ -324,30 +356,50 @@ async function responseValue(response: Response, target: string, peer: RemotePee
   return decoded;
 }
 
-export async function request(
+export function request(
   route: string,
-  readable: boolean,
+  referentiallyTransparent: boolean,
   args: unknown[],
   create = false,
 ): Promise<any> {
   const peer = peerFromArgs(args);
-  const encoded = new TextEncoder().encode(
-    JSON.stringify(encodeValue(normalizeSetArguments(route, withoutCredentials(args)))),
-  );
-  const asGet = readable && encoded.byteLength <= 2048;
+  const encodedArgs = encodeValue(normalizeSetArguments(route, withoutCredentials(args)));
+  const encodedString = JSON.stringify(encodedArgs);
+  const encoded = new TextEncoder().encode(encodedString);
+  const cacheKey = `${route}\0${encodedString}`;
+  const cacheable = referentiallyTransparent && maxCacheEntries > 0 && cacheableArguments(encodedArgs);
+  if (cacheable) {
+    const cached = resultCache.get(cacheKey);
+    if (cached) {
+      resultCache.delete(cacheKey);
+      resultCache.set(cacheKey, cached);
+      return cached;
+    }
+  }
+  const asGet = referentiallyTransparent && encoded.byteLength <= 2048;
   const base = `${peer.url}/${route}`;
   const target = asGet ? `${base}?args=${base64url(encoded)}&f=json` : base;
   const headers: Record<string, string> = { Accept: "application/json" };
   if (!asGet) headers["Content-Type"] = "application/json";
   if (peer.token) headers.Authorization = `token ${peer.token}`;
-  const response = await fetch(target, {
+  const promise = fetch(target, {
     method: asGet ? "GET" : "POST",
     headers,
     ...(asGet ? {} : { body: encoded }),
+  }).then((response) => responseValue(response, target, peer)).then((result) => {
+    if (create && result !== null && typeof result === "object") result["remote-peer"] = peer;
+    return result;
   });
-  const result = await responseValue(response, target, peer);
-  if (create && result !== null && typeof result === "object") result["remote-peer"] = peer;
-  return result;
+  if (cacheable) {
+    const cached = promise.catch((error) => {
+      if (resultCache.get(cacheKey) === cached) resultCache.delete(cacheKey);
+      throw error;
+    });
+    resultCache.set(cacheKey, cached);
+    if (resultCache.size > maxCacheEntries) resultCache.delete(resultCache.keys().next().value!);
+    return cached;
+  }
+  return promise;
 }
 
 export function uuid(value: string): DatahikeUuid {

--- a/ts-client/src/index.ts
+++ b/ts-client/src/index.ts
@@ -1,8 +1,8 @@
 import * as api from "./api.generated.js";
-import { isPromise, listen, randomUuid, unlisten, uuid } from "./core.js";
+import { clearCache, configureCache, isPromise, listen, randomUuid, unlisten, uuid } from "./core.js";
 
 export * from "./api.generated.js";
 export type * from "./core.js";
-export { isPromise, listen, randomUuid, unlisten, uuid };
+export { clearCache, configureCache, isPromise, listen, randomUuid, unlisten, uuid };
 
-export default { ...api, isPromise, listen, randomUuid, unlisten, uuid };
+export default { ...api, clearCache, configureCache, isPromise, listen, randomUuid, unlisten, uuid };

--- a/ts-client/test/remote.test.mjs
+++ b/ts-client/test/remote.test.mjs
@@ -24,10 +24,15 @@ function eventWhere(predicate, timeout = 5000) {
 test("TypeScript thin client against the JVM server", { skip: !url || !token }, async () => {
   const calls = [];
   const realFetch = globalThis.fetch;
+  let failNextQuery = false;
   let conn;
   let key;
   globalThis.fetch = (input, init) => {
     calls.push({ url: String(input), method: init?.method });
+    if (failNextQuery && String(input).includes("/q")) {
+      failNextQuery = false;
+      return Promise.reject(new Error("deliberate fetch failure"));
+    }
     return realFetch(input, init);
   };
 
@@ -46,11 +51,32 @@ test("TypeScript thin client against the JVM server", { skip: !url || !token }, 
     assert.ok(firstReport["tx-data"].every((datom) => typeof datom.e === "number"));
 
     const db = await d.db(conn);
-    const small = await d.q("[:find ?n :where [?e :name ?n]]", db);
+    d.clearCache();
+    const query = "[:find ?n :where [?e :name ?n]]";
+    const qCallsBefore = calls.filter((call) => call.url.includes("/q")).length;
+    const [small, duplicate] = await Promise.all([d.q(query, db), d.q(query, db)]);
     assert.deepEqual(small.map((row) => row[0]).sort(), ["Ada", "Grace"]);
+    assert.deepEqual(duplicate, small);
     const qCalls = calls.filter((call) => call.url.includes("/q"));
+    assert.equal(qCalls.length, qCallsBefore + 1);
     assert.equal(qCalls.at(-1).method, "GET");
     assert.match(qCalls.at(-1).url, /\?args=.*&f=json$/);
+
+    d.clearCache();
+    await d.q(query, db);
+    assert.equal(calls.filter((call) => call.url.includes("/q")).length, qCallsBefore + 2);
+
+    const dbCallsBefore = calls.filter((call) => call.url.endsWith("/db")).length;
+    await d.db(conn);
+    await d.db(conn);
+    assert.equal(calls.filter((call) => call.url.endsWith("/db")).length, dbCallsBefore + 2);
+
+    const failedQuery = "[:find ?n :where [?e :name ?n] [(identity true)]]";
+    const failedCallsBefore = calls.filter((call) => call.url.includes("/q")).length;
+    failNextQuery = true;
+    await assert.rejects(d.q(failedQuery, db), /deliberate fetch failure/);
+    await d.q(failedQuery, db);
+    assert.equal(calls.filter((call) => call.url.includes("/q")).length, failedCallsBefore + 2);
 
     const ages = Array.from({ length: 3000 }, (_, index) => index);
     const large = await d.q("[:find ?n :in $ [?a ...] :where [?e :age ?a] [?e :name ?n]]", db, ages);
@@ -76,6 +102,9 @@ test("TypeScript thin client against the JVM server", { skip: !url || !token }, 
     const laterDb = await d.db(conn);
     assert.equal(report["commit-id"], report["db-after"]["commit-id"]);
     assert.equal(report["commit-id"], laterDb["commit-id"]);
+    const laterCallsBefore = calls.filter((call) => call.url.includes("/q")).length;
+    assert.deepEqual((await d.q(query, laterDb)).map((row) => row[0]).sort(), ["Ada", "Grace"]);
+    assert.equal(calls.filter((call) => call.url.includes("/q")).length, laterCallsBefore + 1);
     assert.deepEqual(await d.q("[:find ?v :where [?e :listener/value ?v]]", report["db-after"]), [[":received"]]);
 
     d.unlisten(conn, key);


### PR DESCRIPTION
Builds on #1068. Merge that first; it is independent of #1070, which also builds on #1068.

## The rule

A Datahike database value is immutable, so a read against a database handle whose commit id is fixed returns the same answer forever and can be cached with no invalidation logic at all. A read that carries a **connection** handle means "now" and must never be cached. Everything here follows from that one distinction, which Datahike draws in its API and a database with only "now" cannot.

## Server

A referentially transparent GET whose arguments contain a database value, and no connection or entity, answers with `Cache-Control: max-age=31536000, immutable` instead of the configured `max-age`. Everything else is unchanged. `public` is still only added where it was before, so an authenticated response is not stored by shared caches; this makes the *browser's own* HTTP cache a correct persistent cache for snapshot reads, which is the reason the client needs no storage layer.

## Client

A small in-memory LRU in the TypeScript client, keyed by route and encoded arguments, entered only when the call is referentially transparent and its arguments carry a database value and no connection. It stores the promise, so two components asking the same question in one tick make one request, and a rejection is evicted so a failure is not remembered. `configureCache({maxEntries})` and `clearCache()` are exported; the default is 128 entries.

No localStorage, no IndexedDB, no dependency. Persistence across sessions is the browser's HTTP cache, which is isolated per origin and cleared with site data; offline reads are the replica's job. An in-memory cache also cannot outlive a logout, which a store of our own would have had to handle.

| | before | after |
|---|---|---|
| `remote/index.mjs` gzipped | 4,430 | 4,922 |

## Note on a deliberate asymmetry

The server declines to mark entity-carrying reads immutable while the client will cache them. Both are sound, since an entity handle carries a snapshot; the server is simply the more conservative of the two. Worth knowing rather than worth churning.

## Tests

Client, against a live server: the same query twice on one handle makes one request; a handle from a later commit makes a new one; a call carrying a connection is never served from the cache; `clearCache()` forces a request; a failed request is not remembered. Server: a `q` against a handle answers `immutable`, a call carrying a connection does not, and nothing changes when `:cache` is unset. Both index tiers, plus the full JVM tier and `bb npm-build`.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3