### PR TITLE
Add named transaction guards and transaction-scoped index backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ When something is added, it's typically marked *Experimental*. When the API cont
   conflicting owner. Transaction maps accept
   `:tx-options {:allow-index-backfill? true}` without changing persistent
   configuration. Adding uniqueness to an already indexed attribute also
-  checks existing values for duplicates.
+  checks existing values for duplicates. Validation scans current AVET in value
+  order instead of retaining a set of all distinct values. Backfill remains
+  synchronous within the transaction; the index build as a whole is not a
+  bounded-heap or background migration.
 
 - **JVM thin-client change stream.** *Experimental.* `datahike.http.client`
   now provides `listen` and `unlisten` for Clojure remote connections, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Named transaction predicates and transaction-scoped index backfill.**
+  Independent consumers can register store predicates without replacing each
+  other; `ensure-tx-pred!` atomically installs an empty named slot or rejects a
+  conflicting owner. Transaction maps accept
+  `:tx-options {:allow-index-backfill? true}` without changing persistent
+  configuration. Adding uniqueness to an already indexed attribute also
+  checks existing values for duplicates.
+
 - **JVM thin-client change stream.** *Experimental.* `datahike.http.client`
   now provides `listen` and `unlisten` for Clojure remote connections, with
   the same SSE reports, automatic reconnect and resume, terminal deletion and

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -38,6 +38,7 @@
               :else               (log/raise "Bad argument to transact, expected map, vector or sequence."
                                              {:error         :transact/syntax
                                               :argument-type (type arg-map)}))]
+    (dbt/validate-tx-options! (:tx-options arg))
     (dw/transact! connection arg)))
 
 (defn transact [connection arg-map]
@@ -123,10 +124,12 @@
 
 (defn with
   ([db arg-map]
-   (let [tx-data (if (:tx-data arg-map) (:tx-data arg-map) arg-map)
-         tx-meta (if (:tx-meta arg-map) (:tx-meta arg-map) nil)]
-     (with db tx-data tx-meta)))
+   (if (and (map? arg-map) (contains? arg-map :tx-data))
+     (with db (:tx-data arg-map) (:tx-meta arg-map) (:tx-options arg-map))
+     (with db arg-map nil nil)))
   ([db tx-data tx-meta]
+   (with db tx-data tx-meta nil))
+  ([db tx-data tx-meta tx-options]
    (if (dcore/is-filtered db)
      (log/raise "Filtered DB cannot be modified" {:error :transaction/filtered})
      ;; Operation provenance is carried only as far as writer-side transaction
@@ -137,7 +140,7 @@
                                      :db-after  db
                                      :tx-data   []
                                      :tempids   {}
-                                     :tx-meta   tx-meta}) tx-data)
+                                     :tx-meta   tx-meta}) tx-data tx-options)
              :datahike/tx-ops))))
 
 (defn db-with [db tx-data]

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -214,7 +214,7 @@
      :stability :stable
      :supports-remote? true
      :referentially-transparent? false
-     :doc "Applies transaction to the database and updates connection. Blocks until committed. WARNING: Do not call from listener callbacks or transaction functions — use transact! instead to avoid deadlocks."
+     :doc "Applies transaction to the database and updates connection. Blocks until committed. The map form accepts :tx-options {:allow-index-backfill? true} to permit index/uniqueness backfill for this transaction only; it does not change the database config. WARNING: Do not call from listener callbacks or transaction functions — use transact! instead to avoid deadlocks."
      :examples [{:desc "Add single datom"
                  :code "(transact conn [[:db/add 1 :name \"Ivan\"]])"}
                 {:desc "Retract datom"
@@ -258,20 +258,21 @@
     ;; is what malli rejects (`:malli.core/duplicate-arities`), and it is why
     ;; this operation spent a while excluded from registration entirely.
     ;;
-    ;; The Java binding keeps all three overloads it has always had:
+    ;; The Java binding keeps its original overloads (plus the 4-arity):
     ;; `codegen/java`'s `expand-or-args` turns an `[:or …]` argument into one
     ;; overload per distinct Java type, so `STransactions`/`SWithArgs` still
     ;; emit `with(Object, List)` — marshalling through
     ;; `Util.normalizeCollections` — beside `with(Object, Object)`.
     {:args [:function
             [:=> [:cat :datahike/SDB [:or :datahike/STransactions :datahike/SWithArgs]] :datahike/STransactionReport]
-            [:=> [:cat :datahike/SDB :datahike/STransactions :datahike/STxMeta] :datahike/STransactionReport]]
+            [:=> [:cat :datahike/SDB :datahike/STransactions :datahike/STxMeta] :datahike/STransactionReport]
+            [:=> [:cat :datahike/SDB :datahike/STransactions :datahike/STxMeta :datahike/STxOptions] :datahike/STransactionReport]]
      :ret :datahike/STransactionReport
      :categories [:transaction :immutable]
      :stability :stable
      :supports-remote? false
      :referentially-transparent? true
-     :doc "Applies transaction to immutable db value. Returns transaction report."
+     :doc "Applies transaction to immutable db value. Returns transaction report. Accepts :tx-options in the map form, or as a fourth argument after tx-meta. The only option is :allow-index-backfill? (boolean): true permits index/uniqueness backfill for this transaction without changing the database config."
      :examples [{:desc "Transaction on db value"
                  :code "(with @conn [[:db/add 1 :name \"Ivan\"]])"}
                 {:desc "With metadata"

--- a/src/datahike/api/types.cljc
+++ b/src/datahike/api/types.cljc
@@ -72,6 +72,11 @@
   "Transaction metadata - optional collection."
   [:maybe :any])
 
+(def STxOptions
+  "Transaction-local execution options; never persisted in the database."
+  [:maybe [:map {:closed true}
+           [:allow-index-backfill? {:optional true} :boolean]]])
+
 (def STransactionReport
   "Transaction result map.
 
@@ -110,7 +115,8 @@
   "Arguments for 'with' operation."
   [:map
    [:tx-data STransactions]
-   [:tx-meta {:optional true} STxMeta]])
+   [:tx-meta {:optional true} STxMeta]
+   [:tx-options {:optional true} STxOptions]])
 
 (def SIndexLookupArgs
   "Index lookup arguments."
@@ -168,6 +174,7 @@
     :datahike/SDatom SDatom
     :datahike/SDatoms SDatoms
     :datahike/STxMeta STxMeta
+    :datahike/STxOptions STxOptions
     :datahike/STransactionReport STransactionReport
     :datahike/STransactions STransactions
     :datahike/SPullOptions SPullOptions

--- a/src/datahike/codegen/typescript.clj
+++ b/src/datahike/codegen/typescript.clj
@@ -316,6 +316,7 @@ export type Transaction =
 export interface WithArgs {
   'tx-data': Transaction[];
   'tx-meta'?: any;
+  'tx-options'?: { 'allow-index-backfill?'?: boolean } | null;
 }
 
 export interface QueryArgs {

--- a/src/datahike/core.cljc
+++ b/src/datahike/core.cljc
@@ -128,8 +128,9 @@
 
 (defn with
   "Same as [[transact!]], but applies to an immutable database value. Returns transaction report (see [[transact!]])."
-  ([db tx-data] (with db tx-data nil))
-  ([db tx-data tx-meta]
+  ([db tx-data] (with db tx-data nil nil))
+  ([db tx-data tx-meta] (with db tx-data tx-meta nil))
+  ([db tx-data tx-meta tx-options]
    {:pre [(dbu/db? db)]}
    (if (is-filtered db)
      (throw (ex-info "Filtered DB cannot be modified" {:error :transaction/filtered}))
@@ -143,7 +144,7 @@
                          :tx-data   []
                          :tempids   {}
                          :tx-meta   tx-meta})
-                       tx-data)
+                       tx-data tx-options)
                       (catch #?(:clj Throwable :cljs js/Error) failure
                         (sec/abort-tracked-secondary-transients!)
                         (throw failure))))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -1231,7 +1231,7 @@
 
 (declare transact-tx-data)
 
-(defn- retry-with-tempid [initial-report report es tempid upserted-eid]
+(defn- retry-with-tempid [initial-report report es tempid upserted-eid tx-options]
   (if (contains? (:tempids initial-report) tempid)
     (log/raise "Conflicting upsert: " tempid " resolves"
                " both to " upserted-eid " and " (get-in initial-report [:tempids tempid])
@@ -1242,7 +1242,7 @@
                        (assoc tempid upserted-eid))
           report' (assoc initial-report :tempids tempids')]
       (sec/abort-tracked-secondary-transients!)
-      (transact-tx-data report' es))))
+      (transact-tx-data report' es tx-options))))
 
 (defn assert-preds [db [_ e _ preds]]
   #?(:cljs (throw (ex-info "tx predicate resolution is not supported in cljs at this time" {:e e :preds preds}))
@@ -1710,7 +1710,9 @@
                                           (let [o (get old-schema ident)
                                                 n (get new-schema ident)]
                                             (and (map? o) (indexed-entry? n)
-                                                 (not (indexed-entry? o)))))))
+                                                 (or (not (indexed-entry? o))
+                                                     (and (:db/unique n)
+                                                          (not (:db/unique o)))))))))
                           (keys new-schema))]
         (if (empty? enabled)
           report
@@ -1738,22 +1740,24 @@
                                               {:error :transact/schema :attribute ident
                                                :value (.-v d)})
                                    (vswap! seen conj k))))))
