### PR TITLE
Add bounded sort and private index build storage

### DIFF
--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -428,7 +428,7 @@ Configure the scratch directory and per-index limits on the local writer:
 
 The directory must already exist. Without `:directory`, scratch uses the
 JVM temporary directory. Defaults allow a 1 MiB encoded notification and
-256 MiB per journal, including eight-byte frame headers. Encoding also limits
+256 MiB per journal, including 24-byte frame headers. Encoding also limits
 individual scalar allocations and nesting. Exceeding a limit rejects the
 transaction without advancing its database or accepted journal boundary.
 Wait for the build to finish, cancel it, or start a new build with larger limits

--- a/externs/node_fs.js
+++ b/externs/node_fs.js
@@ -22,6 +22,14 @@ fs.writeSync = function(fd, buffer, offset, length, position) {};
 fs.fsyncSync = function(fd) {};
 fs.mkdirSync = function(path, options) {};
 fs.readdirSync = function(path, options) {};
+fs.opendirSync = function(path, options) {};
+/** @constructor */
+var Dir = function() {};
+Dir.prototype.readSync = function() {};
+Dir.prototype.closeSync = function() {};
+/** @constructor */
+var Dirent = function() {};
+Dirent.prototype.name;
 fs.unlinkSync = function(path) {};
 fs.renameSync = function(oldPath, newPath) {};
 fs.copyFileSync = function(src, dest, flags) {};

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -56,6 +56,34 @@
   [descriptor f init]
   (file/reduce-journal descriptor f init))
 
