### PR TITLE
Test transaction failure propagation from directory-sync barriers

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -27,7 +27,9 @@
         ;; 0.9.391 adds guarded, process-wide metrics sinks around API, blob I/O
         ;; and lock waits. With no sink installed its measurement sites take the
         ;; allocation-free fast path.
-        org.replikativ/konserve                     {:mvn/version "0.9.391"}
+        ;; 0.9.393 makes directory persistence fail closed and supplies the
+        ;; Windows native barrier (JDK 22+ on Windows; Unix JDK 21 unchanged).
+        org.replikativ/konserve                     {:mvn/version "0.9.393"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}
@@ -179,7 +181,7 @@
                                ;; tested and shipped versions came apart.
                                org.replikativ/kabel          {:mvn/version "0.3.136"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
-                               org.replikativ/geheimnis      {:mvn/version "0.2.33"
+                               org.replikativ/geheimnis      {:mvn/version "0.2.39"
                                                               :exclusions [org.clojure/clojurescript]}
 
                                ;; Standalone-server backends. Keep these versions in sync with
@@ -229,7 +231,7 @@
                          ;; to this artifact so Datahike's browser builds retain
                          ;; their normal dependency graph.
                          :override-deps {org.replikativ/konserve
-                                         {:mvn/version "0.9.391"
+                                         {:mvn/version "0.9.393"
                                           :exclusions [org.clojure/clojurescript]}
                                          com.github.pkpkpk/cljs-cache
                                          {:mvn/version "1.0.21"
@@ -259,7 +261,7 @@
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
                                       org.replikativ/kabel          {:mvn/version "0.3.136"}
                                       org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
-                                      org.replikativ/geheimnis      {:mvn/version "0.2.33"
+                                      org.replikativ/geheimnis      {:mvn/version "0.2.39"
                                                                      :exclusions [org.clojure/clojurescript]}
                                       http-kit/http-kit             {:mvn/version "2.8.1"}
 

--- a/doc/storage-backends.md
+++ b/doc/storage-backends.md
@@ -22,6 +22,12 @@ Datahike provides pluggable storage through [konserve](https://github.com/replik
 
 ### File Backend
 
+On Windows, the JVM file backend requires JDK 22+ and
+`--enable-native-access=ALL-UNNAMED` for Konserve's directory persistence barrier.
+This does not raise the Unix JVM requirement. Native binary builds use GraalVM
+25. Persistence errors fail the write; do not enable unsafe directory-sync
+fallback to bypass them.
+
 **Use when**: You want to use Unix tools (rsync, git, backup scripts) to manage your database.
 
 **Key advantage**: Deltas in persistent data structures translate directly into individual file deltas, making incremental backups and synchronization highly efficient.

--- a/test/datahike/test/directory_sync_test.clj
+++ b/test/datahike/test/directory_sync_test.clj
@@ -1,0 +1,51 @@
+(ns datahike.test.directory-sync-test
+  "A storage durability barrier failure must never become a successful tx-report."
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [konserve.filestore])
+  (:import [java.nio.file Files AccessDeniedException]
+           [java.io IOException]
+           [java.util UUID]))
+
+(defn- bounded-result [f]
+  (let [task (future (try (f) (catch Throwable e e)))
+        result (deref task 15000 ::timeout)]
+    (when (= ::timeout result) (future-cancel task))
+    result))
+
+(deftest directory-sync-failure-fails-the-transaction
+  (doseq [failure [(AccessDeniedException. "injected directory-open failure")
+                   (IOException. "injected directory-force failure")]]
+    (let [parent (Files/createTempDirectory "datahike-directory-sync-"
+                                            (make-array java.nio.file.attribute.FileAttribute 0))
+          path (str (.resolve parent "store"))
+          cfg {:store {:backend :file :path path :id (UUID/randomUUID)}
+               :schema-flexibility :read :keep-history? false}
+          connection (atom nil)]
+      (try
+        (d/create-database cfg)
+        (let [conn (d/connect cfg)
+              _ (reset! connection conn)
+              _ (d/transact conn [{:db/id 1 :n 1}])
+              before @conn
+              calls (atom 0)
+              result (with-redefs-fn
+                       {(ns-resolve 'konserve.filestore 'sync-base)
+                        (fn [& _] (swap! calls inc) (throw failure))}
+                       #(bounded-result (fn [] (d/transact conn [{:db/id 2 :n 2}]))))]
+          (is (pos? @calls) "The real file-store directory barrier was reached")
+          (is (instance? Throwable result) "No successful tx-report or hung transaction")
+          (when (instance? Throwable result)
+            (is (some #(identical? failure %)
+                      (take-while some? (iterate ex-cause result)))
+                "The caller receives the storage failure, possibly wrapped"))
+          (is (= (:meta before) (:meta @conn)) "Failed commit is not published to the connection")
+          ;; No assertion of disk rollback: a failed persistence barrier can
+          ;; occur after replacement. Recovery must inspect actual stored state.
+          (is (instance? Throwable
+                         (bounded-result #(d/transact conn [{:db/id 3 :n 3}])))))
+        (finally
+          (when-let [conn @connection]
+            (try (d/release conn) (catch Exception _)))
+          (d/delete-database cfg)
+          (Files/deleteIfExists parent))))))


### PR DESCRIPTION
## Summary
Add a JVM file-store regression test injecting AccessDeniedException and IOException at the Konserve directory-sync boundary after a successful seed transaction.

Verify that the barrier is reached, the transaction returns an error within a bounded time with the original storage cause, the connection does not publish the failed commit, and subsequent writes fail because the writer has stopped. Deliberately make no disk-rollback assertion: a failed barrier can follow a rename.

## Validation
- Against revised Konserve replikativ/konserve#190 (41c5a4b), using a local dependency override: 1 test, 10 assertions passed.
- Against the released dependencies declared by current Datahike main, together with writer-error-test: 4 tests, 23 assertions passed.
- Linux JVM tests only; no Windows or power-cut qualification.

No runtime or dependency changes. This covers Datahike error propagation, not whether a backend silently suppresses an error. Konserve #190 separately tests and fixes that boundary.