### PR TITLE
Bound secondary-index backfill journals with local disk scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ When something is added, it's typically marked *Experimental*. When the API cont
 
 ## 0.8
 
+- **Disk-backed secondary backfill journals.** JVM local-exclusive writers
+  capture concurrent changes in bounded-frame scratch files instead of retaining
+  decoded changes across database snapshots. Configure `:backfill-journal` on
+  the writer to set a scratch directory, frame limit and per-index disk quota.
+  Exceeding a limit rejects the transaction without publishing it. Installation
+  still replays the full journal; this does not bound adapter memory or enable
+  background AVET construction.
+
 - **Named transaction predicates and transaction-scoped index backfill.**
   Independent consumers can register store predicates without replacing each
   other; `ensure-tx-pred!` atomically installs an empty named slot or rejects a

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -413,15 +413,44 @@ from abandoned database values.
 
 ### Backfill scalability
 
-The current beta path keeps the writer available during the snapshot scan. It
-records concurrent changes in an in-memory, per-index delta journal, then
-replays that journal in a short serialized install operation. This closes the
-lost-write race for mutable and immutable adapters, but the journal is not
-bounded. Registering an index while sustained write volume greatly exceeds
-backfill throughput can therefore consume substantial memory.
+The snapshot scan runs in the background. On the JVM, concurrent changes are
+recorded in local disk scratch, with a fixed read boundary in each database
+snapshot. The journal does not retain all changes as decoded values in heap.
+Pure `d/with` does not write scratch files.
+
+Configure the scratch directory and per-index limits on the local writer:
+
+```clojure
+:writer {:backend :self
+         :writer-ownership :exclusive
+         :backfill-journal {:directory "/path/to/scratch"
+                            :max-frame-bytes 1048576
+                            :max-bytes 268435456}}
+```
+
+The directory must already exist. Without `:directory`, scratch uses the
+JVM temporary directory. Defaults allow a 1 MiB encoded notification and
+256 MiB per journal, including eight-byte frame headers. Encoding also limits
+individual scalar allocations and nesting. Exceeding a limit rejects the
+transaction without advancing its database or accepted journal boundary.
+Wait for the build to finish, cancel it, or start a new build with larger limits
+before retrying. Ordinary writes that do not affect the building index are not
+charged to that journal.
+
+Installation still replays the accumulated journal in the serialized writer;
+a large journal can therefore pause writes. These limits bound journal buffers
+and disk use, not the adapter's own index-building memory, transaction input,
+or aggregate resources across many simultaneous builds. Background AVET
+construction is not supported; attribute-index backfill remains synchronous.
+
+Scratch is removed after successful installation, cancellation, or orderly
+writer shutdown. Reconnect rebuilds from durable primary data rather than
+resuming scratch. An abrupt process exit can leave temporary files; use a
+dedicated scratch directory with an operational cleanup policy for stopped
+processes. Do not remove files belonging to an active writer.
 
 For that reason this path currently requires the local self writer with
-`:writer-ownership :exclusive`. Shared writers cannot coordinate an in-memory
+`:writer-ownership :exclusive`. Shared writers cannot coordinate this local
 journal across processes, and remote writers cannot transfer a native live
 generation between build and install. If pre-existing data requires a backfill,
 Datahike rejects those writer configurations before committing the index schema.

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -407,9 +407,7 @@ Pure `d/db-with` can update a durable index only when the adapter declares that
 its transient is wholly in memory (`IPureSecondaryMutation`). Stratum does;
 Scriptum and Proximum currently do not, because opening their builders performs
 external writes. A pure transaction touching either fails before a builder is
-opened. Connection transactions support all three. An immutable in-memory delta
-overlay is the intended way to remove this limitation without leaking resources
-from abandoned database values.
+opened. Connection transactions support all three.
 
 ### Backfill scalability
 
@@ -457,25 +455,13 @@ Datahike rejects those writer configurations before committing the index schema.
 Empty indices can still become ready immediately because no asynchronous handoff
 is needed.
 
-The intended scalable follow-up is a resumable generation protocol:
-
-1. Capture and durably pin a base commit.
-2. Scan the snapshot in bounded, checkpointed batches.
-3. Catch up through successive `datahike.experimental.diff/tx-range` windows.
-4. Validate the build generation and install it inside one writer operation.
-
-`tx-range` currently requires `:keep-history? true`, persistent-set indices,
-and materializes each requested window, so it cannot yet replace the general
-path. The snapshot the scan reads is already pinned with a [durable GC
+The snapshot the scan reads is pinned with a [durable GC
 root](./gc.md#durable-roots) (`:pin`, renewed in the background and released by
 the ready commit); a build whose lease is lost is discarded at install instead
-of being published over swept snapshot nodes. The adapter's unpublished build
-generation is not yet named by a durable checkpoint. The shared Konserve guard
-protects it exactly in-process, and the durable `:building` schema state makes a
+of being published over swept snapshot nodes. A shared Konserve guard
+protects the unpublished generation in-process, and the durable `:building` schema state makes a
 collector in any process defer its sweep until the ready commit lands. This
-pauses reclamation, not transactions or the backfill. A resumable
-generation-specific `:checkpoint` root (or a durable Konserve fence) can later
-allow collection to proceed safely during long builds.
+pauses reclamation, not transactions or the backfill.
 
 ## Purge propagation
 

--- a/src/datahike/backfill/capture.clj
+++ b/src/datahike/backfill/capture.clj
@@ -7,10 +7,10 @@
     (journal/dispose! descriptor)
     (catch Exception e
       (log/warn :datahike/backfill-scratch-cleanup-failed
-                {:id (:id descriptor) :message (ex-message e)}))))
+                {:id (journal/descriptor-id descriptor) :message (ex-message e)}))))
 
 (defn dispose-owned!
-  "Release scratch files owned by a stopped writer. Never called on a live
+  "Release scratch owned by a stopped writer. Never called on a live
    writer: earlier immutable cursors may still be needed by queued reports."
   [owned]
   (locking owned
@@ -23,10 +23,10 @@
   [owned report]
   (doseq [descriptor (::retired report)]
     (dispose-safely! descriptor)
-    (swap! owned dissoc (:id descriptor))))
+    (swap! owned dissoc (journal/descriptor-id descriptor))))
 
 (defn prepare-report!
-  "Spool notifications after transaction predicates accept a report, before
+  "Capture notifications after transaction predicates accept a report, before
    chaining or enqueuing it. Each database retains its exact immutable prefix.
    Scratch is not a durability source: reconnect rebuilds from primary data."
   [owned report]
@@ -57,7 +57,7 @@
                                           (let [d (journal/create!
                                                    (get-in after [:config :writer :backfill-journal] {}))]
                                             (swap! created conj d)
-                                            (swap! owned assoc (:id d) d)
+                                            (swap! owned assoc (journal/descriptor-id d) d)
                                             d))]
                        (assoc journals ident (journal/append! descriptor notifications)))
                      journals))
@@ -69,10 +69,10 @@
               (seq retired) (assoc ::retired retired)))
           (catch Throwable e
           ;; Previously accepted prefixes remain authoritative if a later
-          ;; journal fails. Their invisible tails are discarded on next append.
+          ;; journal fails. Unaccepted tails must not become visible on retry.
             (doseq [descriptor @created]
               (dispose-safely! descriptor)
-              (swap! owned dissoc (:id descriptor)))
+              (swap! owned dissoc (journal/descriptor-id descriptor)))
             (throw e)))))))
 
 (defn reduce-deltas

--- a/src/datahike/backfill/capture.clj
+++ b/src/datahike/backfill/capture.clj
@@ -1,0 +1,91 @@
+(ns ^:no-doc datahike.backfill.capture
+  (:require [datahike.backfill.journal :as journal]
+            [replikativ.logging :as log]))
+
+(defn- dispose-safely! [descriptor]
+  (try
+    (journal/dispose! descriptor)
+    (catch Exception e
+      (log/warn :datahike/backfill-scratch-cleanup-failed
+                {:id (:id descriptor) :message (ex-message e)}))))
+
+(defn dispose-owned!
+  "Release scratch files owned by a stopped writer. Never called on a live
+   writer: earlier immutable cursors may still be needed by queued reports."
+  [owned]
+  (locking owned
+    (doseq [[_ descriptor] @owned]
+      (dispose-safely! descriptor))
+    (reset! owned (with-meta {} {::closed? true}))))
+
+(defn finish!
+  "Release journals detached by a durably published report."
+  [owned report]
+  (doseq [descriptor (::retired report)]
+    (dispose-safely! descriptor)
+    (swap! owned dissoc (:id descriptor))))
+
+(defn prepare-report!
+  "Spool notifications after transaction predicates accept a report, before
+   chaining or enqueuing it. Each database retains its exact immutable prefix.
+   Scratch is not a durability source: reconnect rebuilds from primary data."
+  [owned report]
+  (if (or (not (:db-after report))
+          (and (empty? (get-in report [:db-after :secondary-index-build-deltas]))
+               (empty? (get-in report [:db-before :secondary-index-build-journals]))))
+    report
+    (locking owned
+      (when (::closed? (meta @owned))
+        (throw (ex-info "Backfill journal owner is closed." {:type :writer-shut-down})))
+      (let [before (:db-before report)
+            after (:db-after report)
+            previous (:secondary-index-build-journals before)
+            current? (fn [ident]
+                       (and (= :building (get-in after [:schema ident :db.secondary/status]))
+                            (= (get-in before [:schema ident :db.secondary/building-since-tx])
+                               (get-in after [:schema ident :db.secondary/building-since-tx]))))
+            retained (into {} (filter (comp current? key)) previous)
+            retired (mapv val (remove (comp current? key) previous))
+            created (atom [])]
+        (try
+          (let [journals
+                (reduce-kv
+                 (fn [journals ident notifications]
+                   (if (and (seq notifications)
+                            (= :building (get-in after [:schema ident :db.secondary/status])))
+                     (let [descriptor (or (get journals ident)
+                                          (let [d (journal/create!
+                                                   (get-in after [:config :writer :backfill-journal] {}))]
+                                            (swap! created conj d)
+                                            (swap! owned assoc (:id d) d)
+                                            d))]
+                       (assoc journals ident (journal/append! descriptor notifications)))
+                     journals))
+                 retained (:secondary-index-build-deltas after {}))]
+            (cond-> (-> report
+                        (update :db-after dissoc :secondary-index-build-deltas
+                                :secondary-index-build-journals))
+              (seq journals) (assoc-in [:db-after :secondary-index-build-journals] journals)
+              (seq retired) (assoc ::retired retired)))
+          (catch Throwable e
+          ;; Previously accepted prefixes remain authoritative if a later
+          ;; journal fails. Their invisible tails are discarded on next append.
+            (doseq [descriptor @created]
+              (dispose-safely! descriptor)
+              (swap! owned dissoc (:id descriptor)))
+            (throw e)))))))
+
+(defn reduce-deltas
+  "Replay exactly the database's captured prefix, then any pure pending data."
+  [db ident f init]
+  (let [stopped? (volatile! false)
+        step (fn [acc notification]
+               (let [result (f acc notification)]
+                 (when (reduced? result) (vreset! stopped? true))
+                 result))
+        captured (if-let [descriptor (get-in db [:secondary-index-build-journals ident])]
+                   (journal/reduce-journal descriptor step init)
+                   init)]
+    (if @stopped?
+      captured
+      (reduce f captured (get-in db [:secondary-index-build-deltas ident] [])))))

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -49,7 +49,7 @@
     (swap! owners assoc (:id descriptor) (dissoc descriptor :end))
     descriptor))
 