+(defn start-cursor
+  "Return an opaque cursor before the first notification of this journal.
+   Cursors support value equality, not field access or numeric arithmetic."
+  [descriptor]
+  (file/start-cursor descriptor))
+
+(defn end-cursor
+  "Return an opaque cursor at this descriptor's accepted end. A cursor is
+   valid only while its boundary remains in the owned, retained lineage."
+  [descriptor]
+  (file/end-cursor descriptor))
+
+(defn compare-cursors
+  "Compare two cursor positions within this descriptor's accepted prefix.
+   Reject foreign, abandoned or out-of-prefix cursors. Returns negative, zero
+   or positive; callers must not infer byte distances from the result."
+  [descriptor left right]
+  (file/compare-cursors descriptor left right))
+
+(defn reduce-range
+  "Reduce from an issued cursor through this descriptor's exact accepted end.
+   f receives accumulator, notification and an opaque next cursor. Honors
+   reduced; the returned cursor can resume a later call while retained.
+   The backend checks cursor identity and validity; callers still own build
+   generations, leases and transaction grouping. Synchronous JVM operation."
+  [descriptor start f init]
+  (file/reduce-range descriptor start f init))
+
 (defn dispose!
   "Release this owner's scratch once no accepted report or reader needs it.
    Idempotent after success; failure may require cleanup to be retried."

--- a/src/datahike/backfill/journal/file.clj
+++ b/src/datahike/backfill/journal/file.clj
@@ -11,6 +11,21 @@
 (def ^:private owners (atom {}))
 (defn descriptor-id [descriptor] (:id descriptor))
 
+(def ^:private header-bytes 24)
+
+(deftype Cursor [owner ^long start ^long end incarnation]
+  Object
+  (equals [_ other]
+    (and (instance? Cursor other)
+         (identical? owner (.-owner ^Cursor other))
+         (= start (.-start ^Cursor other))
+         (= end (.-end ^Cursor other))
+         (= incarnation (.-incarnation ^Cursor other))))
+  (hashCode [_]
+    (hash [(System/identityHashCode owner) start end incarnation])))
+
+(alter-meta! #'->Cursor assoc :private true)
+
 (def ^:private codec {:profile :archival
                       :registry (elements/install-element-handlers (boring/tag-registry))})
 
@@ -38,7 +53,7 @@
 
 (defn create!
   "Create an owned scratch file. Limits include frame payload bytes and total
-   file bytes respectively; each notification has an eight-byte length header."
+   file bytes respectively. Each frame has a 24-byte length/incarnation header."
   [options]
   (let [{:keys [directory max-frame-bytes max-bytes]} (validate-options! options)
         attrs (make-array FileAttribute 0)
@@ -46,19 +61,81 @@
                (Files/createTempFile (Path/of (str directory) (make-array String 0))
                                      "datahike-build-" ".journal" attrs)
                (Files/createTempFile "datahike-build-" ".journal" attrs))
+        owner (Object.)
         descriptor {:id (UUID/randomUUID) :path (str path) :end 0
+                    ::cursor (Cursor. owner -1 0 nil)
                     :max-frame-bytes max-frame-bytes :max-bytes max-bytes}]
-    (swap! owners assoc (:id descriptor) (dissoc descriptor :end))
+    (swap! owners assoc (:id descriptor)
+           {:metadata (dissoc descriptor :end ::cursor) :capability owner})
     descriptor))
 
 (defn- checked-path ^Path [descriptor]
-  (when-not (and (= (get @owners (:id descriptor)) (dissoc descriptor :end))
-                 (integer? (:end descriptor)) (<= 0 (:end descriptor) (:max-bytes descriptor)))
+  (when-not (let [owner (get @owners (:id descriptor))
+                  cursor (::cursor descriptor)]
+              (and owner (= (:metadata owner) (dissoc descriptor :end ::cursor))
+                   (instance? Cursor cursor)
+                   (identical? (:capability owner) (.-owner ^Cursor cursor))
+                   (integer? (:end descriptor))
+                   (= (:end descriptor) (.-end ^Cursor cursor))
+                   (<= 0 (:end descriptor) (:max-bytes descriptor))))
     (fail! :backfill.journal/invalid-descriptor "Unknown or modified journal descriptor." {}))
   (let [path (Path/of (:path descriptor) (make-array String 0))]
     (when (Files/isSymbolicLink path)
       (fail! :backfill.journal/invalid-descriptor "Journal path is a symbolic link." {}))
     path))
+
+(defn- check-boundary!
+  [^RandomAccessFile file descriptor cursor error-type]
+  (when-not (and (instance? Cursor cursor)
+                 (identical? (.-owner ^Cursor (::cursor descriptor)) (.-owner ^Cursor cursor))
+                 (<= 0 (.-end ^Cursor cursor) (:end descriptor)))
+    (fail! error-type "Cursor belongs to another journal or exceeds the accepted prefix." {}))
+  (let [^Cursor cursor cursor
+        start (.-start cursor)
+        end (.-end cursor)]
+    (if (zero? end)
+      (when-not (and (= -1 start) (nil? (.-incarnation cursor)))
+        (fail! error-type "Invalid empty journal cursor." {}))
+      (do
+        (when-not (and (<= 0 start) (<= header-bytes (- end start))
+                       (instance? UUID (.-incarnation cursor)))
+          (fail! error-type "Cursor does not identify a complete frame boundary." {}))
+        (.seek file start)
+        (let [n (.readLong file)
+              incarnation (UUID. (.readLong file) (.readLong file))]
+          (when-not (= incarnation (.-incarnation cursor))
+            (fail! error-type "Journal cursor names an abandoned or modified frame." {}))
+          (when-not (and (<= 1 n (:max-frame-bytes descriptor))
+                         (= n (- end start header-bytes)))
+            (fail! :backfill.journal/corrupt "Invalid journal boundary frame length." {})))))
+    cursor))
+
+(defn- check-end! [^RandomAccessFile file descriptor]
+  (when (< (.length file) (:end descriptor))
+    (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+  (check-boundary! file descriptor (::cursor descriptor) :backfill.journal/invalid-descriptor))
+
+(defn start-cursor [descriptor]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (check-end! file descriptor)
+      (Cursor. (.-owner ^Cursor (::cursor descriptor)) -1 0 nil))))
+
+(defn end-cursor [descriptor]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (check-end! file descriptor))))
+
+(defn compare-cursors
+  "Compare two owned boundaries within this accepted prefix. Stale cursors
+   raise invalid-cursor; a stale descriptor raises invalid-descriptor."
+  [descriptor left right]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (check-end! file descriptor)
+      (check-boundary! file descriptor left :backfill.journal/invalid-cursor)
+      (check-boundary! file descriptor right :backfill.journal/invalid-cursor)
+      (compare (.-end ^Cursor left) (.-end ^Cursor right)))))
 
 (defn- check-scalars!
   "Bound scalar allocations inside the codec before its output cap can act.
@@ -113,65 +190,82 @@
   [{:keys [end max-frame-bytes max-bytes] :as descriptor} notifications]
   (let [path (checked-path descriptor)]
     (with-open [file (RandomAccessFile. (.toFile path) "rw")]
-      (when (< (.length file) end)
-        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (check-end! file descriptor)
       (.setLength file end)
       (.seek file end)
-      (try
-        (doseq [notification notifications]
-          (check-scalars! notification max-frame-bytes)
-          (let [start (.getFilePointer file)
-                payload-start (+ start 8)
-                count-bytes (volatile! 0)
-                reserve! (fn [n]
-                           (when (> (+ @count-bytes n) max-frame-bytes)
-                             (fail! :backfill.journal/frame-too-large "Journal frame exceeds byte limit." {}))
-                           (when (> (+ payload-start @count-bytes n) max-bytes)
-                             (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
-                           (vswap! count-bytes + n))
-                out (proxy [OutputStream] []
-                      (write
-                        ([v] (if (number? v)
-                               (do (reserve! 1) (.write file (int v)))
-                               (let [n (alength ^bytes v)]
-                                 (reserve! n) (.write file ^bytes v 0 n))))
-                        ([bs offset n] (reserve! n) (.write file ^bytes bs (int offset) (int n)))))]
-            (when (> payload-start max-bytes)
-              (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
-            (.writeLong file 0)
-            (boring/write-to! (boring/writer (min 8192 max-frame-bytes) codec) notification out)
-            (let [next-end (.getFilePointer file)]
-              (.seek file start)
-              (.writeLong file @count-bytes)
-              (.seek file next-end))))
-        (assoc descriptor :end (.getFilePointer file))
-        (catch Throwable e
-          (try (.setLength file end)
-               (catch Throwable rollback (.addSuppressed e rollback)))
-          (throw e))))))
+      (let [last-cursor (volatile! (::cursor descriptor))]
+        (try
+          (doseq [notification notifications]
+            (check-scalars! notification max-frame-bytes)
+            (let [start (.getFilePointer file)
+                  _ (when (> header-bytes (- max-bytes start))
+                      (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+                  payload-start (+ start header-bytes)
+                  incarnation (UUID/randomUUID)
+                  count-bytes (volatile! 0)
+                  reserve! (fn [n]
+                             (when (> (+ @count-bytes n) max-frame-bytes)
+                               (fail! :backfill.journal/frame-too-large "Journal frame exceeds byte limit." {}))
+                             (when (> (+ @count-bytes n) (- max-bytes payload-start))
+                               (fail! :backfill.journal/quota-exceeded "Journal exceeds disk quota." {}))
+                             (vswap! count-bytes + n))
+                  out (proxy [OutputStream] []
+                        (write
+                          ([v] (if (number? v)
+                                 (do (reserve! 1) (.write file (int v)))
+                                 (let [n (alength ^bytes v)]
+                                   (reserve! n) (.write file ^bytes v 0 n))))
+                          ([bs offset n] (reserve! n) (.write file ^bytes bs (int offset) (int n)))))]
+              (.writeLong file 0)
+              (.writeLong file (.getMostSignificantBits incarnation))
+              (.writeLong file (.getLeastSignificantBits incarnation))
+              (boring/write-to! (boring/writer (min 8192 max-frame-bytes) codec) notification out)
+              (let [next-end (.getFilePointer file)]
+                (.seek file start)
+                (.writeLong file @count-bytes)
+                (.seek file next-end)
+                (vreset! last-cursor
+                         (Cursor. (.-owner ^Cursor (::cursor descriptor)) start next-end incarnation)))))
+          (assoc descriptor :end (.getFilePointer file) ::cursor @last-cursor)
+          (catch Throwable e
+            (try (.setLength file end)
+                 (catch Throwable rollback (.addSuppressed e rollback)))
+            (throw e)))))))
 
-(defn reduce-journal
-  "Reduce exactly the descriptor's prefix, decoding one bounded frame at a time.
-   Honors reduced and closes the file on completion, early return or exception."
-  [{:keys [end max-frame-bytes] :as descriptor} f init]
+(defn reduce-range
+  "Reduce from an issued cursor through this accepted prefix. Callback receives
+   accumulator, value and an opaque next cursor. No earlier payload is decoded.
+   Boundary validation reads only the descriptor-end and start frame headers.
+   Numeric/foreign/abandoned cursors are rejected; raw file corruption is corrupt.
+   Always closes its reader, including reduced, callback and codec exceptions."
+  [{:keys [end max-frame-bytes] :as descriptor} start f init]
   (let [path (checked-path descriptor)]
     (with-open [file (RandomAccessFile. (.toFile path) "r")]
-      (when (< (.length file) end)
-        (fail! :backfill.journal/corrupt "Journal is shorter than its accepted prefix." {}))
+      (check-end! file descriptor)
+      (check-boundary! file descriptor start :backfill.journal/invalid-cursor)
+      (.seek file (.-end ^Cursor start))
       (loop [acc init]
         (let [position (.getFilePointer file)]
           (if (= position end)
             acc
             (do
-              (when (> (+ position 8) end)
+              (when (> header-bytes (- end position))
                 (fail! :backfill.journal/corrupt "Incomplete journal header." {}))
-              (let [n (.readLong file)]
-                (when-not (<= 1 n (min max-frame-bytes (- end position 8)))
+              (let [n (.readLong file)
+                    incarnation (UUID. (.readLong file) (.readLong file))]
+                (when-not (<= 1 n (min max-frame-bytes (- end position header-bytes)))
                   (fail! :backfill.journal/corrupt "Invalid journal frame length." {}))
                 (let [payload (byte-array n)
                       _ (.readFully file payload)
-                      next-acc (f acc (boring/decode payload codec))]
+                      cursor (Cursor. (.-owner ^Cursor (::cursor descriptor))
+                                      position (.getFilePointer file) incarnation)
+                      next-acc (f acc (boring/decode payload codec) cursor)]
                   (if (reduced? next-acc) @next-acc (recur next-acc)))))))))))
+
+(defn reduce-journal
+  "Reduce exactly this accepted prefix, decoding one bounded frame at a time."
+  [descriptor f init]
+  (reduce-range descriptor (start-cursor descriptor) (fn [acc value _] (f acc value)) init))
 
 (defn dispose!
   "Delete only this process's exact owned scratch file. Idempotent."

--- a/src/datahike/backfill/sort.clj
+++ b/src/datahike/backfill/sort.clj
@@ -1,0 +1,251 @@
+(ns ^:no-doc datahike.backfill.sort
+  "Scoped JVM external sorting with bounded windows, records and merge fan-in.
+   Limits account for retained record data, not exact JVM object sizes."
+  (:require [boring.core :as boring]
+            [datahike.migrate.cbor :as cbor])
+  (:import [java.io ByteArrayOutputStream DataInputStream DataOutputStream
+            BufferedInputStream BufferedOutputStream FileInputStream FileOutputStream OutputStream EOFException]
+           [java.nio.file Files Path CopyOption]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- fail! [kind message data]
+  (throw (ex-info message (assoc data :type kind))))
+
+(defn validate-options! [options]
+  (when-not (or (nil? options) (map? options))
+    (fail! ::invalid-options "Sort options must be a map." {}))
+  (let [defaults {:window-bytes 16777216 :window-records 65536
+                  :max-record-bytes 1048576 :fan-in 16 :max-bytes 4294967296}
+        allowed (conj (set (keys defaults)) :directory)
+        opts (merge defaults options)]
+    (when (some #(not (contains? allowed %)) (keys options))
+      (fail! ::invalid-options "Unknown sort option." {}))
+    (doseq [k (keys defaults)]
+      (when-not (and (integer? (get opts k)) (pos? (get opts k))
+                     (<= (get opts k) Long/MAX_VALUE))
+        (fail! ::invalid-options "Sort limits must be positive bounded integers." {:option k})))
+    (when (or (< (:fan-in opts) 2) (> (:fan-in opts) 128)
+              (> (:max-record-bytes opts) Integer/MAX_VALUE))
+      (fail! ::invalid-options "Invalid fan-in or record limit." {}))
+    (when-not (or (nil? (:directory opts)) (instance? Path (:directory opts))
+                  (and (string? (:directory opts)) (seq (:directory opts))))
+      (fail! ::invalid-options "Directory must be a nonempty path." {}))
+    opts))
+
+(defn- record-charge!
+  "Bound codec scalar allocations and traversal before encoding. Charges count
+   collection elements as well as payload, so tiny scalar encodings cannot make
+   an arbitrarily large retained object graph fit a window."
+  [record limit]
+  (let [charge (volatile! 0)]
+    (letfn [(add! [n]
+              (vswap! charge + n)
+              (when (> @charge limit)
+                (fail! ::record-too-large "Record exceeds structural budget." {})))
+            (visit! [x depth]
+              (when (> depth 128)
+                (fail! ::record-too-large "Record nesting exceeds limit." {}))
+              (add! 32)
+              (cond
+                (string? x) (add! (* 3 (long (.length ^String x))))
+                (or (keyword? x) (symbol? x))
+                (do (visit! (name x) (inc depth))
+                    (when-let [n (namespace x)] (visit! n (inc depth))))
+                (instance? java.math.BigInteger x) (add! (inc (quot (.bitLength ^java.math.BigInteger x) 8)))
+                (instance? clojure.lang.BigInt x) (visit! (.toBigInteger ^clojure.lang.BigInt x) (inc depth))
+                (instance? java.math.BigDecimal x) (visit! (.unscaledValue ^java.math.BigDecimal x) (inc depth))
+                (ratio? x) (do (visit! (numerator x) (inc depth))
+                               (visit! (denominator x) (inc depth)))
+                (map? x) (doseq [[k v] x] (visit! k (inc depth)) (visit! v (inc depth)))
+                (or (sequential? x) (set? x)) (doseq [v x] (visit! v (inc depth)))
+                (and x (.isArray (class x)))
+                (let [component (.getComponentType (class x))
+                      n (java.lang.reflect.Array/getLength x)]
+                  (if (.isPrimitive component)
+                    (add! (* (long n) (cond
+                                        (or (= component Byte/TYPE) (= component Boolean/TYPE)) 1
+                                        (or (= component Short/TYPE) (= component Character/TYPE)) 2
+                                        (or (= component Float/TYPE) (= component Integer/TYPE)) 4
+                                        :else 8)))
+                    (doseq [v (seq x)] (visit! v (inc depth)))))
+                (or (nil? x) (boolean? x) (number? x) (char? x)
+                    (instance? java.util.Date x) (instance? java.util.UUID x)) nil
+                :else (fail! ::unsupported-value "Unsupported sort value." {:class (str (class x))})))]
+      (visit! record 0)
+      @charge)))
+
+(defn- encode! [record {:keys [max-record-bytes window-bytes]}]
+  (let [charge (record-charge! record (min window-bytes max-record-bytes))
+        buffer (ByteArrayOutputStream. (int (min 8192 max-record-bytes)))
+        count-bytes (volatile! 0)
+        reserve! (fn [n]
+                   (when (> (+ @count-bytes n) max-record-bytes)
+                     (fail! ::record-too-large "Encoded record exceeds byte limit." {}))
+                   (vswap! count-bytes + n))
+        out (proxy [OutputStream] []
+              (write
+                ([v] (if (number? v)
+                       (do (reserve! 1) (.write buffer (int v)))
+                       (let [n (alength ^bytes v)]
+                         (reserve! n) (.write buffer ^bytes v 0 n))))
+                ([bs offset n] (reserve! n) (.write buffer ^bytes bs (int offset) (int n)))))]
+    (boring/write-to! (boring/writer (min 8192 max-record-bytes) cbor/opts) record out)
+    (let [bytes (.toByteArray buffer)
+          total (+ charge (alength bytes) 64)]
+      (when (> total window-bytes)
+        (fail! ::record-too-large "Record cannot fit the sort window." {}))
+      {:record record :bytes bytes :charge total})))
+
+(defn- run-path ^Path [^Path directory pass run]
+  (.resolve directory (str "p" pass "-r" run ".cbor")))
+
+(defn- write-frame! [^DataOutputStream out usage limit ^bytes bytes]
+  (let [n (+ 4 (long (alength bytes)))]
+    (when (> (+ @usage n) limit)
+      (fail! ::quota-exceeded "Sort exceeds scratch quota." {}))
+    (.writeInt out (alength bytes))
+    (.write out bytes)
+    (vswap! usage + n)))
+
+(defn- open-reader ^DataInputStream [^Path path]
+  (DataInputStream. (BufferedInputStream. (FileInputStream. (.toFile path)))))
+
+(defn- read-frame! [^DataInputStream in limit]
+  (let [first-byte (.read in)]
+    (when (not= -1 first-byte)
+      (try
+        (let [n (bit-or (bit-shift-left first-byte 24)
+                        (bit-shift-left (.readUnsignedByte in) 16)
+                        (bit-shift-left (.readUnsignedByte in) 8)
+                        (.readUnsignedByte in))]
+          (when-not (<= 1 n limit)
+            (fail! ::corrupt "Invalid sort frame length." {}))
+          (let [bytes (byte-array n)]
+            (.readFully in bytes)
+            {:bytes bytes :record (cbor/decode-record bytes)}))
+        (catch EOFException e
+          (throw (ex-info "Incomplete sort frame." {:type ::corrupt} e)))))))
+
+(defn- with-output! [^Path path f]
+  (with-open [out (DataOutputStream. (BufferedOutputStream. (FileOutputStream. (.toFile path))))]
+    (f out)))
+
+(defn- spill! [directory run window cmp usage opts]
+  (with-output! (run-path directory 0 run)
+    (fn [out]
+      (doseq [entry (sort (fn [a b] (cmp (:record a) (:record b))) window)]
+        (write-frame! out usage (:max-bytes opts) (:bytes entry))))))
+
+(defn- initial-runs! [records directory cmp usage opts]
+  (let [{:keys [window-bytes window-records]} opts
+        {:keys [run window]}
+        (reduce (fn [{:keys [run window charge]} record]
+                  (let [entry (encode! record opts)]
+                    (if (and (seq window)
+                             (or (= (count window) window-records)
+                                 (> (+ charge (:charge entry)) window-bytes)))
+                      (do (spill! directory run window cmp usage opts)
+                          {:run (inc run) :window [entry] :charge (:charge entry)})
+                      {:run run :window (conj window entry) :charge (+ charge (:charge entry))})))
+                {:run 0 :window [] :charge 0} records)]
+    (when (seq window) (spill! directory run window cmp usage opts))
+    (+ run (if (seq window) 1 0))))
+
+(defn- merge-group! [directory pass start end target cmp usage opts]
+  (let [readers (volatile! [])
+        primary (volatile! nil)]
+    (try
+      (doseq [i (range start end)]
+        (vswap! readers conj (open-reader (run-path directory pass i))))
+      (let [entry-cmp (fn [a b]
+                        (let [c (cmp (:record a) (:record b))]
+                          (if (zero? c) (compare (:reader a) (:reader b)) c)))]
+        (with-output! (run-path directory (inc pass) target)
+          (fn [out]
+            (loop [q (reduce-kv (fn [q i in]
+                                  (if-let [entry (read-frame! in (:max-record-bytes opts))]
+                                    (conj q (assoc entry :reader i)) q))
+                                (sorted-set-by entry-cmp) @readers)]
+              (when-let [entry (first q)]
+                (write-frame! out usage (:max-bytes opts) (:bytes entry))
+                (let [q (disj q entry)
+                      next-entry (read-frame! (nth @readers (:reader entry)) (:max-record-bytes opts))]
+                  (recur (if next-entry (conj q (assoc next-entry :reader (:reader entry))) q))))))))
+      (catch Throwable e (vreset! primary e) (throw e))
+      (finally
+        (let [failure (volatile! nil)]
+          (doseq [^DataInputStream in @readers]
+            (try (.close in) (catch Throwable e (when-not @failure (vreset! failure e)))))
+          (when-let [e @failure]
+            (if-let [^Throwable original @primary]
+              (.addSuppressed original e)
+              (throw e)))))))
+  (doseq [i (range start end)]
+    (let [path (run-path directory pass i)
+          size (Files/size path)]
+      (Files/delete path)
+      (vswap! usage - size))))
+
+(defn- sorted-file! [records directory cmp usage opts]
+  (loop [pass 0 runs (initial-runs! records directory cmp usage opts)]
+    (cond
+      (zero? runs) nil
+      (= 1 runs) (run-path directory pass 0)
+      :else
+      (let [fan-in (:fan-in opts)
+            next-runs (quot (+ runs (dec fan-in)) fan-in)]
+        (doseq [group (range next-runs)]
+          (let [start (* group fan-in)
+                end (min runs (+ start fan-in))]
+            (if (= (inc start) end)
+              (Files/move (run-path directory pass start) (run-path directory (inc pass) group)
+                          (make-array CopyOption 0))
+              (merge-group! directory pass start end group cmp usage opts))))
+        (recur (inc pass) next-runs)))))
+
+(defn- cleanup! [^Path directory]
+  (let [failure (volatile! nil)]
+    (with-open [entries (Files/newDirectoryStream directory)]
+      (doseq [^Path path entries]
+        (try (Files/deleteIfExists path)
+             (catch Throwable e (when-not @failure (vreset! failure e))))))
+    (try (Files/deleteIfExists directory)
+         (catch Throwable e (when-not @failure (vreset! failure e))))
+    (when-let [e @failure] (throw e))))
+
+(defn with-sorted-records!
+  "Call consume with a sorted sequence valid only during that call. The caller
+   must not return a lazy result referring to it. Closes readers and removes
+   owned scratch on success, early return or exception. Comparator receives
+   migration records; its allocations and the caller's retained input/output
+   are outside the budget. Windows are charged for encoded data plus a
+   conservative structural estimate. Merge retains at most fan-in records.
+   Scratch quota includes simultaneous old and new runs during a merge."
+  [records cmp options consume]
+  (let [opts (validate-options! options)
+        attrs (make-array FileAttribute 0)
+        directory (if-let [parent (:directory opts)]
+                    (Files/createTempDirectory (Path/of (str parent) (make-array String 0)) "datahike-sort-" attrs)
+                    (Files/createTempDirectory "datahike-sort-" attrs))
+        primary (volatile! nil)]
+    (try
+      (if-let [path (sorted-file! records directory cmp (volatile! 0) opts)]
+        (with-open [in (open-reader path)]
+          (letfn [(step []
+                    (lazy-seq
+                     (when-let [entry (read-frame! in (:max-record-bytes opts))]
+                       (cons (:record entry) (step)))))]
+            (consume (step))))
+        (consume nil))
+      (catch Throwable e (vreset! primary e) (throw e))
+      (finally
+        (try (cleanup! directory)
+             (catch Throwable e
+               (if-let [^Throwable original @primary]
+                 (.addSuppressed original e)
+                 (throw e))))))))
+
+(defn reduce-sorted!
+  "Reduce sorted records inside the scratch scope; honors reduced."
+  [records cmp options f init]
+  (with-sorted-records! records cmp options #(reduce f init %)))

--- a/src/datahike/backfill/sort.clj
+++ b/src/datahike/backfill/sort.clj
@@ -2,7 +2,8 @@
   "Scoped JVM external sorting with bounded windows, records and merge fan-in.
    Limits account for retained record data, not exact JVM object sizes."
   (:require [boring.core :as boring]
-            [datahike.migrate.cbor :as cbor])
+            [datahike.migrate.cbor :as cbor]
+            [datahike.sort :as engine])
   (:import [java.io ByteArrayOutputStream DataInputStream DataOutputStream
             BufferedInputStream BufferedOutputStream FileInputStream FileOutputStream OutputStream EOFException]
            [java.nio.file Files Path CopyOption]
@@ -126,82 +127,30 @@
         (catch EOFException e
           (throw (ex-info "Incomplete sort frame." {:type ::corrupt} e)))))))
 
-(defn- with-output! [^Path path f]
-  (with-open [out (DataOutputStream. (BufferedOutputStream. (FileOutputStream. (.toFile path))))]
-    (f out)))
-
-(defn- spill! [directory run window cmp usage opts]
-  (with-output! (run-path directory 0 run)
-    (fn [out]
-      (doseq [entry (sort (fn [a b] (cmp (:record a) (:record b))) window)]
-        (write-frame! out usage (:max-bytes opts) (:bytes entry))))))
-
-(defn- initial-runs! [records directory cmp usage opts]
-  (let [{:keys [window-bytes window-records]} opts
-        {:keys [run window]}
-        (reduce (fn [{:keys [run window charge]} record]
-                  (let [entry (encode! record opts)]
-                    (if (and (seq window)
-                             (or (= (count window) window-records)
-                                 (> (+ charge (:charge entry)) window-bytes)))
-                      (do (spill! directory run window cmp usage opts)
-                          {:run (inc run) :window [entry] :charge (:charge entry)})
-                      {:run run :window (conj window entry) :charge (+ charge (:charge entry))})))
-                {:run 0 :window [] :charge 0} records)]
-    (when (seq window) (spill! directory run window cmp usage opts))
-    (+ run (if (seq window) 1 0))))
-
-(defn- merge-group! [directory pass start end target cmp usage opts]
-  (let [readers (volatile! [])
-        primary (volatile! nil)]
-    (try
-      (doseq [i (range start end)]
-        (vswap! readers conj (open-reader (run-path directory pass i))))
-      (let [entry-cmp (fn [a b]
-                        (let [c (cmp (:record a) (:record b))]
-                          (if (zero? c) (compare (:reader a) (:reader b)) c)))]
-        (with-output! (run-path directory (inc pass) target)
-          (fn [out]
-            (loop [q (reduce-kv (fn [q i in]
-                                  (if-let [entry (read-frame! in (:max-record-bytes opts))]
-                                    (conj q (assoc entry :reader i)) q))
-                                (sorted-set-by entry-cmp) @readers)]
-              (when-let [entry (first q)]
-                (write-frame! out usage (:max-bytes opts) (:bytes entry))
-                (let [q (disj q entry)
-                      next-entry (read-frame! (nth @readers (:reader entry)) (:max-record-bytes opts))]
-                  (recur (if next-entry (conj q (assoc next-entry :reader (:reader entry))) q))))))))
-      (catch Throwable e (vreset! primary e) (throw e))
-      (finally
-        (let [failure (volatile! nil)]
-          (doseq [^DataInputStream in @readers]
-            (try (.close in) (catch Throwable e (when-not @failure (vreset! failure e)))))
-          (when-let [e @failure]
-            (if-let [^Throwable original @primary]
-              (.addSuppressed original e)
-              (throw e)))))))
-  (doseq [i (range start end)]
-    (let [path (run-path directory pass i)
-          size (Files/size path)]
-      (Files/delete path)
-      (vswap! usage - size))))
-
-(defn- sorted-file! [records directory cmp usage opts]
-  (loop [pass 0 runs (initial-runs! records directory cmp usage opts)]
-    (cond
-      (zero? runs) nil
-      (= 1 runs) (run-path directory pass 0)
-      :else
-      (let [fan-in (:fan-in opts)
-            next-runs (quot (+ runs (dec fan-in)) fan-in)]
-        (doseq [group (range next-runs)]
-          (let [start (* group fan-in)
-                end (min runs (+ start fan-in))]
-            (if (= (inc start) end)
-              (Files/move (run-path directory pass start) (run-path directory (inc pass) group)
-                          (make-array CopyOption 0))
-              (merge-group! directory pass start end group cmp usage opts))))
-        (recur (inc pass) next-runs)))))
+(defn- file-backend [directory usage opts]
+  {:prepare #(encode! % opts)
+   :open-reader
+   (fn [[pass run]]
+     (let [in (open-reader (run-path directory pass run))]
+       {:next! #(read-frame! in (:max-record-bytes opts))
+        :close! #(.close ^DataInputStream in)}))
+   :open-writer
+   (fn [[pass run]]
+     (let [path (run-path directory pass run)
+           out (DataOutputStream. (BufferedOutputStream. (FileOutputStream. (.toFile path))))]
+       {:write! #(write-frame! out usage (:max-bytes opts) (:bytes %))
+        :close! #(.close out)}))
+   :delete!
+   (fn [[pass run]]
+     (let [path (run-path directory pass run)
+           size (Files/size path)]
+       (Files/delete path)
+       (vswap! usage - size)))
+   :move!
+   (fn [[from-pass from-run] [to-pass to-run]]
+     (Files/move (run-path directory from-pass from-run)
+                 (run-path directory to-pass to-run)
+                 (make-array CopyOption 0)))})
 
 (defn- cleanup! [^Path directory]
   (let [failure (volatile! nil)]
@@ -229,8 +178,10 @@
                     (Files/createTempDirectory "datahike-sort-" attrs))
         primary (volatile! nil)]
     (try
-      (if-let [path (sorted-file! records directory cmp (volatile! 0) opts)]
-        (with-open [in (open-reader path)]
+      (if-let [[pass run] (engine/sorted-file! records {:cmp cmp}
+                                               (file-backend directory (volatile! 0) opts)
+                                               opts)]
+        (with-open [in (open-reader (run-path directory pass run))]
           (letfn [(step []
                     (lazy-seq
                      (when-let [entry (read-frame! in (:max-record-bytes opts))]

--- a/src/datahike/backfill/storage.clj
+++ b/src/datahike/backfill/storage.clj
@@ -1,0 +1,221 @@
+(ns ^:no-doc datahike.backfill.storage
+  "Private JVM PSS node storage. Caller must hold the durable build sweep
+   deferral, source pin and local GC guard until publication or cancellation.
+   This primitive does not establish those protections or enable online AVET."
+  (:require [datahike.datom :as dd]
+            [datahike.index.interface :as di]
+            [datahike.index.persistent-set]
+            [konserve.core :as k]
+            [org.replikativ.persistent-sorted-set.impl.nodes :as nodes])
+  (:import [java.util UUID Date]
+           [java.net URI]
+           [java.math BigInteger BigDecimal]
+           [java.lang.reflect Array]
+           [org.replikativ.persistent_sorted_set IStorage ANode Branch]))
+
+(def ^:private defaults
+  {:max-node-keys 4096 :max-node-weight 8388608
+   :pending-node-limit 64 :pending-weight-limit 16777216
+   :cache-node-limit 64 :cache-weight-limit 16777216})
+
+(defn- fail! [type message data]
+  (throw (ex-info message (assoc data :type type))))
+
+(defn- options! [config options]
+  (when-not (and (= :datahike.index/persistent-set (:index config))
+                 (false? (:crypto-hash? config)))
+    (fail! :backfill.storage/unsupported
+           "Private builds require JVM persistent-set with crypto-hash? false."
+           (select-keys config [:index :crypto-hash?])))
+  (when-not (or (nil? options) (map? options))
+    (fail! :backfill.storage/invalid-options "Storage options must be a map." {}))
+  (when (some #(not (contains? defaults %)) (keys options))
+    (fail! :backfill.storage/invalid-options "Unknown storage option." {}))
+  (let [options (merge defaults options)]
+    (doseq [[key value] options]
+      (when-not (and (integer? value) (pos? value) (<= value Integer/MAX_VALUE))
+        (fail! :backfill.storage/invalid-options "Storage limits must be positive bounded integers."
+               {key value})))
+    (when (> (:max-node-weight options) (:pending-weight-limit options))
+      (fail! :backfill.storage/invalid-options "A node must fit in the pending weight limit." {}))
+    options))
+
+(defn- weight!
+  "Conservative payload accounting units, NOT measured JVM retained heap.
+   Charge each occurrence (including sharing) and bound traversal/depth."
+  [value limit]
+  (let [total (volatile! 0)]
+    (letfn [(charge! [n]
+              (when (> (vswap! total + n) limit)
+                (fail! :backfill.storage/node-too-large "Node exceeds its weight limit." {:limit limit})))
+            (visit! [x depth]
+              (when (> depth 64)
+                (fail! :backfill.storage/node-too-large "Node exceeds its nesting limit." {}))
+              (charge! 64)
+              (when-let [metadata (meta x)] (visit! metadata (inc depth)))
+              (cond
+                (nil? x) nil
+                (string? x) (charge! (* 2 (.length ^String x)))
+                (or (keyword? x) (symbol? x))
+                (do (visit! (name x) (inc depth)) (visit! (namespace x) (inc depth)))
+                (instance? BigInteger x) (charge! (+ 32 (quot (+ 7 (.bitLength ^BigInteger x)) 8)))
+                (instance? clojure.lang.BigInt x) (visit! (.toBigInteger ^clojure.lang.BigInt x) (inc depth))
+                (instance? BigDecimal x) (visit! (.unscaledValue ^BigDecimal x) (inc depth))
+                (instance? clojure.lang.Ratio x)
+                (do (visit! (numerator x) (inc depth)) (visit! (denominator x) (inc depth)))
+                (or (instance? Long x) (instance? Integer x) (instance? Short x)
+                    (instance? Byte x) (instance? Double x) (instance? Float x)
+                    (boolean? x) (char? x) (instance? UUID x) (instance? Date x)) nil
+                (instance? URI x) (visit! (str x) (inc depth))
+                (instance? datahike.datom.Datom x)
+                (doseq [v [(.-e ^datahike.datom.Datom x) (.-a ^datahike.datom.Datom x)
+                           (.-v ^datahike.datom.Datom x)
+                           (dd/datom-tx x) (dd/datom-added x)]]
+                  (visit! v (inc depth)))
+                (.isArray (class x))
+                (let [n (Array/getLength x)]
+                  (charge! (* 8 n))
+                  (when-not (.isPrimitive (.getComponentType (class x)))
+                    (dotimes [i n] (visit! (Array/get x i) (inc depth)))))
+                (map? x) (doseq [[key value] x] (visit! key (inc depth)) (visit! value (inc depth)))
+                (or (sequential? x) (set? x)) (doseq [v x] (visit! v (inc depth)))
+                :else (fail! :backfill.storage/unsupported-value
+                             "Unsupported private node value." {:class (str (class x))})))]
+      (visit! value 0)
+      @total)))
+
+(defn- blob! [node options]
+  (when-not (instance? ANode node)
+    (fail! :backfill.storage/unsupported-value "Expected a persistent-set node." {}))
+  (let [^ANode node node]
+    (when (> (alength (.-_keys node)) (:max-node-keys options))
+      (fail! :backfill.storage/node-too-large "Node exceeds its key capacity limit." {}))
+    ;; Slot projection can recursively materialize buffered descendants before
+    ;; weight accounting. Refuse it rather than claiming that allocation bounded.
+    (when (pos? (.diffBufSize (.-_settings node)))
+      (fail! :backfill.storage/unsupported "Private storage does not support diff buffers." {}))
+    (let [blob (nodes/node->blob node)]
+      [blob (weight! blob (:max-node-weight options))])))
+
+(defn- live! [state]
+  (when (:closed? @state)
+    (fail! :backfill.storage/closed "Private storage is closed." {}))
+  (when (:failed? @state)
+    (fail! :backfill.storage/failed "Private storage failed; discard the build." {})))
+
+(defn- node-from-blob [blob]
+  ;; reader-context memoizes settings without a size limit. Keep its lifetime
+  ;; local so heterogeneous historical node settings cannot grow a hidden cache.
+  (let [context (nodes/reader-context {})]
+    (if (contains? blob :level)
+      (nodes/blob->branch context blob)
+      (nodes/blob->leaf context blob))))
+
+(defn- cache! [state options address blob weight]
+  (when (<= weight (:cache-weight-limit options))
+    (swap! state
+           (fn [s]
+             (let [old-weight (get-in s [:cache address :weight] 0)
+                   tick (inc (:tick s))]
+               (loop [s (-> s
+                            (assoc :tick tick)
+                            (assoc-in [:cache address] {:blob blob :weight weight :tick tick})
+                            (update :cache-weight + (- weight old-weight)))]
+                 (if (or (> (count (:cache s)) (:cache-node-limit options))
+                         (> (:cache-weight s) (:cache-weight-limit options)))
+                   (let [[key entry] (apply min-key (comp :tick val) (:cache s))]
+                     (recur (-> s (update :cache dissoc key) (update :cache-weight - (:weight entry)))))
+                   s)))))))
+
+(defn- flush-state! [store state]
+  (live! state)
+  (try
+    (doseq [[address blob _weight] (:pending @state)]
+      ;; Same immutable synchronous write discipline as writing/write-pending-kvs!,
+      ;; without introducing a writing -> storage -> writing namespace cycle.
+      (k/assoc store address (node-from-blob blob) {:immutable? true} {:sync? true})
+      (swap! state update-in [:stats :persisted] inc))
+    (swap! state assoc :pending [] :pending-weight 0)
+    nil
+    (catch Throwable e
+      (swap! state assoc :failed? true)
+      (throw e))))
+
+(defrecord PrivateStorage [store options state]
+  IStorage
+  (store [_ node]
+    (locking state
+      (live! state)
+      (let [[blob weight] (blob! node options)
+            address (UUID/randomUUID)]
+        (when (or (>= (count (:pending @state)) (:pending-node-limit options))
+                  (> (+ (:pending-weight @state) weight) (:pending-weight-limit options)))
+          (flush-state! store state))
+        (swap! state (fn [s] (-> s
+                                 (update :pending conj [address blob weight])
+                                 (update :pending-weight + weight)
+                                 (update-in [:stats :writes] inc))))
+        (cache! state options address blob weight)
+        address)))
+  (restore [_ address]
+    (locking state
+      (live! state)
+      (let [[blob weight]
+            (or (when-let [entry (get-in @state [:cache address])]
+                  [(:blob entry) (:weight entry)])
+                (some (fn [[key blob weight]] (when (= key address) [blob weight])) (:pending @state))
+                (let [node (k/get store address nil {:sync? true})]
+                  (when-not node
+                    (fail! :backfill.storage/node-not-found "Private build node not found." {:address address}))
+                  (swap! state update-in [:stats :reads] inc)
+                  (blob! node options)))]
+        (cache! state options address blob weight)
+        ;; Never cache returned mutable nodes/child pointers: only detached blobs.
+        (node-from-blob blob))))
+  (accessed [_ _address]
+    (locking state (live! state) (swap! state update-in [:stats :accessed] inc))
+    nil)
+  (markFreed [_ _address] nil)
+  (isFreed [_ _address] false)
+  (freedInfo [_ _address] nil)
+  java.io.Closeable
+  (close [_]
+    (locking state
+      (swap! state assoc :closed? true :pending [] :pending-weight 0 :cache {} :cache-weight 0))))
+
+(defn create!
+  "Create private storage without I/O. Store must already carry PSS serializers.
+   Caller owns GC protection. No freelist, source cache or pending buffers are
+   inherited. Weight limits bound accounted payload, not exact JVM heap or the
+   backend's own caching. One candidate node/projection can coexist with the
+   bounded buffers during admission; backend decoding and the caller's tree
+   frontier are outside those budgets. Node topology is isolated, but stored
+   values must not be mutated. Diff-buffer nodes are explicitly unsupported."
+  ([store config] (create! store config nil))
+  ([store config options]
+   (let [options (options! config options)]
+     (when (pos? (get store :datahike/diff-buf-size 0))
+       (fail! :backfill.storage/unsupported "Private storage does not support diff buffers." {}))
+     (->PrivateStorage (dissoc store :storage di/node-cache-key) options
+                       (atom {:pending [] :pending-weight 0 :cache {} :cache-weight 0 :tick 0
+                              :closed? false :failed? false
+                              :stats {:writes 0 :reads 0 :accessed 0 :persisted 0}})))))
+
+(defn build-store
+  "Store view for init-index-sorted. It does not expose live storage buffers."
+  [storage]
+  (assoc (:store storage) :storage storage))
+
+(defn flush!
+  "Synchronously persist private pending nodes. A failed flush poisons the build."
+  [storage]
+  (locking (:state storage)
+    (flush-state! (:store storage) (:state storage))))
+
+(defn resources
+  "Bounded counters; does not expose or retain node payloads."
+  [storage]
+  (let [s @(:state storage)]
+    (merge (select-keys s [:pending-weight :cache-weight :closed? :failed?])
+           (:stats s)
+           {:pending-nodes (count (:pending s)) :cached-nodes (count (:cache s))})))

--- a/src/datahike/migrate/fs.cljc
+++ b/src/datahike/migrate/fs.cljc
@@ -119,6 +119,24 @@
   #?(:clj (some->> (.listFiles (io/file p)) (mapv #(.getName ^File %)))
      :cljs (when (directory? p) (vec (.readdirSync (fs) (str p))))))
 
+(defn reduce-names
+  "Reduce directory names without retaining a listing. Closes the directory
+   handle on exhaustion, reduced, or failure. Requires synchronous Node IO."
+  [p f init]
+  #?(:clj
+     (with-open [entries (Files/newDirectoryStream (.toPath (io/file p)))]
+       (reduce (fn [acc path] (f acc (str (.getFileName ^java.nio.file.Path path))))
+               init entries))
+     :cljs
+     (let [dir (.opendirSync (fs) (str p))]
+       (try
+         (loop [acc init]
+           (if-let [entry (.readSync dir)]
+             (let [next-acc (f acc (.-name entry))]
+               (if (reduced? next-acc) @next-acc (recur next-acc)))
+             acc))
+         (finally (.closeSync dir))))))
+
 ;; ---------------------------------------------------------------------------
 ;; mutation
 

--- a/src/datahike/migrate/sort.cljc
+++ b/src/datahike/migrate/sort.cljc
@@ -1,87 +1,15 @@
 (ns ^:no-doc datahike.migrate.sort
-  "External merge sort for the export path, so ordering a dump uses memory bounded
-   by `:sort-buffer` rather than by the database size. `(api/datoms db :eavt)` is
-   lazy over the index but ordered by `e`, not `t`; a dump must be ordered by
-   transaction, so we spill sorted runs to temp files and k-way merge them.
-
-   Records are `[e a v t op]` vectors; run files are CBOR sequences (RFC 8742),
-   one top-level item per record.
-
-   The merge carries DECODED records rather than encoded bytes. Under the EDN
-   codec it carried line strings and re-parsed each one to get its sort key,
-   which meant every record was decoded twice on every merge pass; a record is
-   no larger in memory than the string it came from, so carrying it is both
-   simpler and strictly less work.
-
-   ## Portability
-
-   This runs on Node as well as the JVM, which it did not when it was `sort.clj`.
-   Nothing about the ALGORITHM was the obstacle, and the comments claiming a lazy
-   seq made it JVM-only were wrong about the reason: the hazard those comments
-   describe — a lazy seq performing IO cannot live inside a core.async go block —
-   is about CHANNEL IO, and there is none here. Every read is a synchronous local
-   file read (`.read` on the JVM, `fs.readSync` on Node), so the seq realises on
-   the calling stack exactly as it always did, and the sort never touches
-   konserve. The actual obstacles were `java.io.File` and `java.util.PriorityQueue`,
-   and both have portable spellings."
-  (:require [datahike.migrate.cbor :as mcbor]
+  "Migration ordering and CBOR-sequence IO for the shared external sorter.
+   Windows are record-count bounded; individual migration records have no byte
+   cap. File IO is synchronous on both JVM and Node."
+  (:require [clojure.string :as str]
+            [datahike.sort :as sorter]
+            [datahike.migrate.cbor :as mcbor]
             [datahike.migrate.fs :as fs]))
 
 (defn sort-key
-  "EXPORT ordering: transaction first (schema/refs before use, causal history),
-   `:db/txInstant` first within a tx (tx entity established before its datoms),
-   then `e`,`a` for a deterministic total order.
-
-   This is the dump's order and a format guarantee, not an implementation
-   detail — a consumer reading the log benefits from knowing it is causally
-   ordered. It is NOT the order any index wants, which is why the sort takes a
-   COMPARATOR as a parameter: a bulk index build re-sorts the same records into
-   eavt/aevt/avet order, and that is a different order over the same data rather
-   than a different dump.
-
-   Note `(str …)` for the attribute AND the value: a stable total order without
-   requiring them to be mutually Comparable. `v` is heterogeneous, so
-   `(compare 3 \"x\")` would throw.
-
-   `op` comes BEFORE `v`, retraction before assertion, and the order of those two
-   keys is the whole guarantee. It used to be the other way round, and that made
-   the guarantee a coincidence: a card-one overwrite's two records differ in `v`,
-   so `v` decided and `op` was never consulted. Retraction-first then held only
-   when the old value's string happened to sort before the new one's. Measured:
-   `[1 :score 1 100 false]` / `[1 :score 10 100 true]` came out retract-first
-   because `\"1\" < \"10\"`, while the same pair with the values swapped came out
-   ASSERT-FIRST. The test that was supposed to pin this used 1 and 10 and so
-   verified the collation accident rather than the rule.
-
-   Retraction first is the meaningful order as well as a deterministic one: it is
-   how datahike itself emits an overwrite, so a reader folding the log sees the
-   old value removed and then the new one asserted.
-
-   `v` stays in the key, last, purely to keep the order total: two records
-   differing only in value must not tie, or the merge would order them by
-   whichever run reached the cursor first.
-
-   `norm-val` before `str`, and that is not cosmetic. `(str some-byte-array)` is
-   `\"[B@1a2b3c4d\"` — the JVM IDENTITY hash — so two records differing only in a
-   binary value sorted in an order that varied between JVM runs. Measured: six
-   exports of one stored database from six fresh JVMs produced FIVE distinct
-   chunk SHA-256s, which falsifies this namespace's own byte-identity claim for
-   the three primitive-array value types (`:db.type/bytes`, `:db.type/float-array`,
-   `:db.type/double-array` — and a `:db.type/tuple` holding one, which is a vector
-   and so needs `norm-val` to reach INSIDE the value). Two further consequences:
-   a 32-bit identity hash can COLLIDE, so the totality promised just above also
-   failed probabilistically; and ClojureScript stringifies a `Uint8Array` by
-   CONTENT (`\"1,2,3\"`), so the JVM and Node ordered the same database
-   differently.
-
-   `norm-val` is content-based, class-distinct across the three array types, and
-   already what the semantic digest uses (`fp-step`), so the two agree. It
-   returns any value CONTAINING no array unchanged, so this key is byte-for-byte
-   the old one for every other type and existing dumps do not move.
-
-   It lives in `datahike.migrate.cbor` rather than `…/manifest` on purpose:
-   manifest requires `datahike.api`, and pulling that into this leaf namespace
-   to compute a sort key would be a large dependency for a small function."
+  "Export order: transaction, txInstant first, entity, attribute, retract before
+   assert, then value. Arrays are normalized by content and type on both runtimes."
   [record]
   [(nth record 3)
    (if (= (nth record 1) :db/txInstant) 0 1)
@@ -91,304 +19,195 @@
    (str (mcbor/norm-val (nth record 2)))])
 
 (def by-sort-key
-  "Comparator over RECORDS implementing the export order.
-
-   A comparator rather than a key function, because index orders cannot be
-   expressed as a Comparable key: an eavt key would be `[e a v t]`, and `v` is
-   heterogeneous, so `(compare [1 :a \"x\" 5] [1 :a 7 5])` throws. datahike's own
-   index comparators (`datom/index-type->cmp-quick`) exist for exactly that
-   reason, and a bulk index build will pass one of those here — over Datoms —
-   rather than a key function.
-
-   A bare comparator recomputes both keys on EVERY comparison — see
-   `export-order`, which is what the export path actually passes."
+  "Comparator implementing export order. Prefer export-order to cache keys."
   (fn [a b] (compare (sort-key a) (sort-key b))))
 
 (def export-order
-  "The export order as a key function AND the comparator derived from it.
-
-   `by-sort-key` rebuilt both keys on every comparison. Measured on 20,000
-   records: 521,590 `sort-key` calls, 26.1 per record — and `sort-key` is not
-   cheap, since `norm-val` hashes an array value with hasch. The classic remedy
-   is decorate-sort-undecorate, and this namespace's docstring has claimed for
-   some time that the export path already did it. It did not.
-
-   `clojure.core/sort-by` is NOT the fix: it is `(sort (fn [x y] (compare (keyfn x)
-   (keyfn y))))`, so it recomputes exactly as much. Measured: 35,558 calls for
-   2,000 records. The decoration has to be explicit.
-
-   A keyed order carries the KEY FUNCTION ONLY. It deliberately does not also
-   carry the derived comparator: every site here branches on the key function
-   first, so a comparator alongside it would never be consulted, and a value
-   that is never read is a value that can be wrong without anyone noticing —
-   including wrong in the one direction that matters, where runs are sorted by
-   one order and merged by another. There is no pair to keep in step because
-   there is no pair.
-
-   Not every order can be expressed this way, which is why the bare-comparator
-   path stays. `init/sort-family!` sorts by `datom/index-type->cmp-quick`, an
-   INDEX order over `[e a v t]` where `v` is heterogeneous — `(compare [1 :a \"x\" 5]
-   [1 :a 7 5])` throws, so there is no Comparable key to precompute. Those
-   callers pass a function and get the old behaviour, unchanged."
+  "Export order with keys cached once per admitted record per merge pass.
+   Index sorts may instead pass a comparator for heterogeneous datom values."
   {::key-fn sort-key})
 
-(defn- as-order
-  "Normalise the `cmp` argument, which is either a keyed order or a bare
-   comparator. Accepting both is what lets every signature here stay as it was.
-
-   A `throw` rather than an `assert`, deliberately. A map without `::key-fn`
-   falls through to `(sort nil records)` — natural ordering on RECORDS, which
-   throws on a heterogeneous `v` and, worse, SUCCEEDS on a homogeneous one and
-   writes a dump in the wrong order. `shadow-cljs.edn` sets `:elide-asserts
-   false` on the dev and test builds but not on `:browser-release` or
-   `:npm-release`, where `:advanced` elides them by default — so an assertion
-   here would exist everywhere except the artifacts we publish, which is where a
-   silently misordered dump would be hardest to notice. It costs one `contains?`
-   per SORT CALL, not per record: measured at 204 calls for a 2000-record sort
-   spilling to 200 runs."
-  [x]
+(defn- as-order [x]
   (if (map? x)
     (if (contains? x ::key-fn)
-      x
-      (throw (ex-info (str "A map passed as a sort order must carry "
-                           "`::key-fn`; pass a bare comparator otherwise.")
+      {:key-fn (::key-fn x)}
+      (throw (ex-info "A map sort order must carry ::key-fn; otherwise pass a comparator."
                       {:error :migrate/invalid-sort-order :order x})))
-    {::cmp x}))
+    {:cmp x}))
 
-(defn- sort-window
-  "Sort one in-memory window under `order`.
+(defn- options [run-size]
+  (when-not (and (integer? run-size) (pos? run-size))
+    (throw (ex-info "Sort run size must be a positive integer."
+                    {:error :migrate/invalid-sort-buffer :sort-buffer run-size})))
+  {:window-records run-size :fan-in 64})
 
-   Undecorated EAGERLY — `mapv`, not `map` — so the keys, which are the fat part
-   since a key holds the stringified value, become garbage as soon as the sort is
-   done rather than staying reachable for as long as the caller holds the result.
+(defn- delete-file! [path]
+  (when (and (fs/exists? path) (not (fs/delete! path)))
+    (throw (ex-info "Cannot remove sort run." {:error :migrate/sort-cleanup :path path}))))
 
-   Then `seq`, which is about the IDENTITY of the returned object and nothing
-   else. Measured: a `ChunkedSeq` holds its vector and an `ArraySeq` holds its
-   array, so advancing to the end of either still keeps the first element
-   reachable — no memory is saved. What changes is that the object handed back
-   is a seq over the collection rather than the collection, so a consumer
-   holding a later position does not hold the returned object itself. That is
-   exactly what `migrate_retention_test` observes through a `WeakReference`, and
-   it is what `sort` did before, so this keeps parity rather than inventing a
-   property. The window's records stay resident either way, which is what
-   `external-sort` means by sorting in memory.
+(defn- suppress! [error cleanup-error]
+  #?(:clj (when-not (identical? error cleanup-error)
+            (.addSuppressed ^Throwable error ^Throwable cleanup-error))
+     :cljs nil))
 
-   Keys are compared directly rather than by sorting the pairs: comparing
-   `[key record]` pairs would fall through to comparing RECORDS on a key tie, and
-   records are heterogeneous in `v`, so that throws."
-  [window {::keys [cmp key-fn]}]
-  (if key-fn
-    (->> window
-         (mapv (fn [r] [(key-fn r) r]))
-         (sort-by #(nth % 0))
-         (mapv #(nth % 1))
-         seq)
-    (sort cmp window)))
+(defn- close-after-error! [close! error]
+  (try (close!)
+       (catch #?(:clj Throwable :cljs :default) cleanup-error
+         (suppress! error cleanup-error)))
+  (throw error))
 
-(defn- spill-window!
-  "Sort one window and write it to a fresh run file under `tmp-dir`."
-  [window tmp-dir cmp]
-  (let [f (fs/temp-file! tmp-dir "dh-run-" ".cbor")
-        sink (fs/open-sink f)]
+(defn- reader! [path]
+  (let [{:keys [source close]} (fs/reader path)
+        remaining (volatile! nil)
+        closed? (volatile! false)
+        close! (fn []
+                 (when-not @closed?
+                   (vreset! closed? true)
+                   (vreset! remaining nil)
+                   (close)))]
     (try
-      (doseq [r (sort-window window (as-order cmp))]
-        (fs/write! sink (mcbor/encode-record r)))
-      (finally (fs/close-sink! sink)))
-    f))
+      (vreset! remaining (mcbor/decode-records source))
+      {:next! (fn []
+                (when-not @closed?
+                  (if-let [s (seq @remaining)]
+                    (let [record (first s)]
+                      (vreset! remaining (rest s))
+                      {:record record})
+                    (do (close!) nil))))
+       :close! close!}
+      (catch #?(:clj Throwable :cljs :default) e
+        (close-after-error! close! e)))))
+
+(defn- backend [path-of]
+  {:prepare (fn [record] {:record record})
+   :open-reader #(reader! (path-of %))
+   :open-writer (fn [id]
+                  (let [sink (fs/open-sink (path-of id))]
+                    {:write! #(fs/write! sink (mcbor/encode-record (:record %)))
+                     :close! #(fs/close-sink! sink)}))
+   :delete! #(delete-file! (path-of %))
+   :move! (fn [from to]
+            (when-not (fs/rename! (path-of from) (path-of to))
+              (throw (ex-info "Cannot move sort run." {:error :migrate/sort-move}))))})
+
+(defn- scratch [tmp-dir]
+  (let [prefix (str (fs/file-name (fs/temp-file! tmp-dir "dh-sort-" "")) "-")
+        path-of (fn [[pass run]] (fs/join tmp-dir (str prefix pass "-" run ".cbor")))]
+    {:backend (backend path-of)
+     :path-of path-of
+     :cleanup! (fn []
+                 (let [failure (volatile! nil)]
+                   (fs/reduce-names tmp-dir
+                                    (fn [_ name]
+                                      (when (str/starts-with? name prefix)
+                                        (try (delete-file! (fs/join tmp-dir name))
+                                             (catch #?(:clj Throwable :cljs :default) e
+                                               (if-let [original @failure]
+                                                 (suppress! original e)
+                                                 (vreset! failure e)))))) nil)
+                   (when-let [error @failure] (throw error))))}))
+
+(defn- scoped-resource [{:keys [records close!]} cleanup!]
+  (let [closed? (volatile! false)
+        close-all! (fn []
+                     (when-not @closed?
+                       (vreset! closed? true)
+                       (try (close!)
+                            (catch #?(:clj Throwable :cljs :default) e
+                              (close-after-error! cleanup! e)))
+                       (cleanup!)))]
+    {:close! close-all!
+     :records ((fn step [rs]
+                 (lazy-seq
+                  (when-not @closed?
+                    (try
+                      (if-let [s (seq rs)]
+                        (cons (first s) (step (rest s)))
+                        (do (close-all!) nil))
+                      (catch #?(:clj Throwable :cljs :default) e
+                        (close-after-error! close-all! e))))))
+               records)}))
 
 (defn spill-runs
-  "Consume a (lazy) seq of records in windows of `run-size`, sort each window with
-   `cmp`, and write it to a temp run file under `tmp-dir`. Returns the vector of
-   run paths. Memory is bounded by one window."
+  "Write sorted runs and return their paths. This compatibility helper retains
+   one path per run; external-sort uses bounded run bookkeeping instead."
   ([records run-size tmp-dir] (spill-runs records run-size tmp-dir export-order))
   ([records run-size tmp-dir cmp]
-   (loop [rs (seq records) files []]
-     (if (nil? rs)
-       files
-       (recur (seq (drop run-size rs))
-              (conj files (spill-window! (into [] (take run-size) rs) tmp-dir cmp)))))))
-
-(defn- record-seq-closing
-  "Lazy seq of records from a CBOR-sequence run file, closing the source when
-   exhausted. `decode-records` is bounded by the largest single item, so a run
-   file larger than the heap still merges.
-
-   `delete?` also removes the file once it is drained. A merge pass reads each
-   run exactly once and has no use for it afterwards, so freeing it there caps
-   scratch usage at roughly the data volume instead of twice it — PostgreSQL
-   builds `logtape.c` entirely around reclaiming this space, and while we cannot
-   recycle mid-file, dropping a whole exhausted run costs nothing.
-   `read-sorted-file` must NOT delete: its file is read repeatedly, once per
-   index family."
-  ([p] (record-seq-closing p false))
-  ([p delete?]
-   (let [{:keys [source close]} (fs/reader p)]
-     ((fn step [rs]
-        (lazy-seq
-         (if-let [s (seq rs)]
-           (cons (first s) (step (rest s)))
-           (do (close)
-               (when delete? (fs/delete! p))
-               nil))))
-      (mcbor/decode-records source)))))
+   (let [order (as-order cmp) opts (options run-size)
+         {:keys [backend path-of cleanup!]} (scratch tmp-dir)]
+     (try
+       (let [n (sorter/initial-runs! records order backend opts)]
+         (mapv #(path-of [0 %]) (range n)))
+       (catch #?(:clj Throwable :cljs :default) e
+         (close-after-error! cleanup! e))))))
 
 (defn merge-runs
-  "K-way merge of sorted run files into a single lazy seq of RECORDS, globally
-   ordered by `cmp`. Memory is bounded by the number of runs.
-
-   A `sorted-set-by` over cursors rather than a priority queue: it is the
-   portable spelling, it is O(log k) like the queue it replaces, and — because a
-   sorted set must totally order its elements — it forces the tie-break the
-   `PriorityQueue` version silently lacked. Ties now break by RUN INDEX, so two
-   records comparing equal under `cmp` come out in a deterministic order instead
-   of whichever cursor the heap happened to surface. That is the instability
-   `sort-key` documents as a defect, fixed rather than worked around.
-
-   The index is also what keeps the set from swallowing cursors: without it two
-   cursors holding equal records would compare equal, and `conj` would discard
-   one along with everything behind it. Exactly one entry per cursor is resident
-   at a time, so the index is unique across the set."
+  "Merge sorted files lazily, closing readers on exhaustion or error. With
+   consume? true, delete exhausted inputs. Fully consume the result.
+   Memory scales with run count."
   ([run-files] (merge-runs run-files export-order false))
   ([run-files cmp] (merge-runs run-files cmp false))
   ([run-files cmp consume?]
-   (let [{::keys [cmp key-fn]} (as-order cmp)
-         ;; The merge recomputed too, and more often than it looks: the
-         ;; `sorted-set-by` does O(log k) comparisons per record surfaced, and
-         ;; `reduce-runs` may run several passes, so a record's key was rebuilt
-         ;; O(log k) times PER PASS. Carrying it on the cursor makes it once per
-         ;; record per pass. Exactly one entry per cursor is resident, so this
-         ;; adds k keys, not n.
-         cursor-key (if key-fn #(key-fn %) (constantly nil))
-         cursor-cmp (if key-fn
-                      (fn [a b]
-                        (let [c (compare (:key a) (:key b))]
-                          (if (zero? c) (compare (:idx a) (:idx b)) c)))
-                      (fn [a b]
-                        (let [c (cmp (:record a) (:record b))]
-                          (if (zero? c) (compare (:idx a) (:idx b)) c))))
-         cursors (keep-indexed (fn [i f]
-                                 (when-let [rs (seq (record-seq-closing f consume?))]
-                                   {:record (first rs) :key (cursor-key (first rs))
-                                    :rest (rest rs) :idx i}))
-                               run-files)]
-     ((fn step [pq]
-        (lazy-seq
-         (when-let [c (first pq)]
-           (let [{:keys [record rest idx]} c
-                 pq' (disj pq c)
-                 pq' (if-let [nr (first rest)]
-                       (conj pq' {:record nr :key (cursor-key nr)
-                                  :rest (next rest) :idx idx})
-                       pq')]
-             (cons record (step pq'))))))
-      (into (sorted-set-by cursor-cmp) cursors)))))
+   (:records (sorter/merge-runs-resource! run-files (as-order cmp) (backend identity) consume?))))
 
-(def ^:private max-fanin
-  "Maximum run files merged at once, so a run never opens more file descriptors than
-   a conservative OS limit — bounding fan-in rather than assuming a high `ulimit`."
-  64)
-
-(defn- merge-into-file
-  "Merge a group of sorted run files into one new sorted run file, deleting the
-   inputs as they drain. Opens at most (count run-files) descriptors.
-
-   A group of ONE is returned untouched. Merging a single run means decoding and
-   re-encoding an entire run file to produce a byte-identical one, which is a
-   full pass over that data for no change in content."
-  [run-files tmp-dir cmp]
-  (if (= 1 (count run-files))
-    (first run-files)
-    (let [out (fs/temp-file! tmp-dir "dh-merge-" ".cbor")
-          sink (fs/open-sink out)]
-      (try
-        (doseq [r (merge-runs run-files cmp true)]
-          (fs/write! sink (mcbor/encode-record r)))
-        (finally (fs/close-sink! sink)))
-      ;; belt and braces: a run whose cursor never drained (an aborted merge)
-      ;; still goes away here
-      (doseq [f run-files] (fs/delete! f))
-      out)))
-
-(defn- reduce-runs
-  "Merge `runs` down to at most `max-fanin` files, so the caller's final merge is
-   a single streaming pass.
-
-   Each round merges only as many runs as it must, rather than
-   `(partition-all max-fanin)`. That partition has a sharp corner: 65 runs
-   splits into [64 1], performing a full 64-way merge AND a pointless
-   single-file copy, i.e. one gratuitous pass over the entire dataset. The
-   textbook remedy is to make the FIRST pass partial — with 65 runs this merges
-   2 and leaves the other 63 alone.
-
-   `k` is clamped to `max-fanin` so no round opens more descriptors than the cap,
-   and to at least 2 so a round always makes progress."
-  [runs tmp-dir cmp]
-  (loop [runs runs]
-    (if (<= (count runs) max-fanin)
-      runs
-      (let [r (count runs)
-            k (min max-fanin (max 2 (inc (- r max-fanin))))]
-        (recur (cons (merge-into-file (take k runs) tmp-dir cmp)
-                     (drop k runs)))))))
-
-(defn external-sort
-  "Given a lazy seq of records, return a lazy seq of RECORDS globally
-   ordered by `cmp`, using external merge sort bounded by `run-size`. When the
-   number of runs exceeds `max-fanin`, they are merged in passes so no single merge
-   opens more than `max-fanin` files. Spill files are created under `tmp-dir`; the
-   caller cleans up `tmp-dir` after the returned seq is fully consumed.
-
-   An input that fits in ONE window never touches the filesystem: it is sorted in
-   memory and handed back. PostgreSQL makes the same distinction — `tuplesort`
-   only calls `inittapes()` once memory is actually exhausted — and without it a
-   ten-record sort creates a temp file, writes it, and reads it back."
-  ([records run-size tmp-dir] (external-sort records run-size tmp-dir export-order))
+(defn open-sorted-records!
+  "Return {:records seq :close! fn}. Close after use, including early termination.
+   The close function does not retain the result's head. An input fitting one
+   window is sorted in memory without creating files."
+  ([records run-size tmp-dir] (open-sorted-records! records run-size tmp-dir export-order))
   ([records run-size tmp-dir cmp]
-   (let [rs (seq records)
+   (let [order (as-order cmp) opts (options run-size)
+         rs (seq records)
          window (into [] (take run-size) rs)
          more (seq (drop run-size rs))]
      (if (nil? more)
-       (sort-window window (as-order cmp))
-       (-> (into [(spill-window! window tmp-dir cmp)]
-                 (spill-runs more run-size tmp-dir cmp))
-           (reduce-runs tmp-dir cmp)
-           (merge-runs cmp true))))))
+       {:records (sorter/sort-window window order) :close! (fn [])}
+       (let [{:keys [backend cleanup!]} (scratch tmp-dir)]
+         (try
+           (let [n (sorter/initial-runs! (concat window more) order backend opts)
+                 runs (sorter/reduce-runs! n order backend opts)]
+             (scoped-resource (sorter/merge-runs-resource! runs order backend true) cleanup!))
+           (catch #?(:clj Throwable :cljs :default) e
+             (close-after-error! cleanup! e))))))))
+
+(defn external-sort
+  "Return sorted records, closing and deleting owned runs on exhaustion/error.
+   Fully consume the result. For early termination use with-sorted-records! or
+   open-sorted-records!. Files use synchronous local IO on both JVM and Node."
+  ([records run-size tmp-dir] (external-sort records run-size tmp-dir export-order))
+  ([records run-size tmp-dir cmp]
+   (:records (open-sorted-records! records run-size tmp-dir cmp))))
+
+(defn with-sorted-records!
+  "Call consume with a sorted sequence valid only within this synchronous call.
+   Do not return a lazy result or a channel whose work still needs the sequence."
+  [records run-size tmp-dir cmp consume]
+  (let [{:keys [records close!]} (open-sorted-records! records run-size tmp-dir cmp)]
+    (try
+      (let [result (consume records)] (close!) result)
+      (catch #?(:clj Throwable :cljs :default) e
+        (close-after-error! close! e)))))
 
 (defn external-sort-to-file
-  "As `external-sort`, but collapse the result to ONE sorted CBOR-sequence file
-   and return its path. The caller owns the file and should delete it.
-
-   `external-sort` returns a lazy seq backed by open run files, which
-   `record-seq-closing` closes on exhaustion — so it can be consumed exactly
-   once. A bulk index build needs the same sorted order TWICE: once for the
-   temporal tree, which takes every record, and once for the current tree, which
-   takes the subset surviving `history/current-from-eavt-sorted`. Sorting twice
-   would double the most expensive step for no reason.
-
-   Reading the returned file with `read-sorted-file` is a fresh source each time,
-   still bounded by one record.
-
-   When the input spills to exactly ONE run, that run already IS a sorted
-   CBOR-sequence file and is returned as-is. Decoding and re-encoding it would be
-   a full pass over the whole dataset producing byte-identical output — and since
-   `:sort-buffer` defaults to a million records, that was the common case rather
-   than a corner: a bulk build of a database smaller than the buffer paid three
-   entirely wasted serialization passes, one per index family."
+  "Return one sorted CBOR-sequence file, reusable with read-sorted-file.
+   The caller owns the file. A single run is returned without reencoding."
   ([records run-size tmp-dir] (external-sort-to-file records run-size tmp-dir export-order))
   ([records run-size tmp-dir cmp]
-   (let [runs (spill-runs records run-size tmp-dir cmp)]
-     (if (= 1 (count runs))
-       (first runs)
-       (let [out (fs/temp-file! tmp-dir "dh-sorted-" ".cbor")
-             sink (fs/open-sink out)]
-         (try
-           (doseq [r (-> runs (reduce-runs tmp-dir cmp) (merge-runs cmp true))]
-             (fs/write! sink (mcbor/encode-record r)))
-           (finally (fs/close-sink! sink)))
-         out)))))
+   (let [order (as-order cmp) opts (options run-size)
+         {:keys [backend path-of cleanup!]} (scratch tmp-dir)]
+     (try
+       (if-let [id (sorter/sorted-file! records order backend opts)]
+         (path-of id)
+         (let [writer ((:open-writer backend) [0 0])]
+           ((:close! writer))
+           (path-of [0 0])))
+       (catch #?(:clj Throwable :cljs :default) e
+         (close-after-error! cleanup! e))))))
 
 (defn read-sorted-file
-  "Lazy seq of records from a file written by `external-sort-to-file`, closing the
-   source when exhausted. Bounded by one record; callable repeatedly."
+  "Read a sorted file afresh. Fully consume the sequence to close its reader;
+   the file remains available for another pass."
   [p]
-  (record-seq-closing p))
+  ;; A single run needs no comparisons between records. In particular, do not
+  ;; compute export keys while rereading a file sorted in an index's order.
+  (:records (sorter/merge-runs-resource! [p] {:cmp (fn [_ _] 0)} (backend identity) false)))

--- a/src/datahike/sort.cljc
+++ b/src/datahike/sort.cljc
@@ -1,0 +1,202 @@
+(ns ^:no-doc datahike.sort
+  "Synchronous external merge sorting shared by local-file adapters.
+   Adapters own codecs, paths, quotas and private scratch directories. This
+   engine owns windows, bounded merge scheduling and open-resource lifetimes.
+   Run identifiers are [pass index]; records and byte buffers stay on entries.")
+
+(defn- suppress! [primary cleanup]
+  #?(:clj (when-not (identical? primary cleanup)
+            (.addSuppressed ^Throwable primary ^Throwable cleanup))
+     :cljs nil))
+
+(defn- close-after! [close! primary]
+  (try (close!)
+       (catch #?(:clj Throwable :cljs :default) error
+         (if primary (suppress! primary error) (throw error)))))
+
+(defn- decorate [entry {:keys [key-fn]}]
+  (if key-fn (assoc entry ::key (key-fn (:record entry))) entry))
+
+(defn- entry-comparator [{:keys [key-fn cmp]}]
+  (if key-fn
+    (fn [a b] (compare (::key a) (::key b)))
+    (fn [a b] (cmp (:record a) (:record b)))))
+
+(defn sort-window
+  "Sort records in memory. Keyed orders evaluate a key once per record and
+   eagerly discard decorations before returning the result sequence."
+  [records {:keys [key-fn cmp]}]
+  (if key-fn
+    (->> records
+         (mapv (fn [record] [(key-fn record) record]))
+         (sort-by first)
+         (mapv second)
+         seq)
+    (sort cmp records)))
+
+(defn- with-writer! [backend run-id consume]
+  (let [writer ((:open-writer backend) run-id)
+        primary (volatile! nil)]
+    (try
+      (consume (:write! writer))
+      (catch #?(:clj Throwable :cljs :default) error
+        (vreset! primary error)
+        (throw error))
+      (finally (close-after! (:close! writer) @primary)))))
+
+(defn- spill! [backend run-id entries order]
+  (with-writer! backend run-id
+    (fn [write!]
+      (doseq [entry (sort (entry-comparator order) entries)]
+        (write! entry)))))
+
+(defn initial-runs!
+  "Prepare each input once and spill sorted windows. Returns the number of
+   initial runs, named [0 index], without retaining a collection of paths.
+   Entry :charge is supplied by the adapter; nil window-bytes disables that
+   window limit. Adapter preparation must enforce individual record bounds."
+  [records order backend {:keys [window-records window-bytes]}]
+  (let [{:keys [run window]}
+        (reduce (fn [{:keys [run window charge]} record]
+                  (let [entry (decorate ((:prepare backend) record) order)
+                        entry-charge (or (:charge entry) 0)]
+                    (when (and window-bytes (> entry-charge window-bytes))
+                      (throw (ex-info "Record exceeds the sort window."
+                                      {:type ::record-too-large})))
+                    (if (and (seq window)
+                             (or (>= (count window) window-records)
+                                 (and window-bytes (> entry-charge (- window-bytes charge)))))
+                      (do (spill! backend [0 run] window order)
+                          {:run (inc run) :window [entry] :charge entry-charge})
+                      {:run run :window (conj window entry) :charge (+ charge entry-charge)})))
+                {:run 0 :window [] :charge 0} records)]
+    (when (seq window) (spill! backend [0 run] window order))
+    (+ run (if (seq window) 1 0))))
+
+(defn- merge-entry-resource! [run-ids order backend consume?]
+  (let [readers (volatile! [])
+        queue (volatile! nil)
+        closed? (volatile! false)
+        cmp (entry-comparator order)
+        cursor-cmp (fn [a b]
+                     (let [c (cmp a b)]
+                       (if (zero? c) (compare (::reader a) (::reader b)) c)))
+        close-reader! (fn [{:keys [reader closed?]}]
+                        (when-not @closed?
+                          (vreset! closed? true)
+                          ((:close! reader))))
+        close! (fn []
+                 (when-not @closed?
+                   (vreset! closed? true)
+                   (vreset! queue nil)
+                   (let [failure (volatile! nil)]
+                     (doseq [reader @readers]
+                       (try (close-reader! reader)
+                            (catch #?(:clj Throwable :cljs :default) error
+                              (if-let [first-error @failure]
+                                (suppress! first-error error)
+                                (vreset! failure error)))))
+                     (vreset! readers [])
+                     (when-let [error @failure] (throw error)))))
+        next-entry! (fn [i]
+                      (let [{:keys [reader run-id] :as handle} (nth @readers i)]
+                        (if-let [entry ((:next! reader))]
+                          (assoc (decorate entry order) ::reader i)
+                          (do (close-reader! handle)
+                              (when consume? ((:delete! backend) run-id))
+                              nil))))]
+    (try
+      (vreset! queue (sorted-set-by cursor-cmp))
+      (doseq [run-id run-ids]
+        (let [reader ((:open-reader backend) run-id)
+              i (count @readers)]
+          (vswap! readers conj {:reader reader :run-id run-id :closed? (volatile! false)})
+          (when-let [entry (next-entry! i)]
+            (vswap! queue conj entry))))
+      (letfn [(next! []
+                (when-not @closed?
+                  (try
+                    (if-let [entry (first @queue)]
+                      (let [i (::reader entry)]
+                        (vswap! queue disj entry)
+                        (when-let [next-entry (next-entry! i)]
+                          (vswap! queue conj next-entry))
+                        (dissoc entry ::reader ::key))
+                      (do (close!) nil))
+                    (catch #?(:clj Throwable :cljs :default) error
+                      (close-after! close! error)
+                      (throw error)))))]
+        {:next! next! :close! close!})
+      (catch #?(:clj Throwable :cljs :default) error
+        (close-after! close! error)
+        (throw error)))))
+
+(defn merge-runs-resource!
+  "Open a sorted run merge. Close explicitly on early abandonment; exhaustion
+   and read/comparison failures close automatically. consume? deletes drained
+   inputs. run-ids must be bounded by the caller's fan-in. The close closure
+   retains only bounded reader/queue state, never the returned lazy sequence."
+  [run-ids order backend consume?]
+  (let [{:keys [next! close!]} (merge-entry-resource! run-ids order backend consume?)]
+    (letfn [(step []
+              (lazy-seq
+               (when-let [entry (next!)]
+                 (cons (:record entry) (step)))))]
+      {:records (step) :close! close!})))
+
+(defn- merge-into! [run-ids target order backend]
+  (if (= 1 (count run-ids))
+    ((:move! backend) (first run-ids) target)
+    (let [{:keys [next! close!]} (merge-entry-resource! run-ids order backend true)
+          primary (volatile! nil)]
+      (try
+        (with-writer! backend target
+          (fn [write!]
+            ;; Do not capture a lazy sequence head in this callback: on CLJS
+            ;; that would retain the entire merged run until the sink closes.
+            (loop []
+              (when-let [entry (next!)]
+                (write! entry)
+                (recur)))))
+        (catch #?(:clj Throwable :cljs :default) error
+          (vreset! primary error)
+          (throw error))
+        (finally (close-after! close! @primary))))))
+
+(defn reduce-runs!
+  "Reduce initial runs to at most fan-in, preserving contiguous stable groups.
+   Run metadata is pass/count plus one bounded group, never all run paths.
+   Near the final fan-in, merge only enough groups to reach that cap: fan-in+1
+   runs merge their first two and carry the rest without reencoding. Larger
+   inputs use balanced full passes instead of repeatedly rewriting a growing
+   accumulator run. Singleton carries use the adapter's move operation."
+  [run-count order backend {:keys [fan-in]}]
+  (loop [pass 0 runs run-count]
+    (if (<= runs fan-in)
+      (mapv #(vector pass %) (range runs))
+      (let [partial? (<= runs (* fan-in fan-in))
+            next-runs
+            (loop [start 0 target 0 removals (if partial? (- runs fan-in) nil)]
+              (if (= start runs)
+                target
+                (let [size (if partial?
+                             (if (pos? removals) (min fan-in (inc removals)) 1)
+                             (min fan-in (- runs start)))
+                      end (+ start size)]
+                  (merge-into! (mapv #(vector pass %) (range start end))
+                               [(inc pass) target] order backend)
+                  (recur end (inc target)
+                         (when partial? (- removals (dec size)))))))]
+        (recur (inc pass) next-runs)))))
+
+(defn sorted-file!
+  "Materialize one sorted run, or nil for empty input. A sole initial run is
+   returned untouched. The adapter owns returned scratch and failure cleanup."
+  [records order backend opts]
+  (let [runs (reduce-runs! (initial-runs! records order backend opts) order backend opts)]
+    (case (count runs)
+      0 nil
+      1 (first runs)
+      (let [target [(inc (ffirst runs)) 0]]
+        (merge-into! runs target order backend)
+        target))))

--- a/test/datahike/test/backfill_range_file_test.clj
+++ b/test/datahike/test/backfill_range_file_test.clj
@@ -1,0 +1,91 @@
+(ns datahike.test.backfill-range-file-test
+  (:require [clojure.test :refer [deftest is]]
+            [boring.core :as boring]
+            [datahike.backfill.journal.file :as journal])
+  (:import [java.io RandomAccessFile]))
+
+(defn- error-type [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+(deftest suffix-replacement-invalidates-only-abandoned-boundaries
+  (let [empty-prefix (journal/create! {})]
+    (try
+      (let [retained (journal/append! empty-prefix [:kept])
+            retained-cursor (journal/end-cursor retained)
+            abandoned (journal/append! retained [:old])
+            abandoned-cursor (journal/end-cursor abandoned)
+            replacement (journal/append! retained [:new])
+            replacement-cursor (journal/end-cursor replacement)]
+        (is (= (:end abandoned) (:end replacement)) "same byte position must not certify a rewritten frame")
+        (is (not= abandoned-cursor replacement-cursor))
+        (is (= retained-cursor (journal/end-cursor retained)))
+        (is (= [:kept] (journal/reduce-journal retained conj [])))
+        (is (= [:new] (journal/reduce-range replacement retained-cursor
+                                            (fn [acc value _] (conj acc value)) [])))
+        (is (= -1 (journal/compare-cursors replacement retained-cursor replacement-cursor)))
+        (doseq [operation [#(journal/reduce-range replacement abandoned-cursor
+                                                  (fn [acc _ _] acc) nil)
+                           #(journal/compare-cursors replacement retained-cursor abandoned-cursor)]]
+          (is (= :backfill.journal/invalid-cursor (error-type operation))))
+        (doseq [operation [#(journal/start-cursor abandoned)
+                           #(journal/end-cursor abandoned)
+                           #(journal/reduce-journal abandoned conj [])
+                           #(journal/append! abandoned [:must-not-write])]]
+          (is (= :backfill.journal/invalid-descriptor (error-type operation))))
+        (is (= [:kept :new] (journal/reduce-journal replacement conj []))
+            "rejecting an abandoned append must not truncate the live replacement"))
+      (finally (journal/dispose! empty-prefix)))))
+
+(deftest cursors-are-owned-opaque-boundaries-not-numeric-offsets
+  (let [a (journal/create! {})
+        b (journal/create! {})]
+    (try
+      (let [first-prefix (journal/append! a [:first])
+            final-prefix (journal/append! first-prefix [:last])
+            zero (journal/start-cursor final-prefix)
+            first-end (journal/end-cursor first-prefix)
+            final-end (journal/end-cursor final-prefix)]
+        (is (not (map? zero)))
+        (is (= 1 (count (set [zero (journal/start-cursor first-prefix)]))))
+        (is (= 0 (journal/compare-cursors final-prefix zero (journal/start-cursor a))))
+        (is (= 1 (journal/compare-cursors final-prefix final-end first-end)))
+        (doseq [invalid [nil 0 (:end first-prefix) {:offset (:end first-prefix)}
+                         (Object.) (journal/start-cursor b) final-end]]
+          (is (= :backfill.journal/invalid-cursor
+                 (error-type #(journal/reduce-range first-prefix invalid
+                                                    (fn [acc _ _] acc) nil)))))
+        (doseq [modified [(assoc first-prefix :end (inc (:end first-prefix)))
+                          (assoc first-prefix :end 0)
+                          (assoc first-prefix :datahike.backfill.journal.file/cursor
+                                 {:offset (:end first-prefix)})]]
+          (is (= :backfill.journal/invalid-descriptor
+                 (error-type #(journal/end-cursor modified))))
+          (is (= :backfill.journal/invalid-descriptor
+                 (error-type #(journal/append! modified [:must-not-write])))))
+        (is (= [:first :last] (journal/reduce-journal final-prefix conj [])))
+        (is (= [] (journal/reduce-range final-prefix final-end
+                                        (fn [acc value _] (conj acc value)) []))))
+      (finally (journal/dispose! a) (journal/dispose! b)))))
+
+(deftest range-validation-does-not-decode-earlier-payloads
+  (let [empty-prefix (journal/create! {})]
+    (try
+      (let [first-prefix (journal/append! empty-prefix [:first])
+            final-prefix (journal/append! first-prefix [:last])
+            start (journal/end-cursor first-prefix)
+            decode boring/decode
+            decoded (atom 0)]
+        (with-redefs [boring/decode (fn [& args] (swap! decoded inc) (apply decode args))]
+          (is (= [:last] (journal/reduce-range final-prefix start
+                                               (fn [acc value _] (conj acc value)) []))))
+        (is (= 1 @decoded))
+        (let [next-cursor (journal/reduce-range final-prefix start
+                                                (fn [_ _ next] (reduced next)) nil)]
+          (is (= (journal/end-cursor final-prefix) next-cursor)))
+        (with-open [file (RandomAccessFile. (:path final-prefix) "rw")]
+          (.seek file (:end first-prefix))
+          (.writeLong file Long/MAX_VALUE))
+        (is (= :backfill.journal/corrupt
+               (error-type #(journal/reduce-range final-prefix start
+                                                  (fn [acc _ _] acc) nil)))))
+      (finally (journal/dispose! empty-prefix)))))

--- a/test/datahike/test/backfill_range_test.clj
+++ b/test/datahike/test/backfill_range_test.clj
@@ -1,0 +1,95 @@
+(ns datahike.test.backfill-range-test
+  (:require [clojure.test :refer [deftest is]]
+            [boring.core :as boring]
+            [datahike.backfill.journal :as journal]))
+
+(deftest incremental-replay-seeks-to-exact-frame-boundaries
+  (let [empty-prefix (journal/create! {})]
+    (try
+      (let [first-prefix (journal/append! empty-prefix [:first])
+            second-prefix (journal/append! first-prefix [:second])
+            final-prefix (journal/append! second-prefix [:third])
+            decode boring/decode
+            decoded (atom 0)
+            step (fn [acc value end] (conj acc [value end]))]
+        (is (= [[:first (journal/end-cursor first-prefix)] [:second (journal/end-cursor second-prefix)]
+                [:third (journal/end-cursor final-prefix)]]
+               (journal/reduce-range final-prefix (journal/start-cursor final-prefix) step [])))
+        (with-redefs [boring/decode (fn [& args] (swap! decoded inc) (apply decode args))]
+          (is (= [[:third (journal/end-cursor final-prefix)]]
+                 (journal/reduce-range final-prefix (journal/end-cursor second-prefix) step []))))
+        (is (= 1 @decoded) "earlier payloads are not decoded when resuming")
+        (is (= [] (journal/reduce-range final-prefix (journal/end-cursor final-prefix) step [])))
+        (is (thrown-with-msg? Exception #"callback"
+                              (journal/reduce-range final-prefix (journal/end-cursor first-prefix)
+                                                    (fn [& _] (throw (Exception. "callback"))) nil)))
+        (with-redefs [boring/decode (fn [& _] (throw (Exception. "decode")))]
+          (is (thrown-with-msg? Exception #"decode"
+                                (journal/reduce-range final-prefix (journal/end-cursor first-prefix) step []))))
+        (is (= [[:second (journal/end-cursor second-prefix)]]
+               (journal/reduce-range second-prefix (journal/end-cursor first-prefix) step []))
+            "a retained prefix does not consume later accepted writes")
+        (let [cursor (journal/reduce-range final-prefix (journal/start-cursor final-prefix)
+                                           (fn [_ _ end] (reduced end)) nil)]
+          (is (= (journal/end-cursor first-prefix) cursor))
+          (is (= [[:second (journal/end-cursor second-prefix)] [:third (journal/end-cursor final-prefix)]]
+                 (journal/reduce-range final-prefix cursor step []))))
+        (doseq [cursor [-1 1.5 nil {} (Object.)]]
+          (is (= :backfill.journal/invalid-cursor
+                 (try (journal/reduce-range final-prefix cursor step [])
+                      (catch clojure.lang.ExceptionInfo e (:type (ex-data e))))))))
+      (finally (journal/dispose! empty-prefix)))))
+
+(defn- error-type [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+(deftest opaque-cursors-are-scoped-and-ordered-within-a-prefix
+  (let [a (journal/create! {})
+        b (journal/create! {})]
+    (try
+      (let [first-prefix (journal/append! a [:first])
+            second-prefix (journal/append! first-prefix [:second])
+            start (journal/start-cursor a)
+            middle (journal/end-cursor first-prefix)
+            end (journal/end-cursor second-prefix)]
+        (is (not (map? middle)))
+        (is (not (number? middle)))
+        (is (= start (journal/start-cursor second-prefix)))
+        (is (= 0 (journal/compare-cursors second-prefix middle
+                                          (journal/end-cursor first-prefix))))
+        (is (neg? (journal/compare-cursors second-prefix start middle)))
+        (is (pos? (journal/compare-cursors second-prefix end middle)))
+        (is (= [] (journal/reduce-range a start conj [])))
+        (doseq [foreign [(journal/start-cursor b) (journal/end-cursor b)]]
+          (is (= :backfill.journal/invalid-cursor
+                 (error-type #(journal/reduce-range second-prefix foreign conj []))))
+          (is (= :backfill.journal/invalid-cursor
+                 (error-type #(journal/compare-cursors second-prefix start foreign)))))
+        (is (= :backfill.journal/invalid-cursor
+               (error-type #(journal/reduce-range first-prefix end conj []))))
+        (is (= :backfill.journal/invalid-cursor
+               (error-type #(journal/compare-cursors first-prefix start end)))))
+      (finally (journal/dispose! a) (journal/dispose! b)))))
+
+(deftest replacing-a-suffix-invalidates-its-cursors-not-the-retained-prefix
+  (let [a (journal/create! {})]
+    (try
+      (let [retained (journal/append! a [:kept])
+            retained-end (journal/end-cursor retained)
+            abandoned (journal/append! retained [:old])
+            stale-end (journal/end-cursor abandoned)
+            replacement (journal/append! retained [:new])
+            end (journal/end-cursor replacement)]
+        ;; Same-size payload replacement must not make the old cursor valid.
+        (is (not= stale-end end))
+        (is (= :backfill.journal/invalid-cursor
+               (error-type #(journal/reduce-range replacement stale-end conj []))))
+        (is (= :backfill.journal/invalid-cursor
+               (error-type #(journal/compare-cursors replacement retained-end stale-end))))
+        (is (thrown? clojure.lang.ExceptionInfo (journal/end-cursor abandoned)))
+        (is (thrown? clojure.lang.ExceptionInfo (journal/append! abandoned [:invalid])))
+        (is (= [:new] (journal/reduce-range replacement retained-end
+                                            (fn [acc value _] (conj acc value)) [])))
+        (is (= [:kept] (journal/reduce-journal retained conj [])))
+        (is (= retained-end (journal/end-cursor retained))))
+      (finally (journal/dispose! a)))))

--- a/test/datahike/test/backfill_sort_test.clj
+++ b/test/datahike/test/backfill_sort_test.clj
@@ -129,17 +129,29 @@
         (is (zero? @live))))))
 
 (deftest byte-budget-causes-spills-and-input-failure-cleans-up
-  (let [spill-var (ns-resolve 'datahike.backfill.sort 'spill!)
-        original @spill-var
-        spills (atom [])]
-    (with-redefs-fn {spill-var (fn [directory run window cmp usage opts]
-                                 (swap! spills conj (reduce + (map :charge window)))
-                                 (original directory run window cmp usage opts))}
+  (let [backend-var (ns-resolve 'datahike.backfill.sort 'file-backend)
+        original @backend-var
+        spills (atom {})]
+    (with-redefs-fn {backend-var
+                     (fn [directory usage opts]
+                       (let [backend (original directory usage opts)
+                             open-writer (:open-writer backend)]
+                         (assoc backend :open-writer
+                                (fn [[pass :as id]]
+                                  (let [writer (open-writer id)
+                                        write! (:write! writer)]
+                                    (if (zero? pass)
+                                      (assoc writer :write!
+                                             (fn [entry]
+                                               (swap! spills update id (fnil + 0) (:charge entry))
+                                               (write! entry)))
+                                      writer))))))}
       (fn []
-        (sort/reduce-sorted! (repeat 20 [1 :v 1 10 true]) msort/by-sort-key
-                             {:window-bytes 512 :window-records 1000} (fn [n _] (inc n)) 0)
+        (is (= 20 (sort/reduce-sorted! (repeat 20 [1 :v 1 10 true]) msort/by-sort-key
+                                       {:window-bytes 512 :window-records 1000}
+                                       (fn [n _] (inc n)) 0)))
         (is (> (count @spills) 1) "byte limit spills before record limit")
-        (is (every? #(<= % 512) @spills)))))
+        (is (every? #(<= % 512) (vals @spills))))))
   (with-directory
     (fn [directory]
       (is (= ::input
@@ -154,9 +166,11 @@
       (let [record [1 :v 1 10 true]
             frame-bytes (+ 4 (alength ^bytes (cbor/encode-record record)))]
         (is (= :datahike.backfill.sort/quota-exceeded
-               (error-type #(sort/reduce-sorted! [record record] msort/by-sort-key
-                                                 {:directory directory :window-records 1
-                                                  :max-bytes (dec (* 3 frame-bytes))}
+               ;; Each input still has unread records when the first output
+               ;; frame is written, so old and new bytes really coexist.
+               (error-type #(sort/reduce-sorted! (repeat 6 record) msort/by-sort-key
+                                                 {:directory directory :window-records 3
+                                                  :max-bytes (dec (* 7 frame-bytes))}
                                                  conj [])))))))
   (let [read-frame (ns-resolve 'datahike.backfill.sort 'read-frame!)]
     (doseq [bytes [[0 0 0] [0 0 0 100] [127 -1 -1 -1]]]

--- a/test/datahike/test/backfill_sort_test.clj
+++ b/test/datahike/test/backfill_sort_test.clj
@@ -1,0 +1,178 @@
+(ns datahike.test.backfill-sort-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.backfill.sort :as sort]
+            [datahike.migrate.cbor :as cbor]
+            [datahike.migrate.sort :as msort]
+            [boring.core :as boring])
+  (:import [java.io DataInputStream ByteArrayInputStream]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- with-directory [f]
+  (let [directory (Files/createTempDirectory "backfill-sort-test-" (make-array FileAttribute 0))]
+    (try
+      (f directory)
+      (with-open [entries (Files/newDirectoryStream directory)]
+        (is (empty? (iterator-seq (.iterator entries))) "owned scratch removed"))
+      (finally (Files/delete directory)))))
+
+(defn- error-type [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))
+
+(deftest bounded-sort-matches-reference
+  (with-directory
+    (fn [directory]
+      (doseq [records [[] [[1 :value 1 10 true]]
+                       (vec (for [i (range 200)] [(- 200 i) :value (mod i 7) 10 true]))]
+              window [1 7 1000]]
+        (is (= (clojure.core/sort msort/by-sort-key records)
+               (sort/reduce-sorted! records msort/by-sort-key
+                                    {:directory directory :window-records window :fan-in 3}
+                                    conj [])))))))
+
+(deftest stable-comparator-ties-survive-many-passes
+  (let [records (mapv #(vector % :value % 10 true) (range 100))]
+    (is (= records (sort/reduce-sorted! records (constantly 0)
+                                        {:window-records 2 :fan-in 3} conj [])))))
+
+(deftest byte-window-and-value-roundtrip
+  (with-directory
+    (fn [directory]
+      (let [records [[3 :value (byte-array [1 2 3]) 10 true]
+                     [2 :value (float-array [1.0 2.0]) 10 false]
+                     [1 :value [(double-array [3.0]) :tuple] 10 true]]
+            result (sort/reduce-sorted! records #(compare (first %1) (first %2))
+                                        {:directory directory :window-bytes 512 :fan-in 2} conj [])]
+        (is (= [1 2 3] (mapv first result)))
+        (is (= [1 2 3] (vec (nth (nth result 2) 2))))
+        (is (= [1.0 2.0] (vec (nth (nth result 1) 2))))
+        (is (= [3.0] (vec (first (nth (first result) 2)))))))))
+
+(deftest resource-scope-covers-early-exit-and-exceptions
+  (doseq [consumer [(fn [rs] (first rs))
+                    (fn [rs] (reduce (fn [_ r] (reduced r)) nil rs))
+                    (fn [rs] (first rs) (throw (ex-info "consumer" {:type ::consumer})))]]
+    (with-directory
+      (fn [directory]
+        (try
+          (sort/with-sorted-records! (map #(vector % :value % 10 true) (range 100))
+            msort/by-sort-key
+            {:directory directory :window-records 1 :fan-in 3} consumer)
+          (catch clojure.lang.ExceptionInfo e (is (= ::consumer (:type (ex-data e)))))))))
+  (with-directory
+    (fn [directory]
+      (is (= ::comparison
+             (error-type #(sort/reduce-sorted! [[2 :v 1 10 true] [1 :v 1 10 true]]
+                                               (fn [_ _] (throw (ex-info "comparison" {:type ::comparison})))
+                                               {:directory directory :window-records 1} conj [])))))))
+
+(deftest invalid-limits-and-quota-fail-cleanly
+  (doseq [opts [{:fan-in 1} {:fan-in 129} {:window-bytes 0}
+                {:max-record-bytes -1} {:max-bytes 1.2} {:unknown true}]]
+    (is (= :datahike.backfill.sort/invalid-options
+           (error-type #(sort/validate-options! opts)))))
+  (with-directory
+    (fn [directory]
+      (is (= :datahike.backfill.sort/quota-exceeded
+             (error-type #(sort/reduce-sorted! [[1 :v "value" 10 true]] msort/by-sort-key
+                                               {:directory directory :max-bytes 1} conj []))))))
+  (with-directory
+    (fn [directory]
+      (let [encoded? (atom false)]
+        (with-redefs [boring/write-to! (fn [& _] (reset! encoded? true))]
+          (is (= :datahike.backfill.sort/record-too-large
+                 (error-type #(sort/reduce-sorted! [[1 :v (apply str (repeat 1000 "x")) 10 true]]
+                                                   msort/by-sort-key
+                                                   {:directory directory :max-record-bytes 512} conj [])))))
+        (is (false? @encoded?) "reject oversized scalar before codec allocation")))))
+
+(deftest codec-output-is-capped-before-buffer-growth
+  (with-directory
+    (fn [directory]
+      (with-redefs [boring/write-to! (fn [_ _ out]
+                                       (dotimes [_ 10] (.write ^java.io.OutputStream out (byte-array 256))))]
+        (is (= :datahike.backfill.sort/record-too-large
+               (error-type #(sort/reduce-sorted! [[1 :v 1 10 true]] msort/by-sort-key
+                                                 {:directory directory :max-record-bytes 512} conj []))))))))
+
+(deftest fan-in-and-exception-close-every-reader
+  (let [reader-var (ns-resolve 'datahike.backfill.sort 'open-reader)
+        original @reader-var
+        live (atom 0)
+        peak (atom 0)
+        opens (atom 0)
+        tracked (fn [path]
+                  (let [in (original path)]
+                    (swap! opens inc)
+                    (swap! peak max (swap! live inc))
+                    (proxy [DataInputStream] [in]
+                      (close [] (try (.close ^DataInputStream in)
+                                     (finally (swap! live dec)))))))]
+    (with-redefs-fn {reader-var tracked}
+      (fn []
+        (with-directory
+          (fn [directory]
+            (is (= 100 (sort/reduce-sorted! (map #(vector % :v % 10 true) (range 100))
+                                            msort/by-sort-key
+                                            {:directory directory :window-records 1 :fan-in 3}
+                                            (fn [n _] (inc n)) 0)))))
+        (is (zero? @live))
+        (is (<= @peak 3))
+        (is (> @opens 100))
+        (with-directory
+          (fn [directory]
+            (is (= ::merge-error
+                   (error-type #(sort/reduce-sorted! [[1 :v 1 10 true] [2 :v 2 10 true]]
+                                                     (fn [_ _] (throw (ex-info "merge" {:type ::merge-error})))
+                                                     {:directory directory :window-records 1 :fan-in 3}
+                                                     conj []))))))
+        (is (zero? @live))))))
+
+(deftest byte-budget-causes-spills-and-input-failure-cleans-up
+  (let [spill-var (ns-resolve 'datahike.backfill.sort 'spill!)
+        original @spill-var
+        spills (atom [])]
+    (with-redefs-fn {spill-var (fn [directory run window cmp usage opts]
+                                 (swap! spills conj (reduce + (map :charge window)))
+                                 (original directory run window cmp usage opts))}
+      (fn []
+        (sort/reduce-sorted! (repeat 20 [1 :v 1 10 true]) msort/by-sort-key
+                             {:window-bytes 512 :window-records 1000} (fn [n _] (inc n)) 0)
+        (is (> (count @spills) 1) "byte limit spills before record limit")
+        (is (every? #(<= % 512) @spills)))))
+  (with-directory
+    (fn [directory]
+      (is (= ::input
+             (error-type #(sort/reduce-sorted!
+                           (concat [[1 :v 1 10 true] [2 :v 2 10 true]]
+                                   (lazy-seq (throw (ex-info "input" {:type ::input}))))
+                           msort/by-sort-key {:directory directory :window-records 1} conj [])))))))
+
+(deftest merge-quota-and-frame-corruption
+  (with-directory
+    (fn [directory]
+      (let [record [1 :v 1 10 true]
+            frame-bytes (+ 4 (alength ^bytes (cbor/encode-record record)))]
+        (is (= :datahike.backfill.sort/quota-exceeded
+               (error-type #(sort/reduce-sorted! [record record] msort/by-sort-key
+                                                 {:directory directory :window-records 1
+                                                  :max-bytes (dec (* 3 frame-bytes))}
+                                                 conj [])))))))
+  (let [read-frame (ns-resolve 'datahike.backfill.sort 'read-frame!)]
+    (doseq [bytes [[0 0 0] [0 0 0 100] [127 -1 -1 -1]]]
+      (with-open [in (DataInputStream. (ByteArrayInputStream. (byte-array bytes)))]
+        (is (= :datahike.backfill.sort/corrupt (error-type #(read-frame in 128))))))))
+
+(deftest ratio-scalars-are-preflighted
+  (let [large (.add (.shiftLeft java.math.BigInteger/ONE 10000) java.math.BigInteger/ONE)
+        ratio (/ large 3)
+        encoded? (atom false)]
+    (is (ratio? ratio))
+    (with-directory
+      (fn [directory]
+        (with-redefs [boring/write-to! (fn [& _] (reset! encoded? true))]
+          (is (= :datahike.backfill.sort/record-too-large
+                 (error-type #(sort/reduce-sorted! [[1 :v ratio 10 true]] msort/by-sort-key
+                                                   {:directory directory :max-record-bytes 512}
+                                                   conj [])))))
+        (is (false? @encoded?))))))

--- a/test/datahike/test/backfill_storage_test.clj
+++ b/test/datahike/test/backfill_storage_test.clj
@@ -1,0 +1,244 @@
+(ns datahike.test.backfill-storage-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.backfill.storage :as storage]
+            [datahike.datom :as dd]
+            [datahike.index.interface :as di]
+            [datahike.test.utils :as utils]
+            [konserve.core :as k]
+            [org.replikativ.persistent-sorted-set :as pss]
+            [org.replikativ.persistent-sorted-set.impl.nodes :as nodes])
+  (:import [org.replikativ.persistent_sorted_set IStorage ANode]))
+
+(defn- error-type [f]
+  (try (f) nil (catch Exception e (:type (ex-data e)))))
+
+(defn- with-db [f]
+  (let [conn (utils/setup-db {:crypto-hash? false
+                              :index :datahike.index/persistent-set
+                              :writer {:writer-ownership :exclusive}})
+        config (:config @conn)]
+    (try (f conn) (finally (d/release conn) (d/delete-database config)))))
+
+(deftest unsupported-and-invalid-options-have-no-io
+  (with-redefs [k/assoc (fn [& _] (throw (AssertionError. "Unexpected write")))
+                k/get (fn [& _] (throw (AssertionError. "Unexpected read")))]
+    (doseq [config [{:index :datahike.index/hitchhiker-tree :crypto-hash? false}
+                    {:index :datahike.index/persistent-set :crypto-hash? true}]]
+      (is (= :backfill.storage/unsupported (error-type #(storage/create! {} config)))))
+    (doseq [options [false {:unknown 1} {:pending-node-limit 0}
+                     {:max-node-weight 100 :pending-weight-limit 99}]]
+      (is (= :backfill.storage/invalid-options
+             (error-type #(storage/create! {} {:index :datahike.index/persistent-set :crypto-hash? false}
+                                           options)))))))
+
+(deftest private-build-roundtrip-and-live-isolation
+  (with-db
+    (fn [conn]
+      (d/transact conn [{:db/ident :score :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one :db/index true}
+                        {:db/id -1 :score 1}])
+      (let [db @conn
+            live (get-in db [:store :storage])
+            old (vec (:avet db))
+            before (into {} (map (fn [key] [key @(get live key)]))
+                         [:pending-writes :freelist :freed-addresses :freed-set :cache :stats])
+            poison (random-uuid)
+            _ (swap! (:freelist live) conj poison)
+            before (assoc before :freelist @(:freelist live))
+            private (storage/create! (:store db) (:config db)
+                                     {:pending-node-limit 2 :cache-node-limit 2})]
+        (try
+          (let [datoms (map #(dd/datom % :score % 42) (range 1 401))
+                view (assoc (storage/build-store private) :datahike/branching-factor 8)
+                tree (di/init-index-sorted :datahike.index/persistent-set view datoms :avet 0
+                                           {:indexed #{:score}})]
+            (storage/flush! private)
+            (is (= (vec datoms) (vec tree)))
+            (is (<= (:cached-nodes (storage/resources private)) 2))
+            (is (= 0 (:pending-nodes (storage/resources private))))
+            (is (pos? (:persisted (storage/resources private))))
+            (is (not (k/exists? (:store db) poison {:sync? true})))
+            ;; Every mutable source storage component remains exactly untouched.
+            (doseq [[key value] before] (is (= value @(get live key)) (str key)))
+            (is (= old (vec (:avet db)))))
+          (finally (.close ^java.io.Closeable private)))))))
+
+(deftest replay-keeps-no-private-free-ledger
+  (with-db
+    (fn [conn]
+      (let [private (storage/create! (:store @conn) (:config @conn)
+                                     {:pending-node-limit 2 :cache-node-limit 2})
+            view (assoc (storage/build-store private) :datahike/branching-factor 8)]
+        (try
+          (let [base (di/init-index-sorted :datahike.index/persistent-set view
+                                           (map #(dd/datom % :score % 42) (range 1 101)) :avet 0
+                                           {:indexed #{:score}})]
+            (storage/flush! private)
+            (loop [tree base i 0]
+              (when (< i 100)
+                (let [value (dd/datom (+ 1000 i) :score (+ 1000 i) 43)
+                      changed (conj tree value)
+                      _ (pss/store changed)
+                      restored (disj changed value)]
+                  (pss/store restored)
+                  (is (<= (:pending-nodes (storage/resources private)) 2))
+                  (recur restored (inc i)))))
+            (storage/flush! private)
+            (is (= 100 (count base)))
+            (is (nil? (:freed-set private)))
+            (is (nil? (:freed-addresses private)))
+            (dotimes [_ 10000] (.markFreed ^IStorage private (random-uuid)))
+            (is (false? (.isFreed ^IStorage private (random-uuid))))
+            (is (<= (:cached-nodes (storage/resources private)) 2)))
+          (finally (.close ^java.io.Closeable private)))
+        (is (= {:pending-nodes 0 :cached-nodes 0 :pending-weight 0 :cache-weight 0 :closed? true}
+               (select-keys (storage/resources private)
+                            [:pending-nodes :cached-nodes :pending-weight :cache-weight :closed?])))
+        (is (= :backfill.storage/closed (error-type #(storage/flush! private))))))))
+
+(deftest oversized-nodes-and-failed-flush
+  (with-db
+    (fn [conn]
+      (let [private (storage/create! (:store @conn) (:config @conn)
+                                     {:max-node-weight 2048 :pending-weight-limit 4096})
+            view (assoc (storage/build-store private) :datahike/branching-factor 8)]
+        (try
+          (is (= :backfill.storage/node-too-large
+                 (error-type #(di/init-index-sorted :datahike.index/persistent-set view
+                                                    [(dd/datom 1 :score (apply str (repeat 2000 "x")) 42)]
+                                                    :avet 0 {:indexed #{:score}}))))
+          (is (= 0 (:pending-nodes (storage/resources private))))
+          (di/init-index-sorted :datahike.index/persistent-set view
+                                [(dd/datom 1 :score 1 42)] :avet 0 {:indexed #{:score}})
+          (with-redefs [k/assoc (fn [& _] (throw (ex-info "write failed" {:type :injected})))]
+            (is (= :injected (error-type #(storage/flush! private)))))
+          (is (:failed? (storage/resources private)))
+          (is (= :backfill.storage/failed (error-type #(storage/flush! private))))
+          (finally (.close ^java.io.Closeable private)))))))
+
+(defn- leaf [value]
+  (nodes/blob->leaf (nodes/reader-context {})
+                    {:keys [(dd/datom 1 :score value 42)]
+                     :branching-factor 8 :diff-buf-size 0}))
+
+(deftest restored-topology-has-no-mutable-aliases
+  (with-db
+    (fn [conn]
+      (with-open [^java.io.Closeable private (storage/create! (:store @conn) (:config @conn))]
+        (let [original ^ANode (leaf 1)
+              address (.store ^IStorage private original)
+              first-copy ^ANode (.restore ^IStorage private address)
+              second-copy ^ANode (.restore ^IStorage private address)]
+          (is (not (identical? original first-copy)))
+          (is (not (identical? first-copy second-copy)))
+          (is (not (identical? (.-_keys first-copy) (.-_keys second-copy))))
+          ;; Deliberately mutate topology, not domain values. Neither the pending
+          ;; blob nor another restored node may share these mutable arrays.
+          (aset (.-_keys original) 0 (dd/datom 1 :score 100 42))
+          (aset (.-_keys first-copy) 0 (dd/datom 1 :score 200 42))
+          (is (= 1 (:v (aget (.-_keys second-copy) 0))))
+          (storage/flush! private)
+          (let [third-copy ^ANode (.restore ^IStorage private address)]
+            (is (= 1 (:v (aget (.-_keys third-copy) 0))))
+            (aset (.-_keys third-copy) 0 (dd/datom 1 :score 300 42)))
+          (let [persisted ^ANode (k/get (:store @conn) address nil {:sync? true})]
+            (is (= 1 (:v (aget (.-_keys persisted) 0))))))))))
+
+(deftest flushed-roots-reopen-with-ordinary-storage-after-close
+  (with-db
+    (fn [conn]
+      (let [db @conn
+            private (storage/create! (:store db) (:config db)
+                                     {:pending-node-limit 2 :cache-node-limit 2})
+            datoms (mapv #(dd/datom % :score % 42) (range 1 401))
+            root (try
+                   (let [tree (di/init-index-sorted
+                               :datahike.index/persistent-set
+                               (assoc (storage/build-store private) :datahike/branching-factor 8)
+                               datoms :avet 0 {:indexed #{:score}})
+                         root (pss/store tree)]
+                     (storage/flush! private)
+                     root)
+                   (finally (.close ^java.io.Closeable private)))
+            before (storage/resources private)
+            reopened (pss/restore-by (dd/index-type->cmp-quick :avet false)
+                                     root (get-in db [:store :storage]))]
+        (is (= datoms (vec reopened)))
+        (is (= before (storage/resources private)))
+        (is (:closed? before))
+        (is (= 0 (:pending-nodes before) (:cached-nodes before)))))))
+
+(defn- assert-budgets [private options]
+  (let [resources (storage/resources private)]
+    (doseq [[counter limit] [[:pending-nodes :pending-node-limit]
+                             [:cached-nodes :cache-node-limit]
+                             [:pending-weight :pending-weight-limit]
+                             [:cache-weight :cache-weight-limit]]]
+      (is (<= 0 (counter resources) (limit options)) (str counter)))))
+
+(deftest count-and-weight-budgets-hold-after-every-operation
+  (with-db
+    (fn [conn]
+      (let [node (leaf (apply str (repeat 200 "x")))
+            weight (with-open [^java.io.Closeable probe (storage/create! (:store @conn) (:config @conn))]
+                     (.store ^IStorage probe node)
+                     (:pending-weight (storage/resources probe)))]
+        (doseq [[mode options]
+                [[:weight {:max-node-weight weight
+                           :pending-node-limit 32 :cache-node-limit 32
+                           :pending-weight-limit (inc weight) :cache-weight-limit (inc weight)}]
+                 [:count {:max-node-weight weight
+                          :pending-node-limit 2 :cache-node-limit 2
+                          :pending-weight-limit (* 32 weight) :cache-weight-limit (* 32 weight)}]]]
+          (with-open [^java.io.Closeable private (storage/create! (:store @conn) (:config @conn) options)]
+            (let [addresses
+                  (mapv (fn [_]
+                          (let [address (.store ^IStorage private node)]
+                            (assert-budgets private options)
+                            (.restore ^IStorage private address)
+                            (assert-budgets private options)
+                            (.accessed ^IStorage private address)
+                            (assert-budgets private options)
+                            address))
+                        (range 12))]
+              (is (pos? (:persisted (storage/resources private))) (str mode " triggers flushing"))
+              (when (= mode :weight)
+                (is (= 1 (:pending-nodes (storage/resources private))))
+                (is (= 1 (:cached-nodes (storage/resources private)))))
+              (doseq [address addresses]
+                (.restore ^IStorage private address)
+                (assert-budgets private options))
+              (storage/flush! private)
+              (assert-budgets private options))))))))
+
+(deftest partial-flush-poisons-build-and-close-clears-buffers
+  (with-db
+    (fn [conn]
+      (let [private (storage/create! (:store @conn) (:config @conn))
+            first-address (.store ^IStorage private (leaf 1))
+            second-address (.store ^IStorage private (leaf 2))
+            original-assoc k/assoc
+            calls (atom 0)]
+        (try
+          (with-redefs [k/assoc (fn [& args]
+                                  (if (= 1 (swap! calls inc))
+                                    (apply original-assoc args)
+                                    (throw (ex-info "second write failed" {:type :injected}))))]
+            (is (= :injected (error-type #(storage/flush! private)))))
+          (is (= 2 @calls))
+          (is (= 1 (:persisted (storage/resources private))))
+          (is (k/exists? (:store @conn) first-address {:sync? true}))
+          (is (not (k/exists? (:store @conn) second-address {:sync? true})))
+          (is (= :backfill.storage/failed
+                 (error-type #(.restore ^IStorage private first-address))))
+          (is (= :backfill.storage/failed
+                 (error-type #(.store ^IStorage private (leaf 3)))))
+          (is (= :backfill.storage/failed (error-type #(storage/flush! private))))
+          (finally (.close ^java.io.Closeable private)))
+        (.close ^java.io.Closeable private)
+        (is (= {:closed? true :failed? true :pending-nodes 0 :cached-nodes 0
+                :pending-weight 0 :cache-weight 0}
+               (select-keys (storage/resources private)
+                            [:closed? :failed? :pending-nodes :cached-nodes
+                             :pending-weight :cache-weight])))))))

--- a/test/datahike/test/migrate_sort_test.cljc
+++ b/test/datahike/test/migrate_sort_test.cljc
@@ -16,7 +16,76 @@
    COUNT rather than order alone."
   (:require [clojure.test :refer [deftest testing is]]
             [datahike.migrate.fs :as fs]
+            [datahike.migrate.cbor :as cbor]
             [datahike.migrate.sort :as msort]))
+
+(deftest scoped-sort-closes-on-early-return-and-failure
+  (let [dir (fs/temp-dir! "dh-sort-scope-")
+        unrelated (fs/join dir "keep.txt")
+        live (atom 0)
+        peak (atom 0)
+        original fs/reader]
+    (fs/spit-text! unrelated "keep")
+    (try
+      (with-redefs [fs/reader
+                    (fn [path]
+                      (let [{:keys [close] :as reader} (original path)
+                            closed? (atom false)]
+                        (swap! live inc)
+                        (swap! peak max @live)
+                        (assoc reader :close
+                               (fn []
+                                 (when (compare-and-set! closed? false true)
+                                   (try (close) (finally (swap! live dec))))))))]
+        (doseq [consume [first #(reduce (fn [_ x] (reduced x)) nil %)
+                         (fn [_] (throw (ex-info "consumer" {:error ::consumer})))]]
+          (try
+            (msort/with-sorted-records! (map #(vector % :a % 1 true) (range 150))
+              1 dir msort/export-order consume)
+            (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e
+              (is (= ::consumer (:error (ex-data e)))))))
+        (is (zero? @live))
+        (is (<= 1 @peak 64))
+        (is (= ["keep.txt"] (fs/list-names dir))))
+      (finally (fs/delete! unrelated) (fs/delete! dir)))))
+
+(deftest migration-optimizations-count-real-work
+  (let [dir (fs/temp-dir! "dh-sort-work-")
+        rs (mapv #(vector % :a % 1 true) (range 65))
+        encodes (atom 0)
+        keys (atom 0)
+        encode cbor/encode-record
+        order {::msort/key-fn (fn [r] (swap! keys inc) (first r))}]
+    (try
+      (with-redefs [cbor/encode-record (fn [r] (swap! encodes inc) (encode r))]
+        (is (= rs (vec (msort/external-sort rs 100 dir order))))
+        (is (= 65 @keys) "one key per in-memory record")
+        (is (zero? @encodes) "no encoding for an in-memory sort")
+        (reset! keys 0)
+        (is (= rs (vec (msort/external-sort rs 1 dir order))))
+        (is (= 67 @encodes) "65 initial records plus only the two-run partial merge")
+        (is (= 132 @keys) "keys computed once for each initial/decoded entry")
+        (reset! encodes 0)
+        (let [path (msort/external-sort-to-file rs 100 dir order)]
+          (is (= 65 @encodes) "a single materialized run is not copied")
+          (with-redefs [msort/sort-key (fn [_] (throw (ex-info "Unexpected sort key on reread" {})))]
+            (is (= rs (vec (msort/read-sorted-file path)))))
+          (fs/delete! path)))
+      (finally (fs/delete! dir)))))
+
+(deftest decoder-construction-error-survives-reader-close-failure
+  (doseq [same-error? [false true]]
+    (let [primary (ex-info "decode" {})
+          cleanup (if same-error? primary (ex-info "close" {}))
+          closed? (atom false)]
+      (with-redefs [fs/reader (fn [_] {:source nil
+                                       :close (fn [] (reset! closed? true) (throw cleanup))})
+                    cbor/decode-records (fn [_] (throw primary))]
+        (is (identical? primary
+                        (try (msort/merge-runs ["unused"])
+                             nil
+                             (catch #?(:clj Throwable :cljs :default) e e))))
+        (is @closed?)))))
 
 (defn- cleanup! [dir]
   (doseq [n (or (fs/list-names dir) [])]

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -88,6 +88,7 @@
             ;; the external merge sort, which runs here now that it no longer
             ;; speaks java.io.File and java.util.PriorityQueue.
             [datahike.test.migrate-sort-test]
+            [datahike.test.sort-test]
             [datahike.test.value-comparison-test]
             ;; the streaming bulk index build, which runs here now that
             ;; persistent-sorted-set has a cljs `from-sorted-seq`.
@@ -903,6 +904,7 @@
                'datahike.test.migrate-manifest-test
                'datahike.test.blob-identity-test
                'datahike.test.migrate-sort-test
+               'datahike.test.sort-test
                'datahike.test.value-comparison-test
                'datahike.test.bulk-build-node-test
                'datahike.test.migrate-node-test

--- a/test/datahike/test/sort_test.cljc
+++ b/test/datahike/test/sort_test.cljc
@@ -1,0 +1,202 @@
+(ns datahike.test.sort-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.sort :as sort]))
+
+(defn- instrumented-backend
+  ([] (instrumented-backend {}))
+  ([{:keys [runs fault reader-limit] :or {runs {} reader-limit 128}}]
+   (let [state (atom {:runs runs :events [] :counts {} :prepared 0 :read-values 0
+                      :readers 0 :writers 0 :peak-readers 0 :peak-writers 0})
+         event! (fn [op id]
+                  (let [after (swap! state #(-> % (update :events conj [op id])
+                                                (update-in [:counts [op id]] (fnil inc 0))))]
+                    (when fault (fault op id (get-in after [:counts [op id]])))))
+         acquire! (fn [kind]
+                    (let [after (swap! state update kind inc)]
+                      (swap! state update (if (= kind :readers) :peak-readers :peak-writers)
+                             max (get after kind))))]
+     {:state state
+      :backend
+      {:prepare (fn [record]
+                  (event! :prepare nil)
+                  (swap! state update :prepared inc)
+                  {:record record :charge (or (:charge record) 1)})
+       :open-reader
+       (fn [id]
+         (event! :open-reader id)
+         (when (>= (:readers @state) reader-limit)
+           (throw (ex-info "Reader limit exceeded" {:test/error :reader-limit})))
+         (when-not (contains? (:runs @state) id)
+           (throw (ex-info "Unknown run" {:run id})))
+         (acquire! :readers)
+         (let [remaining (atom (seq (get-in @state [:runs id])))
+               closed? (atom false)]
+           {:next! (fn []
+                     (event! :next id)
+                     (let [entry (first @remaining)]
+                       (swap! remaining next)
+                       (when entry (swap! state update :read-values inc))
+                       entry))
+            :close! (fn []
+                      (when (compare-and-set! closed? false true)
+                        (reset! remaining nil)
+                        (swap! state update :readers dec)
+                        (event! :close-reader id)))}))
+       :open-writer
+       (fn [id]
+         (event! :open-writer id)
+         (acquire! :writers)
+         (let [entries (atom []) closed? (atom false)]
+           {:write! (fn [entry]
+                      (event! :write id)
+                      ;; Model a codec: cached engine keys are not serialized.
+                      (swap! entries conj (select-keys entry [:record :charge])))
+            :close! (fn []
+                      (when (compare-and-set! closed? false true)
+                        (swap! state #(-> % (update :writers dec) (assoc-in [:runs id] @entries)))
+                        (reset! entries [])
+                        (event! :close-writer id)))}))
+       :delete! (fn [id] (event! :delete id) (swap! state update :runs dissoc id))
+       :move! (fn [from to]
+                (event! :move from)
+                (swap! state update :runs #(assoc (dissoc % from) to (get % from))))}})))
+
+(defn- thrown [f]
+  (try (f) nil (catch #?(:clj Throwable :cljs :default) error error)))
+
+(defn- no-handles? [state]
+  (and (zero? (:readers @state)) (zero? (:writers @state))))
+
+(deftest window-limits-and-in-memory-key-decoration
+  (let [calls (atom 0) records (vec (reverse (range 40)))]
+    (is (= (range 40) (sort/sort-window records {:key-fn #(do (swap! calls inc) %)})))
+    (is (= 40 @calls)))
+  (doseq [[record-cap byte-cap expected] [[3 nil [3 3 1]] [20 5 [2 2 2 1]]]]
+    (let [{:keys [backend state]} (instrumented-backend)
+          records (mapv #(hash-map :key % :charge 2) (range 7))
+          runs (sort/initial-runs! records {:key-fn :key} backend
+                                   {:window-records record-cap :window-bytes byte-cap})]
+      (is (= expected (mapv #(count (get-in @state [:runs [0 %]])) (range runs))))
+      (is (= 7 (:prepared @state)))
+      (is (no-handles? state)))))
+
+(deftest stable-ties-and-key-counts-through-balanced-passes
+  (doseq [n [0 1 65 257 2053] fan [2 7] keyed? [false true]]
+    (let [{:keys [backend state]} (instrumented-backend {:reader-limit fan})
+          calls (atom 0)
+          records (mapv #(vector (mod % 5) %) (range n))
+          order (if keyed? {:key-fn #(do (swap! calls inc) (first %))}
+                    {:cmp #(compare (first %1) (first %2))})
+          id (sort/sorted-file! records order backend
+                                {:window-records 3 :window-bytes nil :fan-in fan})]
+      (is (= (vec (sort-by first records)) (mapv :record (get-in @state [:runs id])))
+          (str n " records; fan-in " fan "; keyed " keyed?))
+      (is (= n (:prepared @state)))
+      (when keyed?
+        (is (= (+ n (:read-values @state)) @calls)
+            "one key per prepared or decoded entry, never per comparison"))
+      (is (<= (:peak-readers @state) fan))
+      (is (<= (:peak-writers @state) 1))
+      (is (no-handles? state)))))
+
+(deftest partial-final-pass-merges-only-two-of-sixty-five-runs
+  (let [{:keys [backend state]} (instrumented-backend {:reader-limit 64})
+        opts {:window-records 1 :window-bytes nil :fan-in 64}
+        count-runs (sort/initial-runs! (range 65) {:cmp compare} backend opts)
+        runs (sort/reduce-runs! count-runs {:cmp compare} backend opts)]
+    (is (= 64 (count runs)))
+    (is (= 2 (:read-values @state)))
+    (is (= 63 (count (filter #(= :move (first %)) (:events @state)))))
+    (is (= 67 (count (filter #(= :write (first %)) (:events @state)))))
+    (let [{:keys [records close!]} (sort/merge-runs-resource! runs {:cmp compare} backend true)]
+      (try (is (= (vec (range 65)) (vec records))) (finally (close!))))
+    (is (empty? (:runs @state)))
+    (is (no-handles? state))))
+
+(deftest empty-and-single-run-avoid-unnecessary-io
+  (doseq [input [[] [3 2 1]]]
+    (let [{:keys [backend state]} (instrumented-backend)
+          id (sort/sorted-file! input {:cmp compare} backend
+                                {:window-records 5 :window-bytes nil :fan-in 2})]
+      (is (= (sort input) (map :record (get-in @state [:runs id]))))
+      (is (zero? (:read-values @state)))
+      (is (not-any? #(contains? #{:open-reader :move} (first %)) (:events @state)))
+      (is (no-handles? state)))))
+
+(deftest explicit-early-close-is-idempotent
+  (let [{:keys [backend state]}
+        (instrumented-backend {:runs {[0 0] [{:record 1} {:record 3}]
+                                      [0 1] [{:record 2} {:record 4}]}})
+        {:keys [records close!]} (sort/merge-runs-resource! [[0 0] [0 1]] {:cmp compare} backend false)]
+    (is (= 1 (first records)))
+    (close!)
+    (close!)
+    (is (no-handles? state))
+    (is (= 2 (count (filter #(= :close-reader (first %)) (:events @state)))))
+    (is (= 2 (count (:runs @state))))))
+
+(deftest acquisition-next-and-comparator-failures-close-acquired-readers
+  (doseq [op [:open-reader :next :compare]]
+    (let [failure (ex-info "primary" {:test/error op})
+          {:keys [backend state]}
+          (instrumented-backend
+           {:runs {[0 0] [{:record 1}] [0 1] [{:record 2}]}
+            :fault (fn [event id _]
+                     (when (and (= event op) (= id [0 1])) (throw failure)))})
+          order {:cmp (fn [a b] (if (= op :compare) (throw failure) (compare a b)))}]
+      (is (identical? failure
+                      (thrown #(sort/merge-runs-resource! [[0 0] [0 1]] order backend true))))
+      (is (no-handles? state)))))
+
+(deftest materialized-merge-failures-preserve-primary-and-close-all-handles
+  (doseq [op [:open-writer :write :close-writer :next :close-reader :compare]]
+    (let [failure (ex-info "primary" {:test/error op})
+          cleanup (ex-info "cleanup" {:test/error :cleanup})
+          failed? (atom false)
+          {:keys [backend state]}
+          (instrumented-backend
+           {:fault (fn [event id occurrence]
+                     (when (or (and (= event op) (= id [1 0]))
+                               (and (contains? #{:next :close-reader} op)
+                                    (= event op) (= id [0 0])
+                                    (= occurrence (if (= op :next) 2 1))))
+                       (reset! failed? true)
+                       (throw failure))
+                     (when (and @failed? (= event :close-reader) (= id [0 1])
+                                (contains? #{:open-writer :write :close-writer :compare} op))
+                       (throw cleanup)))})
+          cmp-calls (atom 0)
+          order {:cmp (fn [a b]
+                        (swap! cmp-calls inc)
+                        (if (= op :compare)
+                          (do (reset! failed? true) (throw failure))
+                          (compare a b)))}
+          error (thrown #(sort/sorted-file! [1 2] order backend
+                                            {:window-records 1 :window-bytes nil :fan-in 2}))]
+      (is (identical? failure error) (str op))
+      #?(:clj (when (contains? #{:open-writer :write :compare} op)
+                (is (some #(identical? cleanup %) (.getSuppressed ^Throwable failure))
+                    "cleanup does not replace the primary failure")))
+      (is (no-handles? state) (str op)))))
+
+(deftest failures-after-spilling-and-during-lazy-consumption-close-resources
+  (let [failure (ex-info "input" {})
+        {:keys [backend state]} (instrumented-backend)
+        records (concat [3 2 1] (lazy-seq (throw failure)))]
+    (is (identical? failure
+                    (thrown #(sort/initial-runs! records {:cmp compare} backend
+                                                 {:window-records 1 :window-bytes nil}))))
+    (is (pos? (count (:runs @state))) "the failure occurred after spilling")
+    (is (no-handles? state)))
+  (let [failure (ex-info "later read" {})
+        {:keys [backend state]}
+        (instrumented-backend
+         {:runs {[0 0] [{:record 1} {:record 3}] [0 1] [{:record 2} {:record 4}]}
+          :fault (fn [event id occurrence]
+                   (when (and (= event :next) (= id [0 0]) (= occurrence 2))
+                     (throw failure)))})
+        {:keys [records close!]} (sort/merge-runs-resource! [[0 0] [0 1]] {:cmp compare} backend false)]
+    (is (identical? failure (thrown #(first records))))
+    (is (no-handles? state))
+    (close!)
+    (is (no-handles? state))))


### PR DESCRIPTION
## Summary

Private JVM building blocks for bounded index backfill, based on main after
#1078. This does not expose background AVET or change the ordinary transaction
path when no backfill journal is active.

- One shared external merge engine for migration and bounded backfill, with
  stable ordering, bounded run bookkeeping and merge fan-in. Migration retains
  JVM/Node CBOR-sequence files, cached keys, its in-memory fast path, reusable
  sorted files and partial final passes. Backfill retains structural/encoded
  record limits, byte-bounded windows and scratch quotas.
- Materialized merges pull records directly without retaining lazy heads.
  Migration offers explicit closeable/scoped consumption; legacy lazy results
  must still be exhausted. Scoped cleanup handles early return and failures.
- Incremental journal replay through opaque, owner-bound cursors. The file
  backend validates frame incarnations, rejecting abandoned-suffix cursors
  without invalidating retained-prefix cursors or retaining a cursor registry.
- Exact accepted-prefix validation before append or replay. Temporary frame
  headers are 24 bytes and count against the configured disk quota.
- Isolated PSS node storage with bounded pending/cache accounting, fresh UUID
  addresses, detached node topology and no lifetime address/free ledger.

Private storage requires PSS, `:crypto-hash? false` and no diff buffers. Its
caller must establish durable build GC deferral, source pin and local GC guard.
Payload accounting is not an exact JVM heap measurement; backend decoding and
the builder frontier remain outside those component budgets. Failed private
builds are discarded; persisted unreachable nodes are reclaimed by normal GC.

Journal and bounded backfill I/O remain synchronous JVM adapters; the shared
sort engine and migration adapter also run on Node. No konserve journal backend,
async writer support, CLJS backfill support, PSS library change or persisted
index-format migration is introduced. Reconnect rebuilds rather than resuming
scratch. #1081 must be rebased and adapted to the opaque cursor interface next.

## Validation

- Independent agent design and correctness reviews completed; memory-retention
  and cleanup-error findings fixed and regression-tested.
- Focused shared-sort/migration/backfill/retention: 39 tests / 310 assertions.
- Advanced Node build: 316 files, zero compiler warnings. Node suite:
  306 tests / 2,024 assertions, zero failures or errors.
- Fresh sort proof: 100,000 records / 409,600,000 logical payload bytes sorted
  under a 256 MiB maximum heap, with scratch cleaned afterward.
- Journal proof: 536,875,008 logical payload bytes, 131,073 frames, full replay
  and a 65,537-frame tail replay under a 256 MiB maximum heap; scratch cleaned.
- Java facade generated and compiled; scoped formatting and diff checks passed.
- Full non-spec JVM matrix: 3,001 tests / 32,997 assertions, zero failures.
- Full instrumented-spec suite: 1,340 tests / 15,684 assertions, zero failures.
- Final migration tier: 280 tests / 1,468 assertions, zero failures. The full non-spec matrix preceded
  the small comparator-only/reread performance refinements; fresh migration,
  focused sorter and Node reruns cover those changes.

The journal heap proof is from 404a7189; its framing/range implementation is
unchanged by the sorter consolidation. Private storage is likewise unchanged;
the earlier private-node >512 MiB / 256 MiB heap experiment remains prior evidence.