-                         (as-> db db
-                           (reduce (fn [db ^Datom d]
-                                     (let [op-count (:op-count db)]
-                                       (-> db
-                                           (update :avet #(di/-insert % d :avet op-count))
-                                           (update :op-count inc))))
-                                   db datoms)
-                           (if (dbi/-keep-history? db)
+                         (if (indexed-entry? (get old-schema ident))
+                           db
+                           (as-> db db
                              (reduce (fn [db ^Datom d]
                                        (let [op-count (:op-count db)]
                                          (-> db
-                                             (update :temporal-avet
-                                                     #(di/-temporal-insert % d :avet op-count))
+                                             (update :avet #(di/-insert % d :avet op-count))
                                              (update :op-count inc))))
-                                     db (schema-attr-history-datoms db ident))
-                             db))))
+                                     db datoms)
+                             (if (dbi/-keep-history? db)
+                               (reduce (fn [db ^Datom d]
+                                         (let [op-count (:op-count db)]
+                                           (-> db
+                                               (update :temporal-avet
+                                                       #(di/-temporal-insert % d :avet op-count))
+                                               (update :op-count inc))))
+                                       db (schema-attr-history-datoms db ident))
+                               db)))))
                      db enabled))))))))
 
 (defn- remove-disabled-indices
@@ -1872,7 +1876,7 @@
    - composite :db/tupleAttrs must not reference attributes defined as
      cardinality-many or as tuples (undeclared references are supported —
      their slots stay nil)."
-  [{:keys [db-before db-after] :as _report}]
+  [{:keys [db-before db-after] :as _report} tx-options]
   (let [old-schema (dbi/-schema db-before)
         new-schema (dbi/-schema db-after)]
     (when-not (identical? old-schema new-schema)
@@ -1920,7 +1924,8 @@
                 ;; accepted as before.
                 (when (and (or (contains? data-checks :index-backfill)
                                (contains? data-checks :unique-backfill))
-                           (not (:allow-index-backfill? (dbi/-config db-after)))
+                           (not (or (:allow-index-backfill? (dbi/-config db-after))
+                                    (:allow-index-backfill? tx-options)))
                            (or (seq (schema-attr-current-datoms db-after ident))
                                (seq (schema-attr-history-datoms db-after ident))))
                   (log/raise (str "Schema change on " ident " enables indexing/uniqueness on a"
@@ -1950,131 +1955,153 @@
                                           ", which is itself a tuple attribute.")
                                      {:error :transact/schema :attribute ident :tuple-attr ta}))))))))))))))
 