-(defn- checked-path [descriptor]
+(defn- checked-path ^Path [descriptor]
   (when-not (and (= (get @owners (:id descriptor)) (dissoc descriptor :end))
                  (integer? (:end descriptor)) (<= 0 (:end descriptor) (:max-bytes descriptor)))
     (fail! :backfill.journal/invalid-descriptor "Unknown or modified journal descriptor." {}))
@@ -72,7 +72,7 @@
                                    (< (inc i) (.length s))
                                    (Character/isLowSurrogate (.charAt s (inc i))))]
                     (recur (+ i (if pair? 2 1))
-                           (+ n (cond pair? 4 (< (int c) 128) 1 (< (int c) 2048) 2 :else 3)))))))
+                           (long (+ n (cond pair? 4 (< (int c) 128) 1 (< (int c) 2048) 2 :else 3))))))))
             (visit [x depth]
               (when (or (> depth 128) (neg? (vswap! budget dec)))
                 (fail! :backfill.journal/frame-too-large "Journal value exceeds traversal budget." {}))

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -1,181 +1,63 @@
-(ns datahike.backfill.journal
-  "Single-writer disk scratch for online builds. Descriptors name immutable
-   prefixes, not resumable logs. A process restart must rebuild from its source."
-  (:require [boring.core :as boring]
-            [datahike.cbor.elements :as elements])
-  (:import [java.io RandomAccessFile OutputStream]
-           [java.nio.file Files Path]
-           [java.nio.file.attribute FileAttribute]
-           [java.util UUID]))
+(ns ^:no-doc datahike.backfill.journal
+  "Owned scratch journals for local index builds.
 
-(def ^:private owners (atom {}))
-(def ^:private codec {:profile :archival
-                      :registry (elements/install-element-handlers (boring/tag-registry))})
+   Descriptors are opaque accepted-prefix handles, not paths, byte offsets,
+   durable log addresses, or resumable build checkpoints. Keep them intact.
+   Older accepted prefixes remain readable while the owner extends a lineage.
+   Appending from an earlier prefix abandons its suffix: callers must first
+   ensure that no accepted report or reader still needs that suffix. These
+   journals are not branching immutable logs.
 
-(defn- fail! [type message data]
-  (throw (ex-info message (assoc data :type type))))
+   Capture completes after transaction predicates accept and before the writer
+   chains/enqueues the report. Only a successful append supplies its replacement
+   descriptor. On failure the input prefix remains authoritative; unreachable
+   scratch may remain until backend cleanup. Physical truncation is not part of
+   this contract. One owner serializes append and disposal, and keeps resources
+   alive until all reports/readers needing them have retired.
+
+   This facade is the synchronous JVM adapter. Calls complete or throw; reducers
+   are synchronous and honor reduced. Use a blocking-capable execution context.
+   A future async adapter must make capture, replay and disposal awaitable at
+   their callers, preserve this ordering, bound in-flight work, and coordinate
+   shutdown with outstanding operations. Returning a channel from a backend
+   alone would not satisfy the current synchronous caller contract. Pure with
+   remains I/O-free; scratch is not a database durability source."
+  (:require [datahike.backfill.journal.file :as file]))
+
+(defn descriptor-id
+  "Stable ownership identity for a descriptor's journal, independent of prefix.
+   Consumers may compare this identity but must not interpret descriptor fields."
+  [descriptor]
+  (file/descriptor-id descriptor))
 
 (defn validate-options!
-  "Validate without I/O and return options with defaults. Nil means defaults.
-   Directory existence/access is checked only when a journal is created."
+  "Validate the selected JVM file backend's options without performing I/O.
+   Directory and encoded-byte quotas are backend-specific configuration."
   [options]
-  (when-not (or (nil? options) (map? options))
-    (fail! :backfill.journal/invalid-options "Journal options must be a map." {}))
-  (when (some #(not (contains? #{:directory :max-frame-bytes :max-bytes} %)) (keys options))
-    (fail! :backfill.journal/invalid-options "Unknown journal option." {:keys (set (keys options))}))
-  (let [{:keys [directory max-frame-bytes max-bytes] :as options}
-        (merge {:max-frame-bytes 1048576 :max-bytes 268435456} options)]
-    (when-not (or (nil? directory) (instance? Path directory)
-                  (and (string? directory) (not (empty? directory))))
-      (fail! :backfill.journal/invalid-options "Journal directory must be a nonempty path string or Path." {}))
-    (doseq [[k v] [[:max-frame-bytes max-frame-bytes] [:max-bytes max-bytes]]]
-      (when-not (and (integer? v) (pos? v)
-                     (<= v (if (= k :max-frame-bytes) Integer/MAX_VALUE Long/MAX_VALUE)))
-        (fail! :backfill.journal/invalid-options "Journal limits must be positive bounded integers." {k v})))
-    options))
+  (file/validate-options! options))
 
 (defn create!
-  "Create an owned scratch file. Limits include frame payload bytes and total
-   file bytes respectively; each notification has an eight-byte length header."
+  "Create owned scratch and return its empty prefix. Completion means the
+   backend can accept appends, not that any database state has committed."
   [options]
-  (let [{:keys [directory max-frame-bytes max-bytes]} (validate-options! options)
-        attrs (make-array FileAttribute 0)
-        path (if directory
-               (Files/createTempFile (Path/of (str directory) (make-array String 0))
-                                     "datahike-build-" ".journal" attrs)
-               (Files/createTempFile "datahike-build-" ".journal" attrs))
-        descriptor {:id (UUID/randomUUID) :path (str path) :end 0
-                    :max-frame-bytes max-frame-bytes :max-bytes max-bytes}]
-    (swap! owners assoc (:id descriptor) (dissoc descriptor :end))
-    descriptor))
-
-(defn- checked-path ^Path [descriptor]
-  (when-not (and (= (get @owners (:id descriptor)) (dissoc descriptor :end))
-                 (integer? (:end descriptor)) (<= 0 (:end descriptor) (:max-bytes descriptor)))
-    (fail! :backfill.journal/invalid-descriptor "Unknown or modified journal descriptor." {}))
-  (let [path (Path/of (:path descriptor) (make-array String 0))]
-    (when (Files/isSymbolicLink path)
-      (fail! :backfill.journal/invalid-descriptor "Journal path is a symbolic link." {}))
-    path))
-
-(defn- check-scalars!
-  "Bound scalar allocations inside the codec before its output cap can act.
-   Traversal has a node budget too, avoiding unbounded collection preflight."
-  [value limit]
-  (let [budget (volatile! (long limit))]
-    (letfn [(text-size [^String s]
-              (loop [i 0 n 0]
-                (if (or (> n limit) (= i (.length s)))
-                  n
-                  (let [c (.charAt s i)
-                        pair? (and (Character/isHighSurrogate c)
-                                   (< (inc i) (.length s))
-                                   (Character/isLowSurrogate (.charAt s (inc i))))]
-                    (recur (+ i (if pair? 2 1))
-                           (long (+ n (cond pair? 4 (< (int c) 128) 1 (< (int c) 2048) 2 :else 3))))))))
-            (visit [x depth]
-              (when (or (> depth 128) (neg? (vswap! budget dec)))
-                (fail! :backfill.journal/frame-too-large "Journal value exceeds traversal budget." {}))
-              (let [size (cond
-                           (string? x) (text-size x)
-                           (or (keyword? x) (symbol? x))
-                           (+ (text-size (name x)) (if-let [ns (namespace x)] (inc (text-size ns)) 0))
-                           (instance? java.math.BigInteger x) (inc (quot (.bitLength ^java.math.BigInteger x) 8))
-                           (instance? clojure.lang.BigInt x) (inc (quot (.bitLength (.toBigInteger ^clojure.lang.BigInt x)) 8))
-                           (instance? java.math.BigDecimal x) (inc (quot (.bitLength (.unscaledValue ^java.math.BigDecimal x)) 8))
-                           (and x (.isArray (class x)))
-                           (* (long (java.lang.reflect.Array/getLength x))
-                              (let [component (.getComponentType (class x))]
-                                (cond
-                                  (or (= component Byte/TYPE) (= component Boolean/TYPE)) 1
-                                  (or (= component Short/TYPE) (= component Character/TYPE)) 2
-                                  (or (= component Float/TYPE) (= component Integer/TYPE)) 4
-                                  :else 8)))
-                           :else 0)]
-                (when (> size limit)
-                  (fail! :backfill.journal/frame-too-large "Journal scalar exceeds frame allocation budget." {})))
-              (cond
-                (ratio? x) (do (visit (numerator x) (inc depth))
-                               (visit (denominator x) (inc depth)))
-                (map? x) (doseq [[k v] x] (visit k (inc depth)) (visit v (inc depth)))
-                (or (sequential? x) (set? x)) (doseq [v x] (visit v (inc depth)))
-                (and x (.isArray (class x)) (not (.isPrimitive (.getComponentType (class x)))))
-                (doseq [v (seq x)] (visit v (inc depth)))
-                (instance? datahike.datom.Datom x) (doseq [v (seq x)] (visit v (inc depth)))))]
-      (visit value 0))))
+  (file/create! options))
 
 (defn append!
-  "Append notifications after this exact prefix and return its new descriptor.
-   On failure restore the input prefix. One owner serializes append/dispose;
-   concurrent readers may consume previously accepted prefixes."
-  [{:keys [end max-frame-bytes max-bytes] :as descriptor} notifications]
-  (let [path (checked-path descriptor)]
-    (with-open [file (RandomAccessFile. (.toFile path) "rw")]
-      (when (< (.length file) end)
-        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
-      (.setLength file end)
-      (.seek file end)
-      (try
-        (doseq [notification notifications]
-          (check-scalars! notification max-frame-bytes)
-          (let [start (.getFilePointer file)
-                payload-start (+ start 8)
-                count-bytes (volatile! 0)
-                reserve! (fn [n]
-                           (when (> (+ @count-bytes n) max-frame-bytes)
-                             (fail! :backfill.journal/frame-too-large "Journal frame exceeds byte limit." {}))
-                           (when (> (+ payload-start @count-bytes n) max-bytes)
-                             (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
-                           (vswap! count-bytes + n))
-                out (proxy [OutputStream] []
-                      (write
-                        ([v] (if (number? v)
-                               (do (reserve! 1) (.write file (int v)))
-                               (let [n (alength ^bytes v)]
-                                 (reserve! n) (.write file ^bytes v 0 n))))
-                        ([bs offset n] (reserve! n) (.write file ^bytes bs (int offset) (int n)))))]
-            (when (> payload-start max-bytes)
-              (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
-            (.writeLong file 0)
-            (boring/write-to! (boring/writer (min 8192 max-frame-bytes) codec) notification out)
-            (let [next-end (.getFilePointer file)]
-              (.seek file start)
-              (.writeLong file @count-bytes)
-              (.seek file next-end))))
-        (assoc descriptor :end (.getFilePointer file))
-        (catch Throwable e
-          (try (.setLength file end)
-               (catch Throwable rollback (.addSuppressed e rollback)))
-          (throw e))))))
+  "Capture notifications after the supplied prefix and return a new prefix on
+   success. Failure does not accept any notification from this call. The owner
+   must abandon any existing suffix before appending from an older prefix."
+  [descriptor notifications]
+  (file/append! descriptor notifications))
 
 (defn reduce-journal
-  "Reduce exactly the descriptor's prefix, decoding one bounded frame at a time.
-   Honors reduced and closes the file on completion, early return or exception."
-  [{:keys [end max-frame-bytes] :as descriptor} f init]
-  (let [path (checked-path descriptor)]
-    (with-open [file (RandomAccessFile. (.toFile path) "r")]
-      (when (< (.length file) end)
-        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
-      (loop [acc init]
-        (let [position (.getFilePointer file)]
-          (if (= position end)
-            acc
-            (do
-              (when (> (+ position 8) end)
-                (fail! :backfill.journal/corrupt "Incomplete journal header." {}))
-              (let [n (.readLong file)]
-                (when-not (<= 1 n (min max-frame-bytes (- end position 8)))
-                  (fail! :backfill.journal/corrupt "Invalid journal frame length." {}))
-                (let [payload (byte-array n)
-                      _ (.readFully file payload)
-                      next-acc (f acc (boring/decode payload codec))]
-                  (if (reduced? next-acc) @next-acc (recur next-acc)))))))))))
+  "Reduce exactly the supplied prefix, releasing read resources on completion,
+   reduced or exception. The caller controls retention of the accumulator;
+   the file backend decodes one bounded frame at a time."
+  [descriptor f init]
+  (file/reduce-journal descriptor f init))
 
 (defn dispose!
-  "Delete only this process's exact owned scratch file. Idempotent."
+  "Release this owner's scratch once no accepted report or reader needs it.
+   Idempotent after success; failure may require cleanup to be retried."
   [descriptor]
-  (when (contains? @owners (:id descriptor))
-    (let [path (checked-path descriptor)]
-      (Files/deleteIfExists path)
-      (swap! owners dissoc (:id descriptor))))
-  nil)
+  (file/dispose! descriptor))

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -95,6 +95,8 @@
                 (when (> size limit)
                   (fail! :backfill.journal/frame-too-large "Journal scalar exceeds frame allocation budget." {})))
               (cond
+                (ratio? x) (do (visit (numerator x) (inc depth))
+                               (visit (denominator x) (inc depth)))
                 (map? x) (doseq [[k v] x] (visit k (inc depth)) (visit v (inc depth)))
                 (or (sequential? x) (set? x)) (doseq [v x] (visit v (inc depth)))
                 (and x (.isArray (class x)) (not (.isPrimitive (.getComponentType (class x)))))

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -1,0 +1,179 @@
+(ns datahike.backfill.journal
+  "Single-writer disk scratch for online builds. Descriptors name immutable
+   prefixes, not resumable logs. A process restart must rebuild from its source."
+  (:require [boring.core :as boring]
+            [datahike.cbor.elements :as elements])
+  (:import [java.io RandomAccessFile OutputStream]
+           [java.nio.file Files Path]
+           [java.nio.file.attribute FileAttribute]
+           [java.util UUID]))
+
+(def ^:private owners (atom {}))
+(def ^:private codec {:profile :archival
+                      :registry (elements/install-element-handlers (boring/tag-registry))})
+
+(defn- fail! [type message data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn validate-options!
+  "Validate without I/O and return options with defaults. Nil means defaults.
+   Directory existence/access is checked only when a journal is created."
+  [options]
+  (when-not (or (nil? options) (map? options))
+    (fail! :backfill.journal/invalid-options "Journal options must be a map." {}))
+  (when (some #(not (contains? #{:directory :max-frame-bytes :max-bytes} %)) (keys options))
+    (fail! :backfill.journal/invalid-options "Unknown journal option." {:keys (set (keys options))}))
+  (let [{:keys [directory max-frame-bytes max-bytes] :as options}
+        (merge {:max-frame-bytes 1048576 :max-bytes 268435456} options)]
+    (when-not (or (nil? directory) (instance? Path directory)
+                  (and (string? directory) (not (empty? directory))))
+      (fail! :backfill.journal/invalid-options "Journal directory must be a nonempty path string or Path." {}))
+    (doseq [[k v] [[:max-frame-bytes max-frame-bytes] [:max-bytes max-bytes]]]
+      (when-not (and (integer? v) (pos? v)
+                     (<= v (if (= k :max-frame-bytes) Integer/MAX_VALUE Long/MAX_VALUE)))
+        (fail! :backfill.journal/invalid-options "Journal limits must be positive bounded integers." {k v})))
+    options))
+
+(defn create!
+  "Create an owned scratch file. Limits include frame payload bytes and total
+   file bytes respectively; each notification has an eight-byte length header."
+  [options]
+  (let [{:keys [directory max-frame-bytes max-bytes]} (validate-options! options)
+        attrs (make-array FileAttribute 0)
+        path (if directory
+               (Files/createTempFile (Path/of (str directory) (make-array String 0))
+                                     "datahike-build-" ".journal" attrs)
+               (Files/createTempFile "datahike-build-" ".journal" attrs))
+        descriptor {:id (UUID/randomUUID) :path (str path) :end 0
+                    :max-frame-bytes max-frame-bytes :max-bytes max-bytes}]
+    (swap! owners assoc (:id descriptor) (dissoc descriptor :end))
+    descriptor))
+
+(defn- checked-path [descriptor]
+  (when-not (and (= (get @owners (:id descriptor)) (dissoc descriptor :end))
+                 (integer? (:end descriptor)) (<= 0 (:end descriptor) (:max-bytes descriptor)))
+    (fail! :backfill.journal/invalid-descriptor "Unknown or modified journal descriptor." {}))
+  (let [path (Path/of (:path descriptor) (make-array String 0))]
+    (when (Files/isSymbolicLink path)
+      (fail! :backfill.journal/invalid-descriptor "Journal path is a symbolic link." {}))
+    path))
+
+(defn- check-scalars!
+  "Bound scalar allocations inside the codec before its output cap can act.
+   Traversal has a node budget too, avoiding unbounded collection preflight."
+  [value limit]
+  (let [budget (volatile! (long limit))]
+    (letfn [(text-size [^String s]
+              (loop [i 0 n 0]
+                (if (or (> n limit) (= i (.length s)))
+                  n
+                  (let [c (.charAt s i)
+                        pair? (and (Character/isHighSurrogate c)
+                                   (< (inc i) (.length s))
+                                   (Character/isLowSurrogate (.charAt s (inc i))))]
+                    (recur (+ i (if pair? 2 1))
+                           (+ n (cond pair? 4 (< (int c) 128) 1 (< (int c) 2048) 2 :else 3)))))))
+            (visit [x depth]
+              (when (or (> depth 128) (neg? (vswap! budget dec)))
+                (fail! :backfill.journal/frame-too-large "Journal value exceeds traversal budget." {}))
+              (let [size (cond
+                           (string? x) (text-size x)
+                           (or (keyword? x) (symbol? x))
+                           (+ (text-size (name x)) (if-let [ns (namespace x)] (inc (text-size ns)) 0))
+                           (instance? java.math.BigInteger x) (inc (quot (.bitLength ^java.math.BigInteger x) 8))
+                           (instance? clojure.lang.BigInt x) (inc (quot (.bitLength (.toBigInteger ^clojure.lang.BigInt x)) 8))
+                           (instance? java.math.BigDecimal x) (inc (quot (.bitLength (.unscaledValue ^java.math.BigDecimal x)) 8))
+                           (and x (.isArray (class x)))
+                           (* (long (java.lang.reflect.Array/getLength x))
+                              (let [component (.getComponentType (class x))]
+                                (cond
+                                  (or (= component Byte/TYPE) (= component Boolean/TYPE)) 1
+                                  (or (= component Short/TYPE) (= component Character/TYPE)) 2
+                                  (or (= component Float/TYPE) (= component Integer/TYPE)) 4
+                                  :else 8)))
+                           :else 0)]
+                (when (> size limit)
+                  (fail! :backfill.journal/frame-too-large "Journal scalar exceeds frame allocation budget." {})))
+              (cond
+                (map? x) (doseq [[k v] x] (visit k (inc depth)) (visit v (inc depth)))
+                (or (sequential? x) (set? x)) (doseq [v x] (visit v (inc depth)))
+                (and x (.isArray (class x)) (not (.isPrimitive (.getComponentType (class x)))))
+                (doseq [v (seq x)] (visit v (inc depth)))
+                (instance? datahike.datom.Datom x) (doseq [v (seq x)] (visit v (inc depth)))))]
+      (visit value 0))))
+
+(defn append!
+  "Append notifications after this exact prefix and return its new descriptor.
+   On failure restore the input prefix. One owner serializes append/dispose;
+   concurrent readers may consume previously accepted prefixes."
+  [{:keys [end max-frame-bytes max-bytes] :as descriptor} notifications]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "rw")]
+      (when (< (.length file) end)
+        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (.setLength file end)
+      (.seek file end)
+      (try
+        (doseq [notification notifications]
+          (check-scalars! notification max-frame-bytes)
+          (let [start (.getFilePointer file)
+                payload-start (+ start 8)
+                count-bytes (volatile! 0)
+                reserve! (fn [n]
+                           (when (> (+ @count-bytes n) max-frame-bytes)
+                             (fail! :backfill.journal/frame-too-large "Journal frame exceeds byte limit." {}))
+                           (when (> (+ payload-start @count-bytes n) max-bytes)
+                             (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+                           (vswap! count-bytes + n))
+                out (proxy [OutputStream] []
+                      (write
+                        ([v] (if (number? v)
+                               (do (reserve! 1) (.write file (int v)))
+                               (let [n (alength ^bytes v)]
+                                 (reserve! n) (.write file ^bytes v 0 n))))
+                        ([bs offset n] (reserve! n) (.write file ^bytes bs (int offset) (int n)))))]
+            (when (> payload-start max-bytes)
+              (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+            (.writeLong file 0)
+            (boring/write-to! (boring/writer (min 8192 max-frame-bytes) codec) notification out)
+            (let [next-end (.getFilePointer file)]
+              (.seek file start)
+              (.writeLong file @count-bytes)
+              (.seek file next-end))))
+        (assoc descriptor :end (.getFilePointer file))
+        (catch Throwable e
+          (try (.setLength file end)
+               (catch Throwable rollback (.addSuppressed e rollback)))
+          (throw e))))))
+
+(defn reduce-journal
+  "Reduce exactly the descriptor's prefix, decoding one bounded frame at a time.
+   Honors reduced and closes the file on completion, early return or exception."
+  [{:keys [end max-frame-bytes] :as descriptor} f init]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (when (< (.length file) end)
+        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (loop [acc init]
+        (let [position (.getFilePointer file)]
+          (if (= position end)
+            acc
+            (do
+              (when (> (+ position 8) end)
+                (fail! :backfill.journal/corrupt "Incomplete journal header." {}))
+              (let [n (.readLong file)]
+                (when-not (<= 1 n (min max-frame-bytes (- end position 8)))
+                  (fail! :backfill.journal/corrupt "Invalid journal frame length." {}))
+                (let [payload (byte-array n)
+                      _ (.readFully file payload)
+                      next-acc (f acc (boring/decode payload codec))]
+                  (if (reduced? next-acc) @next-acc (recur next-acc)))))))))))
+
+(defn dispose!
+  "Delete only this process's exact owned scratch file. Idempotent."
+  [descriptor]
+  (when (contains? @owners (:id descriptor))
+    (let [path (checked-path descriptor)]
+      (Files/deleteIfExists path)
+      (swap! owners dissoc (:id descriptor))))
+  nil)

--- a/src/datahike/backfill/journal/file.clj
+++ b/src/datahike/backfill/journal/file.clj
@@ -1,0 +1,183 @@
+(ns ^:no-doc datahike.backfill.journal.file
+  "Single-writer disk scratch for online builds. Descriptors name immutable
+   prefixes, not resumable logs. A process restart must rebuild from its source."
+  (:require [boring.core :as boring]
+            [datahike.cbor.elements :as elements])
+  (:import [java.io RandomAccessFile OutputStream]
+           [java.nio.file Files Path]
+           [java.nio.file.attribute FileAttribute]
+           [java.util UUID]))
+
+(def ^:private owners (atom {}))
+(defn descriptor-id [descriptor] (:id descriptor))
+
+(def ^:private codec {:profile :archival
+                      :registry (elements/install-element-handlers (boring/tag-registry))})
+
+(defn- fail! [type message data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn validate-options!
+  "Validate without I/O and return options with defaults. Nil means defaults.
+   Directory existence/access is checked only when a journal is created."
+  [options]
+  (when-not (or (nil? options) (map? options))
+    (fail! :backfill.journal/invalid-options "Journal options must be a map." {}))
+  (when (some #(not (contains? #{:directory :max-frame-bytes :max-bytes} %)) (keys options))
+    (fail! :backfill.journal/invalid-options "Unknown journal option." {:keys (set (keys options))}))
+  (let [{:keys [directory max-frame-bytes max-bytes] :as options}
+        (merge {:max-frame-bytes 1048576 :max-bytes 268435456} options)]
+    (when-not (or (nil? directory) (instance? Path directory)
+                  (and (string? directory) (not (empty? directory))))
+      (fail! :backfill.journal/invalid-options "Journal directory must be a nonempty path string or Path." {}))
+    (doseq [[k v] [[:max-frame-bytes max-frame-bytes] [:max-bytes max-bytes]]]
+      (when-not (and (integer? v) (pos? v)
+                     (<= v (if (= k :max-frame-bytes) Integer/MAX_VALUE Long/MAX_VALUE)))
+        (fail! :backfill.journal/invalid-options "Journal limits must be positive bounded integers." {k v})))
+    options))
+
+(defn create!
+  "Create an owned scratch file. Limits include frame payload bytes and total
+   file bytes respectively; each notification has an eight-byte length header."
+  [options]
+  (let [{:keys [directory max-frame-bytes max-bytes]} (validate-options! options)
+        attrs (make-array FileAttribute 0)
+        path (if directory
+               (Files/createTempFile (Path/of (str directory) (make-array String 0))
+                                     "datahike-build-" ".journal" attrs)
+               (Files/createTempFile "datahike-build-" ".journal" attrs))
+        descriptor {:id (UUID/randomUUID) :path (str path) :end 0
+                    :max-frame-bytes max-frame-bytes :max-bytes max-bytes}]
+    (swap! owners assoc (:id descriptor) (dissoc descriptor :end))
+    descriptor))
+
+(defn- checked-path ^Path [descriptor]
+  (when-not (and (= (get @owners (:id descriptor)) (dissoc descriptor :end))
+                 (integer? (:end descriptor)) (<= 0 (:end descriptor) (:max-bytes descriptor)))
+    (fail! :backfill.journal/invalid-descriptor "Unknown or modified journal descriptor." {}))
+  (let [path (Path/of (:path descriptor) (make-array String 0))]
+    (when (Files/isSymbolicLink path)
+      (fail! :backfill.journal/invalid-descriptor "Journal path is a symbolic link." {}))
+    path))
+
+(defn- check-scalars!
+  "Bound scalar allocations inside the codec before its output cap can act.
+   Traversal has a node budget too, avoiding unbounded collection preflight."
+  [value limit]
+  (let [budget (volatile! (long limit))]
+    (letfn [(text-size [^String s]
+              (loop [i 0 n 0]
+                (if (or (> n limit) (= i (.length s)))
+                  n
+                  (let [c (.charAt s i)
+                        pair? (and (Character/isHighSurrogate c)
+                                   (< (inc i) (.length s))
+                                   (Character/isLowSurrogate (.charAt s (inc i))))]
+                    (recur (+ i (if pair? 2 1))
+                           (long (+ n (cond pair? 4 (< (int c) 128) 1 (< (int c) 2048) 2 :else 3))))))))
+            (visit [x depth]
+              (when (or (> depth 128) (neg? (vswap! budget dec)))
+                (fail! :backfill.journal/frame-too-large "Journal value exceeds traversal budget." {}))
+              (let [size (cond
+                           (string? x) (text-size x)
+                           (or (keyword? x) (symbol? x))
+                           (+ (text-size (name x)) (if-let [ns (namespace x)] (inc (text-size ns)) 0))
+                           (instance? java.math.BigInteger x) (inc (quot (.bitLength ^java.math.BigInteger x) 8))
+                           (instance? clojure.lang.BigInt x) (inc (quot (.bitLength (.toBigInteger ^clojure.lang.BigInt x)) 8))
+                           (instance? java.math.BigDecimal x) (inc (quot (.bitLength (.unscaledValue ^java.math.BigDecimal x)) 8))
+                           (and x (.isArray (class x)))
+                           (* (long (java.lang.reflect.Array/getLength x))
+                              (let [component (.getComponentType (class x))]
+                                (cond
+                                  (or (= component Byte/TYPE) (= component Boolean/TYPE)) 1
+                                  (or (= component Short/TYPE) (= component Character/TYPE)) 2
+                                  (or (= component Float/TYPE) (= component Integer/TYPE)) 4
+                                  :else 8)))
+                           :else 0)]
+                (when (> size limit)
+                  (fail! :backfill.journal/frame-too-large "Journal scalar exceeds frame allocation budget." {})))
+              (cond
+                (ratio? x) (do (visit (numerator x) (inc depth))
+                               (visit (denominator x) (inc depth)))
+                (map? x) (doseq [[k v] x] (visit k (inc depth)) (visit v (inc depth)))
+                (or (sequential? x) (set? x)) (doseq [v x] (visit v (inc depth)))
+                (and x (.isArray (class x)) (not (.isPrimitive (.getComponentType (class x)))))
+                (doseq [v (seq x)] (visit v (inc depth)))
+                (instance? datahike.datom.Datom x) (doseq [v (seq x)] (visit v (inc depth)))))]
+      (visit value 0))))
+
+(defn append!
+  "Append notifications after this exact prefix and return its new descriptor.
+   On failure restore the input prefix. One owner serializes append/dispose;
+   concurrent readers may consume previously accepted prefixes."
+  [{:keys [end max-frame-bytes max-bytes] :as descriptor} notifications]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "rw")]
+      (when (< (.length file) end)
+        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (.setLength file end)
+      (.seek file end)
+      (try
+        (doseq [notification notifications]
+          (check-scalars! notification max-frame-bytes)
+          (let [start (.getFilePointer file)
+                payload-start (+ start 8)
+                count-bytes (volatile! 0)
+                reserve! (fn [n]
+                           (when (> (+ @count-bytes n) max-frame-bytes)
+                             (fail! :backfill.journal/frame-too-large "Journal frame exceeds byte limit." {}))
+                           (when (> (+ payload-start @count-bytes n) max-bytes)
+                             (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+                           (vswap! count-bytes + n))
+                out (proxy [OutputStream] []
+                      (write
+                        ([v] (if (number? v)
+                               (do (reserve! 1) (.write file (int v)))
+                               (let [n (alength ^bytes v)]
+                                 (reserve! n) (.write file ^bytes v 0 n))))
+                        ([bs offset n] (reserve! n) (.write file ^bytes bs (int offset) (int n)))))]
+            (when (> payload-start max-bytes)
+              (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+            (.writeLong file 0)
+            (boring/write-to! (boring/writer (min 8192 max-frame-bytes) codec) notification out)
+            (let [next-end (.getFilePointer file)]
+              (.seek file start)
+              (.writeLong file @count-bytes)
+              (.seek file next-end))))
+        (assoc descriptor :end (.getFilePointer file))
+        (catch Throwable e
+          (try (.setLength file end)
+               (catch Throwable rollback (.addSuppressed e rollback)))
+          (throw e))))))
+
+(defn reduce-journal
+  "Reduce exactly the descriptor's prefix, decoding one bounded frame at a time.
+   Honors reduced and closes the file on completion, early return or exception."
+  [{:keys [end max-frame-bytes] :as descriptor} f init]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (when (< (.length file) end)
+        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (loop [acc init]
+        (let [position (.getFilePointer file)]
+          (if (= position end)
+            acc
+            (do
+              (when (> (+ position 8) end)
+                (fail! :backfill.journal/corrupt "Incomplete journal header." {}))
+              (let [n (.readLong file)]
+                (when-not (<= 1 n (min max-frame-bytes (- end position 8)))
+                  (fail! :backfill.journal/corrupt "Invalid journal frame length." {}))
+                (let [payload (byte-array n)
+                      _ (.readFully file payload)
+                      next-acc (f acc (boring/decode payload codec))]
+                  (if (reduced? next-acc) @next-acc (recur next-acc)))))))))))
+
+(defn dispose!
+  "Delete only this process's exact owned scratch file. Idempotent."
+  [descriptor]
+  (when (contains? @owners (:id descriptor))
+    (let [path (checked-path descriptor)]
+      (Files/deleteIfExists path)
+      (swap! owners dissoc (:id descriptor))))
+  nil)

--- a/src/datahike/config.cljc
+++ b/src/datahike/config.cljc
@@ -147,7 +147,7 @@
       (if-let [inert (seq (filter (partial contains? writer)
                                   [:writer-ownership :streaming? :require-fencing
                                    :max-batch :head-conflict-retries
-                                   :head-conflict-backoff-ms]))]
+                                   :head-conflict-backoff-ms :backfill-journal]))]
         (log/raise (str "These options configure the :self writer and are inert on a remote writer backend. "
                         "Configure the writer where it runs — the process that owns it — and remove them here.")
                    {:type    :self-writer-options-on-remote-writer

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -459,9 +459,9 @@
                        (= :disabled status) db'
 
                        ;; The background worker exclusively owns the building
-                       ;; instance. Journal concurrent changes for the short
-                       ;; serialized install step instead of racing it or
-                       ;; replacing an immutable result with a stale snapshot.
+                       ;; instance. Collect this transaction's notifications;
+                       ;; the writer spools them only after predicates accept
+                       ;; the report. Pure db-with keeps this collection local.
                        (= :building status)
                        (update-in db' [:secondary-index-build-deltas idx-ident]
                                   (fnil conj []) tx-report)

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -8,6 +8,8 @@
             [datahike.store :as ds]
             [datahike.writing :as w]
             [datahike.tx-preds :as txp]
+            #?(:clj [datahike.backfill.capture :as capture])
+            #?(:clj [datahike.backfill.journal :as journal])
             [datahike.gc :as gc]
             [datahike.tools :as dt :refer [throwable-promise get-time-ms]]
             [konserve.core :as k]
@@ -29,7 +31,7 @@
   (-refresh-on-deref? [_] "Returns whether dereferencing the connection must refresh its branch head from storage."))
 
 (defrecord LocalWriter [thread writer-ownership transaction-queue-size commit-queue-size
-                        transaction-queue commit-queue]
+                        transaction-queue commit-queue journal-owner]
   PWriter
   (-dispatch! [_ arg-map]
     (let [p (promise-chan)]
@@ -45,7 +47,10 @@
       p))
   (-shutdown [_]
     (close! transaction-queue)
-    thread)
+    #?(:clj (go (let [result (<! thread)]
+                  (when journal-owner (capture/dispose-owned! journal-owner))
+                  result))
+       :cljs thread))
   ;; A local writer always installs its own committed db-after in the connection.
   ;; Shared ownership still refreshes on deref because OTHER writers do not stream
   ;; their commits into this process.
@@ -160,11 +165,12 @@
    before a batch is applied and conditionally published. With exclusive
    ownership this JVM keeps the head in memory. See [[create-writer]]."
   [connection write-fn-map transaction-queue-size commit-queue-size commit-wait-time
-   shared? {:keys [max-batch retries backoff]
+   shared? {:keys [max-batch retries backoff journal-owner]
             :or   {max-batch MAX_SHARED_WRITER_BATCH
                    retries   MAX_HEAD_CONFLICT_RETRIES
                    backoff   DEFAULT_HEAD_CONFLICT_BACKOFF_MS}}]
-  (let [transaction-queue-buffer    (buffer transaction-queue-size)
+  (let [journal-owner #?(:clj (or journal-owner (atom {})) :cljs nil)
+        transaction-queue-buffer    (buffer transaction-queue-size)
         transaction-queue           (chan transaction-queue-buffer)
         commit-queue-buffer         (buffer commit-queue-size)
         commit-queue                (chan commit-queue-buffer)
@@ -402,9 +408,11 @@
                                                             {:type :writer/unknown-op
                                                              :op op
                                                              :supported (set (keys write-fn-map))})))
-                                          #?(:clj (if bindings
-                                                    (with-bindings* bindings apply op-fn old args)
-                                                    (apply op-fn old args))
+                                          #?(:clj (capture/prepare-report!
+                                                   journal-owner
+                                                   (if bindings
+                                                     (with-bindings* bindings apply op-fn old args)
+                                                     (apply op-fn old args)))
                                              :cljs (apply op-fn old args))))
                               ;; Catch all Throwables to handle AssertionError and other Errors
                               ;; These should crash the writer, but we deliver to callback first to prevent hangs
