### PR TITLE
Preserve NaN ordering fix for the 1.0 index upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Scalar NaNs have a consistent numeric index order.** NaN sorts after all
+  other numbers; repeated NaNs compare equal. Cardinality-one writes between
+  finite values and NaN now emit the corresponding retraction and assertion.
+  **Upgrade:** restart all writers; legacy persistent-set records containing
+  scalar NaNs (including NaNs inside tuples) are refused until exported using
+  the old runtime and rebuilt into a new database. See
+  [the upgrade procedure](doc/nan-index-upgrade.md). Earlier
+  versions could order NaN entries incorrectly or silently omit writes; an
+  index rebuild cannot recover omitted writes. Signed-zero comparison and
+  scalar datom hashing are unchanged.
+
 - **Bounded query execution.** Queries accept `:timeout` in milliseconds and
   fail with `:datahike/query-timeout` when the engine reaches the deadline,
   including planner, relational, rule and nested-query execution. The dynamic

--- a/doc/nan-index-upgrade.md
+++ b/doc/nan-index-upgrade.md
@@ -1,0 +1,50 @@
+# Upgrading databases containing NaN
+
+> Design draft for the planned 1.0 storage upgrade. The comparator correction
+> and safety tests are preserved here for review; the format marker and recovery
+> procedure below are proposals, not an approved release or migration policy.
+> Coordinate them with any entity-ID/transaction-ID range changes and decide
+> whether the unified migration must preserve branches and commit history.
+
+The persistent-set index now orders scalar floating-point NaNs after all other
+numbers. NaNs compare equal to one another. The previous numeric comparator
+treated NaN as equal to every number, which could suppress writes or leave
+persisted index entries in an order incompatible with the corrected comparator.
+NaN inside a tuple has the same problem. Primitive float/double arrays use a
+separate comparator and are unaffected by this change.
+
+Stop all writers and restart the application when upgrading. Do not hot-reload
+this comparator into a process with open databases, and do not run old and new
+writers against the same store during migration.
+
+New persistent-set records carry `:pss-comparator-version 1`. Before exposing a
+legacy record without this field, Datahike scans all six physical index roots,
+including history. A record containing scalar NaN fails with
+`:index/comparator-migration-required`. Unknown version markers fail with
+`:index/unsupported-comparator-version`. Reads never modify a legacy record;
+the next normal commit stamps an unaffected database. Historical commits and
+branches are checked independently when loaded. Large legacy databases therefore
+incur a full scan on each materialization until a new commit records the format.
+
+For an affected database:
+
+1. Keep a backup of the original store. Using the **old runtime**, export each
+   branch/snapshot that needs to survive with
+   `(datahike.migrate/export-db db dump-path {:history? true})`.
+2. Under the **new runtime**, create a separate, empty database with compatible
+   schema/history settings and import the dump:
+   `(datahike.migrate/import-db conn dump-path
+     {:build-indexes? true :eids :preserve})`.
+3. Check the import report's `:verified?`, live and historical datom counts, and
+   application queries. Reopen the new database and check indexed NaN lookups
+   before redirecting application traffic.
+
+Bulk index import requires persistent-set indexes, no attribute references, and
+no secondary-index schema. For configurations outside those requirements, use
+the regular import path with `{:eids :preserve}` and verify the result. Import
+creates a new commit history; it does not preserve the old branch graph or commit
+IDs. Index rebuilding cannot recover writes that the old comparator omitted.
+
+The Hitchhiker Tree backend uses its own persisted key comparator and does not
+receive a persistent-set format marker. Its comparison semantics and migration
+requirements are separate from this persistent-set upgrade check.

--- a/src/datahike/datom.cljc
+++ b/src/datahike/datom.cljc
@@ -426,6 +426,16 @@
                     (recur (next xs) (next ys))
                     c)))))))
 
