### PR TITLE
Wait for the tx-report subscription before writing in the test

### DIFF
--- a/test/datahike/test/http/kabel_test.clj
+++ b/test/datahike/test/http/kabel_test.clj
@@ -16,6 +16,7 @@
    [datahike.json :as json]
    [datahike.migrate.fs :as fs]
    [datahike.kabel.cbor-handlers :as cbor]
+   [kabel.pubsub :as pubsub]
    [kabel.auth.jwt :as jwt]
    [kabel.auth.websocket :as auth]
    [kabel.peer :as peer]
@@ -118,6 +119,20 @@
   (.getLocalPort ^org.eclipse.jetty.server.ServerConnector
    (first (.getConnectors instance))))
 
+(defn- await-subscribed!
+  "Wait until the server has registered this peer's subscription to `topic`.
+
+   `subscribe-tx-reports!` settles when the request has gone out, not when the
+   far end serves it, so a write issued immediately after could be published
+   to nobody and the test would wait for an event that was never sent."
+  [peer topic]
+  (is (loop [attempts 200]
+        (cond
+          (:handshake-complete? (pubsub/subscription peer topic)) true
+          (zero? attempts) false
+          :else (do (Thread/sleep 25) (recur (dec attempts)))))
+      (str "subscription to " topic " became ready")))
+
 (defn- next-report
   ([events] (next-report events 5000))
   ([events timeout-ms]
@@ -187,6 +202,7 @@
       (<?? S (remote/connect S peer (str "ws://127.0.0.1:" kabel-port)))
       (<?? S (tx-broadcast/subscribe-tx-reports! peer store-id
                                                  #(put! reports %)))
+      (await-subscribed! peer (tx-broadcast/tx-report-topic store-id))
       (let [http-peer {:backend :datahike-server
                        :url (str "http://127.0.0.1:" (local-port server))
                        :token "http-kabel-token"


### PR DESCRIPTION
Fixes the red `datahike.test.http.kabel-test/standalone-broadcasts-http-and-kabel-writes-once` on main.

## What is wrong

The test subscribes to a store's transaction-report topic and writes immediately afterwards. `tx-broadcast/subscribe-tx-reports!` settles when the subscribe request has gone out, **not** when the server has registered the subscriber against that topic: the server registers and only then sends handshake-complete, which is what sets the client's readiness flag. A write in that window is published to a topic with no subscriber yet, so the broadcast is genuinely lost rather than late.

That is exactly the shape of the failure: the commit reaches SSE, which goes through another path, and the Kabel topic event is nil.

The window is small, which is why it lost only on loaded machines and only on some tiers. It does not reproduce here in repeated runs, so the local runs below show the fix does no harm rather than proving the race is gone; the evidence for that is CI.

## The fix

Wait for the subscription to report itself established before the first write.

## How it got onto main

This fix is not new. I wrote it when #1068's hitchhiker-tree job hit this failure, and cherry-picked it onto #1066, where CI then passed. When #1066 was rebased onto main I replayed only its feature commit and dropped this one, and did not check the test file that showed up in the diff. So the test landed without its fix.

## Verified

The base-engine tier that failed on main (`DATAHIKE_QUERY_PLANNER=false`, 1263 tests) and five consecutive runs of the affected namespace.

https://claude.ai/code/session_01J9RUNkHFidHP8EVQVCSqf3