### PR TITLE
Query deadlines, and the Kabel listener enforces the store policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Bounded query execution.** Queries accept `:timeout` in milliseconds and
+  fail with `:datahike/query-timeout` when the engine reaches the deadline,
+  including planner, relational, rule and nested-query execution. The dynamic
+  `datahike.query/*query-timeout-ms*` supplies an ambient cap which a query may
+  shorten but not extend. HTTP and Kabel requests use the server's
+  `:query-timeout-ms` (30000 by default; `false` or `nil` disables it), and HTTP
+  reports a clean 503 response rather than an internal-error stack trace.
+- **Kabel creates obey `:create-database`.** The listener now applies the same
+  backend allow-list or server-pinned store root as HTTP creation. The policy
+  wins over the listener's own store configuration, preserves the client id,
+  and returns `:datahike.http/store-refused` when it rejects a create.
+
 - **The npm thin client is now TypeScript.** The `datahike/remote` entry uses
   a hand-written `fetch` transport and tagged-JSON codec instead of carrying
   the ClojureScript runtime and boring. Its generated API still follows the

--- a/doc/browser-replicas.md
+++ b/doc/browser-replicas.md
@@ -27,6 +27,7 @@ catalog and the permissions:
  :port 4444
  :token "replace-with-a-long-random-token"          ; the break-glass identity
  :system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
+ :create-database {:store {:backend :file :path "/var/lib/datahike/browser-databases"}}
  :kabel {:host "0.0.0.0"
          :port 47296
          :jwt {:alg :HS256                            ; or :RS256 with :public-key, or an :issuers registry
@@ -47,7 +48,9 @@ Port 4444 is the HTTP API, used below to manage permissions. Port 47296 is
 the WebSocket the browser connects to; put TLS in front of it and use `wss://`
 anywhere but on a loopback development setup. The server never lets a client
 choose a filesystem path: every browser database is stored below the
-listener's `:store :path` in a directory named for its id.
+`:create-database :store :path` in a directory named for its id. That policy
+wins over the listener's `:store`; when no policy is set, the listener's
+`:store :path` is used instead.
 
 The server validates tokens; it does not issue them. Your application does,
 with the algorithm and key above, and the token's `sub` is the user. Any

--- a/doc/http-routes.md
+++ b/doc/http-routes.md
@@ -463,11 +463,14 @@ process may write. `:create-database` in the server config restricts that:
 ```
 
 With `:store` the client's store is replaced: the server keeps the id the
-client chose, or picks one, and places the database below its own root, as
-the Kabel listener does with its `:store`. With `:backends` the client's
-store is kept but its backend must be in the set. A refused create is `403`
-with `{:type :datahike.http/store-refused}`. Both keys may be given; without
-the option the server logs at start that creation is unrestricted.
+client chose, or picks one, and places the database below its own root. The
+same policy applies to Kabel creates. Its policy store wins over the Kabel
+listener's own `:store`; without a policy, the listener store remains the
+location. With `:backends` the resulting listener store or HTTP client's store
+must be in the set. A refused create is `403` over HTTP and carries
+`{:type :datahike.http/store-refused}` over both transports. Both keys may be
+given; without the option the server logs at start that HTTP creation is
+unrestricted.
 
 ### Query functions
 
@@ -515,6 +518,18 @@ fails with `Unknown function` (`:error :query/where`). `:query-functions
 :permissive` in the server config restores runtime resolution and is logged
 as a warning at start; it is for a server whose every client is trusted.
 
+### Query deadlines
+
+A server that accepts client queries needs a finite execution budget: an
+authorized client can otherwise submit a Cartesian product or recursive rule
+that occupies an execution thread indefinitely. Every HTTP request and Kabel
+dispatch therefore binds `:query-timeout-ms`, 30000 milliseconds by default.
+Set it to `false` or `nil` to disable the server cap. A query may include its
+own `:timeout` in milliseconds to ask for a shorter deadline, but cannot raise
+the server's ambient limit. A timeout returns HTTP 503 with
+`{:type :datahike/query-timeout, :timeout-ms ...}`; 503 denotes a temporary
+service resource limit rather than a timeout at an upstream gateway.
+
 The standalone server enforces the first two items at bind time: without a
 nonblank token or a validator, every resolved bind address must be loopback.
 Missing and wildcard hosts count as public. `:auth :upstream` is valid only for
@@ -537,11 +552,19 @@ clojure -M:http-server --config config.edn
  :join?    false
  :token    "securerandompassword"
  :dev-mode false
+ :query-timeout-ms 30000 ; default; false or nil disables the cap
  :query-functions :safe     ; the default; :permissive only for trusted clients
  :create-database {:store {:backend :file :path "/var/lib/datahike/databases"}}
  :level    :info
  :log-format :text}
 ```
+
+
+Cancellation is cooperative: the engine checks the deadline at its clause and
+join boundaries, so a query stops between steps rather than being interrupted
+mid-step. In practice a query that scans and joins is stopped promptly; the
+deadline is a bound on how long a request occupies a thread, not a hard
+real-time guarantee.
 
 ### Operator landing page
 

--- a/http-server/datahike/http/config.clj
+++ b/http-server/datahike/http/config.clj
@@ -59,6 +59,7 @@
    {:key :token        :parse non-blank}
    {:key :dev-mode     :parse parse-bool}
    {:key :shutdown-timeout-ms :parse parse-nonnegative-long}
+   {:key :query-timeout-ms :parse parse-nonnegative-long}
    {:key :query-functions :parse parse-query-functions}
    {:key :level        :parse parse-level}
    {:key :log-format   :parse parse-log-format}
@@ -83,6 +84,7 @@
    [nil "--token-file FILE" "Read the shared token from FILE" :parse-fn non-blank]
    [nil "--dev-mode BOOLEAN" "Enable or disable development authentication" :parse-fn parse-bool]
    [nil "--shutdown-timeout-ms MILLIS" "Grace period for in-flight requests" :parse-fn parse-nonnegative-long]
+   [nil "--query-timeout-ms MILLIS" "Maximum query duration (default 30000)" :parse-fn parse-nonnegative-long]
    [nil "--query-functions MODE" "Functions client queries may call: safe (default) or permissive" :parse-fn parse-query-functions]
    ["-l" "--level LEVEL" "Log level" :parse-fn parse-level]
    [nil "--log-format FORMAT" "Log format: text or json" :parse-fn parse-log-format]

--- a/http-server/datahike/http/kabel.clj
+++ b/http-server/datahike/http/kabel.clj
@@ -15,6 +15,7 @@
             [datahike.api :as d]
             [datahike.connections :refer [*connections*]]
             [datahike.http.routes :as routes]
+            [datahike.http.stores :as stores]
             [datahike.kabel.cbor-handlers :as cbor]
             [datahike.kabel.handlers :as handlers]
             [kabel.auth.websocket :as auth]
@@ -65,13 +66,22 @@
           (fail "A Kabel :file store requires a nonblank :path" {}))
         (assoc config :kabel (assoc kabel :host host :peer-id peer-id :store store))))))
 