@@ -570,7 +578,8 @@
                        ;; must fence against what we just wrote rather than the
                        ;; stamp the batch opened with.
                        last-rev nil]
-                  (when tx
+                  (if-not tx
+                    #?(:clj (capture/dispose-owned! journal-owner) :cljs nil)
                     (let [txs (into [tx] (take-while some?) (repeatedly #(poll! commit-queue)))]
               ;; empty channel of pending transactions
                       (log/trace :datahike/batch-commit {:batch-size (count txs)})
@@ -615,6 +624,7 @@
                                 finalized-txs
                                 (mapv (fn [[tx-report callback]]
                                         [(-> tx-report
+                                             (dissoc :datahike.backfill.capture/retired)
                                              (assoc-in [:tx-meta :db/commitId] commit-id)
                                              (assoc :db-after commit-db))
                                          callback])
@@ -639,6 +649,9 @@
                                        :when build-guard]
                                  (w/finish-secondary-index-build! build-guard)))
                             (reset! build-cleanup-complete? true)
+                            #?(:clj
+                               (doseq [[tx-report _] txs]
+                                 (capture/finish! journal-owner tx-report)))
                             (reset! connection commit-db)
                             ;; This is the one exact durable-commit boundary. A
                             ;; drained group may contain many transaction reports,
@@ -943,7 +956,7 @@
   #{:backend :writer-ownership :transaction-queue-size :commit-queue-size
     :commit-wait-time :write-fn-map
     :max-batch :head-conflict-retries :head-conflict-backoff-ms
-    :require-fencing})
+    :require-fencing :backfill-journal})
 
 (defn check-fencing!
   "Raise unless `store` can fence branch-head writes as far as `require-fencing`
@@ -982,6 +995,10 @@
                 require-fencing]
          :as writer-config} (dc/normalize-writer-config writer-config)
         shared? (= :shared writer-ownership)]