-(defn transact-tx-data [{:keys [db-before] :as initial-report} initial-es]
-  (when-not (or (nil? initial-es)
-                (sequential? initial-es))
-    (log/raise "Bad transaction data " initial-es ", expected sequential collection"
-               {:error :transact/syntax, :tx-data initial-es}))
-  (let [has-tuples? (seq (dbi/-attrs-by (:db-after initial-report) :db.type/tuple))
-        initial-es' (if has-tuples?
-                      (interleave initial-es (repeat ::flush-tuples))
-                      initial-es)
-        initial-report (-> initial-report
-                           (update :datahike/tx-ops #(or % #{}))
-                           (update :tx-meta
-                                   #(merge {:db/txInstant (next-tx-instant db-before)} %)))
+(defn validate-tx-options!
+  "Validate transaction-local execution options. nil means no options. These
+   are not transaction metadata and must never be persisted on the database."
+  [tx-options]
+  (when-not (or (nil? tx-options) (map? tx-options))
+    (log/raise "Bad transaction options, expected a map or nil"
+               {:error :transact/invalid-options :tx-options tx-options}))
+  (when (map? tx-options)
+    (when-let [unknown (seq (remove #{:allow-index-backfill?} (keys tx-options)))]
+      (log/raise "Unknown transaction options: " (vec unknown)
+                 {:error :transact/invalid-options :unknown-options (vec unknown)}))
+    (when (and (contains? tx-options :allow-index-backfill?)
+               (not (boolean? (:allow-index-backfill? tx-options))))
+      (log/raise ":allow-index-backfill? must be a boolean"
+                 {:error :transact/invalid-options
+                  :option :allow-index-backfill?
+                  :value (:allow-index-backfill? tx-options)})))
+  tx-options)
+
+(defn transact-tx-data
+  ([initial-report initial-es] (transact-tx-data initial-report initial-es nil))
+  ([{:keys [db-before] :as initial-report} initial-es tx-options]
+   (validate-tx-options! tx-options)
+   (when-not (or (nil? initial-es)
+                 (sequential? initial-es))
+     (log/raise "Bad transaction data " initial-es ", expected sequential collection"
+                {:error :transact/syntax, :tx-data initial-es}))
+   (let [has-tuples? (seq (dbi/-attrs-by (:db-after initial-report) :db.type/tuple))
+         initial-es' (if has-tuples?
+                       (interleave initial-es (repeat ::flush-tuples))
+                       initial-es)
+         initial-report (-> initial-report
+                            (update :datahike/tx-ops #(or % #{}))
+                            (update :tx-meta
+                                    #(merge {:db/txInstant (next-tx-instant db-before)} %)))
         ;; Reject zero-width or reverse valid-time windows. A tx
         ;; with `:db.valid/from >= :db.valid/to` would produce a
         ;; tx-entity that no `d/valid-at` query can ever match
         ;; (the AVET predicate is `vf <= at < vt`, unsatisfiable
         ;; when from >= to) — a silent data-quality bug. Throw at
         ;; the transactor so it surfaces immediately.
-        _ (let [tm (:tx-meta initial-report)
-                vf (:db.valid/from tm)
-                vt (:db.valid/to tm)]
-            (when (and vf vt (not (bp/date-before? vf vt)))
-              (log/raise (str "Invalid valid-time window: :db.valid/from "
-                              "must be strictly before :db.valid/to "
-                              "(got from=" vf ", to=" vt ")")
-                         {:error :transact/invalid-valid-times
-                          :db.valid/from vf
-                          :db.valid/to vt})))
-        meta-entities (flush-tx-meta initial-report)]
-    (loop [report (update initial-report :db-after transient)
-           es (if (dbi/-keep-history? db-before)
-                (concat meta-entities
-                        initial-es')
-                initial-es')]
-      (let [[entity & entities] es
-            {:keys [tempids db-after]} report
-            db db-after]
-        (cond
-          (empty? es)
-          (do
+         _ (let [tm (:tx-meta initial-report)
+                 vf (:db.valid/from tm)
+                 vt (:db.valid/to tm)]
+             (when (and vf vt (not (bp/date-before? vf vt)))
+               (log/raise (str "Invalid valid-time window: :db.valid/from "
+                               "must be strictly before :db.valid/to "
+                               "(got from=" vf ", to=" vt ")")
+                          {:error :transact/invalid-valid-times
+                           :db.valid/from vf
+                           :db.valid/to vt})))
+         meta-entities (flush-tx-meta initial-report)]
+     (loop [report (update initial-report :db-after transient)
+            es (if (dbi/-keep-history? db-before)
+                 (concat meta-entities
+                         initial-es')
+                 initial-es')]
+       (let [[entity & entities] es
+             {:keys [tempids db-after]} report
+             db db-after]
+         (cond
+           (empty? es)
+           (do
             ;; Cross-tx vf<vt validation: any prior tx-entity touched
             ;; by this commit's vt-meta writes is checked against the
             ;; final combined state. Throws on invalid window. The
             ;; ::pending-vt-validation bookkeeping is stripped before
             ;; the report exits, matching the ::queued-tuples cleanup
             ;; discipline.
-            (validate-cross-tx-vt-windows! report)
+             (validate-cross-tx-vt-windows! report)
             ;; Deferred schema validation on the RESULTING state — covers
             ;; raw datom vectors, retracts and any datom order uniformly
             ;; (check-schema-update only sees the entity-map path).
-            (validate-schema-changes! report)
-            (validate-ident-renames! report)
-            (-> report
+             (validate-schema-changes! report tx-options)
+             (validate-ident-renames! report)
+             (-> report
                 ;; Index-backfill migration for :db/index / :db/unique
                 ;; enabled on existing attributes — must run while
                 ;; :db-after is still transient.
-                backfill-enabled-indices
+                 backfill-enabled-indices
                 ;; The inverse transition is equally atomic: remove the full
                 ;; current AVET slice before this database value is published.
-                remove-disabled-indices
-                (dissoc ::pending-vt-validation)
-                (assoc-in [:tempids :db/current-tx] (current-tx report))
-                (update-in [:db-after :max-tx] inc)
-                (update :db-after persistent!)
-                (update :db-after finalize-secondary-indices)))
+                 remove-disabled-indices
+                 (dissoc ::pending-vt-validation)
+                 (assoc-in [:tempids :db/current-tx] (current-tx report))
+                 (update-in [:db-after :max-tx] inc)
+                 (update :db-after persistent!)
+                 (update :db-after finalize-secondary-indices)))
 
-          (nil? entity)
-          (recur report entities)
+           (nil? entity)
+           (recur report entities)
 
-          (= ::flush-tuples entity)
-          (if (contains? report ::queued-tuples)
-            (recur
-             (dissoc report ::queued-tuples)
-             (concat (flush-tuples report) entities))
-            (recur report entities))
+           (= ::flush-tuples entity)
+           (if (contains? report ::queued-tuples)
+             (recur
+              (dissoc report ::queued-tuples)
+              (concat (flush-tuples report) entities))
+             (recur report entities))
 
-          (map? entity)
-          (let [{:keys [new-report new-entities retry? old-eid upserted-eid]} (entity-map->op-vec db report entity)]
-            (if retry?
-              (retry-with-tempid initial-report report initial-es old-eid upserted-eid)
-              (recur new-report (concat new-entities entities))))
+           (map? entity)
+           (let [{:keys [new-report new-entities retry? old-eid upserted-eid]} (entity-map->op-vec db report entity)]
+             (if retry?
+               (retry-with-tempid initial-report report initial-es old-eid upserted-eid tx-options)
+               (recur new-report (concat new-entities entities))))
 
-          (sequential? entity)
-          (let [[op e a v] entity]
-            (when (dbu/tuple? db a)
-              (check-tuple db entity))
-            (cond
+           (sequential? entity)
+           (let [[op e a v] entity]
+             (when (dbu/tuple? db a)
+               (check-tuple db entity))
+             (cond
 
-              (tx-id? e)
-              (recur (allocate-eid report e (current-tx report)) (cons [op (current-tx report) a v] entities))
+               (tx-id? e)
+               (recur (allocate-eid report e (current-tx report)) (cons [op (current-tx report) a v] entities))
 
-              (and (dbu/ref? db a) (tx-id? v))
-              (recur (allocate-eid report v (current-tx report)) (cons [op e a (current-tx report)] entities))
+               (and (dbu/ref? db a) (tx-id? v))
+               (recur (allocate-eid report v (current-tx report)) (cons [op e a (current-tx report)] entities))
 
-              (tempid? e)
-              (if (not= op :db/add)
-                (log/raise "Can't use tempid in '" entity "'. Tempids are allowed in :db/add only"
-                           {:error :transact/syntax, :op entity})
-                (let [upserted-eid (when (dbu/is-attr? db a :db.unique/identity)
-                                     (:e (first (dbi/datoms db :avet [a v]))))
-                      allocated-eid (get tempids e)]
-                  (if (and upserted-eid allocated-eid (not= upserted-eid allocated-eid))
-                    (retry-with-tempid initial-report report initial-es e upserted-eid)
-                    (let [eid (or upserted-eid allocated-eid (next-eid db))]
-                      (recur (allocate-eid report e eid) (cons [op eid a v] entities))))))
+               (tempid? e)
+               (if (not= op :db/add)
+                 (log/raise "Can't use tempid in '" entity "'. Tempids are allowed in :db/add only"
+                            {:error :transact/syntax, :op entity})
+                 (let [upserted-eid (when (dbu/is-attr? db a :db.unique/identity)
+                                      (:e (first (dbi/datoms db :avet [a v]))))
+                       allocated-eid (get tempids e)]
+                   (if (and upserted-eid allocated-eid (not= upserted-eid allocated-eid))
+                     (retry-with-tempid initial-report report initial-es e upserted-eid tx-options)
+                     (let [eid (or upserted-eid allocated-eid (next-eid db))]
+                       (recur (allocate-eid report e eid) (cons [op eid a v] entities))))))
 
-              (and (dbu/ref? db a) (tempid? v))
-              (if-let [vid (get tempids v)]
-                (recur report (cons [op e a vid] entities))
-                (recur (allocate-eid report v (next-eid db)) es))
+               (and (dbu/ref? db a) (tempid? v))
+               (if-let [vid (get tempids v)]
+                 (recur report (cons [op e a vid] entities))
+                 (recur (allocate-eid report v (next-eid db)) es))
 
-              :else
-              (let [[new-report new-entities] (apply-db-op db report entity)]
-                (recur new-report (concat new-entities entities)))))
+               :else
+               (let [[new-report new-entities] (apply-db-op db report entity)]
+                 (recur new-report (concat new-entities entities)))))
 
-          (datom? entity)
-          (let [[e a v tx added] entity]
-            (if added
-              (recur (transact-add report [:db/add e a v tx]) entities)
-              (recur (transact-retract-datom report entity true) entities)))
+           (datom? entity)
+           (let [[e a v tx added] entity]
+             (if added
+               (recur (transact-add report [:db/add e a v tx]) entities)
+               (recur (transact-retract-datom report entity true) entities)))
 
-          :else
-          (log/raise "Bad entity type at " entity ", expected map or vector"
-                     {:error :transact/syntax, :tx-data entity}))))))
+           :else
+           (log/raise "Bad entity type at " entity ", expected map or vector"
+                      {:error :transact/syntax, :tx-data entity})))))))
 
 (defn transact-entities-directly
   "Load `initial-es` (raw `[e a v t op]` records) into `(:db-after

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -1684,12 +1684,35 @@
         (.-e d)
         (recur ds (.-e d))))))
 
+(defn- validate-unique-avet!
+  "Validate current values in AVET order, retaining only the previous datom.
+   The candidate AVET must be complete before calling this function. Historical
+   repetitions do not violate current uniqueness. Uses the index comparator,
+   including its array and tuple value semantics."
+  [db ident]
+  (let [a (if (:attribute-refs? (dbi/-config db))
+            (get (:ident-ref-map db) ident ident)
+            ident)]
+    (loop [remaining (seq (di/-slice (:avet db)
+                                     (datom e0 a nil tx0)
+                                     (datom emax a nil txmax)
+                                     :avet))
+           previous nil]
+      (when-let [^Datom current (first remaining)]
+        (when (and previous
+                   (zero? (dd/compare-value (.-v ^Datom previous) (.-v current))))
+          (log/raise (str "Cannot add :db/unique to " ident
+                          ": existing duplicate value " (.-v current))
+                     {:error :transact/schema :attribute ident
+                      :value (.-v current)}))
+        (recur (next remaining) current)))))
+
 (defn- backfill-enabled-indices
   "Index-backfill migration: for every attribute whose :db/index or
    :db/unique was ENABLED by this transaction (assess-schema-transition's
    :index-backfill / :unique-backfill data checks), populate AVET (and
    :temporal-avet on history dbs) with the attribute's pre-existing
-   datoms, after verifying value uniqueness when :db/unique was added.
+   datoms, then verify current value uniqueness when :db/unique was added.
    Runs on the still-transient :db-after right before it is made
    persistent — the same discipline as finalize-secondary-indices.
 
@@ -1720,44 +1743,30 @@
                   (fn [db]
                     (reduce
                      (fn [db ident]
-                       (let [datoms (schema-attr-current-datoms db ident)
-                             unique? (get-in new-schema [ident :db/unique])]
-                         ;; Uniqueness gate: a duplicate among existing values
-                         ;; makes the constraint unsatisfiable — reject the
-                         ;; transaction (the SQL layer maps :transact/unique
-                         ;; to its duplicate-key error).
-                         (when unique?
-                           ;; Duplicate detection must use the INDEX's value
-                           ;; equality (arr/wrap-comparable gives byte/float
-                           ;; arrays value semantics), not JVM .equals — and
-                           ;; must compile on CLJS (no java.util.HashSet).
-                           (let [seen (volatile! #{})]
-                             (doseq [^Datom d datoms]
-                               (let [k (arr/wrap-comparable (.-v d))]
-                                 (if (contains? @seen k)
-                                   (log/raise (str "Cannot add :db/unique to " ident
-                                                   ": existing duplicate value " (.-v d))
-                                              {:error :transact/schema :attribute ident
-                                               :value (.-v d)})
-                                   (vswap! seen conj k))))))
-                         (if (indexed-entry? (get old-schema ident))
-                           db
-                           (as-> db db
-                             (reduce (fn [db ^Datom d]
-                                       (let [op-count (:op-count db)]
-                                         (-> db
-                                             (update :avet #(di/-insert % d :avet op-count))
-                                             (update :op-count inc))))
-                                     db datoms)
-                             (if (dbi/-keep-history? db)
-                               (reduce (fn [db ^Datom d]
-                                         (let [op-count (:op-count db)]
-                                           (-> db
-                                               (update :temporal-avet
-                                                       #(di/-temporal-insert % d :avet op-count))
-                                               (update :op-count inc))))
-                                       db (schema-attr-history-datoms db ident))
-                               db)))))
+                       (let [unique? (get-in new-schema [ident :db/unique])
+                             db (if (indexed-entry? (get old-schema ident))
+                                  db
+                                  (as-> db db
+                                    (reduce (fn [db ^Datom d]
+                                              (let [op-count (:op-count db)]
+                                                (-> db
+                                                    (update :avet #(di/-insert % d :avet op-count))
+                                                    (update :op-count inc))))
+                                            db (schema-attr-current-datoms db ident))
+                                    (if (dbi/-keep-history? db)
+                                      (reduce (fn [db ^Datom d]
+                                                (let [op-count (:op-count db)]
+                                                  (-> db
+                                                      (update :temporal-avet
+                                                              #(di/-temporal-insert % d :avet op-count))
+                                                      (update :op-count inc))))
+                                              db (schema-attr-history-datoms db ident))
+                                      db)))]
+                         ;; Validate only after the candidate index is complete.
+                         ;; An ordered scan needs no all-values hash set, and
+                         ;; rejection still precedes publication of any changes.
+                         (when unique? (validate-unique-avet! db ident))
+                         db))
                      db enabled))))))))
 
 (defn- remove-disabled-indices

--- a/src/datahike/tx_preds.cljc
+++ b/src/datahike/tx_preds.cljc
@@ -29,28 +29,67 @@
 
      (register-tx-pred! store-id (fn [report] … throw to reject))
 
-   Signature is intentionally minimal (one fn per store) and NOT a stable public
-   API yet; a named-predicate list and a symbol-in-data wiring are possible later.")
+   Predicates are registered by name so independent consumers can govern the
+   same store without replacing one another. The two-argument registration API
+   retains the original unnamed/default slot for compatibility.")
 
 (defonce ^:private registry (atom {}))
 
+(def ^:private default-pred-id ::default)
+
 (defn register-tx-pred!
   "Register tx-pred `f` = `(fn [tx-report] …)` for `store-id`. Runs on every
-   committed write to that store; throw an Exception to reject. Returns store-id."
-  [store-id f]
+   committed write to that store; throw an Exception to reject. The three-arg
+   form registers an independently removable named predicate. Returns store-id."
+  ([store-id f]
+   (register-tx-pred! store-id default-pred-id f))
+  ([store-id pred-id f]
+   (assert (ifn? f) "tx-pred must be a function")
+   (swap! registry assoc-in [store-id pred-id] f)
+   store-id))
+
+(defn ensure-tx-pred!
+  "Install the named predicate only when its slot is empty. Returns :installed
+   or :present when the identical function is already registered. A different
+   function at the same id is an error; callers cannot replace another guard
+   while establishing their own writer invariant."
+  [store-id pred-id f]
   (assert (ifn? f) "tx-pred must be a function")
-  (swap! registry assoc store-id f)
-  store-id)
+  (loop []
+    (let [registered @registry
+          existing (get-in registered [store-id pred-id])]
+      (cond
+        (identical? existing f) :present
+        (some? existing)
+        (throw (ex-info "A different transaction predicate is registered at this id"
+                        {:type :tx-pred/id-collision
+                         :store-id store-id :pred-id pred-id}))
+        (compare-and-set! registry registered
+                          (assoc-in registered [store-id pred-id] f))
+        :installed
+        :else (recur)))))
 
 (defn unregister-tx-pred!
-  [store-id]
-  (swap! registry dissoc store-id)
-  nil)
+  ([store-id]
+   (unregister-tx-pred! store-id default-pred-id))
+  ([store-id pred-id]
+   (swap! registry
+          (fn [registered]
+            (let [remaining (dissoc (get registered store-id) pred-id)]
+              (if (seq remaining)
+                (assoc registered store-id remaining)
+                (dissoc registered store-id)))))
+   nil))
 
 (defn tx-pred-for
   "The tx-pred fn registered for `store-id`, or nil."
   [store-id]
-  (get @registry store-id))
+  (get-in @registry [store-id default-pred-id]))
+
+(defn tx-preds-for
+  "The named transaction predicates registered for `store-id`."
+  [store-id]
+  (get @registry store-id {}))
 
 (defn check-report
   "Run the store's tx-pred (if any) on `tx-report`. Throws to reject; returns the
@@ -59,7 +98,9 @@
    bounded by the small operation vocabulary; an ungoverned store still pays
    only that collection plus a single registry lookup."
   [tx-report]
-  (when-let [f (tx-pred-for (get-in tx-report [:db-after :config :store :id]))]
+  (doseq [[_ f] (sort-by (comp pr-str key)
+                         (tx-preds-for
+                          (get-in tx-report [:db-after :config :store :id])))]
     (f tx-report))
   ;; Operation provenance is a writer-side governance aid, not part of the
   ;; Datomic-shaped transaction report contract. Strip it once, after the

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -2009,11 +2009,11 @@
            :idx-idents (set new-building)
            :writer writer-config})))))
 
-(defn transact! [old {:keys [tx-data tx-meta]}]
+(defn transact! [old {:keys [tx-data tx-meta tx-options]}]
   (log/debug :datahike/transact {:tx-count (count tx-data)})
   (log/trace :datahike/transact-detail {:tx-data tx-data :tx-meta tx-meta})
   (let [tx-report (binding [sec/*durable-secondary-write-context* :commit]
-                    (core/with old tx-data tx-meta))]
+                    (core/with old tx-data tx-meta tx-options))]
     #?(:clj (validate-secondary-backfill-writer! old tx-report))
     (complete-db-update old tx-report)))
 

--- a/test/datahike/test/codegen_or_args_test.clj
+++ b/test/datahike/test/codegen_or_args_test.clj
@@ -31,10 +31,10 @@
     (is (= #{["Object" "List"] ["Object" "Object"]} (spec-sigs 'transact!)))
     (is (= #{["Object" "List"] ["Object" "Object"]} (spec-sigs 'db-with))))
 
-  (testing "`with` keeps exactly the three overloads it had before its schema
-            was rewritten from three same-arity branches into one `[:or …]`.
-            This is the operation the whole exclusion mechanism existed for."
-    (is (= #{["Object" "List"] ["Object" "Object"] ["Object" "List" "Object"]}
+  (testing "`with` keeps the original three overloads and adds the transaction
+            options arity without changing how the existing calls marshal."
+    (is (= #{["Object" "List"] ["Object" "Object"] ["Object" "List" "Object"]
+             ["Object" "List" "Object" "Object"]}
            (spec-sigs 'with)))))
 
 (deftest non-additive-expansion-is-refused

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -331,11 +331,12 @@
         server (start-server {:port port :host "127.0.0.1" :join? false :dev-mode false
                               :token "securerandompassword"})
         remote {:backend :datahike-server :url (str "http://localhost:" port)
-                :token "securerandompassword" :format :transit}]
+                :token "securerandompassword" :format :transit}
+        cfg {:store {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000007"}
+             :schema-flexibility :read
+             :remote-peer remote}]
     (try
-      (let [cfg  (api/create-database {:store {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000007"}
-                                       :schema-flexibility :read
-                                       :remote-peer        remote})
+      (let [cfg  (api/create-database cfg)
             conn (api/connect cfg)
             _    (api/transact conn [{:name "Peter"}])
             db   @conn]
@@ -353,7 +354,9 @@
                      '[:find ?x :where [_ :name ?n] [(clojure.core/requiring-resolve (quote clojure.core/inc)) ?x]]]]
             (is (thrown? Exception (api/q q db)) (pr-str q)))))
       (finally
-        (stop-server server)))
+        (try
+          (api/delete-database cfg)
+          (finally (stop-server server)))))
     (is (identical? before qr/*symbol-resolver*) "the server never touches the process's own resolver"))
   (testing "an unknown mode is refused at start"
     (is (thrown-with-msg? Exception #"safe or :permissive"
@@ -371,10 +374,13 @@
                                   :token "securerandompassword"
                                   :create-database {:backends #{:memory}}})]
         (try
-          (is (map? (create port {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000011"})))
-          (is (thrown-with-msg? Exception #"403"
-                                (create port {:backend :file :path "/tmp/anywhere" :id #uuid "de110000-0000-0000-0000-000000000012"}))
-              "a backend outside the set is refused before anything is created")
+          (let [cfg (create port {:backend :memory :id #uuid "de110000-0000-0000-0000-000000000011"})]
+            (try
+              (is (map? cfg))
+              (is (thrown-with-msg? Exception #"403"
+                                    (create port {:backend :file :path "/tmp/anywhere" :id #uuid "de110000-0000-0000-0000-000000000012"}))
+                  "a backend outside the set is refused before anything is created")
+              (finally (api/delete-database cfg))))
           (finally (stop-server server)))))
     (testing "the server chooses the store below its root"
       (let [port 23200
@@ -385,11 +391,15 @@
         (try
           (let [id  #uuid "de110000-0000-0000-0000-000000000013"
                 cfg (create port {:backend :memory :id id})]
-            (is (= :file (get-in cfg [:store :backend])) "the client's backend is not what gets created")
-            (is (= id (get-in cfg [:store :id])) "the client's id is kept")
-            (is (.startsWith ^String (get-in cfg [:store :path]) root) "the path is the server's"))
+            (try
+              (is (= :file (get-in cfg [:store :backend])) "the client's backend is not what gets created")
+              (is (= id (get-in cfg [:store :id])) "the client's id is kept")
+              (is (.startsWith ^String (get-in cfg [:store :path]) root) "the path is the server's")
+              (finally (api/delete-database cfg))))
           (let [cfg (create port {:backend :file :path "/etc" :id #uuid "de110000-0000-0000-0000-000000000014"})]
-            (is (.startsWith ^String (get-in cfg [:store :path]) root) "a client path is ignored"))
+            (try
+              (is (.startsWith ^String (get-in cfg [:store :path]) root) "a client path is ignored")
+              (finally (api/delete-database cfg))))
           (finally (stop-server server)))))
     (testing "a policy the server cannot act on is refused at start"
       (is (thrown-with-msg? Exception #":create-database"

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -64,6 +64,7 @@
             ;; Attribute-value constraints — registry resolution (pure, here)
             ;; and an async enforcement test below.
             [datahike.test.attr-preds-test]
+            [datahike.test.tx-preds-test]
             ;; Dump digests. A dump written on the JVM is verified here, so the
             ;; SHA-256 and the xor64+sum64 semantic digest must come out
             ;; bit-identical — and 64-bit arithmetic is exactly what cljs does
@@ -120,6 +121,34 @@
    both. Only the ROOT stops being assumed to be a POSIX `/tmp`."
   [nm]
   (path.join (os.tmpdir) nm))
+
+(deftest transaction-backfill-option-is-local-in-cljs
+  (async done
+         (go
+           (let [cfg {:store {:backend :memory :id (random-uuid)}
+                      :schema-flexibility :write :allow-index-backfill? false}]
+             (<! (d/create-database cfg))
+             (let [conn (d/connect cfg)]
+               (try
+                 (<! (d/transact! conn
+                                  (mapv (fn [ident]
+                                          {:db/ident ident :db/valueType :db.type/string
+                                           :db/cardinality :db.cardinality/one})
+                                        [:option/left :option/right])))
+                 (<! (d/transact! conn [{:option/left "left" :option/right "right"}]))
+                 (let [report (<! (d/transact!
+                                   conn {:tx-data [{:db/ident :option/left :db/index true}]
+                                         :tx-options {:allow-index-backfill? true}}))]
+                   (is (some? (:db-after report)))
+                   (is (= 1 (count (d/datoms (d/db conn) :avet :option/left "left"))))
+                   (is (false? (get-in (d/db conn) [:config :allow-index-backfill?]))))
+                 (is (instance? js/Error
+                                (<! (d/transact! conn [{:db/ident :option/right :db/index true}]))))
+                 (catch :default e (is false (str e)))
+                 (finally
+                   (d/release conn)
+                   (<! (d/delete-database cfg))
+                   (done))))))))
 
 (deftest bigdec-roundtrip-test
   ;; :db.type/bigdec must accept a fress `Bigdec` (unscaled js/BigInt + scale) in
@@ -871,4 +900,5 @@
                'datahike.test.experimental.anomaly-test
                'datahike.test.lru-weighted-test
                'datahike.test.lru-weighted-property-test
-               'datahike.test.attr-preds-test))
+               'datahike.test.attr-preds-test
+               'datahike.test.tx-preds-test))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -150,6 +150,39 @@
                    (<! (d/delete-database cfg))
                    (done))))))))
 
+(deftest ordered-unique-upgrade-in-cljs
+  (async done
+         (go
+           (let [cfg {:store {:backend :memory :id (random-uuid)}
+                      :schema-flexibility :write}]
+             (<! (d/create-database cfg))
+             (let [conn (d/connect cfg)]
+               (try
+                 (doseq [indexed? [false true]]
+                   (let [attr (if indexed? :ordered/indexed :ordered/unindexed)
+                         upgrade {:tx-data [[:db/add attr :db/unique :db.unique/value]]
+                                  :tx-options {:allow-index-backfill? true}}]
+                     (<! (d/transact! conn [{:db/ident attr :db/valueType :db.type/string
+                                             :db/cardinality :db.cardinality/one
+                                             :db/index indexed?}]))
+                     (<! (d/transact! conn [[:db/add 100 attr "z"]
+                                            [:db/add 101 attr "a"]
+                                            [:db/add 102 attr "z"]]))
+                     (let [before (d/db conn)]
+                       (is (instance? js/Error (<! (d/transact! conn upgrade))))
+                       (is (= (:max-tx before) (:max-tx (d/db conn)))))
+                     (let [report (<! (d/transact! conn
+                                                   (update upgrade :tx-data
+                                                           #(into [[:db/add 102 attr "b"]] %))))]
+                       (is (some? (:db-after report)))
+                       (is (= ["a" "b" "z"]
+                              (mapv :v (d/datoms (d/db conn) :avet attr)))))))
+                 (catch :default e (is false (str e)))
+                 (finally
+                   (d/release conn)
+                   (<! (d/delete-database cfg))
+                   (done))))))))
+
 (deftest bigdec-roundtrip-test
   ;; :db.type/bigdec must accept a fress `Bigdec` (unscaled js/BigInt + scale) in
   ;; cljs and round-trip it. The spec was `(complement any?)` — it rejected EVERY

--- a/test/datahike/test/transaction_options_test.clj
+++ b/test/datahike/test/transaction_options_test.clj
@@ -1,0 +1,254 @@
+(ns datahike.test.transaction-options-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.api.types :as types]
+            [datahike.core :as core]
+            [datahike.db.transaction :as dbt]
+            [datahike.writing :as writing]
+            [malli.core :as m]
+            [malli.instrument :as mi]))
+
+(def ^:private backfill {:allow-index-backfill? true})
+
+(defn- with-db
+  ([f] (with-db {} f))
+  ([extra-config f]
+   (let [config (merge {:store {:backend :memory :id (random-uuid)}
+                        :schema-flexibility :write
+                        :keep-history? true
+                        :max-string-length 0
+                        :allow-index-backfill? false}
+                       extra-config)]
+     (d/create-database config)
+     (let [conn (d/connect config)]
+       (try
+         (d/transact conn
+                     [{:db/ident :sample/id :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                      {:db/ident :sample/value :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :sample/other :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}
+                      {:db/ident :sample/retired :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}])
+         (f conn)
+         (finally
+           (d/release conn)
+           (d/delete-database config)))))))
+
+(defn- datom-set [db index & components]
+  (into #{} (map (juxt :e :a :v :tx :added)) (apply d/datoms db index components)))
+
+(defn- error-data [f]
+  (try (f) nil
+       (catch Exception e
+         (loop [cause e]
+           (if (or (:error (ex-data cause)) (nil? (ex-cause cause)))
+             (ex-data cause)
+             (recur (ex-cause cause)))))))
+
+(deftest transaction-option-backfills-current-and-history-avet
+  (doseq [attribute-refs? [false true]
+          keep-history? [false true]]
+    (testing (str "attribute refs " attribute-refs? ", history " keep-history?)
+      (with-db
+        {:attribute-refs? attribute-refs? :keep-history? keep-history?}
+        (fn [conn]
+          (d/transact conn [{:db/id 100 :sample/value "old" :sample/retired "gone"}
+                            {:db/id 101 :sample/value "retained"}])
+          (d/transact conn [[:db/add 100 :sample/value "new"]
+                            [:db/retract 100 :sample/retired "gone"]])
+          (let [before @conn
+                attrs [:sample/value :sample/retired]
+                current (into {} (map (fn [a] [a (datom-set before :aevt a)])) attrs)
+                history (when keep-history?
+                          (into {} (map (fn [a] [a (datom-set (d/history before) :aevt a)])) attrs))
+                report (d/transact conn {:tx-data (mapv (fn [a] [:db/add a :db/index true]) attrs)
+                                         :tx-options backfill})
+                after (:db-after report)]
+            (doseq [a attrs]
+              (is (= (current a) (datom-set after :avet a)))
+              (when keep-history?
+                (is (= (history a) (datom-set (d/history after) :avet a)))))
+            (is (= (:config before) (:config after)))
+            (is (not (contains? report :tx-options)))
+            (is (not (contains? (:tx-meta report) :tx-options)))
+            (is (not (contains? after :tx-options)))
+            (is (not (contains? (:meta after) :tx-options)))))))))
+
+(deftest option-is-local-to-one-transaction
+  (with-db
+    (fn [conn]
+      (d/transact conn [{:db/ident :allow-index-backfill? :db/valueType :db.type/boolean
+                         :db/cardinality :db.cardinality/one}])
+      (d/transact conn [{:sample/value "value" :sample/other "other"}])
+      (d/transact conn {:tx-data [[:db/add :sample/value :db/index true]]
+                        :tx-options backfill})
+      (let [before @conn
+            tx [[:db/add :sample/other :db/index true]]]
+        (doseq [options [nil {} {:allow-index-backfill? false}]]
+          (is (= :transact/schema
+                 (:error (error-data #(d/with before tx nil options)))))
+          (is (= :transact/schema
+                 (:error (error-data #(d/transact conn {:tx-data tx :tx-options options}))))))
+        (is (= {:error :transact/schema :attribute :sample/other}
+               (select-keys (error-data #(d/transact conn {:tx-data tx :tx-meta backfill}))
+                            [:error :attribute]))
+            "transaction metadata is not an execution option")
+        (is (= (:max-tx before) (:max-tx @conn)))
+        (is (= (:config before) (:config @conn)))
+        (is (not (get-in @conn [:schema :sample/other :db/index])))
+        (is (d/transact conn {:tx-data tx :tx-options backfill}))))))
+
+(deftest persisted-config-still-permits-backfill
+  (with-db
+    {:allow-index-backfill? true}
+    (fn [conn]
+      (d/transact conn [{:sample/value "value" :sample/other "other"}])
+      (is (d/transact conn [[:db/add :sample/value :db/index true]]))
+      (is (d/transact conn {:tx-data [[:db/add :sample/other :db/index true]]
+                            :tx-options {:allow-index-backfill? false}}))
+      (is (true? (get-in @conn [:config :allow-index-backfill?]))))))
+
+(deftest immutable-and-writer-backfill-are-equivalent
+  (with-db
+    (fn [conn]
+      (d/transact conn [{:db/id 100 :sample/value "old"}])
+      (d/transact conn [[:db/add 100 :sample/value "new"]])
+      (let [before @conn
+            tx [[:db/add :sample/value :db/index true]
+                [:db/add -1 :sample/value "added"]]
+            tx-meta {:db/txInstant (java.util.Date. 2000000000000)}
+            previews [(core/with before tx tx-meta backfill)
+                      (d/with before tx tx-meta backfill)
+                      (d/with before {:tx-data tx :tx-meta tx-meta :tx-options backfill})]
+            committed @(d/transact! conn {:tx-data tx :tx-meta tx-meta :tx-options backfill})]
+        (doseq [preview previews]
+          (is (= (:tempids preview) (:tempids committed)))
+          (is (= (:tx-data preview) (:tx-data committed)))
+          (is (= (:tx-meta preview) (dissoc (:tx-meta committed) :db/commitId)))
+          (is (= (:schema (:db-after preview)) (:schema (:db-after committed))))
+          (is (= (:config before) (:config (:db-after preview))))
+          (doseq [index [:eavt :aevt :avet]]
+            (is (= (datom-set (:db-after preview) index)
+                   (datom-set (:db-after committed) index)))
+            (is (= (datom-set (d/history (:db-after preview)) index)
+                   (datom-set (d/history (:db-after committed)) index)))))))))
+
+(deftest retries-retain-transaction-options
+  (doseq [upsert-tx [[[:db/add -1 :sample/other "updated"]
+                      [:db/add -1 :sample/id "existing"]]
+                     [{:db/id -1 :sample/other "updated"}
+                      {:db/id -1 :sample/id "existing"}]]]
+    (with-db
+      (fn [conn]
+        (d/transact conn [{:db/id 100 :sample/id "existing" :sample/value "value"}])
+        (let [tx (conj upsert-tx [:db/add :sample/value :db/index true])
+              original dbt/transact-tx-data
+              calls (atom 0)]
+          (with-redefs [dbt/transact-tx-data (fn [& args]
+                                               (swap! calls inc)
+                                               (apply original args))]
+            (let [preview (d/with @conn tx nil backfill)]
+              (is (= 2 @calls) "the tempid conflict really restarted the transaction")
+              (is (= 100 (get (:tempids preview) -1)))
+              (is (= "updated" (:sample/other (d/entity (:db-after preview) 100))))
+              (is (= 1 (count (d/datoms (:db-after preview) :avet :sample/value)))))
+            (reset! calls 0)
+            (let [report (d/transact conn {:tx-data tx :tx-options backfill})]
+              (is (= 2 @calls))
+              (is (= 100 (get (:tempids report) -1)))
+              (is (= 1 (count (d/datoms @conn :avet :sample/value))))))
+          (is (false? (get-in @conn [:config :allow-index-backfill?]))))))))
+
+(deftest unique-backfill-validates-existing-values-atomically
+  (with-db
+    (fn [conn]
+      (d/transact conn [{:db/id 100 :sample/value "duplicate"}
+                        {:db/id 101 :sample/value "duplicate"}])
+      (let [before @conn
+            tx [[:db/add :sample/value :db/unique :db.unique/identity]]]
+        (is (= :transact/schema
+               (:error (error-data #(d/with before tx nil backfill)))))
+        (is (= :transact/schema
+               (:error (error-data #(d/transact conn {:tx-data tx :tx-options backfill})))))
+        (is (= (:max-tx before) (:max-tx @conn)))
+        (is (= (:meta before) (:meta @conn)))
+        (is (nil? (get-in @conn [:schema :sample/value :db/unique])))
+        (d/transact conn [[:db/add 101 :sample/value "different"]])
+        (is (d/transact conn {:tx-data tx :tx-options backfill}))
+        (is (= 100 (:db/id (d/entity @conn [:sample/value "duplicate"]))))
+        (is (= :transact/unique
+               (:error (error-data #(d/transact conn [[:db/add 102 :sample/value "duplicate"]])))))))))
+
+(deftest newly-unique-existing-index-is-validated-without-rebuilding
+  (doseq [attribute-refs? [false true]
+          unique [:db.unique/value :db.unique/identity]]
+    (with-db
+      {:attribute-refs? attribute-refs?}
+      (fn [conn]
+        (d/transact conn [[:db/add :sample/value :db/index true]])
+        (d/transact conn [{:db/id 100 :sample/value "duplicate"}
+                          {:db/id 101 :sample/value "duplicate"}])
+        (let [before @conn
+              tx [[:db/add :sample/value :db/unique unique]]]
+          (is (= :transact/schema
+                 (:error (error-data #(d/with before tx nil backfill)))))
+          (is (= :transact/schema
+                 (:error (error-data #(d/transact conn {:tx-data tx :tx-options backfill})))))
+          (is (= (:max-tx before) (:max-tx @conn)))
+          (is (= (:meta before) (:meta @conn)))
+          (is (nil? (get-in @conn [:schema :sample/value :db/unique])))
+          (d/transact conn [[:db/add 101 :sample/value "different"]])
+          (let [before @conn
+                baseline (d/with before [[:db/add :sample/value :db/doc "no backfill"]])
+                preview (d/with before tx nil backfill)
+                committed (d/transact conn {:tx-data tx :tx-options backfill})]
+            (is (= (:op-count (:db-after baseline)) (:op-count (:db-after preview)))
+                "adding uniqueness must not reinsert already indexed current/history datoms")
+            (doseq [report [preview committed]]
+              (is (= unique (get-in report [:db-after :schema :sample/value :db/unique])))
+              (is (= (datom-set before :avet :sample/value)
+                     (datom-set (:db-after report) :avet :sample/value)))
+              (is (= (datom-set (d/history before) :avet :sample/value)
+                     (datom-set (d/history (:db-after report)) :avet :sample/value))))))))))
+
+(deftest invalid-options-are-rejected-at-every-entry-point
+  (with-db
+    (fn [conn]
+      (let [before @conn
+            invalid [true false 1 [] #{:allow-index-backfill?}
+                     {:unknown true}
+                     {:allow-index-backfill? true :unknown false}
+                     {:allow-index-backfill? nil}
+                     {:allow-index-backfill? 1}
+                     {:allow-index-backfill? "true"}
+                     {:allow-index-backfill? :yes}]]
+        (doseq [options invalid]
+          (testing (pr-str options)
+            (doseq [call [#(core/with before [] nil options)
+                          #(d/with before [] nil options)
+                          #(d/with before {:tx-data [] :tx-options options})
+                          #(d/transact conn {:tx-data [] :tx-options options})
+                          #(d/transact! conn {:tx-data [] :tx-options options})
+                          #(writing/transact! before {:tx-data [] :tx-options options})]]
+              (is (= :transact/invalid-options (:error (error-data call)))))
+            (is (not (m/validate types/STxOptions options)))))
+        (doseq [options [nil {} {:allow-index-backfill? false} backfill]]
+          (is (m/validate types/STxOptions options)))
+        (is (= (:max-tx before) (:max-tx @conn)))))))
+
+(deftest public-api-options-work-under-instrumentation
+  (with-db
+    (fn [conn]
+      (d/transact conn [{:sample/value "value"}])
+      (let [violations (atom [])
+            tx [[:db/add :sample/value :db/index true]]]
+        (mi/instrument! {:report (fn [type data]
+                                   (swap! violations conj [type (:fn-name data)]))})
+        (try
+          (is (d/with @conn tx nil backfill))
+          (is (d/with @conn {:tx-data tx :tx-options backfill}))
+          (is (d/transact conn {:tx-data tx :tx-options backfill}))
+          (is (empty? @violations))
+          (finally (mi/unstrument!)))))))

--- a/test/datahike/test/transaction_options_test.clj
+++ b/test/datahike/test/transaction_options_test.clj
@@ -3,7 +3,9 @@
             [datahike.api :as d]
             [datahike.api.types :as types]
             [datahike.core :as core]
+            [datahike.datom :as datom]
             [datahike.db.transaction :as dbt]
+            [datahike.index :as index]
             [datahike.writing :as writing]
             [malli.core :as m]
             [malli.instrument :as mi]))
@@ -212,6 +214,55 @@
                      (datom-set (:db-after report) :avet :sample/value)))
               (is (= (datom-set (d/history before) :avet :sample/value)
                      (datom-set (d/history (:db-after report)) :avet :sample/value))))))))))
+
+(deftest ordered-unique-validation-uses-avet-and-stops-at-first-duplicate
+  (with-db
+    (fn [conn]
+      (let [validate! (ns-resolve 'datahike.db.transaction 'validate-unique-avet!)
+            visited (atom 0)
+            ;; Equal arrays must compare by content, not object identity/hash.
+            values [(byte-array [1]) (byte-array [1]) (byte-array [2])]]
+        (with-redefs [index/-slice
+                      (fn [_ _ _ order]
+                        (is (= :avet order))
+                        (map (fn [e v]
+                               (swap! visited inc)
+                               (datom/datom e :sample/value v 1))
+                             (iterate inc 100) values))]
+          (is (= :transact/schema
+                 (:error (error-data #(validate! @conn :sample/value)))))
+          (is (= 2 @visited) "do not realize the remainder after detecting a duplicate"))))))
+
+(deftest ordered-unique-upgrade-validates-final-current-state
+  (doseq [indexed? [false true]
+          attribute-refs? [false true]
+          unique [:db.unique/value :db.unique/identity]]
+    (with-db
+      {:attribute-refs? attribute-refs?}
+      (fn [conn]
+        (when indexed? (d/transact conn [[:db/add :sample/value :db/index true]]))
+        ;; Equal values are separated in entity order (AEVT), adjacent in AVET.
+        (d/transact conn [{:db/id 100 :sample/value "z"}
+                          {:db/id 101 :sample/value "a"}
+                          {:db/id 102 :sample/value "z"}])
+        (let [before @conn
+              upgrade [:db/add :sample/value :db/unique unique]]
+          (is (= :transact/schema
+                 (:error (error-data #(d/transact conn {:tx-data [upgrade]
+                                                        :tx-options backfill})))))
+          (is (= (:max-tx before) (:max-tx @conn)))
+          ;; Repair and upgrade atomically. Historical duplicates are allowed.
+          (let [report (d/transact conn
+                                   {:tx-data [[:db/add 102 :sample/value "b"] upgrade]
+                                    :tx-options backfill})]
+            (is (= ["a" "b" "z"]
+                   (mapv :v (d/datoms (:db-after report) :avet :sample/value))))
+            (is (= #{[100 true] [102 true] [102 false]}
+                   (into #{} (map (juxt :e :added))
+                         (d/datoms (d/history (:db-after report))
+                                   :avet :sample/value "z")))))
+          (is (= :transact/unique
+                 (:error (error-data #(d/transact conn [[:db/add 103 :sample/value "z"]]))))))))))
 
 (deftest invalid-options-are-rejected-at-every-entry-point
   (with-db

--- a/test/datahike/test/transaction_options_test.clj
+++ b/test/datahike/test/transaction_options_test.clj
@@ -233,6 +233,45 @@
                  (:error (error-data #(validate! @conn :sample/value)))))
           (is (= 2 @visited) "do not realize the remainder after detecting a duplicate"))))))
 
+(deftest ordered-unique-upgrade-compares-real-array-values
+  (doseq [indexed? [false true]
+          tuple? [false true]]
+    (with-db
+      (fn [conn]
+        (let [value (fn [n] (if tuple? [(byte-array [n]) 7] (byte-array [n])))
+              upgrade [:db/add :sample/array :db/unique :db.unique/value]]
+          (d/transact conn
+                      [(merge {:db/ident :sample/array
+                               :db/cardinality :db.cardinality/one
+                               :db/index indexed?}
+                              (if tuple?
+                                {:db/valueType :db.type/tuple
+                                 :db/tupleTypes [:db.type/bytes :db.type/long]}
+                                {:db/valueType :db.type/bytes}))])
+          ;; Distinct array instances with equal contents must collide, even
+          ;; when nested inside tuples and separated in entity order.
+          (d/transact conn (mapv (fn [e n] [:db/add e :sample/array (value n)])
+                                 [100 101 102] [2 1 2]))
+          (let [before @conn]
+            (is (= :transact/schema
+                   (:error (error-data #(d/transact conn {:tx-data [upgrade]
+                                                          :tx-options backfill})))))
+            (is (= (:max-tx before) (:max-tx @conn)))
+            (is (nil? (get-in @conn [:schema :sample/array :db/unique])))
+            (is (= 3 (count (d/datoms @conn :aevt :sample/array))))
+            (is (= (if indexed? 3 0)
+                   (count (d/datoms @conn :avet :sample/array)))))
+          (let [report (d/transact conn {:tx-data [[:db/add 102 :sample/array (value 3)]
+                                                   upgrade]
+                                         :tx-options backfill})]
+            (is (= :db.unique/value
+                   (get-in report [:db-after :schema :sample/array :db/unique])))
+            (is (= [1 2 3]
+                   (mapv (fn [d] (first (seq (if tuple? (first (:v d)) (:v d)))))
+                         (d/datoms (:db-after report) :avet :sample/array)))))
+          (is (= :transact/unique
+                 (:error (error-data #(d/transact conn [[:db/add 103 :sample/array (value 2)]]))))))))))
+
 (deftest ordered-unique-upgrade-validates-final-current-state
   (doseq [indexed? [false true]
           attribute-refs? [false true]

--- a/test/datahike/test/tx_preds_test.cljc
+++ b/test/datahike/test/tx_preds_test.cljc
@@ -1,0 +1,80 @@
+(ns datahike.test.tx-preds-test
+  (:require #?(:clj [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [datahike.tx-preds :as tx-preds]))
+
+(defn- report [store-id]
+  {:db-after {:config {:store {:id store-id}}}})
+
+(deftest ensure-predicate-does-not-replace-another-owner
+  (let [id ::ensure-owner
+        f identity]
+    (try
+      (is (= :installed (tx-preds/ensure-tx-pred! id :guard f)))
+      (is (= :present (tx-preds/ensure-tx-pred! id :guard f)))
+      (is (= :tx-pred/id-collision
+             (try (tx-preds/ensure-tx-pred! id :guard (fn [x] x))
+                  nil
+                  (catch #?(:clj Exception :cljs js/Error) e
+                    (:type (ex-data e))))))
+      (is (identical? f (get (tx-preds/tx-preds-for id) :guard)))
+      (finally (tx-preds/unregister-tx-pred! id :guard)))))
+
+#?(:clj
+   (deftest concurrent-ensure-installs-once
+     (let [id ::concurrent-ensure
+           f identity
+           start (promise)]
+       (try
+         (let [attempts (vec (repeatedly 16
+                                         #(future @start
+                                                  (tx-preds/ensure-tx-pred! id :guard f))))]
+           (deliver start true)
+           (is (= {:installed 1 :present 15}
+                  (frequencies (mapv deref attempts)))))
+         (finally (tx-preds/unregister-tx-pred! id :guard))))))
+
+(deftest named-predicates-compose-with-the-legacy-slot
+  (let [store-id ::composed
+        calls (atom [])]
+    (try
+      (tx-preds/register-tx-pred! store-id (fn [_] (swap! calls conj :default)))
+      (tx-preds/register-tx-pred! store-id :audit
+                                  (fn [_] (swap! calls conj :audit)))
+      (tx-preds/check-report (report store-id))
+      (is (= #{:default :audit} (set @calls)))
+      (is (= 2 (count (tx-preds/tx-preds-for store-id))))
+      (is (ifn? (tx-preds/tx-pred-for store-id)))
+
+      (reset! calls [])
+      (tx-preds/unregister-tx-pred! store-id)
+      (tx-preds/check-report (report store-id))
+      (is (= [:audit] @calls))
+      (is (nil? (tx-preds/tx-pred-for store-id)))
+      (finally
+        (tx-preds/unregister-tx-pred! store-id :audit)))))
+
+(deftest named-unregister-is-store-local
+  (let [left ::left
+        right ::right]
+    (try
+      (tx-preds/register-tx-pred! left :guard identity)
+      (tx-preds/register-tx-pred! right :guard identity)
+      (tx-preds/unregister-tx-pred! left :guard)
+      (is (empty? (tx-preds/tx-preds-for left)))
+      (is (= #{:guard} (set (keys (tx-preds/tx-preds-for right)))))
+      (finally
+        (tx-preds/unregister-tx-pred! right :guard)))))
+
+(deftest predicates-run-in-deterministic-name-order
+  (let [store-id ::ordered
+        calls (atom [])]
+    (try
+      (doseq [id [:z :a :m]]
+        (tx-preds/register-tx-pred! store-id id
+                                    (fn [_] (swap! calls conj id))))
+      (tx-preds/check-report (report store-id))
+      (is (= [:a :m :z] @calls))
+      (finally
+        (doseq [id [:z :a :m]]
+          (tx-preds/unregister-tx-pred! store-id id))))))

--- a/ts-client/src/api.generated.ts
+++ b/ts-client/src/api.generated.ts
@@ -276,7 +276,7 @@ export function since(...args: unknown[]): Promise<any> {
 }
 
 /**
- * Applies transaction to the database and updates connection. Blocks until committed. WARNING: Do not call from listener callbacks or transaction functions — use transact! instead to avoid deadlocks.
+ * Applies transaction to the database and updates connection. Blocks until committed. The map form accepts :tx-options {:allow-index-backfill? true} to permit index/uniqueness backfill for this transaction only; it does not change the database config. WARNING: Do not call from listener callbacks or transaction functions — use transact! instead to avoid deadlocks.
  */
 export function transact(arg0: Connection, arg1: Transaction[] | WithArgs): Promise<TransactionReport>;
 export function transact(...args: unknown[]): Promise<any> {

--- a/ts-client/src/core.ts
+++ b/ts-client/src/core.ts
@@ -74,6 +74,7 @@ export type Transaction =
 export interface WithArgs {
   "tx-data": Transaction[];
   "tx-meta"?: any;
+  "tx-options"?: { "allow-index-backfill?"?: boolean } | null;
 }
 
 export interface QueryArgs {


### PR DESCRIPTION
## Summary

This is the smaller replacement for #1074. pg-datahike can establish constraint admission with one ordinary transaction that migrates its catalog and validates the resulting candidate before publication. A general writer barrier is not required.

Retained changes:

- Named transaction predicates, preserving the legacy unnamed slot, plus atomic `ensure-tx-pred!` registration that refuses to replace another owner.
- Transaction-scoped `:tx-options {:allow-index-backfill? true}` for mutable and immutable transactions, retained through retries without changing stored configuration.
- Validation of existing values when an already indexed attribute becomes unique, without rebuilding its existing AVET unnecessarily.
- API/specification and TypeScript contract updates, with focused regression tests.
- HTTP test fixture cleanup so the full multi-index JVM matrix does not reuse databases leaked by an earlier configuration.

There are **no writer-loop changes, no barrier API, no Kabel synchronization changes, and no persisted index-format changes**. The NaN/index-upgrade proposal remains separately deferred in #1075.

## Why retain these pieces?

Unmodified main has one overwriteable predicate slot per store; a pg-datahike-only lock cannot coordinate other consumers of that slot. It also accepts an indexed-to-unique schema transition over duplicate values when connection-level backfill is enabled. The retained changes address those specific gaps without introducing a new synchronization primitive.

## Ordered uniqueness scan follow-up (`8919431e`, regression addition `b8b846f9`)

Uniqueness upgrades now scan the complete candidate AVET in value order, comparing adjacent values with the index comparator. An existing index is reused; an unindexed attribute is backfilled before validation. Duplicate detection retains only the previous datom, not a hash set of every distinct value, and stops at the first duplicate. Historical repetitions remain valid; rejection still rolls back the whole transaction.

This removes the O(distinct values) validation set, **not** the memory costs of index construction or caches. Backfill is still synchronous, not a bounded-heap/background migration.

- Focused suite on each of persistent-set and hitchhiker-tree: 12 tests / 312 assertions, zero failures/errors, including real indexed/unindexed byte-array and tuple-with-byte-array upgrades. The old hash-set implementation accepted duplicate tuple-with-byte-array values; the ordered scan rejects them correctly.
- CLJS: 295 tests / 1,847 assertions, zero failures/errors, including both indexed and unindexed uniqueness upgrades.
- Specification-instrumented suite: 1,286 tests / 14,668 assertions, zero failures.
- Complete pg-datahike unique-index and admission namespaces: 38 tests / 232 assertions, only the two tracked scalar NaN failures, zero errors.
- Full non-spec JVM matrix on production revision `8919431e`: 2,890 tests / 30,953 assertions, zero failures. The later `b8b846f9` adds only the real-array regression, separately passed on both backends as recorded above.
- Fresh CI is running on final regression commit `b8b846f9`. PR remains draft until those checks finish.

## Earlier foundation validation (`657375c8`)

- Baseline admission-ordering experiment on unmodified main: exclusive/shared in-flight writes and conflict replay, 13 assertions passed.
- pg-datahike against this no-barrier candidate: 35 unique-index/admission tests, 198 assertions passed; catalog tests 12/38 passed; admission ordering/replay tests 2/16 passed.
- Retained Datahike features: 14 tests, 250 assertions passed.
- Complete pg-datahike run: 1,737 tests, 7,625 assertions, only two failures in the explicitly deferred native NaN regression. Lint: zero errors.
- Specification-instrumented suite: 1,284 tests / 14,625 assertions, zero failures.
- CLJS: 294 tests / 1,839 assertions, zero failures, including named-predicate and transaction-local backfill tests.
- TypeScript thin-client build/type checks and full Java binding compilation passed.
- SQLLogic: 61 assertions passed; SQLAlchemy: 16 tests passed against the no-barrier server.
- Full non-spec JVM matrix on the committed tree: 2,886 tests / 30,867 assertions, zero failures. The named-slot cleanup correction also passed twice in a fresh REPL and in the specification suite.

The old #1074 remains available for comparison; this PR is intended to replace it, not stack on it.