-(defn- store-config-fn [{:keys [store]}]
-  (fn [store-id _client-config]
-    (case (:backend store)
-      :memory {:backend :memory :id store-id}
-      :file   {:backend :file
-               :path (.getPath (io/file (:path store) (str store-id)))
-               :id store-id})))
+(defn- store-config-fn
+  "Build the database configuration for a Kabel create. The listener's own
+   `:kabel :store` supplies the normal location, then the server's
+   `:create-database` policy is applied; where both apply, the policy wins."
+  [{:keys [kabel create-database]}]
+  (let [{:keys [store]} kabel]
+    (fn [store-id client-config]
+      (let [listener-store
+            (case (:backend store)
+              :memory {:backend :memory :id store-id}
+              :file   {:backend :file
+                       :path (.getPath (io/file (:path store) (str store-id)))
+                       :id store-id})]
+        (:store
+         (stores/assign create-database
+                        (assoc (or client-config {}) :store listener-store)))))))
 
 (defn- remote-name
   "The function a call names, as the symbol kabel resolves it to: kabel
@@ -175,7 +185,7 @@
   [config server {:keys [store] :as kabel} connections]
   (when (= :file (:backend store))
     (binding [*connections* connections]
-      (let [config-fn (store-config-fn kabel)]
+      (let [config-fn (store-config-fn (assoc config :kabel kabel))]
         (doseq [dir (some->> (io/file (:path store)) .listFiles (filter #(.isDirectory ^java.io.File %)))
                 :let [store-id (parse-uuid (.getName ^java.io.File dir))]
                 :when store-id]
@@ -214,7 +224,7 @@
                    cbor/datahike-cbor-middleware)
           served  (remote/serve server {:authorize (authorize-remote config)})]
       (handlers/register-global-handlers!
-       server {:store-config-fn (store-config-fn kabel)
+       server {:store-config-fn (store-config-fn (assoc config :kabel kabel))
                :on-connect (when bus-state
                              #(routes/register-report-listener! config bus-state %))
                :on-report (when bus-state
@@ -223,7 +233,7 @@
                ;; a go block carries its bindings across parks and the local
                ;; writer onto its thread, so the request's resolver holds
                ;; through the whole dispatch
-               :wrap-handler (let [run (routes/query-function-binding config)]
+               :wrap-handler (let [run (routes/request-binding config)]
                                (fn [handler]
                                  (fn [arg-map]
                                    (binding [*connections* connections]

--- a/http-server/datahike/http/routes.clj
+++ b/http-server/datahike/http/routes.clj
@@ -19,6 +19,7 @@
   (:refer-clojure :exclude [read-string filter])
   (:require
    [datahike.http.stores :as stores]
+   [datahike.query :as query]
    [datahike.query.resolve :as qr]
    [clojure.string :as str]
    [clojure.core.async :as async]
@@ -83,6 +84,22 @@
   [e]
   {:status 500
    :body   {:msg (ex-message e) :ex-data (redact (ex-data e))}})
+
+(declare store-refused)
+
+(defn- query-timeout-response
+  "503 means the service deliberately stopped work at its configured resource
+   limit; unlike 504, no upstream gateway timed out. The request may be retried
+   with a cheaper query."
+  [e]
+  {:status 503
+   :body {:msg (ex-message e) :ex-data (redact (ex-data e))}})
+
+(defn- throwable-response [e]
+  (case (:type (ex-data e))
+    :datahike.http/store-refused (store-refused e)
+    :datahike/query-timeout (query-timeout-response e)
+    (error-response e)))
 
 (defn- store-refused
   "403 for a store the server's `:create-database` policy does not allow."
@@ -632,9 +649,7 @@
                  {:headers {"Cache-Control" (str (when (:dev-mode config) "public, ")
                                                  "max-age=" (get-in config [:cache :get :max-age]))}})))))
       (catch Exception e
-        (if (= :datahike.http/store-refused (:type (ex-data e)))
-          (store-refused e)
-          (error-response e))))))
+        (throwable-response e)))))
 
 (declare create-routes)
 
@@ -825,9 +840,7 @@
                                                               (stores/assign (:create-database config) cfg)
                                                               (rest body)))}
                                    (catch Exception e
-                                     (if (= :datahike.http/store-refused (:type (ex-data e)))
-                                       (store-refused e)
-                                       (error-response e)))))))
+                                     (throwable-response e))))))
             :operationId "create-database"},
      :swagger {:tags ["Internal"]}}]
    ["/transact!-writer"
@@ -965,10 +978,28 @@
     (throw (ex-info ":query-functions must be :safe or :permissive"
                     {:type :datahike.http/invalid-config :query-functions query-functions}))))
 