+    #?(:clj (journal/validate-options! (:backfill-journal writer-config))
+       :cljs (when (contains? writer-config :backfill-journal)
+               (log/raise "Backfill scratch journals require a JVM local writer."
+                          {:type :backfill-journal-unsupported-platform})))
     (when-let [unknown (seq (remove self-writer-keys (keys writer-config)))]
       (log/raise "Unknown key(s) in the :self writer config."
                  {:type    :unknown-self-writer-config-keys
@@ -1011,9 +1028,11 @@
     (let [transaction-queue-size (or transaction-queue-size DEFAULT_QUEUE_SIZE)
           commit-queue-size (or commit-queue-size DEFAULT_QUEUE_SIZE)
           commit-wait-time (or commit-wait-time DEFAULT_COMMIT_WAIT_TIME)
+          journal-owner #?(:clj (atom {}) :cljs nil)
           retry-policy {:max-batch (or max-batch MAX_SHARED_WRITER_BATCH)
                         :retries   (or head-conflict-retries MAX_HEAD_CONFLICT_RETRIES)
-                        :backoff   (or head-conflict-backoff-ms DEFAULT_HEAD_CONFLICT_BACKOFF_MS)}
+                        :backoff   (or head-conflict-backoff-ms DEFAULT_HEAD_CONFLICT_BACKOFF_MS)
+                        :journal-owner journal-owner}
           [transaction-queue commit-queue thread]
           (create-thread connection
                          (merge default-write-fn-map
@@ -1029,7 +1048,8 @@
         :commit-queue commit-queue
         :commit-queue-size commit-queue-size
         :thread thread
-        :writer-ownership writer-ownership}))))
+        :writer-ownership writer-ownership
+        :journal-owner journal-owner}))))
 
 ;; Note: :kabel backend is implemented in datahike.kabel.writer
 ;; Require that namespace to register the defmethod

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -5,6 +5,7 @@
             [datahike.gc-guard :as guard]
             [datahike.gc-roots :as roots]
             [datahike.db.transaction :as dbtx]
+            #?(:clj [datahike.backfill.capture :as capture])
             [datahike.db.utils :as dbu]
             [datahike.db.interface :as dbi]
             [datahike.index :as di]
@@ -1890,18 +1891,17 @@
                          :actual-building-since-tx building-since-tx
                          :status status}))
            (assert-build-root-live! build-result)