+(defn- scalar-nan? [v]
+  #?(:clj (or (and (instance? Double v) (Double/isNaN ^double v))
+              (and (instance? Float v) (Float/isNaN ^float v)))
+     :cljs (and (number? v) (js/isNaN v))))
+
+(defn- compare-nan [v1 v2]
+  (cond
+    (scalar-nan? v1) (if (scalar-nan? v2) 0 1)
+    :else -1))
+
 (defn compare-value
   "Compare two values with cross-platform UUID compatibility.
    CLJS UUID comparison is adjusted to match CLJ's signed comparison,
@@ -455,11 +465,19 @@
    reads equal as a duplicate. Repairing this function fixes all four, which is
    why the fix is here and not at the call sites.
 
-   Only values that CONTAIN an array change order; anything already Comparable
-   takes the same path it always did, so existing indices do not move."
+   Scalar NaNs sort after all other numbers and compare equal to each other.
+   Clojure's numeric compare otherwise equates a NaN with every number, losing
+   cardinality-many values and suppressing cardinality-one updates. Finite
+   numeric ordering, including equality of signed zeros, is unchanged. Existing
+   indexes containing NaNs may need rebuilding; lost writes cannot be recovered
+   by changing the comparator."
   [v1 v2]
   #?(:clj (try
             (cond
+              (and (number? v1) (number? v2)
+                   (or (scalar-nan? v1) (scalar-nan? v2)))
+              (compare-nan v1 v2)
+
               (and (da/value-array? v1) (da/value-array? v2))
               (da/compare-arrays v1 v2)
 
@@ -496,6 +514,10 @@
      :cljs
      (try
        (cond
+         (and (number? v1) (number? v2)
+              (or (scalar-nan? v1) (scalar-nan? v2)))
+         (compare-nan v1 v2)
+
          (and (uuid? v1) (uuid? v2))
        ;; Match Java's signed UUID comparison where MSB is treated as signed
        ;; In signed comparison: 0x8... is negative, so 0x8... < 0x0...

--- a/src/datahike/index/compatibility.cljc
+++ b/src/datahike/index/compatibility.cljc
@@ -1,0 +1,52 @@
+(ns datahike.index.compatibility
+  "Checks persisted comparator formats before an index is exposed to readers."
+  (:require [datahike.index :as di]))
+
+(def pss-comparator-version 1)
+
+(defn stored-marker [config]
+  (when (= :datahike.index/persistent-set (:index config))
+    {:pss-comparator-version pss-comparator-version}))
+
+(defn- contains-scalar-nan? [v]
+  (or #?(:clj (or (and (instance? Double v) (Double/isNaN ^double v))
+                  (and (instance? Float v) (Float/isNaN ^float v)))
+         :cljs (and (number? v) (js/isNaN v)))
+      ;; Primitive arrays have their own, unchanged comparator. Sequential
+      ;; values are compared recursively by datom/compare-value.
+      (and (sequential? v) (some contains-scalar-nan? v))))
+
+(defn ensure-compatible!
+  "Reject unknown PSS formats and legacy roots containing scalar NaNs.
+
+   Walk physical index sequences, never comparator-guided slices: a legacy
+   tree's ordering may already disagree with the running comparator. Check all
+   six roots, since NaN may remain only in history or in an inconsistent old
+   index. This deliberately does not mutate or stamp a legacy record. A normal
+   subsequent commit records the current format. HHT uses a separate comparator
+   and is not assigned a PSS format."
+  [stored store]
+  (when (= :datahike.index/persistent-set (get-in stored [:config :index]))
+    (if (contains? stored :pss-comparator-version)
+      (when-not (= pss-comparator-version (:pss-comparator-version stored))
+        (throw (ex-info "Unsupported persistent-set comparator format"
+                        {:error :index/unsupported-comparator-version
+                         :expected pss-comparator-version
+                         :actual (:pss-comparator-version stored)})))
+      (doseq [[key root-key] [[:eavt-key :eavt-root]
+                              [:aevt-key :aevt-root]
+                              [:avet-key :avet-root]
+                              [:temporal-eavt-key :temporal-eavt-root]
+                              [:temporal-aevt-key :temporal-aevt-root]
+                              [:temporal-avet-key :temporal-avet-root]]
+              :let [idx (get stored key)]
+              :when idx]
+        (let [attached (cond-> (di/with-storage :datahike.index/persistent-set
+                                 idx (:storage store))
+                         (get stored root-key) (di/-seed-root! (get stored root-key)))]
+          (when (some #(contains-scalar-nan? (:v %)) (di/-seq attached))
+            (throw (ex-info
+                    "Legacy persistent-set index contains scalar NaN; export with the old runtime and rebuild into a new database before upgrading"
+                    {:error :index/comparator-migration-required
+                     :index key
+                     :target-version pss-comparator-version}))))))))

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -10,6 +10,7 @@
             [datahike.index :as di]
             [datahike.index.persistent-set :as dip]
             [datahike.index.audit :as audit]
+            [datahike.index.compatibility :as compatibility]
             [datahike.index.secondary :as sec]
             [datahike.store :as ds]
             [datahike.tools :as dt]
@@ -50,7 +51,7 @@
    :temporal-eavt-key :temporal-aevt-key :temporal-avet-key
    :schema-meta-key :secondary-index-keys
    :schema :rschema :system-entities :ref-ident-map :ident-ref-map
-   :max-tx :max-eid :op-count :hash :meta])
+   :max-tx :max-eid :op-count :hash :meta :pss-comparator-version])
 
 (defn- stored-head-identity [stored]
   (-> (select-keys stored stored-head-identity-keys)
@@ -469,6 +470,7 @@
                                  :temporal-avet-root (di/-root-node temporal-avet'))))]
       [schema-meta-kv-to-write
        (merge
+        (compatibility/stored-marker config)
         {:schema-meta-key  schema-meta-key
          :config          config
          :meta            meta
@@ -627,6 +629,7 @@
 (defn stored->db
   "Constructs in-memory db instance from stored map value."
   [stored-db store]
+  (compatibility/ensure-compatible! stored-db store)
   (let [{:keys [eavt-key aevt-key avet-key
                 temporal-eavt-key temporal-aevt-key temporal-avet-key
                 eavt-root aevt-root avet-root
@@ -972,6 +975,11 @@
                     max-tx max-eid
                     (dissoc meta :datahike/commit-id)]
                    [hash max-tx max-eid meta])
+         ;; Missing marker preserves the byte-for-byte legacy hash input.
+         ;; New commits bind the comparator format to their content identity.
+         content (cond-> content
+                   (contains? stored-db :pss-comparator-version)
+                   (conj {:pss-comparator-version (:pss-comparator-version stored-db)}))
          content-uuid (uuid content)]
      (if (:crypto-hash? config)
        content-uuid
@@ -1522,7 +1530,8 @@
          ;; Detach roots before they enter the store (see db->stored).
          detach (fn [idx] (di/with-storage (:index config) idx nil))
          pre-cid-stored
-         (merge {:max-tx          max-tx
+         (merge (compatibility/stored-marker config)
+                {:max-tx          max-tx
                  :max-eid         max-eid
                  :op-count        op-count
                  :hash            hash

--- a/test/datahike/test/index_compatibility_test.clj
+++ b/test/datahike/test/index_compatibility_test.clj
@@ -1,0 +1,187 @@
+(ns datahike.test.index-compatibility-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [datahike.api :as d]
+            [datahike.datom :as dd]
+            [datahike.index :as di]
+            [datahike.index.compatibility :as compatibility]
+            [datahike.migrate :as migrate]
+            [datahike.migrate.fs :as fs]
+            [datahike.writing :as writing]
+            [konserve.core :as k]))
+
+(defn- config []
+  {:store {:backend :file :id (random-uuid)
+           :path (fs/temp-store-path! "nan-format-")}
+   :index :datahike.index/persistent-set
+   :keep-history? true :schema-flexibility :write})
+
+(def schema
+  [{:db/ident :n/value :db/valueType :db.type/double
+    :db/cardinality :db.cardinality/one :db/index true}])
+
+(defn- error-data [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (ex-data e))))
+
+(def ^:private current-compare dd/compare-value)
+
+(defn- legacy-compare [a b]
+  ;; Preserve the previous recursive tuple/array/type rules. The captured
+  ;; comparator's sequential branch recurses through the rebound Var, so only
+  ;; numeric comparisons (including numbers inside tuples) use the old rule.
+  (if (and (number? a) (number? b)) (compare a b) (current-compare a b)))
+
+(defn- legacy-db!
+  "Write actual disk roots with the previous numeric comparator and no marker.
+   The rest of the persistence machinery is unchanged. This reproduces the
+   old AVET order rather than stripping the marker off a correctly built tree."
+  ([cfg rows] (legacy-db! cfg schema rows))
+  ([cfg schema rows]
+   (with-redefs [dd/compare-value legacy-compare
+                 compatibility/stored-marker (constantly nil)]
+     (d/create-database cfg)
+     (let [c (d/connect cfg)]
+       (d/transact c (into schema rows))
+       c))))
+
+(deftest hitchhiker-tree-does-not-use-pss-format
+  (let [cfg {:index :datahike.index/hitchhiker-tree}]
+    (is (nil? (compatibility/stored-marker cfg)))
+    (with-redefs [di/-seq (fn [& _] (throw (ex-info "PSS scan used for HHT" {})))]
+      (is (nil? (compatibility/ensure-compatible!
+                 {:config cfg :pss-comparator-version 99 :eavt-key :hht-root} nil))))))
+
+(deftest legacy-nan-roots-refuse-materialization
+  (let [cfg (config)
+        c (legacy-db! cfg [{:db/id 100 :n/value Double/NaN}
+                           {:db/id 101 :n/value 0.0}])]
+    (try
+      (let [store (:store @c)
+            stored (k/get store :db nil {:sync? true})]
+        (is (not (contains? stored :pss-comparator-version)))
+        (is (= [100 101] (mapv :e (filter #(= :n/value (:a %))
+                                          (di/-seq (:avet @c)))))
+            "Legacy physical order puts NaN before zero because entity IDs break the old value tie")
+        (doseq [restore [writing/stored->db writing/stored->db-read-only]]
+          (is (= :index/comparator-migration-required
+                 (:error (error-data #(restore stored store))))))
+        (doseq [root [:eavt-key :aevt-key :avet-key
+                      :temporal-eavt-key :temporal-aevt-key :temporal-avet-key]]
+          (let [single (-> (apply dissoc stored [:eavt-key :aevt-key :avet-key
+                                                 :temporal-eavt-key :temporal-aevt-key :temporal-avet-key])
+                           (assoc root (:eavt-key stored)))]
+            (is (= root (:index (error-data #(compatibility/ensure-compatible! single store)))))))
+        (is (not (contains? (k/get store :db nil {:sync? true}) :pss-comparator-version))
+            "Failed reads do not stamp a legacy head"))
+      (finally (d/release c) (d/delete-database cfg)))))
+
+(deftest clean-legacy-roots-upgrade-on-commit
+  (let [cfg (assoc (config) :crypto-hash? true)
+        c (legacy-db! cfg [{:db/id 100 :n/value 1.0}])
+        before (k/get (:store @c) :db nil {:sync? true})
+        old-cid (get-in before [:meta :datahike/commit-id])]
+    (d/release c)
+    (try
+      (let [c (d/connect cfg)]
+        (try
+          (let [after-read (k/get (:store @c) :db nil {:sync? true})]
+            (is (not (contains? after-read :pss-comparator-version)))
+            (is (= old-cid (get-in after-read [:meta :datahike/commit-id])))
+            (is (= old-cid (writing/create-commit-id after-read after-read))))
+          (d/transact c [[:db/add 100 :n/value 2.0]])
+          (let [historical (k/get (:store @c) old-cid nil {:sync? true})]
+            (is (not (contains? historical :pss-comparator-version)))
+            (is (= old-cid (writing/create-commit-id historical historical)))
+            (is (= old-cid (get-in (writing/stored->db-read-only historical (:store @c))
+                                   [:meta :datahike/commit-id]))))
+          (let [stored (k/get (:store @c) :db nil {:sync? true})]
+            (is (= 1 (:pss-comparator-version stored)))
+            (doseq [unknown [nil 0 2 "1"]
+                    restore [writing/stored->db writing/stored->db-read-only]]
+              (is (= :index/unsupported-comparator-version
+                     (:error (error-data #(restore
+                                           (assoc stored :pss-comparator-version unknown) (:store @c))))))))
+          (finally (d/release c))))
+      (finally (d/delete-database cfg)))))
+
+(deftest legacy-tuple-nan-refuses-public-connect
+  (let [cfg (config)
+        c (legacy-db! cfg
+                      [{:db/ident :n/tuple :db/valueType :db.type/tuple
+                        :db/tupleTypes [:db.type/double :db.type/string]
+                        :db/cardinality :db.cardinality/one :db/index true}]
+                      [{:db/id 100 :n/tuple [Double/NaN "x"]}
+                       {:db/id 101 :n/tuple [0.0 "x"]}])]
+    (is (= [100 101] (mapv :e (filter #(= :n/tuple (:a %)) (di/-seq (:avet @c))))))
+    (d/release c)
+    (try
+      (is (= :index/comparator-migration-required
+             (:error (error-data #(d/connect cfg)))))
+      (finally (d/delete-database cfg)))))
+
+(deftest history-only-nan-refuses-legacy-open
+  (let [cfg (config)
+        c (legacy-db! cfg [{:db/id 100 :n/value Double/NaN}])]
+    (try
+      (with-redefs [dd/compare-value legacy-compare
+                    compatibility/stored-marker (constantly nil)
+                    compatibility/ensure-compatible! (fn [& _])]
+        (d/transact c [[:db/retract 100 :n/value Double/NaN]]))
+      (is (empty? (filter #(= :n/value (:a %)) (di/-seq (:eavt @c)))))
+      (let [stored (k/get (:store @c) :db nil {:sync? true})]
+        (is (= :temporal-eavt-key
+               (:index (error-data #(writing/stored->db stored (:store @c)))))))
+      (finally (d/release c) (d/delete-database cfg)))))
+
+(deftest comparator-marker-is-bound-to-commit-identity
+  (let [cfg (assoc (config) :crypto-hash? true)]
+    (d/create-database cfg)
+    (try
+      (let [c (d/connect cfg)]
+        (try
+          (let [stored (k/get (:store @c) :db nil {:sync? true})
+                cid (get-in stored [:meta :datahike/commit-id])]
+            (is (= cid (writing/create-commit-id stored stored)))
+            (is (not= cid (writing/create-commit-id stored (dissoc stored :pss-comparator-version))))
+            (is (not= cid (writing/create-commit-id stored (assoc stored :pss-comparator-version 2)))))
+          (finally (d/release c))))
+      (finally (d/delete-database cfg)))))
+
+(deftest legacy-nan-export-rebuilds-under-new-comparator
+  (let [cfg (config)
+        target-cfg (config)
+        dump (fs/temp-dir! "nan-migration-")
+        c (legacy-db! cfg [{:db/id 100 :n/value Double/NaN}
+                           {:db/id 101 :n/value 0.0}])]
+    (try
+      ;; Export while running the old comparator, just as an operator must do
+      ;; before switching runtimes. No materialization bypass is added to API.
+      (with-redefs [dd/compare-value legacy-compare]
+        (migrate/export-db @c dump {:history? true}))
+      (d/create-database target-cfg)
+      (let [target (d/connect target-cfg)]
+        (try
+          (is (:verified? (migrate/import-db target dump {:build-indexes? true :eids :preserve})))
+          (is (= [101 100] (mapv :e (d/datoms @target :avet :n/value))))
+          (is (= [100] (mapv :e (d/datoms @target :avet :n/value Double/NaN))))
+          (is (= 1 (:pss-comparator-version (k/get (:store @target) :db nil {:sync? true}))))
+          (finally (d/release target))))
+      (testing "regular import also rebuilds numeric order"
+        (let [regular-cfg (config)]
+          (d/create-database regular-cfg)
+          (try
+            (let [target (d/connect regular-cfg)]
+              (try
+                (is (:verified? (migrate/import-db target dump {:eids :preserve})))
+                (is (= [101 100] (mapv :e (d/datoms @target :avet :n/value))))
+                (finally (d/release target))))
+            (finally (d/delete-database regular-cfg)))))
+      (let [target (d/connect target-cfg)]
+        (try
+          (is (= [101 100] (mapv :e (d/datoms @target :avet :n/value))))
+          (finally (d/release target))))
+      (finally
+        (d/release c)
+        (d/delete-database cfg)
+        (d/delete-database target-cfg)
+        (doseq [f (reverse (file-seq (io/file dump)))] (io/delete-file f true))))))

--- a/test/datahike/test/value_comparison_test.cljc
+++ b/test/datahike/test/value_comparison_test.cljc
@@ -22,6 +22,18 @@
   #?(:clj (byte-array (map unchecked-byte xs))
      :cljs (js/Uint8Array.from (clj->js (map #(bit-and % 0xff) xs)))))
 
+(deftest scalar-nan-has-a-total-numeric-order
+  (doseq [nan #?(:clj [Double/NaN Float/NaN
+                       (Double/longBitsToDouble 9221120237041090561)]
+                 :cljs [js/NaN])
+          finite [##-Inf -1 0 -0.0 0.0 1 1.5 ##Inf]]
+    (is (pos? (dd/compare-value nan finite)))
+    (is (neg? (dd/compare-value finite nan)))
+    (is (zero? (dd/compare-value nan nan)))
+    (is (pos? (dd/compare-value [nan] [finite]))))
+  (is (zero? (dd/compare-value -0.0 0.0)))
+  #?(:clj (is (zero? (dd/compare-value Float/NaN Double/NaN)))))
+
 #?(:clj
    (defn- conn-with [attr]
      (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
@@ -30,6 +42,57 @@
        (let [c (d/connect cfg)]
          (d/transact c [attr])
          c))))
+
+#?(:clj
+   (deftest scalar-nan-writes-and-index-lookups
+     (doseq [[type finite nan] [[:db.type/double 0.0 Double/NaN]
+                                [:db.type/float (float 0) Float/NaN]]]
+       (let [c (conn-with {:db/ident :n/value :db/valueType type
+                           :db/cardinality :db.cardinality/one :db/index true})]
+         (try
+           (d/transact c [{:db/id 100 :n/value finite}])
+           (let [report (d/transact c [[:db/add 100 :n/value nan]])]
+             (is (= 2 (count (filter #(= :n/value (:a %)) (:tx-data report)))))
+             (is (Double/isNaN (double (:n/value (d/entity @c 100))))))
+           (d/transact c [{:db/id 101 :n/value finite}])
+           (is (= [101] (mapv :e (d/datoms @c :avet :n/value finite))))
+           (is (= [100] (mapv :e (d/datoms @c :avet :n/value nan))))
+           (is (= [101 100] (mapv :e (d/datoms @c :avet :n/value))))
+           (let [report (d/transact c [[:db/add 100 :n/value finite]])]
+             (is (= 2 (count (filter #(= :n/value (:a %)) (:tx-data report)))))
+             (is (zero? (:n/value (d/entity @c 100)))))
+           (finally (d/release c)))))))
+
+#?(:clj
+   (deftest scalar-nan-index-order-survives-reconnect
+     (let [root (java.nio.file.Files/createTempDirectory
+                 "datahike-nan-index-"
+                 (make-array java.nio.file.attribute.FileAttribute 0))
+           cfg {:store {:backend :file :id (java.util.UUID/randomUUID)
+                        :path (str (.resolve root "store"))}
+                :keep-history? true :schema-flexibility :write}]
+       (try
+         (d/create-database cfg)
+         (let [c (d/connect cfg)]
+           (try
+             (d/transact c [{:db/ident :n/value :db/valueType :db.type/double
+                             :db/cardinality :db.cardinality/many :db/index true}])
+             ;; Put NaN on the smaller entity: ordering by entity before value
+             ;; would give the wrong AVET order after reopening.
+             (d/transact c [[:db/add 100 :n/value Double/NaN]
+                            [:db/add 101 :n/value 0.0]
+                            [:db/add 101 :n/value Double/NaN]])
+             (is (= 2 (count (d/datoms @c :eavt 101 :n/value))))
+             (finally (d/release c))))
+         (let [c (d/connect cfg)]
+           (try
+             (is (= [101 100 101] (mapv :e (d/datoms @c :avet :n/value))))
+             (is (= [100 101] (mapv :e (d/datoms @c :avet :n/value Double/NaN))))
+             (is (= [101] (mapv :e (d/datoms @c :avet :n/value 0.0))))
+             (finally (d/release c))))
+         (finally
+           (d/delete-database cfg)
+           (java.nio.file.Files/deleteIfExists root))))))
 
 #?(:clj
    (deftest a-tuple-holding-an-array-is-usable


### PR DESCRIPTION
## Deferred 1.0 design candidate — do not merge yet

Separated from #1074 so writer barriers and transaction-scoped backfill can ship without requiring an index-format upgrade. This branch is based directly on main; it does not depend on #1074.

Preserves the scalar/tuple NaN ordering correction, persisted-index safety guard, regression tests, and candidate recovery documentation. The old comparator can suppress finite-to-NaN writes before transaction-report validation, so the correctness issue remains open while the storage upgrade is designed.

## Decisions reserved for the unified upgrade

- Coordinate comparator ordering with proposed entity-ID and transaction-ID range changes.
- Decide the common format/version contract and old/new reader/writer behavior. The current `:pss-comparator-version` marker is a proposal, not a settled 1.0 format.
- Decide the migration/rebuild path and whether branch graphs and commit IDs must survive. The candidate old-runtime export/new-runtime import procedure does not preserve the original commit DAG.
- Preserve current/history datoms and secondary-index behavior, and make unrecoverable previously suppressed writes explicit.

The draft rejects affected legacy persistent-set roots before exposing them; unaffected roots are scanned and stamped only on a subsequent normal commit. Primitive arrays and Hitchhiker Tree ordering are not changed by this correction.

## Evidence and scope

The implementation and tests were previously validated within the combined campaign, including persisted legacy-order fixtures, historical roots, public connection rejection, commit-identity checks, and export/import recovery. This extraction does not claim new validation of the eventual unified 1.0 migration design. CI can validate the isolated candidate, but green checks are not approval to adopt its migration policy.

Keep this PR draft until the 1.0 storage-upgrade review is complete. No writer API or transaction-option changes are included here.