+(defn request-binding
+  "How each HTTP request or Kabel dispatch runs: under the configured query
+   function resolver and a query deadline. `:query-timeout-ms` defaults to
+   30000; an explicit false or nil disables the server cap."
+  [config]
+  (let [run (query-function-binding config)
+        timeout-ms (if (contains? config :query-timeout-ms)
+                     (:query-timeout-ms config)
+                     30000)]
+    (when-not (or (nil? timeout-ms) (false? timeout-ms)
+                  (and (integer? timeout-ms) (<= 0 timeout-ms)))
+      (throw (ex-info ":query-timeout-ms must be false, nil, or a nonnegative integer"
+                      {:type :datahike.http/invalid-config
+                       :query-timeout-ms timeout-ms})))
+    (fn [thunk]
+      (binding [query/*query-timeout-ms* (when timeout-ms timeout-ms)]
+        (run thunk)))))
+
 (defn- wrap-query-functions
-  "Run every request under `config`'s query function resolver."
+  "Run every request under `config`'s query resolver and deadline."
   [handler config]
-  (let [run (query-function-binding config)]
+  (let [run (request-binding config)]
     (fn [request] (run #(handler request)))))
 
 (defn handler
@@ -998,7 +1029,8 @@
    Every request runs under the query function resolver `config` asks for
    (`:query-functions`, `:safe` by default; see `query-function-binding`),
    so what a client sends never resolves symbols the host did not allow,
-   while the host's own queries are untouched.
+   while the host's own queries are untouched. Queries are capped by
+   `:query-timeout-ms` (30000 by default); false or nil disables the cap.
 
    The returned fn carries the atom as metadata; `(release-all! handler)`
    releases what the routes opened when the host shuts down."

--- a/src/datahike/query.cljc
+++ b/src/datahike/query.cljc
@@ -53,7 +53,8 @@
                    [datalog.parser.type Aggregate BindColl BindIgnore BindScalar BindTuple Constant
                     FindColl FindRel FindScalar FindTuple PlainSymbol Pull
                     RulesVar SrcVar Variable]
-                   [java.util Date Map HashSet HashSet])))
+                   [java.util Date Map HashSet HashSet]
+                   [java.util.concurrent Executors ScheduledExecutorService ThreadFactory TimeUnit])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -74,6 +75,74 @@
   "When true (default), query results are cached by [query args db-snapshot].
    Bind to false for benchmarking raw query execution."
   true)
+
+(def ^:dynamic *query-timeout-ms*
+  "The ambient query deadline in milliseconds. nil means no limit. A query's
+   own :timeout may shorten this limit but cannot extend it."
+  nil)
+
+(def ^:dynamic ^:private *query-cancel* nil)
+
+(declare memoized-parse-query)
+
+#?(:clj
+   (defonce ^:private ^ScheduledExecutorService query-timeout-scheduler
+     (Executors/newSingleThreadScheduledExecutor
+      (reify ThreadFactory
+        (newThread [_ runnable]
+          (doto (Thread. runnable "datahike-query-timeouts")
+            (.setDaemon true)))))))
+
+(defn- cancellation-value [cancel]
+  (when cancel @cancel))
+
+(defn- throw-cancellation! [value]
+  (if (= :datahike/query-timeout (:type value))
+    (throw (ex-info "query timed out" value))
+    (throw (ex-info "query canceled" {:datahike/canceled true}))))
+
+(defn- check-cancel! [cancel]
+  (when-let [value (cancellation-value cancel)]
+    (throw-cancellation! value)))
+
+(defn- combined-cancel [cancels]
+  (let [cancels (vec (remove nil? cancels))]
+    (case (count cancels)
+      0 nil
+      1 (first cancels)
+      #?(:clj (reify clojure.lang.IDeref
+                (deref [_] (some cancellation-value cancels)))
+         :cljs (reify IDeref
+                 (-deref [_] (some cancellation-value cancels)))))))
+
+(defn- effective-query-timeout [query]
+  (let [query-timeout (:qtimeout (memoized-parse-query query))
+        limits (remove nil? [*query-timeout-ms* query-timeout])]
+    (when (seq limits) (apply min limits))))
+
+(defn- run-with-query-timeout [query-map f]
+  (let [timeout-ms (effective-query-timeout (:query query-map))
+        timeout-cell (when (some? timeout-ms) (volatile! nil))
+        started #?(:clj (System/nanoTime) :cljs (.now js/Date))
+        fire! (fn []
+                (vreset! timeout-cell
+                         {:type :datahike/query-timeout
+                          :timeout-ms timeout-ms
+                          :elapsed-ms #?(:clj (long (/ (- (System/nanoTime) started) 1000000))
+                                         :cljs (long (- (.now js/Date) started)))}))
+        scheduled #?(:clj (when timeout-cell
+                            (.schedule query-timeout-scheduler
+                                       ^Runnable fire! (long timeout-ms) TimeUnit/MILLISECONDS))
+                     :cljs (when timeout-cell (js/setTimeout fire! timeout-ms)))
+        cancel (combined-cancel [(:cancel query-map) timeout-cell *query-cancel*])]
+    (try
+      (binding [*query-cancel* cancel]
+        (let [result (f (assoc query-map :cancel cancel))]
+          (check-cancel! cancel)
+          result))
+      (finally
+        #?(:clj (when scheduled (.cancel scheduled false))
+           :cljs (when scheduled (js/clearTimeout scheduled)))))))
 
 (declare -collect -resolve-clause resolve-clause raw-q)
 
@@ -802,6 +871,7 @@
       (persistent!
        (reduce
         (fn [acc t1]
+          (when *query-cancel* (check-cancel! *query-cancel*))
           (reduce (fn [acc t2]
                     (conj! acc (join-tuples t1 idxs1 t2 idxs2)))
                   acc (:tuples rel2)))
@@ -1429,7 +1499,8 @@
   (loop [tuples tuples
          hash-table (transient {})]
     (if-some [tuple (first tuples)]
-      (let [key (key-fn tuple)]
+      (let [_ (when *query-cancel* (check-cancel! *query-cancel*))
+            key (key-fn tuple)]
         (recur (next tuples)
                (assoc! hash-table key (conj (get hash-table key '()) tuple))))
       (persistent! hash-table))))
@@ -1452,7 +1523,8 @@
       (let [hash       (hash-attrs key-fn1 tuples1)
             new-tuples (->>
                         (reduce (fn [acc tuple2]
-                                  (let [key (key-fn2 tuple2)]
+                                  (let [_ (when *query-cancel* (check-cancel! *query-cancel*))
+                                        key (key-fn2 tuple2)]
                                     (if-some [tuples1 (get hash key)]
                                       (reduce (fn [acc tuple1]
                                                 (conj! acc (join-tuples tuple1 keep-idxs1 tuple2 keep-idxs2)))
@@ -1465,7 +1537,8 @@
       (let [hash       (hash-attrs key-fn2 tuples2)
             new-tuples (->>
                         (reduce (fn [acc tuple1]
-                                  (let [key (key-fn1 tuple1)]
+                                  (let [_ (when *query-cancel* (check-cancel! *query-cancel*))
+                                        key (key-fn1 tuple1)]
                                     (if-some [tuples2 (get hash key)]
                                       (reduce (fn [acc tuple2]
                                                 (conj! acc (join-tuples tuple1 keep-idxs1 tuple2 keep-idxs2)))
@@ -1654,6 +1727,7 @@
         new-rel (if pred
                   (let [tuple-pred (-call-fn context production pred args)
                         safe-pred (fn [tuple]
+                                    (when *query-cancel* (check-cancel! *query-cancel*))
                                     (try (tuple-pred tuple)
                                          #?(:clj (catch ClassCastException _ false)
                                             :cljs (catch :default _ false))
@@ -1712,7 +1786,8 @@
                                         acc []]
                                    (if-not ts
                                      acc
-                                     (let [tuple (first ts)
+                                     (let [_ (when *query-cancel* (check-cancel! *query-cancel*))
+                                           tuple (first ts)
                                            val (tuple-fn tuple)]
                                        (if (nil? val)
                                          (recur (next ts) plan-attrs2 plan acc)
@@ -1862,9 +1937,7 @@
       ;; an unbounded counter, say — could not be interrupted. That matters more
       ;; now: the planner DECLINES rules whose recursion it cannot bound to this
       ;; solver, so this is where such a rule ends up.
-      (when-let [c (:cancel context)]
-        (when @c
-          (log/raise "query canceled" {:error :query/canceled})))
+      (check-cancel! (:cancel context))
       (if-some [frame (first stack)]
         (let [[clauses [rule-clause & next-clauses]] (split-with #(not (rule? context %)) (:clauses frame))]
           (if (nil? rule-clause)
@@ -5424,7 +5497,7 @@
                          (dhm/query-engine! :secondary-index :aggregate)
                          (-post-process qfind result)))))))))))))
 
-(defn raw-q [{:keys [query args stats? count-fns? offset limit order-by] :as query-map}]
+(defn- raw-q-unbounded [{:keys [query args stats? count-fns? offset limit order-by] :as query-map}]
   (let [sampled? (dhm/sample-query?)
         started (dhm/query-timer sampled?)
         recorded (fn [result-cache f]
@@ -5477,6 +5550,12 @@
                        attr-deps  (merge-attr-deps where-deps find-deps)]
                    (result-cache-put! db cache-key result attr-deps)
                    result))))))))))
+
+(defn raw-q [query-map]
+  (if (or *query-cancel* *query-timeout-ms*
+          (contains? (:query query-map) :timeout))
+    (run-with-query-timeout query-map raw-q-unbounded)
+    (raw-q-unbounded query-map)))
 
 ;; ---------------------------------------------------------------------------
 ;; Register legacy functions for CLJS execute.cljc (breaks circular dep)

--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -41,19 +41,20 @@
 ;;
 ;; `cancel` is an optional IDeref (typically a Volatile) threaded through the
 ;; query context. When its stored value is truthy, the next `check-cancel!`
-;; throws an ex-info with :datahike/canceled true.
+;; throws. A timeout descriptor becomes :datahike/query-timeout; an explicit
+;; protocol cancellation remains :datahike/canceled.
 ;;
-;; Datahike itself is protocol-agnostic — the raised ex-info carries
-;; :datahike/canceled only. Adapter layers (pgwire, client drivers) map
-;; this to their own error codes at the boundary.
+;; Explicit cancellation remains protocol-agnostic and carries
+;; :datahike/canceled only. Adapter layers (pgwire, client drivers) map that
+;; to their own error codes at the boundary.
 ;;
 ;; Cost model: when `cancel` is nil (non-pgwire callers), the nil guard
 ;; short-circuits before any deref — a single ifnull + predicted-not-taken
 ;; branch per check, far below measurement noise.
 
 (defmacro check-cancel!
-  "Throw :datahike/canceled if `cancel` (a Volatile or Atom, or nil) holds a
-   truthy value. No-op on nil. Hot-path safe: callers should bind the value
+  "Throw the typed timeout or :datahike/canceled represented by `cancel` (a
+   Volatile, Atom, composite IDeref, or nil). No-op on nil. Hot-path safe: callers should bind the value
    from `(:cancel ctx)` to a local *outside* any tight loop, then pass the
    local to this macro inside the loop.
 
@@ -64,14 +65,16 @@
   (if (:ns &env)
     ;; CLJS expansion
     `(when-let [c# ~cancel]
-       (when (cljs.core/deref c#)
-         (throw (ex-info "query canceled"
-                         {:datahike/canceled true}))))
+       (when-let [v# (cljs.core/deref c#)]
+         (if (= :datahike/query-timeout (:type v#))
+           (throw (ex-info "query timed out" v#))
+           (throw (ex-info "query canceled" {:datahike/canceled true})))))
     ;; CLJ expansion — direct .deref via IDeref hint
     `(when-let [^clojure.lang.IDeref c# ~cancel]
-       (when (.deref c#)
-         (throw (ex-info "query canceled"
-                         {:datahike/canceled true}))))))
+       (when-let [v# (.deref c#)]
+         (if (= :datahike/query-timeout (:type v#))
+           (throw (ex-info "query timed out" v#))
+           (throw (ex-info "query canceled" {:datahike/canceled true})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-platform helpers

--- a/test/datahike/test/http/config_test.clj
+++ b/test/datahike/test/http/config_test.clj
@@ -12,6 +12,7 @@
   (is (= "DATAHIKE_PORT" (config/env-name :port)))
   (is (= "DATAHIKE_DEV_MODE" (config/env-name :dev-mode)))
   (is (= "DATAHIKE_SHUTDOWN_TIMEOUT_MS" (config/env-name :shutdown-timeout-ms)))
+  (is (= "DATAHIKE_QUERY_TIMEOUT_MS" (config/env-name :query-timeout-ms)))
   (is (= "DATAHIKE_LOG_FORMAT" (config/env-name :log-format)))
   (is (= "DATAHIKE_NREPL_PORT" (config/env-name :nrepl-port)))
   (is (= "DATAHIKE_NREPL_BIND" (config/env-name :nrepl-bind)))
@@ -101,6 +102,7 @@
                                  :token "file-token"
                                  :dev-mode false
                                  :shutdown-timeout-ms 10000
+                                 :query-timeout-ms 10000
                                  :level :info
                                  :metrics false
                                  :system-db {:store {:backend :memory}
@@ -110,6 +112,7 @@
               "DATAHIKE_TOKEN" "env-token"
               "DATAHIKE_DEV_MODE" "true"
               "DATAHIKE_SHUTDOWN_TIMEOUT_MS" "20000"
+              "DATAHIKE_QUERY_TIMEOUT_MS" "20000"
               "DATAHIKE_LEVEL" "warn"
               "DATAHIKE_LOG_FORMAT" "text"
               "DATAHIKE_SYSTEM_DB_PATH" "/env/system"}
@@ -119,6 +122,7 @@
               "--token" "cli-token"
               "--dev-mode" "false"
               "--shutdown-timeout-ms" "30000"
+              "--query-timeout-ms" "30000"
               "--level" "error"
               "--log-format" "json"
               "--system-db-path" "/cli/system"]
@@ -128,6 +132,7 @@
     (is (= "cli-token" (:token resolved)))
     (is (false? (:dev-mode resolved)))
     (is (= 30000 (:shutdown-timeout-ms resolved)))
+    (is (= 30000 (:query-timeout-ms resolved)))
     (is (= :error (:level resolved)))
     (is (= :json (:log-format resolved)))
     (is (false? (:metrics resolved)) "unoverridden EDN remains the full surface")
@@ -173,6 +178,8 @@
                           (config/resolve-config ["--dev-mode" "perhaps"] {})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_SHUTDOWN_TIMEOUT_MS"
                           (config/resolve-config [] {"DATAHIKE_SHUTDOWN_TIMEOUT_MS" "-1"})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid command line"
+                          (config/resolve-config ["--query-timeout-ms" "-1"] {})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid DATAHIKE_LOG_FORMAT"
                           (config/resolve-config [] {"DATAHIKE_LOG_FORMAT" "xml"}))))
   (testing "config parse errors never echo the possibly secret EDN value"

--- a/test/datahike/test/http/kabel_test.clj
+++ b/test/datahike/test/http/kabel_test.clj
@@ -329,6 +329,49 @@
       (finally
         (kabel/stop! resource)))))
 
+(deftest listener-create-database-policy
+  (testing "a backend outside the policy is refused with the policy's type"
+    (let [port (free-port)
+          resource (kabel/start!
+                    {:host "127.0.0.1"
+                     :create-database {:backends #{:memory}}
+                     :kabel {:port port :jwt {:alg :HS256 :secret secret}
+                             :store {:backend :file
+                                     :path (str (fs/temp-dir! "dh-kabel-refused-") "/listener")}}})
+          peer (client (random-uuid) (token-for "alice"))]
+      (try
+        (remote/serve peer)
+        (<?? S (remote/connect S peer (str "ws://127.0.0.1:" port)))
+        (is (= :datahike.http/store-refused
+               (refusal
+                (remote/invoke peer (:peer-id resource) 'datahike.kabel/create-database
+                               {:config {:store {:backend :file :id (random-uuid)}}}))))
+        (finally
+          (<?? S (peer/stop peer))
+          (kabel/stop! resource)))))
+  (testing "a pinned store root overrides the listener store and keeps the client id"
+    (let [port (free-port)
+          store-id (random-uuid)
+          root (str (fs/temp-dir! "dh-kabel-policy-root-") "/databases")
+          db-config {:store {:backend :file :path (str root "/" store-id) :id store-id}}
+          resource (kabel/start!
+                    {:host "127.0.0.1"
+                     :create-database {:store {:backend :file :path root}}
+                     :kabel {:port port :jwt {:alg :HS256 :secret secret}
+                             :store {:backend :memory}}})
+          peer (client (random-uuid) (token-for "alice"))]
+      (try
+        (remote/serve peer)
+        (<?? S (remote/connect S peer (str "ws://127.0.0.1:" port)))
+        (<?? S (remote/invoke peer (:peer-id resource) 'datahike.kabel/create-database
+                              {:config {:store {:backend :memory :id store-id}}}))
+        (is (d/database-exists? db-config))
+        (finally
+          (<?? S (peer/stop peer))
+          (kabel/stop! resource)
+          (when (d/database-exists? db-config)
+            (d/delete-database db-config)))))))
+
 (deftest host-policy-composes-over-the-permission-graph
   (let [config (permissions/configure
                 {:system-db {:store {:backend :memory :id (random-uuid)}}

--- a/test/datahike/test/http/routes_test.clj
+++ b/test/datahike/test/http/routes_test.clj
@@ -366,3 +366,34 @@
               "an unknown args format is refused"))
         (finally
           (.stop server))))))
+
+(deftest query-timeout-is-a-clean-http-error
+  (let [port 23203
+        server (run-jetty (routes/handler {:token token :query-timeout-ms 100})
+                          {:port port :join? false})
+        url (str "http://localhost:" port)
+        registry (rcbor/client-registry)
+        encode #(boring/encode % (rcbor/encode-opts registry))
+        decode #(boring/decode % (rcbor/decode-opts registry))
+        headers {"authorization" (str "token " token)
+                 "accept" "application/cbor"
+                 "content-type" "application/cbor"}
+        post-q (fn [args]
+                 (http/post (str url "/q")
+                            {:headers headers :body (encode args)
+                             :as :bytes :throw false}))]
+    (try
+      (let [response (post-q ['[:find ?x :in [?x ...] :where [(pos? ?x)]] [1 2]])]
+        (is (= 200 (:status response)))
+        (is (= #{[1] [2]} (decode (:body response)))))
+      (let [response (post-q ['{:find [?x ?y]
+                                :in [[?x ...] [?y ...]]
+                                :where [[(not= ?x ?y)]]
+                                :timeout 5}
+                              (range 10000) (range 10000)])
+            body (decode (:body response))]
+        (is (= 503 (:status response)))
+        (is (= :datahike/query-timeout (get-in body [:ex-data :type])))
+        (is (= 5 (get-in body [:ex-data :timeout-ms]))))
+      (finally
+        (.stop server)))))

--- a/test/datahike/test/query_fns_test.cljc
+++ b/test/datahike/test/query_fns_test.cljc
@@ -822,3 +822,20 @@
            (is (= #{["IVAN"] ["PETR"]}
                   (d/q '[:find ?x :where [_ :name ?n] [(app/shout ?n) ?x]] db)))
            (is (unknown? '[:find ?x :where [(load-string "1") ?x]])))))))
+
+#?(:clj
+   (deftest an-outer-deadline-cancels-a-nested-query
+     (let [query '{:find [?result]
+                   :in [?values]
+                   :where [[(datahike.api/q
+                             {:find [?x ?y]
+                              :in [[?x ...] [?y ...]]
+                              :where [[(not= ?x ?y)]]}
+                             ?values ?values) ?result]]
+                   :timeout 5}
+           e (try
+               (d/q query (range 10000))
+               nil
+               (catch ExceptionInfo e e))]
+       (is (= :datahike/query-timeout (:type (ex-data e))))
+       (is (= 5 (:timeout-ms (ex-data e)))))))

--- a/test/datahike/test/query_test.cljc
+++ b/test/datahike/test/query_test.cljc
@@ -1208,3 +1208,32 @@ we query all (parent, child) pairs."
 
     (testing "a repeated argument in a function clause is still not a self-join"
       (is (= #{[2]} (d/q '[:find ?y :in $ [?x ...] :where [(+ ?x ?x) ?y]] db [1]))))))
+
+#?(:clj
+   (deftest query-deadlines
+     (let [slow-query '{:find [?x ?y]
+                        :in [[?x ...] [?y ...]]
+                        :where [[(not= ?x ?y)]]}
+           values (range 10000)
+           timed-out (fn [query]
+                       (try
+                         (d/q query values values)
+                         nil
+                         (catch ExceptionInfo e e)))]
+       (testing "a query's own timeout cancels a deterministic cross product"
+         (let [e (timed-out (assoc slow-query :timeout 5))]
+           (is (= :datahike/query-timeout (:type (ex-data e))))
+           (is (= 5 (:timeout-ms (ex-data e))))
+           (is (nat-int? (:elapsed-ms (ex-data e))))))
+       (testing "a query cannot extend an ambient deadline"
+         (let [e (binding [dq/*query-timeout-ms* 5]
+                   (timed-out (assoc slow-query :timeout 60000)))]
+           (is (= :datahike/query-timeout (:type (ex-data e))))
+           (is (= 5 (:timeout-ms (ex-data e))))))
+       (testing "nil leaves unbounded queries unchanged"
+         (is (= #{[1 3] [2 3]}
+                (binding [dq/*query-timeout-ms* nil]
+                  (d/q '[:find ?x ?y
+                         :in [?x ...] [?y ...]
+                         :where [(< ?x ?y)]]
+                       [1 2] [3]))))))))


### PR DESCRIPTION
Builds on #1068. Independent of #1070 and #1071, which also build on it.

## Query deadlines

An expensive query occupies a request thread until it finishes. That was already true and is more consequential now that the thin client sends every query to the server, so a server accepting client queries needs a bound.

The pieces existed and are reused rather than reinvented: `datalog.parser` already parses a `:timeout` clause into `:qtimeout`, and the engine already has cooperative cancellation through a cell threaded into the query context, which pgwire uses. This wires them together.

- `datahike.query/*query-timeout-ms*` is the ambient limit, nil for none. A query's own `:timeout` combines by **minimum**, so it may shorten the limit and never raise it. That is what makes it a control rather than a suggestion: a client cannot opt out of a server's cap by asking for more.
- One daemon thread schedules a timer per deadline and cancels it when the query ends, so no loop reads a clock and a query with no deadline costs exactly what it did. `bb planner-bench --assert` passes on every shape.
- The deadline reaches the planner, the legacy engine, rules and nested `datahike.api/q`, and composes with pgwire's explicit cancel instead of replacing it: a timeout raises `:datahike/query-timeout` with the limit and the elapsed time, an explicit cancel still raises `:datahike/canceled`.
- The HTTP routes and the Kabel dispatch bind the limit per request from `:query-timeout-ms`, 30000 by default, `false` or `nil` to disable. A timed-out request answers **503** with the ex-data, not a 500 with a stack trace. There is a `--query-timeout-ms` flag and an environment variable alongside the existing ones.

Documented with the honest caveat: cancellation is cooperative, so a query stops at clause and join boundaries rather than being interrupted mid-step. The deadline bounds how long a request occupies a thread; it is not a hard real-time guarantee.

## The Kabel listener enforces `:create-database`

The optional store policy from #1059, `{:backends #{…}}` and `{:store {:backend :file :path root}}`, was applied by the HTTP routes only, while the Kabel listener placed browser databases under its own path and ignored it. The listener now runs its store configuration through the same `datahike.http.stores/assign`, so a deployment that restricts backends or pins a root gets the guarantee on both transports, and a refused create is reported as a refusal rather than a generic failure. Where both the listener's own `:store` and the policy apply, the policy wins.

## Tests

An embedded query with `:timeout` is cancelled with `:datahike/query-timeout` on a deterministic long query; a query asking for more than the ambient limit does not get it; the route answers 503; nothing changes with no timeout configured. For the policy: a Kabel create of a file store is refused under a memory-only allow-list, and a Kabel-created database lands under a pinned root with the client's id. Both index tiers, the Kabel tier, the full JVM tier, the reflection gate and the planner benchmark.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3