-           (let [deltas (get-in old [:secondary-index-build-deltas idx-ident] [])
-                 use-transient? (satisfies? sec/ITransientSecondaryIndex index)
+           (let [use-transient? (satisfies? sec/ITransientSecondaryIndex index)
                  t-idx (if use-transient?
                          (binding [sec/*durable-secondary-write-context* :commit]
                            (sec/-as-transient index))
                          index)
                  _ (reset! transient-index t-idx)
-                 replayed (reduce (fn [idx tx-report]
-                                    (if use-transient?
-                                      (do (sec/-transact! idx tx-report) idx)
-                                      (sec/-transact idx tx-report)))
-                                  t-idx deltas)
+                 replayed (capture/reduce-deltas old idx-ident (fn [idx tx-report]
+                                                                 (if use-transient?
+                                                                   (do (sec/-transact! idx tx-report) idx)
+                                                                   (sec/-transact idx tx-report)))
+                                                 t-idx)
                  final-idx (if use-transient? (sec/-persistent! replayed) replayed)
                  _ (reset! final-index final-idx)
                  db-after (-> old

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -2003,7 +2003,7 @@
          (doseq [idx-ident new-building]
            (close-secondary-index! (get-in db-after [:secondary-indices idx-ident])))
          (log/raise
-          "Asynchronous secondary-index backfill currently requires local exclusive writer ownership. Remote writers cannot transfer a live build generation, and shared writers cannot coordinate its in-memory delta journal across processes."
+          "Asynchronous secondary-index backfill currently requires local exclusive writer ownership. Remote writers cannot transfer a live build generation, and shared writers cannot coordinate its local scratch journal across processes."
           {:type :secondary-index-backfill-unsupported-writer
            :idx-ident (first new-building)
            :idx-idents (set new-building)

--- a/test/datahike/test/backfill_capture_test.clj
+++ b/test/datahike/test/backfill_capture_test.clj
@@ -1,6 +1,7 @@
 (ns datahike.test.backfill-capture-test
   (:require [clojure.test :refer [deftest is]]
-            [datahike.backfill.capture :as capture]))
+            [datahike.backfill.capture :as capture]
+            [datahike.backfill.journal :as journal]))
 
 (defn- build-db []
   {:schema {:a {:db.secondary/status :building :db.secondary/building-since-tx 1}
@@ -11,6 +12,63 @@
   (capture/prepare-report! owner
                            {:db-before before
                             :db-after (assoc before :secondary-index-build-deltas pending)}))
+
+(deftest capture-uses-only-the-facade-for-opaque-descriptors
+  (let [owner (atom {})
+        prefixes (atom {})
+        disposed (atom [])
+        new-prefix (fn [id rows]
+                     (let [handle (Object.)]
+                       (swap! prefixes assoc handle {:id id :rows rows})
+                       handle))
+        descriptor-id (fn [handle] (:id (get @prefixes handle)))
+        readable (fn [handle]
+                   (let [prefix (get @prefixes handle)]
+                     (when (or (nil? prefix) (some #{(:id prefix)} @disposed))
+                       (throw (ex-info "Unknown or disposed fake journal" {})))
+                     prefix))]
+    (with-redefs [journal/create! (fn [_] (new-prefix (Object.) []))
+                  journal/descriptor-id descriptor-id
+                  journal/append! (fn [handle notifications]
+                                    (let [{:keys [id rows]} (readable handle)]
+                                      (new-prefix id (into rows notifications))))
+                  journal/reduce-journal (fn [handle f init]
+                                           (reduce f init (:rows (readable handle))))
+                  journal/dispose! (fn [handle]
+                                     (let [id (descriptor-id handle)]
+                                       (when-not (some #{id} @disposed)
+                                         (swap! disposed conj id)))
+                                     nil)]
+      (try
+        (let [before (:db-after (stage owner (build-db) (array-map :a [:a0] :b [:b0])))
+              a (get-in before [:secondary-index-build-journals :a])
+              b (get-in before [:secondary-index-build-journals :b])
+              after (:db-after (stage owner before {:a [:a1]}))
+              next-a (get-in after [:secondary-index-build-journals :a])]
+          (is (= Object (class a)))
+          (is (not (identical? a next-a)))
+          (is (identical? (descriptor-id a) (descriptor-id next-a)))
+          (is (= #{(descriptor-id a) (descriptor-id b)} (set (keys @owner))))
+          (is (= [:a0] (capture/reduce-deltas before :a conj [])))
+          (is (= [:a0 :a1 :pending]
+                 (capture/reduce-deltas
+                  (assoc after :secondary-index-build-deltas {:a [:pending]}) :a conj [])))
+          (let [retired (capture/prepare-report!
+                         owner {:db-before after
+                                :db-after (assoc-in after [:schema :a :db.secondary/status] :ready)})]
+            (is (empty? @disposed))
+            (is (= [:a0 :a1] (capture/reduce-deltas after :a conj [])))
+            (capture/finish! owner retired)
+            (is (= [(descriptor-id a)] @disposed))
+            (is (= #{(descriptor-id b)} (set (keys @owner))))
+            (is (= [:b0] (capture/reduce-deltas (:db-after retired) :b conj []))))
+          (capture/dispose-owned! owner)
+          (is (= [(descriptor-id a) (descriptor-id b)] @disposed))
+          (is (empty? @owner))
+          (is (= :writer-shut-down
+                 (try (stage owner (build-db) {:a [:too-late]})
+                      nil (catch Exception e (:type (ex-data e)))))))
+        (finally (capture/dispose-owned! owner))))))
 
 (deftest failed-multi-index-capture-preserves-all-accepted-prefixes
   (let [owner (atom {})]

--- a/test/datahike/test/backfill_capture_test.clj
+++ b/test/datahike/test/backfill_capture_test.clj
@@ -1,0 +1,60 @@
+(ns datahike.test.backfill-capture-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.backfill.capture :as capture]))
+
+(defn- build-db []
+  {:schema {:a {:db.secondary/status :building :db.secondary/building-since-tx 1}
+            :b {:db.secondary/status :building :db.secondary/building-since-tx 1}}
+   :config {:writer {:backfill-journal {:max-frame-bytes 64 :max-bytes 1024}}}})
+
+(defn- stage [owner before pending]
+  (capture/prepare-report! owner
+                           {:db-before before
+                            :db-after (assoc before :secondary-index-build-deltas pending)}))
+
+(deftest failed-multi-index-capture-preserves-all-accepted-prefixes
+  (let [owner (atom {})]
+    (try
+      (let [before (:db-after (stage owner (build-db) (array-map :a [:a0] :b [:b0])))
+            failure (try (stage owner before
+                                (array-map :a [:discarded] :b [(apply str (repeat 100 "x"))]))
+                         nil (catch Exception e (:type (ex-data e))))]
+        (is (= :backfill.journal/frame-too-large failure))
+        (is (= [:a0] (capture/reduce-deltas before :a conj [])))
+        (is (= [:b0] (capture/reduce-deltas before :b conj [])))
+        (let [after (:db-after (stage owner before (array-map :a [:a1] :b [:b1])))]
+          (is (nil? (:secondary-index-build-deltas after)))
+          (is (= [:a0 :a1] (capture/reduce-deltas after :a conj [])))
+          (is (= [:b0 :b1] (capture/reduce-deltas after :b conj [])))
+          (is (= [:a0] (capture/reduce-deltas before :a conj [])))))
+      (finally (capture/dispose-owned! owner)))))
+
+(deftest replay-stops-before-pure-pending-tail
+  (let [owner (atom {})]
+    (try
+      (let [before (:db-after (stage owner (build-db) {:a [:captured]}))
+            pure (assoc before :secondary-index-build-deltas {:a [:pending]})
+            visited (atom [])]
+        (is (= :stopped
+               (capture/reduce-deltas pure :a
+                                      (fn [_ x] (swap! visited conj x) (reduced :stopped)) nil)))
+        (is (= [:captured] @visited)))
+      (finally (capture/dispose-owned! owner)))))
+
+(deftest retirement-waits-for-publication-and-owner-cannot-reopen
+  (let [owner (atom {})]
+    (try
+      (let [before (:db-after (stage owner (build-db) {:a [:captured]}))
+            path (get-in before [:secondary-index-build-journals :a :path])
+            report (capture/prepare-report!
+                    owner {:db-before before
+                           :db-after (assoc-in before [:schema :a :db.secondary/status] :ready)})]
+        (is (nil? (:secondary-index-build-journals (:db-after report))))
+        (is (.exists (java.io.File. path)))
+        (capture/finish! owner report)
+        (is (not (.exists (java.io.File. path))))
+        (is (empty? @owner)))
+      (finally (capture/dispose-owned! owner)))
+    (is (= :writer-shut-down
+           (try (stage owner (build-db) {:a [:too-late]})
+                nil (catch Exception e (:type (ex-data e))))))))

--- a/test/datahike/test/backfill_journal_file_test.clj
+++ b/test/datahike/test/backfill_journal_file_test.clj
@@ -1,0 +1,109 @@
+(ns datahike.test.backfill-journal-file-test
+  (:require [clojure.test :refer [deftest is]]
+            [boring.core :as boring]
+            [datahike.backfill.journal.file :as journal]
+            [datahike.datom :as dd]
+            [datahike.array :as arr])
+  (:import [java.io RandomAccessFile]
+           [java.nio.file Files Path]))
+
+(defn- error-type [f]
+  (try (f) nil (catch Exception e (:type (ex-data e)))))
+
+(deftest exact-prefix-roundtrip-and-cleanup
+  (let [a (journal/create! {})]
+    (try
+      (let [notification {:datom (dd/datom 100 :value (byte-array [1 2 3]) 42)
+                          :added? true :value-hash (random-uuid)
+                          :tx-meta {:db/txInstant (java.util.Date. 1234)
+                                    :tuple [(float-array [1 2]) :tag]}}
+            b (journal/append! a [notification])
+            c (journal/append! b [{:second true}])
+            first-value (first (journal/reduce-journal b conj []))]
+        (is (= [] (journal/reduce-journal a conj [])))
+        (is (= 1 (journal/reduce-journal b (fn [n _] (inc n)) 0)))
+        (is (= 2 (journal/reduce-journal c (fn [n _] (inc n)) 0)))
+        (is (= 100 (:e (:datom first-value))))
+        (is (arr/a= (:v (:datom notification)) (:v (:datom first-value))))
+        (is (= (:value-hash notification) (:value-hash first-value)))
+        (is (= (get-in notification [:tx-meta :db/txInstant])
+               (get-in first-value [:tx-meta :db/txInstant])))
+        (is (arr/a= (get-in notification [:tx-meta :tuple 0])
+                    (get-in first-value [:tx-meta :tuple 0])))
+        (is (= :stopped (journal/reduce-journal c (fn [_ _] (reduced :stopped)) nil)))
+        (is (thrown? Exception (journal/reduce-journal c (fn [_ _] (throw (Exception. "stop"))) nil))))
+      (finally (journal/dispose! a)))
+    (is (nil? (journal/dispose! a)))
+    (is (not (Files/exists (Path/of (:path a) (make-array String 0)) (make-array java.nio.file.LinkOption 0))))))
+
+(deftest byte-limits-and-rollback
+  (let [a (journal/create! {:max-frame-bytes 64 :max-bytes 80})]
+    (try
+      (let [b (journal/append! a [:kept])]
+        (is (= :backfill.journal/frame-too-large
+               (error-type #(journal/append! b [(apply str (repeat 1000 "x"))]))))
+        (is (= :backfill.journal/frame-too-large
+               (error-type #(journal/append! b [(range 1000)]))))
+        (is (= :backfill.journal/quota-exceeded
+               (error-type #(journal/append! b (repeat 100 :small)))))
+        (with-open [file (RandomAccessFile. (:path b) "r")]
+          (is (= (:end b) (.length file))))
+        (is (= [:kept] (journal/reduce-journal b conj [])))
+        (let [c (journal/append! b [:next])]
+          (is (= [:kept :next] (journal/reduce-journal c conj []))))
+        ;; A caller retrying its accepted cursor discards an invisible tail.
+        (journal/append! b [:discarded])
+        (let [c (journal/append! b [:replacement])]
+          (is (= [:kept :replacement] (journal/reduce-journal c conj [])))))
+      (finally (journal/dispose! a)))))
+
+(deftest codec-failure-rolls-back-complete-frames-too
+  (let [a (journal/create! {})]
+    (try
+      (let [b (journal/append! a [:before])]
+        (is (thrown? Exception (journal/append! b [:intermediate (Object.)])))
+        (with-open [file (RandomAccessFile. (:path b) "r")]
+          (is (= (:end b) (.length file))))
+        (is (= [:before :after]
+               (journal/reduce-journal (journal/append! b [:after]) conj []))))
+      (finally (journal/dispose! a)))))
+
+(deftest invalid-limits-and-descriptor
+  (doseq [options [true [] {:unknown 1} {:directory 3} {:directory ""}
+                   {:max-bytes nil} {:max-bytes 0} {:max-frame-bytes -1} {:max-bytes 1.5}]]
+    (is (= :backfill.journal/invalid-options (error-type #(journal/create! options)))))
+  (let [a (journal/create! {})]
+    (try
+      (is (= :backfill.journal/invalid-descriptor
+             (error-type #(journal/append! (assoc a :max-bytes 999) [:bad]))))
+      (is (= :backfill.journal/invalid-descriptor
+             (error-type #(journal/dispose! (assoc a :path "/tmp/unowned")))))
+      (finally (journal/dispose! a)))))
+
+(deftest ratio-components-are-bounded-before-encoding
+  (let [a (journal/create! {:max-frame-bytes 64})
+        large (.shiftLeft java.math.BigInteger/ONE 4096)
+        encoded? (atom false)]
+    (try
+      (doseq [value [(/ large 3) (/ 3 large)]]
+        (with-redefs [boring/write-to! (fn [& _] (reset! encoded? true))]
+          (is (= :backfill.journal/frame-too-large
+                 (error-type #(journal/append! a [{:value value}]))))))
+      (is (false? @encoded?))
+      (is (= [] (journal/reduce-journal a conj [])))
+      (finally (journal/dispose! a)))))
+
+(deftest streaming-cap-and-truncated-prefix
+  (let [a (journal/create! {:max-frame-bytes 64})]
+    (try
+      (is (= :backfill.journal/frame-too-large
+             (with-redefs [boring/write-to! (fn [_ _ out]
+                                              (dotimes [_ 65] (.write ^java.io.OutputStream out (int 1))))]
+               (error-type #(journal/append! a [:value])))))
+      (is (= [] (journal/reduce-journal a conj [])))
+      (let [b (journal/append! a [:kept])]
+        (with-open [file (RandomAccessFile. (:path a) "rw")]
+          (.setLength file (dec (:end b))))
+        (is (= :backfill.journal/corrupt
+               (error-type #(journal/reduce-journal b conj [])))))
+      (finally (journal/dispose! a)))))

--- a/test/datahike/test/backfill_journal_test.clj
+++ b/test/datahike/test/backfill_journal_test.clj
@@ -1,0 +1,96 @@
+(ns datahike.test.backfill-journal-test
+  (:require [clojure.test :refer [deftest is]]
+            [boring.core :as boring]
+            [datahike.backfill.journal :as journal]
+            [datahike.datom :as dd]
+            [datahike.array :as arr])
+  (:import [java.io RandomAccessFile]
+           [java.nio.file Files Path]))
+
+(defn- error-type [f]
+  (try (f) nil (catch Exception e (:type (ex-data e)))))
+
+(deftest exact-prefix-roundtrip-and-cleanup
+  (let [a (journal/create! {})]
+    (try
+      (let [notification {:datom (dd/datom 100 :value (byte-array [1 2 3]) 42)
+                          :added? true :value-hash (random-uuid)
+                          :tx-meta {:db/txInstant (java.util.Date. 1234)
+                                    :tuple [(float-array [1 2]) :tag]}}
+            b (journal/append! a [notification])
+            c (journal/append! b [{:second true}])
+            first-value (first (journal/reduce-journal b conj []))]
+        (is (= [] (journal/reduce-journal a conj [])))
+        (is (= 1 (journal/reduce-journal b (fn [n _] (inc n)) 0)))
+        (is (= 2 (journal/reduce-journal c (fn [n _] (inc n)) 0)))
+        (is (= 100 (:e (:datom first-value))))
+        (is (arr/a= (:v (:datom notification)) (:v (:datom first-value))))
+        (is (= (:value-hash notification) (:value-hash first-value)))
+        (is (= (get-in notification [:tx-meta :db/txInstant])
+               (get-in first-value [:tx-meta :db/txInstant])))
+        (is (arr/a= (get-in notification [:tx-meta :tuple 0])
+                    (get-in first-value [:tx-meta :tuple 0])))
+        (is (= :stopped (journal/reduce-journal c (fn [_ _] (reduced :stopped)) nil)))
+        (is (thrown? Exception (journal/reduce-journal c (fn [_ _] (throw (Exception. "stop"))) nil))))
+      (finally (journal/dispose! a)))
+    (is (nil? (journal/dispose! a)))
+    (is (not (Files/exists (Path/of (:path a) (make-array String 0)) (make-array java.nio.file.LinkOption 0))))))
+
+(deftest byte-limits-and-rollback
+  (let [a (journal/create! {:max-frame-bytes 64 :max-bytes 80})]
+    (try
+      (let [b (journal/append! a [:kept])]
+        (is (= :backfill.journal/frame-too-large
+               (error-type #(journal/append! b [(apply str (repeat 1000 "x"))]))))
+        (is (= :backfill.journal/frame-too-large
+               (error-type #(journal/append! b [(range 1000)]))))
+        (is (= :backfill.journal/quota-exceeded
+               (error-type #(journal/append! b (repeat 100 :small)))))
+        (with-open [file (RandomAccessFile. (:path b) "r")]
+          (is (= (:end b) (.length file))))
+        (is (= [:kept] (journal/reduce-journal b conj [])))
+        (let [c (journal/append! b [:next])]
+          (is (= [:kept :next] (journal/reduce-journal c conj []))))
+        ;; A caller retrying its accepted cursor discards an invisible tail.
+        (journal/append! b [:discarded])
+        (let [c (journal/append! b [:replacement])]
+          (is (= [:kept :replacement] (journal/reduce-journal c conj [])))))
+      (finally (journal/dispose! a)))))
+
+(deftest codec-failure-rolls-back-complete-frames-too
+  (let [a (journal/create! {})]
+    (try
+      (let [b (journal/append! a [:before])]
+        (is (thrown? Exception (journal/append! b [:intermediate (Object.)])))
+        (with-open [file (RandomAccessFile. (:path b) "r")]
+          (is (= (:end b) (.length file))))
+        (is (= [:before :after]
+               (journal/reduce-journal (journal/append! b [:after]) conj []))))
+      (finally (journal/dispose! a)))))
+
+(deftest invalid-limits-and-descriptor
+  (doseq [options [true [] {:unknown 1} {:directory 3} {:directory ""}
+                   {:max-bytes nil} {:max-bytes 0} {:max-frame-bytes -1} {:max-bytes 1.5}]]
+    (is (= :backfill.journal/invalid-options (error-type #(journal/create! options)))))
+  (let [a (journal/create! {})]
+    (try
+      (is (= :backfill.journal/invalid-descriptor
+             (error-type #(journal/append! (assoc a :max-bytes 999) [:bad]))))
+      (is (= :backfill.journal/invalid-descriptor
+             (error-type #(journal/dispose! (assoc a :path "/tmp/unowned")))))
+      (finally (journal/dispose! a)))))
+
+(deftest streaming-cap-and-truncated-prefix
+  (let [a (journal/create! {:max-frame-bytes 64})]
+    (try
+      (is (= :backfill.journal/frame-too-large
+             (with-redefs [boring/write-to! (fn [_ _ out]
+                                              (dotimes [_ 65] (.write ^java.io.OutputStream out (int 1))))]
+               (error-type #(journal/append! a [:value])))))
+      (is (= [] (journal/reduce-journal a conj [])))
+      (let [b (journal/append! a [:kept])]
+        (with-open [file (RandomAccessFile. (:path a) "rw")]
+          (.setLength file (dec (:end b))))
+        (is (= :backfill.journal/corrupt
+               (error-type #(journal/reduce-journal b conj [])))))
+      (finally (journal/dispose! a)))))

--- a/test/datahike/test/backfill_journal_test.clj
+++ b/test/datahike/test/backfill_journal_test.clj
@@ -80,6 +80,19 @@
              (error-type #(journal/dispose! (assoc a :path "/tmp/unowned")))))
       (finally (journal/dispose! a)))))
 
+(deftest ratio-components-are-bounded-before-encoding
+  (let [a (journal/create! {:max-frame-bytes 64})
+        large (.shiftLeft java.math.BigInteger/ONE 4096)
+        encoded? (atom false)]
+    (try
+      (doseq [value [(/ large 3) (/ 3 large)]]
+        (with-redefs [boring/write-to! (fn [& _] (reset! encoded? true))]
+          (is (= :backfill.journal/frame-too-large
+                 (error-type #(journal/append! a [{:value value}]))))))
+      (is (false? @encoded?))
+      (is (= [] (journal/reduce-journal a conj [])))
+      (finally (journal/dispose! a)))))
+
 (deftest streaming-cap-and-truncated-prefix
   (let [a (journal/create! {:max-frame-bytes 64})]
     (try

--- a/test/datahike/test/backfill_journal_test.clj
+++ b/test/datahike/test/backfill_journal_test.clj
@@ -1,109 +1,46 @@
 (ns datahike.test.backfill-journal-test
   (:require [clojure.test :refer [deftest is]]
-            [boring.core :as boring]
-            [datahike.backfill.journal :as journal]
-            [datahike.datom :as dd]
-            [datahike.array :as arr])
-  (:import [java.io RandomAccessFile]
-           [java.nio.file Files Path]))
+            [datahike.backfill.journal :as journal]))
 
-(defn- error-type [f]
-  (try (f) nil (catch Exception e (:type (ex-data e)))))
-
-(deftest exact-prefix-roundtrip-and-cleanup
-  (let [a (journal/create! {})]
+(deftest accepted-prefixes-and-owner-lifetime
+  (let [empty-prefix (journal/create! {})]
     (try
-      (let [notification {:datom (dd/datom 100 :value (byte-array [1 2 3]) 42)
-                          :added? true :value-hash (random-uuid)
-                          :tx-meta {:db/txInstant (java.util.Date. 1234)
-                                    :tuple [(float-array [1 2]) :tag]}}
-            b (journal/append! a [notification])
-            c (journal/append! b [{:second true}])
-            first-value (first (journal/reduce-journal b conj []))]
-        (is (= [] (journal/reduce-journal a conj [])))
-        (is (= 1 (journal/reduce-journal b (fn [n _] (inc n)) 0)))
-        (is (= 2 (journal/reduce-journal c (fn [n _] (inc n)) 0)))
-        (is (= 100 (:e (:datom first-value))))
-        (is (arr/a= (:v (:datom notification)) (:v (:datom first-value))))
-        (is (= (:value-hash notification) (:value-hash first-value)))
-        (is (= (get-in notification [:tx-meta :db/txInstant])
-               (get-in first-value [:tx-meta :db/txInstant])))
-        (is (arr/a= (get-in notification [:tx-meta :tuple 0])
-                    (get-in first-value [:tx-meta :tuple 0])))
-        (is (= :stopped (journal/reduce-journal c (fn [_ _] (reduced :stopped)) nil)))
-        (is (thrown? Exception (journal/reduce-journal c (fn [_ _] (throw (Exception. "stop"))) nil))))
-      (finally (journal/dispose! a)))
-    (is (nil? (journal/dispose! a)))
-    (is (not (Files/exists (Path/of (:path a) (make-array String 0)) (make-array java.nio.file.LinkOption 0))))))
+      (let [first-prefix (journal/append! empty-prefix [:first])
+            second-prefix (journal/append! first-prefix [:second])]
+        (is (= (journal/descriptor-id empty-prefix)
+               (journal/descriptor-id first-prefix)
+               (journal/descriptor-id second-prefix)))
+        (is (= [] (journal/reduce-journal empty-prefix conj [])))
+        (is (= [:first] (journal/reduce-journal first-prefix conj [])))
+        (is (= [:first :second] (journal/reduce-journal second-prefix conj [])))
+        (is (= :done (journal/reduce-journal second-prefix
+                                             (fn [_ _] (reduced :done)) nil)))
+        (is (thrown-with-msg? Exception #"reader failed"
+                              (journal/reduce-journal second-prefix
+                                                      (fn [_ _] (throw (Exception. "reader failed"))) nil)))
+        (is (= [:first :second] (journal/reduce-journal second-prefix conj []))))
+      (finally (journal/dispose! empty-prefix)))
+    (is (nil? (journal/dispose! empty-prefix)))))
 
-(deftest byte-limits-and-rollback
-  (let [a (journal/create! {:max-frame-bytes 64 :max-bytes 80})]
+(deftest failed-capture-does-not-accept-a-partial-batch
+  (let [empty-prefix (journal/create! {:max-frame-bytes 64})]
     (try
-      (let [b (journal/append! a [:kept])]
-        (is (= :backfill.journal/frame-too-large
-               (error-type #(journal/append! b [(apply str (repeat 1000 "x"))]))))
-        (is (= :backfill.journal/frame-too-large
-               (error-type #(journal/append! b [(range 1000)]))))
-        (is (= :backfill.journal/quota-exceeded
-               (error-type #(journal/append! b (repeat 100 :small)))))
-        (with-open [file (RandomAccessFile. (:path b) "r")]
-          (is (= (:end b) (.length file))))
-        (is (= [:kept] (journal/reduce-journal b conj [])))
-        (let [c (journal/append! b [:next])]
-          (is (= [:kept :next] (journal/reduce-journal c conj []))))
-        ;; A caller retrying its accepted cursor discards an invisible tail.
-        (journal/append! b [:discarded])
-        (let [c (journal/append! b [:replacement])]
-          (is (= [:kept :replacement] (journal/reduce-journal c conj [])))))
-      (finally (journal/dispose! a)))))
+      (let [accepted (journal/append! empty-prefix [:accepted])]
+        (is (thrown? Exception
+                     (journal/append! accepted [:unaccepted (apply str (repeat 1000 "x"))])))
+        (is (= [:accepted] (journal/reduce-journal accepted conj [])))
+        (let [replacement (journal/append! accepted [:retry])]
+          (is (= [:accepted :retry] (journal/reduce-journal replacement conj [])))
+          (is (= [:accepted] (journal/reduce-journal accepted conj [])))))
+      (finally (journal/dispose! empty-prefix)))))
 
-(deftest codec-failure-rolls-back-complete-frames-too
-  (let [a (journal/create! {})]
+(deftest an-abandoned-suffix-is-not-replayed-by-a-replacement
+  (let [empty-prefix (journal/create! {})]
     (try
-      (let [b (journal/append! a [:before])]
-        (is (thrown? Exception (journal/append! b [:intermediate (Object.)])))
-        (with-open [file (RandomAccessFile. (:path b) "r")]
-          (is (= (:end b) (.length file))))
-        (is (= [:before :after]
-               (journal/reduce-journal (journal/append! b [:after]) conj []))))
-      (finally (journal/dispose! a)))))
-
-(deftest invalid-limits-and-descriptor
-  (doseq [options [true [] {:unknown 1} {:directory 3} {:directory ""}
-                   {:max-bytes nil} {:max-bytes 0} {:max-frame-bytes -1} {:max-bytes 1.5}]]
-    (is (= :backfill.journal/invalid-options (error-type #(journal/create! options)))))
-  (let [a (journal/create! {})]
-    (try
-      (is (= :backfill.journal/invalid-descriptor
-             (error-type #(journal/append! (assoc a :max-bytes 999) [:bad]))))
-      (is (= :backfill.journal/invalid-descriptor
-             (error-type #(journal/dispose! (assoc a :path "/tmp/unowned")))))
-      (finally (journal/dispose! a)))))
-
-(deftest ratio-components-are-bounded-before-encoding
-  (let [a (journal/create! {:max-frame-bytes 64})
-        large (.shiftLeft java.math.BigInteger/ONE 4096)
-        encoded? (atom false)]
-    (try
-      (doseq [value [(/ large 3) (/ 3 large)]]
-        (with-redefs [boring/write-to! (fn [& _] (reset! encoded? true))]
-          (is (= :backfill.journal/frame-too-large
-                 (error-type #(journal/append! a [{:value value}]))))))
-      (is (false? @encoded?))
-      (is (= [] (journal/reduce-journal a conj [])))
-      (finally (journal/dispose! a)))))
-
-(deftest streaming-cap-and-truncated-prefix
-  (let [a (journal/create! {:max-frame-bytes 64})]
-    (try
-      (is (= :backfill.journal/frame-too-large
-             (with-redefs [boring/write-to! (fn [_ _ out]
-                                              (dotimes [_ 65] (.write ^java.io.OutputStream out (int 1))))]
-               (error-type #(journal/append! a [:value])))))
-      (is (= [] (journal/reduce-journal a conj [])))
-      (let [b (journal/append! a [:kept])]
-        (with-open [file (RandomAccessFile. (:path a) "rw")]
-          (.setLength file (dec (:end b))))
-        (is (= :backfill.journal/corrupt
-               (error-type #(journal/reduce-journal b conj [])))))
-      (finally (journal/dispose! a)))))
+      (let [accepted (journal/append! empty-prefix [:accepted])]
+        ;; Intentionally abandon this result; no report or reader retains it.
+        (journal/append! accepted [:abandoned])
+        (let [replacement (journal/append! accepted [:replacement])]
+          (is (= [:accepted :replacement] (journal/reduce-journal replacement conj [])))
+          (is (= [:accepted] (journal/reduce-journal accepted conj [])))))
+      (finally (journal/dispose! empty-prefix)))))

--- a/test/datahike/test/http/permissions_test.clj
+++ b/test/datahike/test/http/permissions_test.clj
@@ -2,6 +2,8 @@
   "The eacl-backed permissions of the server: who may read, write, delete and
    grant, through the API and the remote writer, and across a restart."
   (:require
+   [babashka.http-client :as http]
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [datahike.api :as d]
    [datahike.connections :as connections]
@@ -30,19 +32,40 @@
                  (.getCause e) (recur (.getCause e))
                  :else false)))))
 
+(defn- with-peer-transport [endpoint transport f]
+  (let [request http/request]
+    (with-redefs [http/request
+                  (fn [opts]
+                    (request (if (str/starts-with? (str (:uri opts)) (str @endpoint "/"))
+                               (assoc opts :client @transport)
+                               opts)))]
+      (f))))
+
 (deftest permissions-in-the-system-db
-  (let [port     23210
-        url      (str "http://localhost:" port)
+  (let [endpoint (atom nil)
+        transport (atom nil)
         config   {:token root-token :validator validator
                   :system-db {:store {:backend :file :path (str (fs/temp-dir! "dh-system-") "/system")}}}
         start!   (fn []
-                   (let [conns (atom {}) app (server/app config conns)]
-                     {:server (run-jetty app {:port port :join? false}) :app app :conns conns}))
-        stop!    (fn [{:keys [server app conns]}]
-                   (.stop server)
-                   (routes/release-all! conns)
-                   (permissions/close! (::server/config (meta app))))
-        peer     (fn [t] {:backend :datahike-server :url url :token t})
+                   (let [conns (atom {}) app (server/app config conns)
+                         server (run-jetty app {:port 0 :join? false})
+                         port (.getLocalPort ^org.eclipse.jetty.server.NetworkConnector
+                               (first (.getConnectors ^org.eclipse.jetty.server.Server server)))
+                         http-client (http/client http/default-client-opts)]
+                     (reset! endpoint (str "http://localhost:" port))
+                     (reset! transport http-client)
+                     {:server server :app app :conns conns :http-client http-client}))
+        stop!    (fn [{:keys [server app conns http-client]}]
+                   (try
+                     (.stop server)
+                     (routes/release-all! conns)
+                     (permissions/close! (::server/config (meta app)))
+                     (finally
+                       ;; HttpClient is AutoCloseable on JDK 21+; older supported
+                       ;; runtimes retire the unreferenced pool through GC.
+                       (when (instance? java.lang.AutoCloseable (:client http-client))
+                         (.close ^java.lang.AutoCloseable (:client http-client))))))
+        peer     (fn [t] {:backend :datahike-server :url @endpoint :token t})
         store-id (random-uuid)
         cfg      {:store {:backend :file :path (str (fs/temp-dir! "dh-perm-") "/store") :id store-id}
                   :schema-flexibility :read}
@@ -51,94 +74,98 @@
         list!    (fn [t] (client/request-cbor :get "databases" (peer t) (random-uuid)))
         status!  (fn [t] (client/request-cbor :get "admin/status" (peer t) (random-uuid)))
         s        (atom (start!))]
-    (try
-      (testing "root creates; nobody else may touch the database"
-        (client/create-database (assoc cfg :remote-peer (peer root-token)))
-        (is (= [{:store-id (str store-id) :state :active}]
-               (mapv #(select-keys % [:store-id :state]) (list! root-token))))
-        (is (map? (:node (status! root-token)))
-            "server admins see process-wide query activity")
-        (is (empty? (list! "alice-token"))
-            "the catalog does not reveal databases the caller cannot read")
-        (is (= {:node nil
-                :page {:offset 0 :limit 24 :total 0 :has-more? false}
-                :databases []}
-               (status! "alice-token"))
-            "status reveals neither node activity nor unauthorized databases")
-        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
+    (with-peer-transport endpoint transport
+      (fn []
+        (try
+          (testing "root creates; nobody else may touch the database"
+            (client/create-database (assoc cfg :remote-peer (peer root-token)))
+            (is (= [{:store-id (str store-id) :state :active}]
+                   (mapv #(select-keys % [:store-id :state]) (list! root-token))))
+            (is (map? (:node (status! root-token)))
+                "server admins see process-wide query activity")
+            (is (empty? (list! "alice-token"))
+                "the catalog does not reveal databases the caller cannot read")
+            (is (= {:node nil
+                    :page {:offset 0 :limit 24 :total 0 :has-more? false}
+                    :databases []}
+                   (status! "alice-token"))
+                "status reveals neither node activity nor unauthorized databases")
+            (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))))
 
-      (testing "root grants alice writer and bob reader in one batch; alice may read and write, not delete or grant"
-        (is (= {:written 2}
-               (grant! root-token [{:operation :touch
-                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}
-                                   {:operation :touch
-                                    :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
-        (is (= #{(str store-id)} (set (map :store-id (list! "alice-token")))))
-        (is (= #{(str store-id)} (set (map :store-id (list! "bob-token")))))
-        (let [status (status! "bob-token")]
-          (is (nil? (:node status)))
-          (is (= #{(str store-id)} (set (map :store-id (:databases status))))))
-        (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
-          (client/transact alice [{:name "Ada"}])
-          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
-          (is (forbidden? #(client/delete-database (assoc cfg :remote-peer (peer "alice-token")))))
-          (is (forbidden? #(grant! "alice-token" [{:operation :touch
-                                                   :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
-          (is (true? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
-                                                    {:permission :transact :resource db-obj}))))
-          (is (false? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
-                                                     {:permission :delete :resource db-obj}))))
-          (is (forbidden? #(client/request-cbor :post "permissions/check" (peer "alice-token")
-                                                {:subject {:type :user :id "bob"} :permission :read :resource db-obj}))
-              "asking about someone else needs grant")
-          (client/release alice)))
+          (testing "root grants alice writer and bob reader in one batch; alice may read and write, not delete or grant"
+            (is (= {:written 2}
+                   (grant! root-token [{:operation :touch
+                                        :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}
+                                       {:operation :touch
+                                        :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
+            (is (= #{(str store-id)} (set (map :store-id (list! "alice-token")))))
+            (is (= #{(str store-id)} (set (map :store-id (list! "bob-token")))))
+            (let [status (status! "bob-token")]
+              (is (nil? (:node status)))
+              (is (= #{(str store-id)} (set (map :store-id (:databases status))))))
+            (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
+              (client/transact alice [{:name "Ada"}])
+              (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
+              (is (forbidden? #(client/delete-database (assoc cfg :remote-peer (peer "alice-token")))))
+              (is (forbidden? #(grant! "alice-token" [{:operation :touch
+                                                       :relationship {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}])))
+              (is (true? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                        {:permission :transact :resource db-obj}))))
+              (is (false? (:allowed (client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                         {:permission :delete :resource db-obj}))))
+              (is (forbidden? #(client/request-cbor :post "permissions/check" (peer "alice-token")
+                                                    {:subject {:type :user :id "bob"} :permission :read :resource db-obj}))
+                  "asking about someone else needs grant")
+              (client/release alice)))
 
-      (testing "bob reads and nothing else"
-        (let [bob (client/connect (assoc cfg :remote-peer (peer "bob-token")))]
-          (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @bob)))
-          (is (forbidden? #(client/transact bob [{:name "Bob"}])))
-          (client/release bob)))
+          (testing "bob reads and nothing else"
+            (let [bob (client/connect (assoc cfg :remote-peer (peer "bob-token")))]
+              (is (= #{["Ada"]} (client/q '[:find ?n :where [?e :name ?n]] @bob)))
+              (is (forbidden? #(client/transact bob [{:name "Bob"}])))
+              (client/release bob)))
 
-      (testing "the remote writer is authorized the same way"
+          (testing "the remote writer is authorized the same way"
         ;; Two processes, so two registries: in one, bob's connect would hand
         ;; him alice's cached connection, writer token included.
-        (let [alice (d/connect (assoc cfg :writer {:backend :datahike-server :url url :token "alice-token"}))
-              bob   (binding [connections/*connections* (atom {})]
-                      (d/connect (assoc cfg :writer {:backend :datahike-server :url url :token "bob-token"})))]
-          (is (some? (:db-after (d/transact alice [{:name "Grace"}]))))
-          (is (forbidden? #(d/transact bob [{:name "Bob"}])))
-          (is (= #{["Ada"] ["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @alice)))
-          (d/release alice)
-          (d/release bob)))
+            (let [alice (d/connect (assoc cfg :writer {:backend :datahike-server :url @endpoint :token "alice-token"}))
+                  bob   (binding [connections/*connections* (atom {})]
+                          (d/connect (assoc cfg :writer {:backend :datahike-server :url @endpoint :token "bob-token"})))]
+              (is (some? (:db-after (d/transact alice [{:name "Grace"}]))))
+              (is (forbidden? #(d/transact bob [{:name "Bob"}])))
+              (is (= #{["Ada"] ["Grace"]} (d/q '[:find ?n :where [?e :name ?n]] @alice)))
+              (d/release alice)
+              (d/release bob)))
 
-      (testing "relationships survive a restart, and root stays admin"
-        (stop! @s)
-        (reset! s (start!))
-        (is (= #{{:subject {:type :user :id "alice"} :relation :writer :resource db-obj}
-                 {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}
-               (set (client/request-cbor :post "permissions/relationships" (peer root-token) {:resource db-obj}))))
-        (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
-          (is (= #{["Ada"] ["Grace"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
-          (client/release alice))
-        (is (= {:written 1}
-               (grant! root-token [{:operation :delete
-                                    :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
-        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
-            "a revoked grant is gone at once")
-        (is (try (grant! root-token [{:operation :touch
-                                      :relationship {:subject {:type :user :id "alice"} :relation :reader :resource db-obj}}
-                                     {:operation :touch
-                                      :relationship {:subject {:type :user :id "alice"} :relation :nonsense :resource db-obj}}])
-                 false
-                 (catch Exception _ true))
-            "a batch with a bad relationship is refused whole")
-        (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
-            "…and its good half did not land")
-        (client/delete-database (assoc cfg :remote-peer (peer root-token)))
-        (is (empty? (list! root-token))
-            "soft-deleted catalog entries are absent from the public list"))
-      (finally
-        (stop! @s)))))
+      ;; This tests durable permissions and data through a new connection,
+      ;; not transparent recovery of a pooled socket to the stopped server.
+          (testing "relationships survive a restart, and root stays admin"
+            (stop! @s)
+            (reset! s (start!))
+            (is (= #{{:subject {:type :user :id "alice"} :relation :writer :resource db-obj}
+                     {:subject {:type :user :id "bob"} :relation :reader :resource db-obj}}
+                   (set (client/request-cbor :post "permissions/relationships" (peer root-token) {:resource db-obj}))))
+            (let [alice (client/connect (assoc cfg :remote-peer (peer "alice-token")))]
+              (is (= #{["Ada"] ["Grace"]} (client/q '[:find ?n :where [?e :name ?n]] @alice)))
+              (client/release alice))
+            (is (= {:written 1}
+                   (grant! root-token [{:operation :delete
+                                        :relationship {:subject {:type :user :id "alice"} :relation :writer :resource db-obj}}])))
+            (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
+                "a revoked grant is gone at once")
+            (is (try (grant! root-token [{:operation :touch
+                                          :relationship {:subject {:type :user :id "alice"} :relation :reader :resource db-obj}}
+                                         {:operation :touch
+                                          :relationship {:subject {:type :user :id "alice"} :relation :nonsense :resource db-obj}}])
+                     false
+                     (catch Exception _ true))
+                "a batch with a bad relationship is refused whole")
+            (is (forbidden? #(client/connect (assoc cfg :remote-peer (peer "alice-token"))))
+                "…and its good half did not land")
+            (client/delete-database (assoc cfg :remote-peer (peer root-token)))
+            (is (empty? (list! root-token))
+                "soft-deleted catalog entries are absent from the public list"))
+          (finally
+            (stop! @s)))))))
 
 (deftest memory-system-dbs-do-not-collide
   (let [a (permissions/configure {:token "a" :system-db {:store {:backend :memory}}})

--- a/test/datahike/test/secondary_dynamic_test.clj
+++ b/test/datahike/test/secondary_dynamic_test.clj
@@ -4,6 +4,8 @@
    [clojure.core.async :as async]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [datahike.api :as d]
+   [datahike.backfill.capture :as capture]
+   [datahike.tx-preds :as tx-preds]
    [datahike.gc-guard :as guard]
    [datahike.gc-roots :as roots]
    [konserve.core :as k]
@@ -287,9 +289,8 @@
             (is (= :building
                    (get-in (d/db conn)
                            [:schema :idx/cancel-slow :db.secondary/status])))
-            (is (= 1 (count (get-in (d/db conn)
-                                    [:secondary-index-build-deltas
-                                     :idx/cancel-slow]))))
+            (is (= 1 (capture/reduce-deltas (d/db conn) :idx/cancel-slow
+                                            (fn [n _] (inc n)) 0)))
             (let [report @(writer/cancel-secondary-index-build!
                            conn :idx/cancel-slow boundary)]
               (is (= {:idx-ident :idx/cancel-slow
@@ -367,6 +368,100 @@
             (d/release conn)
             (d/delete-database cfg)))))))
 
+(deftest backfill-journal-keeps-snapshots-compact-and-rejects-before-spooling
+  (let [cfg {:store {:backend :memory :id (random-uuid)}
+             :writer {:backend :self :writer-ownership :exclusive
+                      :backfill-journal {:max-frame-bytes 1024 :max-bytes 8192}}
+             :schema-flexibility :write :max-string-length 0}
+        entered (promise)
+        release (promise)]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (d/transact conn [{:db/ident :person/name :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one}])
+        (d/transact conn [{:person/name "initial"}])
+        (reset! slow-build-control {:entered entered :release release :blocked? (atom false)})
+        (d/transact conn [{:db/ident :idx/journal :db.secondary/type :test/slow-immutable
+                           :db.secondary/attrs [:person/name]}])
+        (is (= true (deref entered 5000 ::timeout)))
+        (d/transact conn [{:person/name "first"}])
+        (let [first-db @conn
+              descriptor (get-in first-db [:secondary-index-build-journals :idx/journal])
+              path (:path descriptor)]
+          (is (pos? (:end descriptor)))
+          (is (nil? (:secondary-index-build-deltas first-db)))
+          ;; Pure previews retain pending notifications without touching disk.
+          (let [preview (d/with first-db [{:person/name "preview"}])]
+            (is (= 1 (count (get-in preview [:db-after :secondary-index-build-deltas :idx/journal]))))
+            (is (= (:end descriptor) (.length (java.io.File. path)))))
+          (tx-preds/register-tx-pred! (get-in cfg [:store :id]) ::reject
+                                      (fn [_] (throw (ex-info "reject before spool" {}))))
+          (try
+            (is (thrown-with-msg? Exception #"reject before spool"
+                                  (d/transact conn [{:person/name "rejected"}])))
+            (is (= (:end descriptor) (.length (java.io.File. path))))
+            (finally (tx-preds/unregister-tx-pred! (get-in cfg [:store :id]) ::reject)))
+          ;; Oversize notifications fail without advancing the accepted prefix.
+          (is (= :backfill.journal/frame-too-large
+                 (try (d/transact conn [{:person/name (apply str (repeat 1100 "x"))}])
+                      nil
+                      (catch Exception e (throwable-type e)))))
+          (is (= (:max-tx first-db) (:max-tx @conn)))
+          (is (= (:end descriptor) (.length (java.io.File. path))))
+          (let [commit-entered (promise)
+                commit-release (promise)
+                captured (promise)
+                installed (promise)
+                capture-count (atom 0)
+                blocked? (atom false)
+                commit! writing/commit!
+                prepare! capture/prepare-report!]
+            (with-redefs [writing/commit!
+                          (fn [& args]
+                            (when (compare-and-set! blocked? false true)
+                              (deliver commit-entered true)
+                              (when (= ::timeout (deref commit-release 10000 ::timeout))
+                                (throw (ex-info "test commit gate timed out" {}))))
+                            (apply commit! args))
+                          capture/prepare-report!
+                          (fn [owner report]
+                            (let [result (prepare! owner report)]
+                              (when (seq (get-in report [:db-after :secondary-index-build-deltas :idx/journal]))
+                                (when (= 10 (swap! capture-count inc))
+                                  (deliver captured (:db-after result))))
+                              (when (= :ready (get-in result [:db-after :schema :idx/journal :db.secondary/status]))
+                                (deliver installed true))
+                              result))]
+              (try
+                (let [pending (mapv #(d/transact! conn [{:person/name (str "later-" %)}]) (range 10))]
+                  (is (= true (deref commit-entered 5000 ::timeout)))
+                  (let [candidate (deref captured 5000 ::timeout)]
+                    (is (not= ::timeout candidate))
+                    (is (nil? (:secondary-index-build-deltas candidate)))
+                    (is (= 11 (capture/reduce-deltas candidate :idx/journal (fn [n _] (inc n)) 0))))
+                  (is (= 1 (capture/reduce-deltas first-db :idx/journal (fn [n _] (inc n)) 0)))
+                  ;; Install uses the speculative journal prefix while commits
+                  ;; are paused; the following write must use the ready index.
+                  (deliver release true)
+                  (is (= true (deref installed 5000 ::timeout)))
+                  (let [after-install (d/transact! conn [{:person/name "after-install"}])]
+                    (deliver commit-release true)
+                    (doseq [p (conj pending after-install)]
+                      (is (map? (deref p 5000 ::timeout))))))
+                (finally (deliver release true) (deliver commit-release true)))))
+          (is (= :ready (await-status conn :idx/journal :ready)))
+          (is (not (.exists (java.io.File. path))))
+          (is (nil? (:secondary-index-build-journals @conn)))
+          (is (= (into #{"initial" "first" "after-install"} (map #(str "later-" %) (range 10)))
+                 (set (map second (:values @(get-in @conn [:secondary-indices :idx/journal])))))))
+        (finally
+          (deliver release true)
+          (reset! slow-build-control nil)
+          (tx-preds/unregister-tx-pred! (get-in cfg [:store :id]) ::reject)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest asynchronous-backfill-replays-concurrent-deltas
   (testing "the writer remains available and immutable index updates are not lost"
     ;; A file store, not :memory: the collector is exercised DURING the scan
@@ -425,8 +520,8 @@
             ;; card-one replacement contributes a retract and an assertion.
             (d/transact conn [[:db/add alice :person/name "Alicia"]])
             (d/transact conn [{:person/name "Charlie"}])
-            (is (= 3 (count (get-in (d/db conn)
-                                    [:secondary-index-build-deltas :idx/slow])))
+            (is (= 3 (capture/reduce-deltas (d/db conn) :idx/slow
+                                            (fn [n _] (inc n)) 0))
                 "concurrent changes are journaled instead of racing the build")
             ;; NOW the head has moved past the scanned snapshot, so with
             ;; `(Date.)` as remove-before that snapshot's own nodes are garbage
@@ -442,8 +537,8 @@
                                             [:secondary-indices :idx/slow])]
               (is (= #{"Alicia" "Bob" "Charlie"}
                      (set (map second values))))
-              (is (nil? (:secondary-index-build-deltas (d/db conn)))
-                  "the install removes its in-memory delta journal")
+              (is (nil? (:secondary-index-build-journals (d/db conn)))
+                  "the install removes its scratch journal descriptor")
               (is (not (guard/in-flight? (get-in cfg [:store :id])))
                   "the ready commit releases the build's GC guard")
               (is (empty? (<?? S (roots/roots (:store @conn))))
@@ -584,10 +679,10 @@
                              :db.secondary/type :test/slow-immutable
                              :db.secondary/attrs [:person/name]}])
           (is (= true (deref entered 5000 ::timeout)))
-          ;; Committed while the scan is paused: journaled in memory only.
+          ;; Committed while the scan is paused: journaled in local scratch.
           (d/transact conn [{:person/name "Carol"}])
-          (is (= 1 (count (get-in (d/db conn)
-                                  [:secondary-index-build-deltas :idx/slow]))))
+          (is (= 1 (capture/reduce-deltas (d/db conn) :idx/slow
+                                          (fn [n _] (inc n)) 0)))
           ;; The process stops before install; the journal dies with it.
           (d/release conn)
           (deliver release true)


### PR DESCRIPTION
## Summary

Replace the cumulative in-memory secondary backfill delta vector with JVM
disk scratch journals. Database values carry immutable accepted-prefix
descriptors rather than retaining all decoded notifications.

- Stage capture only after transaction predicates accept the report, before
  the writer chains its speculative result or enqueues it for commit.
- Enforce streaming frame-byte and per-index disk quotas, with rollback on
  partial append failure. Pure `d/with` remains I/O-free.
- Replay exactly the install operation's prefix, including when writes and
  installation queue while commits are paused.
- Retire journal files after durable publication; clean owned files on normal
  shutdown. Preserve local-exclusive ownership and rebuild-on-reconnect.
- Document configuration and operational limits in the secondary-index guide.

## Scope

This bounds the retained journal, not secondary adapter memory or transaction
input. Install still replays the full accumulated journal in the writer.
Background catch-up, a capped final replay tail, and online AVET construction
remain follow-ups. No comparator/index-format changes or resumable-build claim.
Abrupt process death can leave scratch files; fatal JVM errors may require
explicit release. Configurable byte limits reject affected transactions rather
than silently discarding notifications.

## Validation

- Focused journal, capture and lifecycle tests: 22 tests / 139 assertions passed.
- Real disk experiment: 539,623,424 bytes / 131,072 frames written and replayed
  under a 256 MiB JVM heap; scratch removed after completion.
- CLJS: 295 tests / 1,847 assertions passed.
- Whole-repository reflection check clean (111 namespaces); Java bindings compiled.
- Instrumented JVM: 1,296 tests / 14,781 assertions passed.
- Full non-spec JVM: 2,912 tests / 31,187 assertions, zero failures/errors.

The local full matrix previously hit an HTTP EOF immediately after the
permissions fixture restarted its server. Baseline full PSS and repeated
isolated candidate tests passed, so the underlying cause was not established.
The fixture now owns a fresh HTTP client and OS-assigned port per server
incarnation, preserving all persistence/authorization assertions without
adding production retries. Five namespace repetitions (180 assertions) and
the final full candidate matrix pass. This tests persistence through a new
connection, not transparent recovery of a pooled socket to a stopped server.

Tests cover retained snapshots, byte quotas, codec failure rollback, multi-index
partial staging failure, predicate rejection, pure preview, early reduction,
cleanup, and queued writes→install→writes with commit deliberately paused.
