### PR TITLE
Add fenced background AVET builds and atomic schema activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ When something is added, it's typically marked *Experimental*. When the API cont
   value and attribute purges accept keyword attribute names as well as numeric
   IDs. Entity purge also removes current and historical incoming references;
   these operations previously could leave matching data behind.
+
+- **Background attribute indexing (experimental, JVM).** Build AVET indexes and
+  add uniqueness constraints while reads and writes continue under the old
+  schema. Activation publishes the schema and completed roots atomically.
+  Disk-backed sorting and change capture use configurable limits. Requires a
+  local shared, explicitly fenced writer with non-crypto persistent-set indexes.
+  See [background attribute indexing](doc/avet-backfill.md) for the API, limits,
+  and recovery behavior.
+
+- **Purging retained attribute-index history.** Purges remove matching AVET
+  history even when indexing has since been disabled on the attribute. Enabling
+  the index again no longer exposes those purged historical entries.
 - **Disk-backed secondary backfill journals.** JVM local-exclusive writers
   capture concurrent changes in bounded-frame scratch files instead of retaining
   decoded changes across database snapshots. Configure `:backfill-journal` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ When something is added, it's typically marked *Experimental*. When the API cont
   schema. Activation publishes the schema and completed roots atomically.
   Disk-backed sorting and change capture use configurable limits. Requires a
   local shared, explicitly fenced writer with non-crypto persistent-set indexes.
+  Every garbage collector sharing the store must support AVET build markers;
+  disable legacy collectors before enabling background builds.
   See [background attribute indexing](doc/avet-backfill.md) for the API, limits,
   and recovery behavior.
 

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -158,6 +158,8 @@ are conservative accounting units, not exact retained heap measurements.
 Backend node decoding, the index builder's frontier, the database's ordinary
 caches, and user transaction inputs remain outside these buffer budgets.
 Large values or nodes can exceed an individual-record or node limit.
+`:tail-bytes` counts the journal backend's physical bytes, including frame
+headers; journal cursors themselves remain opaque and are not byte offsets.
 
 A journal limit or append failure rejects the affected user transaction without
 advancing its database state. Cancel the build or wait for it to finish before

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -5,6 +5,12 @@ enable it in a separate atomic commit. The same operation can add a uniqueness
 constraint. Reads and writes continue under the old schema while the build runs.
 This API is experimental.
 
+**Upgrade every garbage collector sharing the store before using this API.**
+Older Datahike versions do not recognize the AVET build marker and can delete
+unpublished index nodes even while the source pin remains live. Alternatively,
+keep garbage collection disabled in older processes until all builds and their
+cleanup have finished. Fencing does not make mixed-version collection safe.
+
 Use a local shared writer with an explicit fencing requirement, the
 persistent-set index, and non-cryptographic index addresses:
 
@@ -143,6 +149,10 @@ defer garbage collection's sweep so that unpublished index nodes are not
 reclaimed. Lost pins prevent activation. A marker left after a crash can keep
 sweeping deferred until a successful cancellation, replacement, or ordinary
 write retires it.
+
+All processes collecting this store must support these build markers. A live
+source pin alone does not protect unpublished candidate nodes from an older
+collector, and checking that pin cannot detect such deletion.
 
 Normal completion, cancellation, and orderly writer shutdown clean up owned
 scratch. A process crash can leave files behind. Use a dedicated scratch

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -1,0 +1,154 @@
+# Background attribute indexing
+
+On the JVM, Datahike can build an attribute's AVET index in the background and
+enable it in a separate atomic commit. The same operation can add a uniqueness
+constraint. Reads and writes continue under the old schema while the build runs.
+This API is experimental.
+
+Use a local shared writer with an explicit fencing requirement, the
+persistent-set index, and non-cryptographic index addresses:
+
+```clojure
+{:index :datahike.index/persistent-set
+ :crypto-hash? false
+ :writer {:backend :self
+          :writer-ownership :shared
+          :require-fencing :process}}
+```
+
+The store must support the requested fencing domain. Select a domain that covers
+your deployment; `:process` is not a cross-process guarantee. Diff buffers,
+exclusive writers, remote writers, and ClojureScript builds are not supported.
+Existing databases must already use the supported index configuration; changing
+configuration is not an index migration.
+
+## Start, inspect, and cancel a build
+
+The request maps existing attribute idents to the properties to enable:
+
+```clojure
+(require '[datahike.api :as d])
+
+(def accepted
+  @(d/begin-avet-build! conn
+     {:customer/email {:db/unique :db.unique/value}
+      :customer/joined-at {:db/index true}}))
+
+(def generation (:avet-build-id accepted))
+
+;; Read a fresh snapshot when checking progress.
+(d/avet-build-status @conn)
+;; => {:id ..., :status :building, :patch {...}}
+;; Later: {:id ..., :status :ready}
+
+;; Cancel only this generation, not a newer replacement.
+@(d/cancel-avet-build! conn generation)
+```
+
+The start promise resolves when the request is committed, **not when the index
+is ready**. The cancellation promise resolves when cancellation is committed;
+worker cleanup may finish afterward. A completed or replaced generation cannot
+be canceled using its old ID.
+
+One build may be active per branch. A request can enable `:db/index true` and
+`:db/unique :db.unique/value` or `:db.unique/identity` on up to 256 existing
+attributes. It cannot create attributes, disable properties, change types or
+cardinality, or include arbitrary transaction data. Uniqueness implies indexing.
+
+`avet-build-status` returns the active request or the most recent result:
+`:building`, `:ready`, `:failed`, or `:canceled`. It returns nil before the first
+request. Results include their generation ID; failed or canceled results also
+include a reason. This is snapshot state, not a worker-liveness check or a
+complete job history. Keep the request report's `:avet-build-id` when monitoring
+a request: reports in one batch share its final `:db-after`, which may already
+describe a later generation.
+
+Ordinary `listen` callbacks receive the public start and cancel reports, not the
+worker's internal activation report. Use `listen-commits` for commit notifications
+or inspect fresh snapshots for readiness, matching the saved generation ID.
+
+## Activation and uniqueness
+
+The build includes current data, retained history, and changes committed while
+it runs. The schema and completed AVET roots become visible together. No reader
+sees an enabled attribute backed by a partially built index.
+
+A uniqueness build checks the existing values outside the serialized writer,
+then checks affected values after each complete replayed transaction. Activation
+also validates values changed by the schema transaction, including derived
+tuples. It does not skip uniqueness validation. Ordinary per-datom uniqueness
+checks still apply; intermediate conflicts in derived tuples can reject an
+activation even if its proposed final values would be distinct.
+
+Duplicates encountered during the build fail the request without enabling the
+constraint or undoing user transactions. Repair the data and submit a new
+request. Until activation commits, the old schema still permits duplicates.
+
+## Resource limits
+
+The builder uses disk-backed sorting and bounded private node buffers. It does
+not retain the full change journal or all values being checked for uniqueness
+in heap. The final writer step admits only a bounded journal tail; a larger tail
+is sent back to the worker for another catch-up pass.
+
+Configure limits under the writer's `:avet-backfill` key:
+
+```clojure
+:avet-backfill
+{:runtime {:journal {:directory "/path/to/scratch"
+                     :max-frame-bytes 1048576
+                     :max-bytes 268435456}
+           :max-contexts 8
+           :max-readers 8}
+ :build {:sort {:directory "/path/to/scratch"
+                :window-bytes 16777216
+                :window-records 65536
+                :max-record-bytes 1048576
+                :fan-in 16
+                :max-bytes 4294967296}
+         :storage {:pending-node-limit 64
+                   :pending-weight-limit 16777216
+                   :cache-node-limit 64
+                   :cache-weight-limit 16777216}}
+ :tail-bytes 1048576
+ :tail-transactions 128
+ :max-jobs 8}
+```
+
+The shown values are defaults except for the directories, which default to the
+JVM temporary directory. A configured directory must already exist. Limits are
+per owned runtime or build, not a global memory or disk budget. Weight limits
+are conservative accounting units, not exact retained heap measurements.
+Backend node decoding, the index builder's frontier, the database's ordinary
+caches, and user transaction inputs remain outside these buffer budgets.
+Large values or nodes can exceed an individual-record or node limit.
+
+A journal limit or append failure rejects the affected user transaction without
+advancing its database state. Cancel the build or wait for it to finish before
+retrying. Sort or private-storage failures fail the background request. Very
+high write rates can delay activation; bounded catch-up does not guarantee a
+completion deadline or a fixed write-pause duration.
+
+## Recovery and garbage collection
+
+Schema changes invalidate an active build. A different writer taking over its
+branch cannot continue the original writer's local journal: its next accepted
+write retires that generation. The write itself can still commit normally.
+After a restart, submit a fresh request or cancel the durable old generation;
+scratch is not a resumable checkpoint. Transaction predicates also apply to
+build requests, activation, and cancellation.
+
+The source snapshot is pinned while the build runs. Active durable build markers
+defer garbage collection's sweep so that unpublished index nodes are not
+reclaimed. Lost pins prevent activation. A marker left after a crash can keep
+sweeping deferred until a successful cancellation, replacement, or ordinary
+write retires it.
+
+Normal completion, cancellation, and orderly writer shutdown clean up owned
+scratch. A process crash can leave files behind. Use a dedicated scratch
+directory and remove abandoned files only after confirming their writer has
+stopped. Reclamation of unused immutable store nodes remains the collector's job.
+
+Ordinary schema transactions remain synchronous. Their existing
+`:allow-index-backfill?` transaction option is separate from this API and does
+not start a background build.

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -94,7 +94,10 @@ A different generation's status does not establish the outcome of your
 request; retain its observed result before starting another build if that
 outcome must be recorded. A monitoring timeout does not cancel the build.
 Cancellation must be requested explicitly and can race with activation;
-inspect a fresh snapshot to determine which operation committed.
+if it is rejected because the generation is no longer active, inspect a fresh
+snapshot. A matching `:ready` result means activation committed; a matching
+`:canceled` result means cancellation committed. If another generation has
+replaced the result, the snapshot alone cannot establish the earlier outcome.
 
 Ordinary `listen` callbacks receive the public start and cancel reports, not the
 worker's internal activation report. Use `listen-commits` for commit notifications

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -5,6 +5,25 @@ enable it in a separate atomic commit. The same operation can add a uniqueness
 constraint. Reads and writes continue under the old schema while the build runs.
 This API is experimental.
 
+## Choose a migration mode
+
+Use an ordinary schema transaction when the caller needs the migration to
+finish before proceeding. It remains synchronous: successful completion means
+the schema change and its required index construction and validation committed
+together. The transaction-local `:allow-index-backfill?` option permits that
+work; it does not start a background job. This path can hold up other writes
+and can require substantial memory for large attributes.
+
+Choose `begin-avet-build!` explicitly for online maintenance when writes need
+to continue during construction. It is not the default and does not replace
+ordinary schema transactions. Its promise acknowledges the request, not a
+completed migration. The caller must monitor that generation to a terminal
+result before relying on the new index or uniqueness constraint. Background
+construction still consumes CPU, I/O, and scratch space and can affect write
+latency or reject writes when journal limits are reached.
+
+## Deployment requirements
+
 **Upgrade every garbage collector sharing the store before using this API.**
 Older Datahike versions do not recognize the AVET build marker and can delete
 unpublished index nodes even while the source pin remains live. Alternatively,
@@ -68,6 +87,14 @@ include a reason. This is snapshot state, not a worker-liveness check or a
 complete job history. Keep the request report's `:avet-build-id` when monitoring
 a request: reports in one batch share its final `:db-after`, which may already
 describe a later generation.
+
+Treat only `:ready` for the saved generation as successful completion.
+`:failed` and `:canceled` are unsuccessful outcomes, not completed migrations.
+A different generation's status does not establish the outcome of your
+request; retain its observed result before starting another build if that
+outcome must be recorded. A monitoring timeout does not cancel the build.
+Cancellation must be requested explicitly and can race with activation;
+inspect a fresh snapshot to determine which operation committed.
 
 Ordinary `listen` callbacks receive the public start and cancel reports, not the
 worker's internal activation report. Use `listen-commits` for commit notifications
@@ -162,7 +189,3 @@ Normal completion, cancellation, and orderly writer shutdown clean up owned
 scratch. A process crash can leave files behind. Use a dedicated scratch
 directory and remove abandoned files only after confirming their writer has
 stopped. Reclamation of unused immutable store nodes remains the collector's job.
-
-Ordinary schema transactions remain synchronous. Their existing
-`:allow-index-backfill?` transaction option is separate from this API and does
-not start a background build.

--- a/doc/avet-backfill.md
+++ b/doc/avet-backfill.md
@@ -135,6 +135,10 @@ retrying. Sort or private-storage failures fail the background request. Very
 high write rates can delay activation; bounded catch-up does not guarantee a
 completion deadline or a fixed write-pause duration.
 
+If build ownership changes between predicate validation and journal staging,
+the in-flight transaction is rejected with `:retryable? true` rather than
+publishing a state its predicates did not validate. Retry against a fresh head.
+
 ## Recovery and garbage collection
 
 Schema changes invalidate an active build. A different writer taking over its

--- a/doc/secondary-indices.md
+++ b/doc/secondary-indices.md
@@ -438,8 +438,10 @@ charged to that journal.
 Installation still replays the accumulated journal in the serialized writer;
 a large journal can therefore pause writes. These limits bound journal buffers
 and disk use, not the adapter's own index-building memory, transaction input,
-or aggregate resources across many simultaneous builds. Background AVET
-construction is not supported; attribute-index backfill remains synchronous.
+or aggregate resources across many simultaneous builds. Attribute indexing has
+a separate [background AVET API](avet-backfill.md), with its own shared-writer
+requirements and limits. Ordinary schema transactions still backfill AVET
+synchronously.
 
 Scratch is removed after successful installation, cancellation, or orderly
 writer shutdown. Reconnect rebuilds from durable primary data rather than

--- a/src/datahike/api/impl.cljc
+++ b/src/datahike/api/impl.cljc
@@ -18,6 +18,7 @@
             [datahike.impl.entity :as de]
             [datahike.versioning :as dv]
             [datahike.bitemporal.predicate :as bp.pred]
+            #?(:clj [clojure.core.async :as async])
             [replikativ.logging :as log]
             #?(:cljs [clojure.core.async :as async :refer [<! >! chan put! close!]]))
   #?(:cljs (:require-macros [superv.async :refer [go-try- <?-]]
@@ -46,6 +47,44 @@
      @(transact! connection arg-map)
      :cljs (throw (ex-info "Synchronous transact not supported in ClojureScript, use transact! instead."
                            {:error :transact/sync-not-supported}))))
+
+#?(:clj
+   (defn- dispatch-avet! [connection op args]
+     (let [database @(:wrapped-atom connection)
+           writer (:writer database)
+           _ (when-not (and (instance? datahike.writer.LocalWriter writer)
+                            (= :self (get-in database [:config :writer :backend] :self)))
+               (throw (ex-info "Background AVET operations require a local JVM writer."
+                               {:type :avet-build-unsupported-writer})))
+           result (dt/throwable-promise)
+           channel (dw/dispatch! writer {:op op :args args})]
+       (async/take!
+        channel
+        (fn [report]
+          (deliver result (or report (ex-info "AVET writer closed without a report."
+                                              {:type :avet-writer-closed})))
+          (when (map? report)
+            (doseq [[listener-id callback] (some-> (:listeners (meta connection)) deref)]
+              (try (callback report)
+                   (catch Throwable e
+                     (log/warn :datahike/avet-listener-failed
+                               {:listener listener-id :message (ex-message e)})))))))
+       result)))
+
+(defn begin-avet-build! [connection patch]
+  #?(:clj (dispatch-avet! connection 'begin-avet-build! [patch])
+     :cljs (throw (ex-info "Background AVET builds require a local JVM writer."
+                           {:type :avet-build-unsupported-platform}))))
+
+(defn cancel-avet-build! [connection generation]
+  #?(:clj (dispatch-avet! connection 'cancel-avet-build! [generation])
+     :cljs (throw (ex-info "Background AVET builds require a local JVM writer."
+                           {:type :avet-build-unsupported-platform}))))
+
+(defn avet-build-status [database]
+  (if-let [build (:avet-build database)]
+    (select-keys build [:id :status :patch])
+    (:avet-build-result database)))
 
 ;; necessary to support initial-tx shorthand, which really should have been avoided
 (defn create-database [& args]

--- a/src/datahike/api/specification.cljc
+++ b/src/datahike/api/specification.cljc
@@ -239,6 +239,36 @@
                  :code "@(transact! conn [{:db/id -1 :name \"Alice\"}])"}]
      :impl datahike.api.impl/transact!}
 
+    begin-avet-build!
+    {:args [:=> [:cat :datahike/SConnection :map] :any]
+     :ret :any
+     :categories [:schema :write :async]
+     :stability :alpha
+     :supports-remote? false
+     :referentially-transparent? false
+     :doc "Start a background AVET build on a local JVM shared, explicitly fenced, non-crypto persistent-set writer. Patch maps existing attribute idents to {:db/index true} and/or {:db/unique :db.unique/value|:db.unique/identity}. Returns a throwable promise for the accepted request report, NOT completion. Its :avet-build-id identifies this request even when reports share a batch's final db-after. The old schema remains effective until atomic activation. Inspect avet-build-status for completion."
+     :impl datahike.api.impl/begin-avet-build!}
+
+    cancel-avet-build!
+    {:args [:=> [:cat :datahike/SConnection :uuid] :any]
+     :ret :any
+     :categories [:schema :write :async]
+     :stability :alpha
+     :supports-remote? false
+     :referentially-transparent? false
+     :doc "Cancel the exact UUID generation of a local JVM AVET build. Returns a throwable promise for its committed cancellation report. A stale generation is rejected without canceling its replacement."
+     :impl datahike.api.impl/cancel-avet-build!}
+
+    avet-build-status
+    {:args [:=> [:cat :datahike/SDB] [:maybe :map]]
+     :ret [:maybe :map]
+     :categories [:schema :query]
+     :stability :alpha
+     :supports-remote? false
+     :referentially-transparent? true
+     :doc "Return this database snapshot's active AVET request or most recent result, or nil. :status is :building, :ready, :failed, or :canceled. :id identifies the generation; failures/cancellation include :reason. This is durable snapshot state, not a worker-liveness check or a history of all builds."
+     :impl datahike.api.impl/avet-build-status}
+
     load-entities
     {:args [:=> [:cat :datahike/SConnection :datahike/STransactions] :any]
      :ret :any

--- a/src/datahike/backfill/admission.clj
+++ b/src/datahike/backfill/admission.clj
@@ -52,7 +52,7 @@
      :attrs (set (keys entries))
      :unique-attrs (into #{} (keep (fn [[ident {:keys [new]}]]
                                      (when (:db/unique new) ident))) entries)
-     :tx-data (into [] (mapcat (fn [[ident {:keys [old new eid]}]]
+     :tx-data (into [] (mapcat (fn [[_ {:keys [old new eid]}]]
                                  (keep (fn [flag]
                                          (when (not= (get old flag) (get new flag))
                                            [:db/add eid flag (get new flag)]))
@@ -70,7 +70,7 @@
 (defn- source-cursor! [source cursor]
   (when-not (and (uuid? (:generation cursor)) (uuid? (:journal-id cursor))
                  (integer? (:sequence cursor)) (pos? (:sequence cursor))
-                 (integer? (:offset cursor)) (pos? (:offset cursor))
+                 (some? (:position cursor))
                  (= (:generation cursor) (get-in source [:avet-build :id]))
                  (= cursor (get-in source [:avet-build-journal :cursor]))
                  (not (:avet-build-invalidated? source))
@@ -117,7 +117,7 @@
                    (= (:generation previous) (:generation cursor) (:generation transaction))
                    (= (:journal-id previous) (:journal-id cursor))
                    (= (inc (:sequence previous)) (:sequence cursor) (:sequence transaction))
-                   (< (:offset previous) (:offset cursor))
+                   (not= (:position previous) (:position cursor))
                    (= :transaction (:kind transaction))
                    (= (:max-tx next-source) (:max-tx transaction))
                    (vector? (:effects transaction)))
@@ -202,9 +202,8 @@
                             (= (:generation cursor) (:generation next-cursor) (:generation frame))
                             (= (:journal-id cursor) (:journal-id next-cursor))
                             (= (inc (:sequence cursor)) (:sequence next-cursor) (:sequence frame))
-                            (integer? (:offset next-cursor))
-                            (< (:offset cursor) (:offset next-cursor))
-                            (<= (:offset next-cursor) (:offset final-cursor))
+                            (some? (:position next-cursor))
+                            (not= (:position cursor) (:position next-cursor))
                             (<= (:sequence next-cursor) (:sequence final-cursor))
                             (integer? (:max-tx frame)) (<= max-tx (:max-tx frame))
                             (vector? (:effects frame)))

--- a/src/datahike/backfill/admission.clj
+++ b/src/datahike/backfill/admission.clj
@@ -1,0 +1,276 @@
+(ns ^:no-doc datahike.backfill.admission
+  "Process-local admission of owned AVET candidates. Not a transaction option
+   or a serialized capability. The coordinator owns journal authenticity,
+   storage lifetime, and final conditional publication."
+  (:require [datahike.backfill.effects :as effects]
+            [datahike.backfill.unique :as unique]
+            [datahike.backfill.storage :as storage]
+            [datahike.db.utils :as dbu]
+            [datahike.schema :as schema]
+            [datahike.index.interface :as di])
+  (:import [org.replikativ.persistent_sorted_set PersistentSortedSet]
+           [datahike.backfill.storage PrivateStorage]))
+
+(defn- fail! [message]
+  (throw (ex-info message {:type ::invalid-admission})))
+
+(defn plan
+  "Resolve an enable-only map of canonical attribute idents to index/unique
+   flags. Produces the exact known-entity transaction; no user data or other
+   schema updates can be appended to an admission. Ordinary schema validation
+   still runs when this transaction is applied."
+  [source patch]
+  (when-not (and (map? patch) (seq patch) (<= (count patch) 256))
+    (fail! "An AVET patch must contain between 1 and 256 attributes."))
+  (let [entries
+        (into (sorted-map)
+              (map (fn [[ident flags]]
+                     (let [old (get-in source [:schema ident])
+                           eid (when (keyword? ident) (dbu/entid source ident))]
+                       (when-not (and (keyword? ident) (not (schema/is-system-keyword? ident))
+                                      (map? old) (integer? eid)
+                                      (map? flags) (seq flags)
+                                      (every? #{:db/index :db/unique} (keys flags))
+                                      (or (not (contains? flags :db/index))
+                                          (true? (:db/index flags)))
+                                      (or (not (contains? flags :db/unique))
+                                          (contains? #{:db.unique/value :db.unique/identity}
+                                                     (:db/unique flags)))
+                                      (or (not (:db/unique old))
+                                          (not (contains? flags :db/unique))
+                                          (= (:db/unique old) (:db/unique flags)))
+                                      (not= old (merge old flags)))
+                         (fail! "AVET patches may only enable flags on existing schema entities."))
+                       (let [new (merge old flags)
+                             assessment (schema/assess-schema-transition
+                                         old new (= :write (get-in source [:config :schema-flexibility])))]
+                         (when (seq (:invalid assessment))
+                           (fail! "Requested AVET flags produce invalid schema."))
+                         [ident {:old old :new new :eid eid}])))
+                   patch))]
+    {:patch patch :schema (:schema source) :entries entries
+     :attrs (set (keys entries))
+     :unique-attrs (into #{} (keep (fn [[ident {:keys [new]}]]
+                                     (when (:db/unique new) ident))) entries)
+     :tx-data (into [] (mapcat (fn [[ident {:keys [old new eid]}]]
+                                 (keep (fn [flag]
+                                         (when (not= (get old flag) (get new flag))
+                                           [:db/add eid flag (get new flag)]))
+                                       [:db/index :db/unique]))) entries)}))
+
+(def ^:private issuer (Object.))
+(deftype ^:private Certificate [issuer state])
+
+(defn- state [certificate]
+  (when-not (and (instance? Certificate certificate)
+                 (identical? issuer (.-issuer ^Certificate certificate)))
+    (fail! "Expected a local checked AVET certificate."))
+  (.-state ^Certificate certificate))
+
+(defn- source-cursor! [source cursor]
+  (when-not (and (uuid? (:generation cursor)) (uuid? (:journal-id cursor))
+                 (integer? (:sequence cursor)) (pos? (:sequence cursor))
+                 (integer? (:offset cursor)) (pos? (:offset cursor))
+                 (= (:generation cursor) (get-in source [:avet-build :id]))
+                 (= cursor (get-in source [:avet-build-journal :cursor]))
+                 (not (:avet-build-invalidated? source))
+                 (empty? (:avet-build-effects source)))
+    (fail! "Candidate source is not at the exact complete build cursor.")))
+
+(defn- observed-attrs [source request]
+  (into (:attrs request)
+        (keep (fn [[ident entry]]
+                (when (and (keyword? ident) (map? entry)
+                           (or (:db/index entry) (:db/unique entry)))
+                  ident)))
+        (:schema source)))
+
+(defn mint!
+  "Worker-only full uniqueness validation. Candidate must be the complete
+   AVET family built from source and owned until publication or cancellation.
+   This constructor scans data: never call it in writer admission. A typed
+   certificate authenticates this validation, not arbitrary caller-built trees."
+  [source candidate patch cursor]
+  (source-cursor! source cursor)
+  (let [request (plan source patch)]
+    (when-not (and (instance? PersistentSortedSet (:current candidate))
+                   (or (nil? (:temporal candidate)) (instance? PersistentSortedSet (:temporal candidate)))
+                   (if (:store source)
+                     (instance? PrivateStorage (:storage candidate))
+                     (nil? (:storage candidate)))
+                   (or (not (get-in source [:config :keep-history?])) (:temporal candidate))
+                   (set? (get-in source [:avet-build :attrs]))
+                   (every? (get-in source [:avet-build :attrs]) (observed-attrs source request)))
+      (fail! "Candidate lacks the complete requested AVET family."))
+    (unique/validate! source (:current candidate) (:unique-attrs request))
+    (Certificate. issuer {:source source :candidate candidate :request request :cursor cursor})))
+
+(defn advance
+  "Coordinator-only advancement over ONE authenticated complete transaction.
+   Replays effects itself, then checks touched values. The coordinator supplies
+   the exact resulting source and journal boundary, never speculative frames."
+  [certificate next-source transaction cursor]
+  (let [{:keys [source candidate request] previous :cursor} (state certificate)]
+    (source-cursor! next-source cursor)
+    (when-not (and (= (:schema source) (:schema next-source))
+                   (= (:avet-build source) (:avet-build next-source))
+                   (= (:generation previous) (:generation cursor) (:generation transaction))
+                   (= (:journal-id previous) (:journal-id cursor))
+                   (= (inc (:sequence previous)) (:sequence cursor) (:sequence transaction))
+                   (< (:offset previous) (:offset cursor))
+                   (= :transaction (:kind transaction))
+                   (= (:max-tx next-source) (:max-tx transaction))
+                   (vector? (:effects transaction)))
+      (fail! "AVET certificate advancement requires the next complete transaction."))
+    (let [candidate' (reduce effects/replay candidate (:effects transaction))]
+      (unique/validate-effects! next-source (:current candidate') (:unique-attrs request)
+                                (:effects transaction))
+      (Certificate. issuer {:source next-source :candidate candidate'
+                            :request request :cursor cursor}))))
+
+(defn transaction-data [certificate] (:tx-data (:request (state certificate))))
+(defn candidate [certificate] (:candidate (state certificate)))
+(defn cursor [certificate] (:cursor (state certificate)))
+
+(defn flush!
+  "Persist both owned candidate trees and their private pending nodes before
+   handoff. Returns a certificate for the flushed root objects. Must run on the
+   worker/coordinator, never inside pure core/with. Advancement clears this seal."
+  [certificate]
+  (let [{:keys [candidate] :as checked} (state certificate)]
+    (if-let [private (:storage candidate)]
+      (let [backend (storage/build-store private)
+            candidate' (cond-> (update candidate :current di/-flush backend)
+                         (:temporal candidate) (update :temporal di/-flush backend))]
+        (storage/flush! private)
+        (Certificate. issuer (assoc checked :candidate candidate' :flushed? true)))
+      certificate)))
+
+(defn- live-candidate [checked]
+  (let [{:keys [source candidate]} checked]
+    (if (:storage candidate)
+      (let [live-storage (get-in source [:store :storage])]
+        (when-not live-storage (fail! "Prepared AVET activation requires live publication storage."))
+        (cond-> (update candidate :current #(di/with-storage :datahike.index/persistent-set % live-storage))
+          (:temporal candidate) (update :temporal #(di/with-storage :datahike.index/persistent-set % live-storage))))
+      candidate)))
+
+(defn rebind-source
+  "Bind an authoritative writer wrapper to the same checked state. The same
+   commit content with a DIFFERENT storage revision is not the same fence.
+   Never substitutes database equality or a transaction number for root identity."
+  [certificate actual-source]
+  (let [{:keys [source cursor] :as checked} (state certificate)
+        commit-id (get-in source [:meta :datahike/commit-id])
+        revision (:datahike.writing/head-revision source)]
+    (source-cursor! actual-source cursor)
+    (when-not (and (some? commit-id) (some? revision)
+                   (= commit-id (get-in actual-source [:meta :datahike/commit-id]))
+                   (= revision (:datahike.writing/head-revision actual-source))
+                   (every? #(identical? (get source %) (get actual-source %))
+                           [:eavt :aevt :avet :temporal-eavt :temporal-aevt :temporal-avet :store])
+                   (= (select-keys source [:schema :rschema :ident-ref-map :ref-ident-map
+                                           :config :meta :avet-build :avet-build-journal
+                                           :secondary-indices :secondary-index-keys :system-entities :hash :max-eid :max-tx :op-count
+                                           :datahike.writing/stored-head-identity])
+                      (select-keys actual-source [:schema :rschema :ident-ref-map :ref-ident-map
+                                                  :config :meta :avet-build :avet-build-journal
+                                                  :secondary-indices :secondary-index-keys :system-entities :hash :max-eid :max-tx :op-count
+                                                  :datahike.writing/stored-head-identity])))
+      (fail! "Writer source differs from the checked roots, schema, commit or storage fence."))
+    (Certificate. issuer (assoc checked :source actual-source))))
+
+(defn advance-range
+  "Advance through a scoped authenticated journal reduction, retaining one
+   candidate and cursor. reduce-frames takes [f init]; f takes [acc frame cursor].
+   Check each complete transaction before proceeding, then bind the result to
+   the exact leased final source. Intermediate source DBs are unnecessary while
+   the generation's schema and ident mapping remain unchanged."
+  [certificate final-source final-cursor reduce-frames]
+  (let [{:keys [source candidate request] previous :cursor} (state certificate)]
+    (source-cursor! final-source final-cursor)
+    (when-not (and (= (:schema source) (:schema final-source))
+                   (= (:ident-ref-map source) (:ident-ref-map final-source))
+                   (= (:avet-build source) (:avet-build final-source))
+                   (= (select-keys previous [:generation :journal-id])
+                      (select-keys final-cursor [:generation :journal-id])))
+      (fail! "AVET range no longer belongs to the checked schema and generation."))
+    (let [result
+          (reduce-frames
+           (fn [{:keys [candidate cursor max-tx]} frame next-cursor]
+             (when-not (and (= :transaction (:kind frame))
+                            (= (:generation cursor) (:generation next-cursor) (:generation frame))
+                            (= (:journal-id cursor) (:journal-id next-cursor))
+                            (= (inc (:sequence cursor)) (:sequence next-cursor) (:sequence frame))
+                            (integer? (:offset next-cursor))
+                            (< (:offset cursor) (:offset next-cursor))
+                            (<= (:offset next-cursor) (:offset final-cursor))
+                            (<= (:sequence next-cursor) (:sequence final-cursor))
+                            (integer? (:max-tx frame)) (<= max-tx (:max-tx frame))
+                            (vector? (:effects frame)))
+               (fail! "AVET range contains a noncontiguous or incomplete transaction."))
+             (let [next-candidate (reduce effects/replay candidate (:effects frame))]
+               (unique/validate-effects! final-source (:current next-candidate)
+                                         (:unique-attrs request) (:effects frame))
+               {:candidate next-candidate :cursor next-cursor :max-tx (:max-tx frame)}))
+           {:candidate candidate :cursor previous :max-tx (:max-tx source)})]
+      (when-not (and (= final-cursor (:cursor result))
+                     (= (:max-tx final-source) (:max-tx result))
+                     (or (not= previous final-cursor) (identical? source final-source)))
+        (fail! "AVET range did not reach the exact leased source boundary."))
+      (Certificate. issuer {:source final-source :candidate (:candidate result)
+                            :request request :cursor final-cursor}))))
+
+(defn check!
+  "Verify exact source identity and generated transaction before any mutation."
+  [certificate source tx-data]
+  (let [{checked :source :keys [request cursor]} (state certificate)]
+    (source-cursor! source cursor)
+    (when-not (and (identical? source checked)
+                   (= (:schema source) (:schema request))
+                   (= tx-data (:tx-data request)))
+      (fail! "Prepared AVET admission does not match this source and schema patch.")))
+  (when-let [private (:storage (:candidate (state certificate)))]
+    (let [{:keys [closed? failed? pending-nodes]} (storage/resources private)]
+      (when (or (not (:flushed? (state certificate))) closed? failed? (pos? pending-nodes))
+        (fail! "Prepared private AVET roots must be flushed and owned before activation."))))
+  certificate)
+
+(defn prepare-db [certificate source]
+  (check! certificate source (transaction-data certificate))
+  (let [{:keys [request] :as checked} (state certificate)
+        candidate (live-candidate checked)]
+    (-> source
+        (assoc :avet (:current candidate) :temporal-avet (:temporal candidate))
+        (dissoc :avet-build :avet-build-journal :avet-build-effects :avet-build-invalidated?)
+        (effects/observe (observed-attrs source request)))))
+
+(defn covers?
+  "Only the exact certified old/new schema entry may skip a synchronous sweep."
+  [certificate ident old-entry new-entry]
+  (when certificate
+    (let [entry (get-in (state certificate) [:request :entries ident])]
+      (and entry (= old-entry (:old entry)) (= new-entry (:new entry))))))
+
+(defn finish
+  "Check activation's exact primary effects after all tuples and metadata have
+   settled. Keep ordinary per-datom uniqueness checks as well."
+  [certificate report]
+  (if-not certificate
+    report
+    (let [{:keys [request] :as checked} (state certificate)
+          candidate (live-candidate checked)
+          after (:db-after report)
+          observations (effects/observations after)
+          ;; A derived tuple may change before its requested index flag becomes
+          ;; schema-visible. Replay the complete activation into the original
+          ;; certified roots, not into roots already changed by native hooks.
+          trees (reduce effects/replay candidate observations)
+          after (assoc after :avet (:current trees) :temporal-avet (:temporal trees))]
+      (doseq [[ident {:keys [old new]}] (:entries request)]
+        (when-not (and (= old (get-in report [:db-before :schema ident]))
+                       (= new (get-in after [:schema ident])))
+          (fail! "Activation did not produce its certified schema patch.")))
+      (unique/validate-effects! after (:avet after) (:unique-attrs request)
+                                observations)
+      (assoc report :db-after (effects/unobserve after)))))

--- a/src/datahike/backfill/avet.clj
+++ b/src/datahike/backfill/avet.clj
@@ -1,0 +1,113 @@
+(ns ^:no-doc datahike.backfill.avet
+  "Private AVET-family construction from an exact pinned source. The caller
+   owns durable build sweep deferral and the local GC guard throughout building
+   and publication. This is not schema activation or uniqueness validation."
+  (:require [datahike.backfill.sort :as sort]
+            [datahike.backfill.control :as control]
+            [datahike.backfill.storage :as storage]
+            [datahike.constants :as constants]
+            [datahike.datom :as dd]
+            [datahike.index.interface :as di]
+            [org.replikativ.persistent-sorted-set :as pss])
+  (:import [datahike.datom Datom]))
+
+(defn- tuple [^Datom d]
+  [(.-e d) (.-a d) (.-v d) (dd/datom-tx d) (dd/datom-added d)])
+
+(defn- datom [record]
+  (dd/datom (nth record 0) (nth record 1) (nth record 2) (nth record 3) (nth record 4)))
+
+(defn- merged-distinct
+  "Merge sorted sequences with comparator equality, retaining one prior key."
+  [cmp left right]
+  (letfn [(step [left right previous]
+            (lazy-seq
+             (loop [left (seq left) right (seq right)]
+               (when (or left right)
+                 (control/check!)
+                 (let [choose-left? (or (nil? right) (and left (<= (cmp (first left) (first right)) 0)))
+                       value (if choose-left? (first left) (first right))
+                       next-left (if choose-left? (next left) left)
+                       next-right (if choose-left? right (next right))]
+                   (if (and previous (zero? (cmp previous value)))
+                     (recur next-left next-right)
+                     (cons value (step next-left next-right value))))))))]
+    (step left right nil)))
+
+(defn- source-slice [source tree-key attribute]
+  (di/-slice (get source tree-key)
+             (dd/datom constants/e0 attribute nil constants/tx0)
+             (dd/datom constants/emax attribute nil constants/txmax)
+             :aevt))
+
+(defn- build-tree! [source private attrs current? sort-options]
+  (let [primary-key (if current? :aevt :temporal-aevt)
+        avet-key (if current? :avet :temporal-avet)
+        cmp (dd/index-type->cmp-quick :avet false)
+        additions (mapcat #(map tuple (source-slice source primary-key %)) attrs)
+        store (storage/build-store private)]
+    (sort/with-sorted-records!
+      additions (fn [a b] (cmp (datom a) (datom b))) sort-options
+      (fn [records]
+        (let [entries (merged-distinct cmp (get source avet-key) (map datom records))
+              ;; Unlike init-index-sorted's :indexed filter, this native builder
+              ;; preserves ALL old entries, including disabled historical attrs.
+              tree (pss/from-sorted-seq
+                    cmp entries {:storage private
+                                 :meta (assoc (meta (get source avet-key)) :index-type :avet)
+                                 :branching-factor (get store :datahike/branching-factor 512)
+                                 :ref-type :weak
+                                 :diff-buf-size 0})]
+          (storage/flush! private)
+          (di/with-storage :datahike.index/persistent-set tree private))))))
+
+(defn close!
+  "Release candidate buffers. Written private nodes remain protected by the
+   caller until publication/cancellation and otherwise become ordinary GC garbage."
+  [candidate]
+  (.close ^java.io.Closeable (:storage candidate)))
+
+(defn build!
+  "Build current/temporal AVET without changing source schema or primary roots.
+   attrs are existing attribute idents to add (already-indexed attrs are safe).
+   Returns {:current tree :temporal tree-or-nil :storage owned-private-storage}.
+   Caller closes successful results. Both sort scopes close before return.
+
+   Sort and storage options retain their own documented budgets; source decoding,
+   the builder frontier and caller-retained DBs are outside those buffer limits.
+   Requires the private storage capability (JVM PSS, non-crypto, no diff buffers)."
+  ([source attrs] (build! source attrs nil))
+  ([source attrs options]
+   (when-not (and (or (nil? options) (map? options))
+                  (every? #{:sort :storage} (keys options))
+                  (or (set? attrs) (sequential? attrs)))
+     (throw (ex-info "Invalid AVET build options or attributes." {:type ::invalid-options})))
+   (let [attrs (reduce (fn [seen ident]
+                         (when-not (and (keyword? ident) (map? (get-in source [:schema ident])))
+                           (throw (ex-info "AVET build requires an existing attribute ident."
+                                           {:type ::invalid-attribute :attribute ident})))
+                         (conj seen ident))
+                       #{} attrs)
+         resolved (mapv (fn [ident]
+                          (if (get-in source [:config :attribute-refs?])
+                            (or (get-in source [:ident-ref-map ident])
+                                (throw (ex-info "Missing attribute reference." {:type ::invalid-attribute :attribute ident})))
+                            ident)) attrs)
+         sort-options (sort/validate-options! (:sort options))
+         private (storage/create! (:store source) (:config source) (:storage options))]
+     (try
+       (let [source (reduce (fn [source key]
+                              (if-let [tree (get source key)]
+                                (assoc source key (storage/copy-index!
+                                                   private tree
+                                                   {:resident-source? (= :memory (get-in source [:config :store :backend]))}))
+                                source))
+                            source [:aevt :avet :temporal-aevt :temporal-avet])]
+         {:current (build-tree! source private resolved true sort-options)
+          :temporal (when (get-in source [:config :keep-history?])
+                      (build-tree! source private resolved false sort-options))
+          :storage private})
+       (catch Throwable e
+         (try (.close ^java.io.Closeable private)
+              (catch Throwable cleanup-error (.addSuppressed e cleanup-error)))
+         (throw e))))))

--- a/src/datahike/backfill/control.cljc
+++ b/src/datahike/backfill/control.cljc
@@ -1,0 +1,6 @@
+(ns ^:no-doc datahike.backfill.control
+  "Internal cooperative worker cancellation. Never a transaction option.")
+
+(def ^:dynamic *check!* (fn [] nil))
+
+(defn check! [] (*check!*))

--- a/src/datahike/backfill/coordinator.clj
+++ b/src/datahike/backfill/coordinator.clj
@@ -220,7 +220,8 @@
           (fn [lease]
             (let [certificate (:certificate @work)
                   before (admission/cursor certificate) after (:cursor lease)]
-              (if (or (> (- (:offset after) (:offset before)) (get-in owner [:options :tail-bytes]))
+              (if (or (> (runtime/range-byte-size (:runtime owner) lease before)
+                         (get-in owner [:options :tail-bytes]))
                       (> (- (:sequence after) (:sequence before)) (get-in owner [:options :tail-transactions])))
                 (do (wake! work #(assoc % :phase :running)) {:status :retry})
                 (let [certificate (admission/flush! (advance! owner certificate lease))

--- a/src/datahike/backfill/coordinator.clj
+++ b/src/datahike/backfill/coordinator.clj
@@ -1,0 +1,300 @@
+(ns ^:no-doc datahike.backfill.coordinator
+  "Owned JVM AVET workers. Writer supplies internal dispatch and successful
+   commit notifications; no public transaction options or durable local tokens."
+  (:require [datahike.backfill.admission :as admission]
+            [datahike.backfill.avet :as avet]
+            [datahike.backfill.control :as control]
+            [datahike.backfill.job :as job]
+            [datahike.backfill.runtime :as runtime]
+            [datahike.gc-guard :as guard]
+            [datahike.gc-roots :as roots]
+            [datahike.store :as ds]
+            [replikativ.logging :as log])
+  (:import [java.util.concurrent ThreadPoolExecutor TimeUnit ArrayBlockingQueue
+            ThreadFactory]))
+
+(defn- fail! [kind message]
+  (throw (ex-info message {:type kind})))
+
+(defn- wake! [work f]
+  (locking work (swap! work f) (.notifyAll ^Object work)))
+
+(defn- submit! [owner request]
+  ;; Dispatch must enqueue, never await writer completion or run admission here.
+  ((get-in owner [:options :submit!]) request))
+
+(defn- renew-work! [work]
+  (when-let [root-id (:root-id @work)]
+    (when (> (- (System/nanoTime) (:renewed-nanos @work)) 60000000000)
+      ;; Renewal is owned by the worker/final-admission call, not a detached loop.
+      (roots/renew! (:source @work) root-id {:sync? true})
+      (swap! work assoc :renewed-nanos (System/nanoTime)))))
+
+(defn- check-work! [work]
+  (when (:cancel? @work) (fail! ::cancelled "AVET worker was cancelled."))
+  (renew-work! work))
+
+(defn- with-prefix [owner id f]
+  (let [lease (runtime/acquire-prefix! (:runtime owner) id)]
+    (try (f lease) (finally (runtime/release-prefix! (:runtime owner) lease)))))
+
+(defn- advance! [owner certificate lease]
+  (let [start (admission/cursor certificate)]
+    (if (= start (:cursor lease))
+      certificate
+      (admission/advance-range
+       certificate (:source-db lease) (:cursor lease)
+       (fn [f init]
+         (runtime/reduce-prefix (:runtime owner) lease start
+                                (fn [acc frame cursor]
+                                  (control/check!) (f acc frame cursor)) init))))))
+
+(defn- cleanup! [owner id work]
+  ;; Keep failed cleanup in the bounded registry so disk/pin failures cannot
+  ;; bypass job capacity. close! retries it and reports remaining failures.
+  (try
+    (when-let [candidate (:candidate @work)]
+      (avet/close! candidate)
+      (swap! work dissoc :candidate :certificate))
+    (when-let [root-id (:root-id @work)]
+      (roots/release! (:source @work) root-id {:sync? true})
+      (swap! work dissoc :root-id))
+    (when-let [token (:guard @work)]
+      (guard/done! (:store-id @work) token)
+      (swap! work dissoc :guard))
+    (swap! (:state owner) update :jobs dissoc id)
+    (catch Throwable e
+      (swap! work assoc :phase :cleanup-failed :cleanup-error e)
+      (log/warn :datahike/avet-cleanup-failed {:generation id :message (ex-message e)}))))
+
+(defn- await-offer! [work]
+  (loop []
+    (let [{:keys [phase cancel? terminal?]} @work]
+      (cond
+        terminal? :done
+        ;; Never reclaim storage from an active writer admission/commit.
+        (contains? #{:admitting :awaiting-commit} phase)
+        (do (renew-work! work) (locking work (.wait ^Object work 100)) (recur))
+        cancel? (fail! ::cancelled "AVET worker was cancelled.")
+        (= :running phase) :again
+        :else (do
+                ;; Renewal I/O must not hold the monitor needed by commit's
+                ;; nonblocking cancellation/notification callback.
+                (check-work! work)
+                (locking work (.wait ^Object work 100))
+                (recur))))))
+
+(defn- await-writer! [work]
+  ;; A renewal/cancellation failure can race the writer taking an offer. Even
+  ;; this exceptional path may not close private storage under an admission.
+  (locking work
+    (loop []
+      (when (and (not (:terminal? @work))
+                 (contains? #{:admitting :awaiting-commit} (:phase @work)))
+        (.wait ^Object work 100)
+        (recur)))))
+
+(defn- run-work! [owner id work]
+  (try
+    (binding [control/*check!* #(check-work! work)]
+      (control/check!)
+      (with-prefix
+        owner id
+        (fn [lease]
+          (let [source (:source-db lease)
+                sid (ds/canonical-store-id (:store source) (get-in source [:config :store]))]
+            (job/supported! source)
+            (when-not (job/matches? source (:avet-build source))
+              (fail! ::stale-source "Committed AVET source no longer matches its descriptor."))
+            (swap! work assoc :source source :store-id sid :guard (guard/writing! sid))
+            (let [root-id (roots/pin! source {:owner {:avet-build id}
+                                              :note "AVET background build"} {:sync? true})]
+              (swap! work assoc :root-id root-id :renewed-nanos (System/nanoTime)))
+            (control/check!)
+            (let [candidate (avet/build! source (keys (get-in source [:avet-build :patch]))
+                                         (get-in owner [:options :build-options]))]
+              (swap! work assoc :candidate candidate)
+              (let [certificate (admission/mint! source candidate
+                                                 (get-in source [:avet-build :patch]) (:cursor lease))]
+                (swap! work assoc :certificate certificate :phase :running))))))
+      (loop []
+        (control/check!)
+        (let [certificate (admission/flush! (with-prefix owner id #(advance! owner (:certificate @work) %)))]
+          (wake! work #(assoc % :certificate certificate :phase :offered :token (Object.)))
+          (submit! owner {:op :install :generation id :token (:token @work)})
+          (when (= :again (await-offer! work)) (recur)))))
+    (catch Throwable e
+      (swap! work assoc :failure e)
+      (when-not (or (:cancel? @work) (:terminal? @work))
+        (try (submit! owner {:op :cancel :generation id :reason :worker-failed})
+             (catch Throwable dispatch-error
+               (.addSuppressed e dispatch-error)))))
+    (finally
+      (wake! work #(assoc % :cancel? true))
+      (await-writer! work)
+      (cleanup! owner id work))))
+
+(defn create!
+  "Create bounded owned worker capacity. :submit! must enqueue internal request
+   maps without waiting for the writer. Call close! after writer admission and
+   commit drain; close never abandons resources used by an in-flight install."
+  [journal-runtime options]
+  (let [options (merge {:max-jobs (get-in journal-runtime [:options :max-contexts])
+                        :tail-bytes 1048576 :tail-transactions 128} options)]
+    (when-not (and (map? options)
+                   (every? #{:submit! :max-jobs :tail-bytes :tail-transactions :build-options} (keys options))
+                   (ifn? (:submit! options))
+                   (every? #(and (integer? %) (pos? %) (<= % Integer/MAX_VALUE))
+                           (map options [:max-jobs :tail-bytes :tail-transactions]))
+                   (<= (:max-jobs options) 1024))
+      (fail! ::invalid-options "Invalid AVET coordinator options."))
+    (let [factory (reify ThreadFactory
+                    (newThread [_ runnable]
+                      (doto (Thread. runnable "datahike-avet-worker") (.setDaemon true))))]
+      {:runtime journal-runtime :options options
+       :state (atom {:closed? false :jobs {}})
+       :executor (ThreadPoolExecutor. 1 1 0 TimeUnit/MILLISECONDS
+                                      (ArrayBlockingQueue. (int (:max-jobs options))) factory)})))
+
+(defn after-commit!
+  "Nonblocking successful-publication notification, AFTER runtime/committed!.
+   No pin/storage I/O and no waiting for workers on the commit loop. A capacity
+   failure fails only the background job, never the committed begin transaction."
+  [owner final-db start]
+  (let [active (get-in final-db [:avet-build :id])
+        state (:state owner)
+        created
+        (locking state
+          (doseq [[id work] (:jobs @state) :when (not= active id)]
+            (wake! work #(assoc % :cancel? true
+                                :terminal? (contains? #{:admitting :awaiting-commit} (:phase %)))))
+          (when (and start (not (:closed? @state)))
+            (let [id (:generation start)]
+              (when-not (get-in @state [:jobs id])
+                (if (>= (count (:jobs @state)) (get-in owner [:options :max-jobs]))
+                  :full
+                  (let [work (atom {:phase :queued :cancel? false})]
+                    (swap! state assoc-in [:jobs id] work)
+                    [id work]))))))]
+    (if (= :full created)
+      ;; Callback is required to be nonblocking. Do not turn failure to enqueue
+      ;; a failed-start cancellation into a durable transaction failure.
+      (do
+        (swap! state assoc :last-start-failure {:generation (:generation start) :reason :worker-capacity})
+        (try (submit! owner {:op :cancel :generation (:generation start) :reason :worker-capacity})
+             (catch Throwable e
+               (log/warn :datahike/avet-start-failed {:generation (:generation start) :message (ex-message e)}))))
+      (when created
+        (let [[id work] created]
+          (try (.execute ^ThreadPoolExecutor (:executor owner) #(run-work! owner id work))
+               (catch Throwable e
+                 (swap! state update :jobs dissoc id)
+                 (swap! state assoc :last-start-failure {:generation id :reason :worker-capacity})
+                 (try (submit! owner {:op :cancel :generation id :reason :worker-capacity})
+                      (catch Throwable nested (.addSuppressed e nested)))
+                 (log/warn :datahike/avet-start-failed {:generation id :message (ex-message e)}))))))
+    nil))
+
+(defn- owned-work! [owner token]
+  (or (some (fn [[id work]] (when (identical? token (:token @work)) [id work]))
+            (:jobs @(:state owner)))
+      (fail! ::stale-offer "Unknown or retired AVET install offer.")))
+
+(defn try-install!
+  "Take exclusive candidate ownership after a writer pending-batch boundary.
+   Returns ready certificate or retry without a transaction. Caller MUST invoke
+   accepted! or abort-install! after a ready result, including predicate errors."
+  [owner actual-source token]
+  (let [[id work] (owned-work! owner token)]
+    (locking work
+      (when-not (and (= :offered (:phase @work)) (not (:cancel? @work))
+                     (= id (get-in actual-source [:avet-build :id])))
+        (fail! ::stale-offer "AVET offer is no longer available for this generation."))
+      (swap! work assoc :phase :admitting))
+    (try
+      (binding [control/*check!* #(check-work! work)]
+        (job/supported! actual-source)
+        (control/check!)
+        (with-prefix
+          owner id
+          (fn [lease]
+            (let [certificate (:certificate @work)
+                  before (admission/cursor certificate) after (:cursor lease)]
+              (if (or (> (- (:offset after) (:offset before)) (get-in owner [:options :tail-bytes]))
+                      (> (- (:sequence after) (:sequence before)) (get-in owner [:options :tail-transactions])))
+                (do (wake! work #(assoc % :phase :running)) {:status :retry})
+                (let [certificate (admission/flush! (advance! owner certificate lease))
+                      certificate (admission/rebind-source certificate actual-source)]
+                  (roots/assert-live! (:source @work) (:root-id @work) roots/DEFAULT_TTL_MS {:sync? true})
+                  (swap! work assoc :certificate certificate)
+                  {:status :ready :certificate certificate}))))))
+      (catch Throwable e
+        ;; Only the explicit bounded-tail outcome is automatically retried.
+        ;; A deterministic admission failure must not race an endless reoffer.
+        (wake! work #(assoc % :phase :running :cancel? true))
+        (throw e)))))
+
+(defn accepted! [owner token]
+  (let [[_ work] (owned-work! owner token)]
+    (locking work
+      (when-not (= :admitting (:phase @work)) (fail! ::stale-offer "AVET admission is not owned."))
+      (swap! work assoc :phase :awaiting-commit)
+      (.notifyAll ^Object work)))
+  nil)
+
+(defn check-install!
+  "Assert an owned admission/queued install remains protected. Writer invokes
+   again immediately before conditional commit, not only before transaction
+   evaluation. Throws before publication if renewal/cancellation invalidated it."
+  [owner token]
+  (let [[_ work] (owned-work! owner token)]
+    (when-not (contains? #{:admitting :awaiting-commit} (:phase @work))
+      (fail! ::stale-offer "Install is not owned by the writer."))
+    (check-work! work)
+    (roots/assert-live! (:source @work) (:root-id @work) roots/DEFAULT_TTL_MS {:sync? true}))
+  nil)
+
+(defn with-install!
+  "Run activation and predicates with cooperative cancellation, before queue
+   acceptance. f must not enqueue/commit or release the install token itself."
+  [owner token f]
+  (let [[_ work] (owned-work! owner token)]
+    (binding [control/*check!* #(check-work! work)]
+      (check-install! owner token)
+      (let [result (f)]
+        (check-install! owner token)
+        result))))
+
+(defn abort-install!
+  "Return nonpublished candidate ownership. Definite conflicts retire it; a
+   predicate/admission failure may retry only within the same runtime lineage."
+  [owner token definite?]
+  (when-let [[_ work] (some (fn [[id work]] (when (identical? token (:token @work)) [id work]))
+                            (:jobs @(:state owner)))]
+    (wake! work #(cond-> (assoc % :phase :running) definite? (assoc :cancel? true))))
+  nil)
+
+(defn invalidate! [owner]
+  (doseq [[_ work] (:jobs @(:state owner))]
+    (wake! work #(assoc % :cancel? true)))
+  nil)
+
+(defn close!
+  "Cancel and JOIN all owned execution. Writer must first settle admissions and
+   commits with accepted/abort/after-commit callbacks. Cleanup failures remain
+   bounded and are reported; a second close retries them."
+  [owner]
+  (swap! (:state owner) assoc :closed? true)
+  (invalidate! owner)
+  (.shutdown ^ThreadPoolExecutor (:executor owner))
+  (let [interrupted? (volatile! false)]
+    (try
+      (loop []
+        (when-not (try (.awaitTermination ^ThreadPoolExecutor (:executor owner) 100 TimeUnit/MILLISECONDS)
+                       (catch InterruptedException _ (vreset! interrupted? true) false))
+          (recur)))
+      (doseq [[id work] (:jobs @(:state owner))] (cleanup! owner id work))
+      (when (seq (:jobs @(:state owner)))
+        (fail! ::cleanup-failed "AVET resources could not all be released; retry close."))
+      (finally (when @interrupted? (.interrupt (Thread/currentThread))))))
+  nil)

--- a/src/datahike/backfill/effects.cljc
+++ b/src/datahike/backfill/effects.cljc
@@ -1,0 +1,157 @@
+(ns ^:no-doc datahike.backfill.effects
+  "Pure primary-index effects for a private AVET generation. Capture does not
+   enable schema, publish cursors, or perform I/O. Writer admission owns those
+   boundaries and must invalidate generations on conflicting schema changes."
+  (:require [datahike.index.interface :as di]
+            [datahike.datom :as dd]))
+
+(def ^:private observer-defaults
+  {:max-effects 65536 :max-bytes 16777216 :max-nodes 262144 :max-depth 64})
+
+(defn- observer-error! [type message]
+  (throw (ex-info message {:type type})))
+
+(defn observer-options!
+  "Validate private observation limits. Bytes are conservative structural
+   accounting units, not a measurement of retained heap."
+  [options]
+  (when-not (and (or (nil? options) (map? options))
+                 (every? (set (keys observer-defaults)) (keys options)))
+    (observer-error! ::invalid-observer "Unknown observer options."))
+  (let [options (merge observer-defaults options)]
+    (doseq [[key value] options]
+      (when-not (and (integer? value) (pos? value)
+                     (<= value (if (= key :max-depth) 64 2147483647)))
+        (observer-error! ::invalid-observer "Observer limits must be positive bounded integers.")))
+    options))
+
+(defn- charge-effect [observer effect]
+  (let [{:keys [max-effects max-bytes max-nodes max-depth]} (:limits observer)
+        used (volatile! (select-keys observer [:bytes :nodes]))]
+    (when (>= (:count observer) max-effects)
+      (observer-error! ::observer-budget "Observer effect limit exceeded."))
+    (letfn [(charge! [n]
+              (when (> (+ (:bytes @used) n) max-bytes)
+                (observer-error! ::observer-budget "Observer structural byte limit exceeded."))
+              (vswap! used update :bytes + n))
+            (visit! [x depth]
+              (when (or (> depth max-depth) (>= (:nodes @used) max-nodes))
+                (observer-error! ::observer-budget "Observer nesting or node limit exceeded."))
+              (vswap! used update :nodes inc)
+              (charge! 64)
+              (when-let [metadata (meta x)] (visit! metadata (inc depth)))
+              (cond
+                (nil? x) nil
+                (string? x) (charge! (* 2 (count x)))
+                (or (keyword? x) (symbol? x))
+                (do (visit! (name x) (inc depth)) (visit! (namespace x) (inc depth)))
+                (dd/datom? x)
+                (doseq [v [(:e x) (:a x) (:v x) (dd/datom-tx x) (dd/datom-added x)]]
+                  (visit! v (inc depth)))
+                #?@(:clj
+                    [(instance? java.math.BigInteger x)
+                     (charge! (+ 32 (quot (+ 7 (.bitLength ^java.math.BigInteger x)) 8)))
+                     (instance? clojure.lang.BigInt x)
+                     (visit! (.toBigInteger ^clojure.lang.BigInt x) (inc depth))
+                     (instance? java.math.BigDecimal x)
+                     (visit! (.unscaledValue ^java.math.BigDecimal x) (inc depth))
+                     (ratio? x)
+                     (do (visit! (numerator x) (inc depth)) (visit! (denominator x) (inc depth)))
+                     (.isArray (class x))
+                     (let [n (java.lang.reflect.Array/getLength x)]
+                       (charge! (* 8 n))
+                       (when-not (.isPrimitive (.getComponentType (class x)))
+                         (dotimes [i n] (visit! (java.lang.reflect.Array/get x i) (inc depth)))))
+                     (instance? java.net.URI x) (visit! (str x) (inc depth))]
+                    :cljs
+                    [(array? x) (do (charge! (* 8 (alength x)))
+                                    (doseq [v x] (visit! v (inc depth))))
+                     (js/ArrayBuffer.isView x) (charge! (.-byteLength x))])
+                (or #?(:clj (or (instance? Long x) (instance? Integer x)
+                                (instance? Short x) (instance? Byte x)
+                                (instance? Double x) (instance? Float x))
+                       :cljs (number? x))
+                    (boolean? x) (uuid? x)
+                    #?(:clj (or (char? x) (instance? java.util.Date x))
+                       :cljs (inst? x))) nil
+                (map? x) (doseq [[k v] x] (visit! k (inc depth)) (visit! v (inc depth)))
+                (or (sequential? x) (set? x)) (doseq [v x] (visit! v (inc depth)))
+                :else (observer-error! ::invalid-observer "Unsupported observed value.")))]
+      (visit! effect 0)
+      (merge observer @used {:count (inc (:count observer))}))))
+
+(defn- observe-effect [db effect]
+  ;; Charge before retaining the effect. Failure leaves the input DB and its
+  ;; immutable budget untouched, including when a transaction retries.
+  (let [observer (charge-effect (::observer db) effect)]
+    (-> db (assoc ::observer observer) (update ::observations (fnil conj []) effect))))
+
+(defn schema-change
+  "Mark an active generation unusable after a schema mutation. Sticky even if
+   later operations restore the original schema: intermediate ident changes
+   can alter which writes the generation captures. Does not reject the tx."
+  [db]
+  (if (:avet-build db) (assoc db :avet-build-invalidated? true) db))
+
+(defn enabled?
+  "Whether exact primary effects are needed by a build or private admission."
+  [db]
+  (or (:avet-build db) (::observer db)))
+
+(defn observe
+  "Attach a pure private mutation observer to an unpublished activation DB.
+   Does not authorize schema changes or uniqueness deferral. The separately
+   validated admission context owns those decisions. No I/O or mutable sink."
+  ([db attrs] (observe db attrs nil))
+  ([db attrs options]
+   (when-not (and (set? attrs) (every? keyword? attrs))
+     (throw (ex-info "Observer attributes must be canonical idents." {:type ::invalid-observer})))
+   (when (::observer db)
+     (throw (ex-info "An admission observer is already attached." {:type ::invalid-observer})))
+   (-> db (assoc ::observer {:attrs attrs :limits (observer-options! options)
+                             :count 0 :bytes 0 :nodes 0})
+       (dissoc ::observations))))
+
+(defn observations [db] (get db ::observations []))
+
+(defn unobserve [db] (dissoc db ::observer ::observations))
+
+(defn emit
+  "Append one native index operation when the active generation covers ident.
+   :attrs contains resolved attribute idents, including existing indexed attrs
+   when the generation replaces the complete AVET family. The supplied datoms
+   are primary values (possibly hashes), not adapter notifications. Historical
+   removals cover every attribute: a full replacement AVET retains disabled
+   historical slices too, but must not retain their purged datoms."
+  [db ident family operation datom old-datom]
+  (let [effect [family operation datom old-datom]]
+    (cond-> db
+      (and (:avet-build db)
+           (or (contains? (get-in db [:avet-build :attrs]) ident)
+               (and (= family :temporal) (= operation :remove))))
+      (update :avet-build-effects (fnil conj []) effect)
+      (contains? (get-in db [::observer :attrs]) ident)
+      (observe-effect effect))))
+
+(defn replay
+  "Apply exact operations to {:current pss :temporal pss}. Only PSS is supported:
+   its operations ignore op-count. The caller owns private storage and flushing."
+  [trees [family operation datom old-datom]]
+  (when-not (contains? (case family
+                         :current #{:insert :remove :upsert}
+                         :temporal #{:temporal-insert :remove :temporal-upsert}
+                         #{}) operation)
+    (throw (ex-info "Invalid AVET effect family or operation."
+                    {:type ::invalid-effect :family family :operation operation})))
+  (update trees family
+          (fn [tree]
+            (when-not tree
+              (throw (ex-info "AVET effect has no target tree." {:type ::invalid-effect :family family})))
+            (case operation
+              :insert (di/-insert tree datom :avet 0)
+              :remove (di/-remove tree datom :avet 0)
+              :upsert (di/-upsert tree datom :avet 0 old-datom)
+              :temporal-insert (di/-temporal-insert tree datom :avet 0)
+              :temporal-upsert (di/-temporal-upsert tree datom :avet 0 old-datom)
+              (throw (ex-info "Unknown AVET effect operation."
+                              {:type ::invalid-effect :operation operation}))))))

--- a/src/datahike/backfill/job.clj
+++ b/src/datahike/backfill/job.clj
@@ -1,0 +1,55 @@
+(ns ^:no-doc datahike.backfill.job
+  "Durable AVET job descriptors and capability checks. No worker ownership,
+   journal cursor, proof object or candidate root is persisted in a descriptor."
+  (:require [clojure.set :as set]
+            [datahike.db.interface :as dbi]
+            [hasch.core :refer [uuid]]
+            [konserve.core :as k]))
+
+(defn supported!
+  "Require a local shared writer with an explicitly requested CAS domain.
+   Call at writer admission, after its authoritative head/revision reload."
+  [database]
+  (let [config (:config database)
+        writer (:writer config)
+        required (:require-fencing writer)]
+    (when-not (and (= :datahike.index/persistent-set (:index config))
+                   (false? (:crypto-hash? config))
+                   (zero? (get (:store database) :datahike/diff-buf-size 0))
+                   (= :self (get writer :backend :self))
+                   (= :shared (get writer :writer-ownership :shared))
+                   (contains? (set k/conditional-write-domains) required)
+                   (k/conditional-write? (:store database) required)
+                   (:datahike.writing/head-revision database))
+      (throw (ex-info
+              "Background AVET requires local shared ownership, explicit supported fencing, a revisioned head, and non-crypto PSS without diff buffers."
+              {:type ::unsupported :index (:index config)
+               :crypto-hash? (:crypto-hash? config)
+               :writer (select-keys writer [:backend :writer-ownership :require-fencing])}))))
+  nil)
+
+(defn schema-token [database]
+  (uuid [(:schema database) (:ident-ref-map database) (:ref-ident-map database)]))
+
+(defn descriptor
+  "Create one canonical durable descriptor from an admission/plan result.
+   Existing effective indexing coverage includes implicit/unique attributes;
+   historical-only removals are captured separately by the effect hooks."
+  [database plan]
+  (when (:avet-build database)
+    (throw (ex-info "An AVET build is already active." {:type ::already-building})))
+  {:id (random-uuid)
+   :status :building
+   :patch (:patch plan)
+   :attrs (set/union (set (dbi/-attrs-by database :db/index)) (:attrs plan))
+   :schema-token (schema-token database)
+   :branch (get-in database [:config :branch])})
+
+(defn matches?
+  "Validate an active descriptor against the writer's current schema and branch.
+   This is a prerequisite check, not the storage CAS or a proof of replay."
+  [database descriptor]
+  (and (uuid? (:id descriptor))
+       (= :building (:status descriptor))
+       (= (:branch descriptor) (get-in database [:config :branch]))
+       (= (:schema-token descriptor) (schema-token database))))

--- a/src/datahike/backfill/journal.clj
+++ b/src/datahike/backfill/journal.clj
@@ -75,6 +75,13 @@
   [descriptor left right]
   (file/compare-cursors descriptor left right))
 
+(defn range-byte-size
+  "Return backend-accounted bytes from left through right. Both cursors remain
+   opaque; callers use this only to enforce a resource budget. Reversed,
+   foreign, abandoned, or out-of-prefix ranges are rejected."
+  [descriptor left right]
+  (file/range-byte-size descriptor left right))
+
 (defn reduce-range
   "Reduce from an issued cursor through this descriptor's exact accepted end.
    f receives accumulator, notification and an opaque next cursor. Honors

--- a/src/datahike/backfill/journal/file.clj
+++ b/src/datahike/backfill/journal/file.clj
@@ -137,6 +137,20 @@
       (check-boundary! file descriptor right :backfill.journal/invalid-cursor)
       (compare (.-end ^Cursor left) (.-end ^Cursor right)))))
 
+(defn range-byte-size
+  "Return the physical byte span between two owned boundaries. This is backend
+   accounting for admission budgets, not a cursor representation guarantee."
+  [descriptor left right]
+  (let [path (checked-path descriptor)]
+    (with-open [file (RandomAccessFile. (.toFile path) "r")]
+      (check-end! file descriptor)
+      (check-boundary! file descriptor left :backfill.journal/invalid-cursor)
+      (check-boundary! file descriptor right :backfill.journal/invalid-cursor)
+      (let [distance (- (.-end ^Cursor right) (.-end ^Cursor left))]
+        (when (neg? distance)
+          (fail! :backfill.journal/invalid-cursor "Journal range is reversed." {}))
+        distance))))
+
 (defn- check-scalars!
   "Bound scalar allocations inside the codec before its output cap can act.
    Traversal has a node budget too, avoiding unbounded collection preflight."

--- a/src/datahike/backfill/runtime.clj
+++ b/src/datahike/backfill/runtime.clj
@@ -30,7 +30,10 @@
   (when (:closed? @state) (fail! ::closed "AVET runtime is closed.")))
 
 (defn- cursor [id descriptor sequence]
-  {:generation id :journal-id (:id descriptor) :offset (:end descriptor) :sequence sequence})
+  {:generation id
+   :journal-id (journal/descriptor-id descriptor)
+   :position (journal/end-cursor descriptor)
+   :sequence sequence})
 
 (defn- cleanup! [state]
   (doseq [[id context] (:contexts @state)
@@ -154,8 +157,9 @@
                                        (get-in report [:db-after :avet-build :id])])
                                     original-reports))
               start? (and context (not (:retired? context)) (not (:started? context)))]
-          ;; A byte offset and sequence must describe the SAME accepted frame
-          ;; boundary, not merely fit independently inside the staged ranges.
+          ;; The opaque cursor position and sequence must describe the SAME
+          ;; accepted frame boundary, not merely fit independently inside the
+          ;; staged ranges.
           ;; The group's original final report is the bounded authority for the
           ;; published prefix. Empty groups may retry cleanup, not advance it.
           (when (and (seq original-reports)
@@ -171,16 +175,25 @@
             (when (and (empty? original-reports) (not= prefix (:committed context)))
               (fail! ::invalid-commit "An empty commit group cannot advance an AVET prefix."))
             (when-not (and (= id (get-in prefix [:cursor :generation]))
-                           (= (get-in context [:descriptor :id]) (get-in prefix [:cursor :journal-id]))
-                           (= (dissoc (:descriptor context) :end) (dissoc (:descriptor prefix) :end))
-                           (= (get-in prefix [:descriptor :end]) (get-in prefix [:cursor :offset]))
+                           (= (journal/descriptor-id (:descriptor context))
+                              (get-in prefix [:cursor :journal-id])
+                              (journal/descriptor-id (:descriptor prefix)))
+                           (zero? (journal/compare-cursors (:descriptor prefix)
+                                                           (get-in prefix [:cursor :position])
+                                                           (journal/end-cursor (:descriptor prefix))))
                            (integer? (get-in prefix [:cursor :sequence]))
                            (<= (get-in context [:committed :cursor :sequence] 0)
                                (get-in prefix [:cursor :sequence])
                                (get-in context [:staged :cursor :sequence]))
-                           (<= (get-in context [:committed :cursor :offset] 0)
-                               (get-in prefix [:cursor :offset] -1)
-                               (get-in context [:staged :cursor :offset])))
+                           (not (pos? (journal/compare-cursors
+                                       (get-in context [:staged :descriptor])
+                                       (or (get-in context [:committed :cursor :position])
+                                           (journal/start-cursor (:descriptor context)))
+                                       (get-in prefix [:cursor :position]))))
+                           (not (pos? (journal/compare-cursors
+                                       (get-in context [:staged :descriptor])
+                                       (get-in prefix [:cursor :position])
+                                       (get-in context [:staged :cursor :position])))))
               (fail! ::invalid-commit "Committed AVET prefix does not belong to this lineage.")))
           ;; Validate the entire publication before retiring any old context.
           (doseq [retired (disj touched id)]
@@ -219,31 +232,50 @@
 
 (defn reduce-prefix
   "Read a leased range. f receives accumulator, complete transaction and next
-   cursor. The start must be a previously supplied cursor (or offset/sequence 0
-   with the same generation/journal identity). No runtime lock is held during I/O."
+   cursor. The start must be a previously supplied boundary. No runtime lock is
+   held during I/O."
   [owner lease start f init]
   (let [state (:state owner)]
     (locking state
       (when-not (= lease (get-in @state [:leases (:id lease)]))
         (fail! ::invalid-lease "Unknown AVET read lease.")))
-    (when-not (and (= (select-keys start [:generation :journal-id])
-                      (select-keys (:cursor lease) [:generation :journal-id]))
-                   (integer? (:offset start)) (integer? (:sequence start))
-                   (<= 0 (:offset start) (get-in lease [:cursor :offset]))
-                   (<= 0 (:sequence start) (get-in lease [:cursor :sequence]))
-                   (or (< (:offset start) (get-in lease [:cursor :offset]))
-                       (= (:sequence start) (get-in lease [:cursor :sequence]))))
-      (fail! ::invalid-cursor "AVET range cursor has the wrong identity or bounds."))
+    (let [position-order (when (and (= (select-keys start [:generation :journal-id])
+                                       (select-keys (:cursor lease) [:generation :journal-id]))
+                                    (some? (:position start)))
+                           (journal/compare-cursors (:descriptor lease)
+                                                    (:position start)
+                                                    (get-in lease [:cursor :position])))]
+      (when-not (and (some? position-order) (not (pos? position-order))
+                     (integer? (:sequence start))
+                     (<= 0 (:sequence start) (get-in lease [:cursor :sequence]))
+                     (or (neg? position-order)
+                         (= (:sequence start) (get-in lease [:cursor :sequence]))))
+        (fail! ::invalid-cursor "AVET range cursor has the wrong identity or bounds.")))
     (let [sequence (volatile! (:sequence start))]
-      (journal/reduce-range (:descriptor lease) (:offset start)
+      (journal/reduce-range (:descriptor lease) (:position start)
                             (fn [acc transaction end]
                               (when-not (and (= :transaction (:kind transaction))
                                              (= (:generation lease) (:generation transaction))
                                              (= (inc @sequence) (:sequence transaction)))
                                 (fail! ::invalid-cursor "AVET transaction sequence is not contiguous."))
                               (vreset! sequence (:sequence transaction))
-                              (f acc transaction (assoc (:cursor lease) :offset end :sequence @sequence)))
+                              (f acc transaction (assoc (:cursor lease) :position end :sequence @sequence)))
                             init))))
+
+(defn range-byte-size
+  "Return backend-accounted bytes between a checked start boundary and the
+   leased end. Cursors remain opaque and no runtime lock is held during I/O."
+  [owner lease start]
+  (let [state (:state owner)]
+    (locking state
+      (when-not (= lease (get-in @state [:leases (:id lease)]))
+        (fail! ::invalid-lease "Unknown AVET read lease.")))
+    (when-not (and (= (select-keys start [:generation :journal-id])
+                      (select-keys (:cursor lease) [:generation :journal-id]))
+                   (some? (:position start)))
+      (fail! ::invalid-cursor "AVET range cursor has the wrong identity."))
+    (journal/range-byte-size (:descriptor lease) (:position start)
+                             (get-in lease [:cursor :position]))))
 
 (defn invalidate!
   "Retire every local lineage after a definite commit conflict or lost owner.

--- a/src/datahike/backfill/runtime.clj
+++ b/src/datahike/backfill/runtime.clj
@@ -1,0 +1,324 @@
+(ns ^:no-doc datahike.backfill.runtime
+  "Owned process-local AVET capture. Call staging only after predicates accept;
+   call committed! once after a successful durable commit with original reports.
+   No worker launch, schema activation, recovery or GC protection lives here."
+  (:require [datahike.backfill.journal :as journal]
+            [replikativ.logging :as log]))
+
+(def ^:private safe-ops
+  '#{transact! begin-avet-build! cancel-avet-build! try-install-avet-build!})
+
+(defn- fail! [type message]
+  (throw (ex-info message {:type type})))
+
+(defn create!
+  "Create an owner without I/O. Complete transactions must fit one journal frame.
+   Context and reader limits bound queued generations and retained read leases."
+  [options]
+  (when-not (or (nil? options) (map? options))
+    (fail! ::invalid-options "Runtime options must be a map."))
+  (when (some #(not (contains? #{:journal :max-contexts :max-readers} %)) (keys options))
+    (fail! ::invalid-options "Unknown runtime option."))
+  (let [options (merge {:max-contexts 8 :max-readers 8} options)]
+    (doseq [limit (map options [:max-contexts :max-readers])]
+      (when-not (and (integer? limit) (<= 1 limit 1024))
+        (fail! ::invalid-options "Runtime limits must be integers from 1 to 1024.")))
+    {:options (assoc options :journal (journal/validate-options! (:journal options)))
+     :state (atom {:closed? false :contexts {} :leases {}})}))
+
+(defn- open! [state]
+  (when (:closed? @state) (fail! ::closed "AVET runtime is closed.")))
+
+(defn- cursor [id descriptor sequence]
+  {:generation id :journal-id (:id descriptor) :offset (:end descriptor) :sequence sequence})
+
+(defn- cleanup! [state]
+  (doseq [[id context] (:contexts @state)
+          :when (and (:retired? context)
+                     (not-any? #(= id (:generation %)) (vals (:leases @state))))]
+    (try (journal/dispose! (:descriptor context))
+         (swap! state update :contexts dissoc id)
+         (catch Exception e
+           (log/warn :datahike/avet-journal-cleanup-failed
+                     {:generation id :message (ex-message e)})))))
+
+(defn normalize-report
+  "Pure proposed durable retirement, before predicates. Reading local ownership
+   does not mutate it or the source DB; rejected reports retire nothing."
+  [owner report op]
+  (if-not (:db-after report)
+    report
+    (let [after (:db-after report)
+          id (get-in after [:avet-build :id])
+          context (get-in @(:state owner) [:contexts id])
+          lost? (and id (= id (get-in report [:db-before :avet-build :id]))
+                     (or (not context) (:retired? context)))
+          invalid? (and id (or lost? (:avet-build-invalidated? after)
+                               (not (contains? safe-ops op))))]
+      (cond
+        invalid? (update report :db-after
+                         #(-> %
+                              (dissoc :avet-build :avet-build-effects :avet-build-invalidated?
+                                      :avet-build-journal ::lost-lineage?)
+                              (assoc :avet-build-result
+                                     {:id id :status :failed
+                                      :reason (cond
+                                                (or lost? (::lost-lineage? after)) :owner-lost
+                                                (:avet-build-invalidated? after) :schema-changed
+                                                :else :unsupported-operation)})))
+        (not id) (update report :db-after dissoc :avet-build-effects :avet-build-invalidated?
+                         :avet-build-journal ::lost-lineage?)
+        :else report))))
+
+(defn prepare-report!
+  "Append one complete transaction, including an empty-effects watermark.
+   Does not advance committed state. Unsupported operations or schema taint
+   fail the build in the accepted report, not the user's transaction."
+  ([owner report op] (prepare-report! owner report op false))
+  ([owner report op normalized?]
+   (if-not (and (:db-after report)
+                (or (get-in report [:db-before :avet-build])
+                    (get-in report [:db-after :avet-build])))
+     (if (get-in report [:db-after ::lost-lineage?])
+       (update report :db-after dissoc ::lost-lineage?)
+       report)
+     (let [state (:state owner)]
+       (locking state
+         (open! state)
+         (let [proposed (normalize-report owner report op)
+               _ (when (and normalized?
+                            (not= (select-keys (:db-after report) [:avet-build :avet-build-result])
+                                  (select-keys (:db-after proposed) [:avet-build :avet-build-result])))
+                   (throw (ex-info "AVET ownership changed after predicate validation; retry transaction."
+                                   {:type ::normalization-conflict :retryable? true})))
+               report proposed
+               after (:db-after report)
+               id (get-in after [:avet-build :id])]
+           (if-not id
+             (update report :db-after dissoc :avet-build-effects :avet-build-invalidated?
+                     :avet-build-journal ::lost-lineage?)
+             (let [existing (get-in @state [:contexts id])
+                   previous (when (= id (get-in report [:db-before :avet-build :id]))
+                              (get-in report [:db-before :avet-build-journal]))
+                   _ (when (and existing
+                                (or (:retired? existing) (not= previous (:staged existing))))
+                       (fail! ::stale-generation "Staged AVET lineage is no longer current."))
+                   _ (when (and (not existing) previous)
+                       (fail! ::stale-generation "AVET journal belongs to another runtime."))
+                   _ (when (and (not existing)
+                                (= id (get-in report [:db-before :avet-build :id])))
+                       (fail! ::stale-generation "A recovered build requires a fresh begin generation."))
+                   _ (when (and (not existing)
+                                (>= (count (:contexts @state)) (get-in owner [:options :max-contexts])))
+                       (fail! ::context-limit "Too many pending AVET generations."))
+                   descriptor (or (:descriptor existing) (journal/create! (get-in owner [:options :journal])))
+                   sequence (inc (get-in existing [:staged :cursor :sequence] 0))]
+               (try
+                 (let [base (or (get-in existing [:staged :descriptor]) descriptor)
+                       appended (journal/append! base
+                                                 [{:kind :transaction :generation id :sequence sequence
+                                                   :max-tx (:max-tx after)
+                                                   :effects (get after :avet-build-effects [])}])
+                       staged {:descriptor appended :cursor (cursor id appended sequence)}]
+                   (swap! state assoc-in [:contexts id]
+                          (assoc (or existing {:descriptor descriptor :retired? false :started? false})
+                                 :staged staged))
+                   (-> report
+                       (update :db-after dissoc :avet-build-effects :avet-build-invalidated?)
+                       (assoc-in [:db-after :avet-build-journal] staged)))
+                 (catch Throwable e
+                   (when-not existing
+                     (try (journal/dispose! descriptor)
+                          (catch Throwable cleanup-error
+                           ;; Failed staging still owns the file. Keep it counted
+                           ;; until a later cleanup can actually remove it.
+                            (swap! state assoc-in [:contexts id]
+                                   {:descriptor descriptor :retired? true :started? false})
+                            (.addSuppressed e cleanup-error))))
+                   (throw e)))))))))))
+
+(defn committed!
+  "Publish one durable group's final prefix; original reports identify retired
+   generations without retiring newer speculative generations queued afterward.
+   Returns a new worker's exact source DB/cursor, or nil. Never launches workers."
+  [owner final-db original-reports]
+  (let [state (:state owner)]
+    (locking state
+      (when-not (:closed? @state)
+        (let [id (get-in final-db [:avet-build :id])
+              prefix (:avet-build-journal final-db)
+              context (get-in @state [:contexts id])
+              touched (into #{} (keep identity)
+                            (mapcat (fn [report]
+                                      [(get-in report [:db-before :avet-build :id])
+                                       (get-in report [:db-after :avet-build :id])])
+                                    original-reports))
+              start? (and context (not (:retired? context)) (not (:started? context)))]
+          ;; A byte offset and sequence must describe the SAME accepted frame
+          ;; boundary, not merely fit independently inside the staged ranges.
+          ;; The group's original final report is the bounded authority for the
+          ;; published prefix. Empty groups may retry cleanup, not advance it.
+          (when (and (seq original-reports)
+                     (let [last-db (:db-after (last original-reports))]
+                       (or (not= (:avet-build final-db) (:avet-build last-db))
+                           (not= prefix (:avet-build-journal last-db)))))
+            (fail! ::invalid-commit "Final AVET state differs from the group's last accepted report."))
+          (when (and (not id) prefix)
+            (fail! ::invalid-commit "An inactive AVET generation cannot publish a journal prefix."))
+          (when id
+            (when (or (not context) (:retired? context))
+              (fail! ::invalid-commit "Committed AVET generation has no live owned context."))
+            (when (and (empty? original-reports) (not= prefix (:committed context)))
+              (fail! ::invalid-commit "An empty commit group cannot advance an AVET prefix."))
+            (when-not (and (= id (get-in prefix [:cursor :generation]))
+                           (= (get-in context [:descriptor :id]) (get-in prefix [:cursor :journal-id]))
+                           (= (dissoc (:descriptor context) :end) (dissoc (:descriptor prefix) :end))
+                           (= (get-in prefix [:descriptor :end]) (get-in prefix [:cursor :offset]))
+                           (integer? (get-in prefix [:cursor :sequence]))
+                           (<= (get-in context [:committed :cursor :sequence] 0)
+                               (get-in prefix [:cursor :sequence])
+                               (get-in context [:staged :cursor :sequence]))
+                           (<= (get-in context [:committed :cursor :offset] 0)
+                               (get-in prefix [:cursor :offset] -1)
+                               (get-in context [:staged :cursor :offset])))
+              (fail! ::invalid-commit "Committed AVET prefix does not belong to this lineage.")))
+          ;; Validate the entire publication before retiring any old context.
+          (doseq [retired (disj touched id)]
+            (when (get-in @state [:contexts retired])
+              (swap! state assoc-in [:contexts retired :retired?] true)))
+          (when id
+            (swap! state update-in [:contexts id] assoc :committed prefix
+                   :committed-db final-db :started? true))
+          (cleanup! state)
+          (when start? {:generation id :source-db final-db :cursor (:cursor prefix)}))))))
+
+(defn acquire-prefix!
+  "Lease the current committed prefix. Release in finally after use; the caller
+   must not concurrently release a lease while its range reader is using it."
+  [owner id]
+  (let [state (:state owner)]
+    (locking state
+      (open! state)
+      (let [context (get-in @state [:contexts id])]
+        (when (or (not context) (:retired? context) (not (:committed context)))
+          (fail! ::unavailable "No live committed AVET prefix."))
+        (when (>= (count (:leases @state)) (get-in owner [:options :max-readers]))
+          (fail! ::reader-limit "Too many AVET readers."))
+        (let [lease (assoc (:committed context) :id (random-uuid) :generation id
+                           :source-db (:committed-db context))]
+          (swap! state assoc-in [:leases (:id lease)] lease)
+          lease)))))
+
+(defn release-prefix! [owner lease]
+  (let [state (:state owner)]
+    (locking state
+      (when-let [held (get-in @state [:leases (:id lease)])]
+        (when-not (= held lease) (fail! ::invalid-lease "Modified AVET read lease."))
+        (swap! state update :leases dissoc (:id lease))
+        (cleanup! state)))))
+
+(defn reduce-prefix
+  "Read a leased range. f receives accumulator, complete transaction and next
+   cursor. The start must be a previously supplied cursor (or offset/sequence 0
+   with the same generation/journal identity). No runtime lock is held during I/O."
+  [owner lease start f init]
+  (let [state (:state owner)]
+    (locking state
+      (when-not (= lease (get-in @state [:leases (:id lease)]))
+        (fail! ::invalid-lease "Unknown AVET read lease.")))
+    (when-not (and (= (select-keys start [:generation :journal-id])
+                      (select-keys (:cursor lease) [:generation :journal-id]))
+                   (integer? (:offset start)) (integer? (:sequence start))
+                   (<= 0 (:offset start) (get-in lease [:cursor :offset]))
+                   (<= 0 (:sequence start) (get-in lease [:cursor :sequence]))
+                   (or (< (:offset start) (get-in lease [:cursor :offset]))
+                       (= (:sequence start) (get-in lease [:cursor :sequence]))))
+      (fail! ::invalid-cursor "AVET range cursor has the wrong identity or bounds."))
+    (let [sequence (volatile! (:sequence start))]
+      (journal/reduce-range (:descriptor lease) (:offset start)
+                            (fn [acc transaction end]
+                              (when-not (and (= :transaction (:kind transaction))
+                                             (= (:generation lease) (:generation transaction))
+                                             (= (inc @sequence) (:sequence transaction)))
+                                (fail! ::invalid-cursor "AVET transaction sequence is not contiguous."))
+                              (vreset! sequence (:sequence transaction))
+                              (f acc transaction (assoc (:cursor lease) :offset end :sequence @sequence)))
+                            init))))
+
+(defn invalidate!
+  "Retire every local lineage after a definite commit conflict or lost owner.
+   Does not close the runtime: fresh begin generations may subsequently stage.
+   Existing read leases retain only their old committed prefixes until released.
+   The orchestrator must also retire the durable descriptor through an accepted
+   report; it must not copy this runtime's journal onto a reloaded foreign head."
+  [owner]
+  (let [state (:state owner)]
+    (locking state
+      (open! state)
+      (let [ids (set (keys (:contexts @state)))]
+        (swap! state update :contexts
+               #(into {} (map (fn [[id context]] [id (assoc context :retired? true)])) %))
+        (cleanup! state)
+        ids))))
+
+(defn fail-generation!
+  "Retire only the named local generation when its internal cancellation could
+   not be accepted. No I/O or durable mutation: the next accepted transaction
+   reconciles the lost lineage through ordinary predicates. Cleanup remains
+   owned by committed!, lease release, reconciliation, or close!."
+  [owner id reason]
+  (when-not (and (uuid? id) (contains? #{:cancel-rejected :dispatch-failed} reason))
+    (fail! ::invalid-failure "Invalid local generation failure."))
+  (let [state (:state owner)]
+    (locking state
+      (when (get-in @state [:contexts id])
+        (swap! state #(-> %
+                          (assoc-in [:contexts id :retired?] true)
+                          (assoc :last-failure {:generation id :reason reason}))))))
+  nil)
+
+(defn reconcile-db!
+  "Reconcile ONLY an authoritative head after a shared batch has drained.
+   Retire foreign/recovered/conflicted local lineage without rejecting ordinary
+   user transactions. The taint becomes durable cancellation only if the next
+   report is accepted; a rejected predicate never publishes a metadata change."
+  [owner database]
+  (let [state (:state owner)]
+    (locking state
+      (open! state)
+      (let [id (get-in database [:avet-build :id])
+            context (get-in @state [:contexts id])
+            had-live? (some #(not (:retired? %)) (vals (:contexts @state)))
+            committed (:committed-db context)
+            same? (and id context (not (:retired? context))
+                       (= (:avet-build-journal database) (:committed context))
+                       (= (:staged context) (:committed context))
+                       (= (get-in database [:meta :datahike/commit-id])
+                          (get-in committed [:meta :datahike/commit-id]))
+                       (= (:datahike.writing/head-revision database)
+                          (:datahike.writing/head-revision committed))
+                       (identical? (:store database) (:store committed))
+                       (every? #(= (get database %) (get committed %))
+                               [:avet-build :schema :rschema :ident-ref-map :ref-ident-map
+                                :config :max-tx :max-eid :op-count :hash :system-entities
+                                :secondary-indices :secondary-index-keys])
+                       (every? #(identical? (get database %) (get committed %))
+                               [:eavt :aevt :avet :temporal-eavt :temporal-aevt :temporal-avet]))]
+        (if same?
+          database
+          (do
+            (invalidate! owner)
+            (cond-> database
+              (or id had-live?) (assoc ::lost-lineage? true)
+              id (assoc :avet-build-invalidated? true))))))))
+
+(defn close!
+  "Fence staging/reads and retire all contexts. Existing leases remain readable
+   until explicitly released; their files must not be unlinked underneath them."
+  [owner]
+  (let [state (:state owner)]
+    (locking state
+      (swap! state (fn [s] (-> s (assoc :closed? true)
+                               (update :contexts #(into {} (map (fn [[id context]]
+                                                                  [id (assoc context :retired? true)])) %)))))
+      (cleanup! state))))

--- a/src/datahike/backfill/sort.clj
+++ b/src/datahike/backfill/sort.clj
@@ -2,6 +2,7 @@
   "Scoped JVM external sorting with bounded windows, records and merge fan-in.
    Limits account for retained record data, not exact JVM object sizes."
   (:require [boring.core :as boring]
+            [datahike.backfill.control :as control]
             [datahike.migrate.cbor :as cbor]
             [datahike.sort :as engine])
   (:import [java.io ByteArrayOutputStream DataInputStream DataOutputStream
@@ -76,6 +77,7 @@
       @charge)))
 
 (defn- encode! [record {:keys [max-record-bytes window-bytes]}]
+  (control/check!)
   (let [charge (record-charge! record (min window-bytes max-record-bytes))
         buffer (ByteArrayOutputStream. (int (min 8192 max-record-bytes)))
         count-bytes (volatile! 0)
@@ -101,6 +103,7 @@
   (.resolve directory (str "p" pass "-r" run ".cbor")))
 
 (defn- write-frame! [^DataOutputStream out usage limit ^bytes bytes]
+  (control/check!)
   (let [n (+ 4 (long (alength bytes)))]
     (when (> (+ @usage n) limit)
       (fail! ::quota-exceeded "Sort exceeds scratch quota." {}))
@@ -112,6 +115,7 @@
   (DataInputStream. (BufferedInputStream. (FileInputStream. (.toFile path)))))
 
 (defn- read-frame! [^DataInputStream in limit]
+  (control/check!)
   (let [first-byte (.read in)]
     (when (not= -1 first-byte)
       (try

--- a/src/datahike/backfill/storage.clj
+++ b/src/datahike/backfill/storage.clj
@@ -3,15 +3,17 @@
    deferral, source pin and local GC guard until publication or cancellation.
    This primitive does not establish those protections or enable online AVET."
   (:require [datahike.datom :as dd]
+            [datahike.backfill.control :as control]
             [datahike.index.interface :as di]
             [datahike.index.persistent-set]
             [konserve.core :as k]
+            [org.replikativ.persistent-sorted-set :as pss]
             [org.replikativ.persistent-sorted-set.impl.nodes :as nodes])
   (:import [java.util UUID Date]
            [java.net URI]
            [java.math BigInteger BigDecimal]
            [java.lang.reflect Array]
-           [org.replikativ.persistent_sorted_set IStorage ANode Branch]))
+           [org.replikativ.persistent_sorted_set IStorage ANode Branch Branch$NodeState PersistentSortedSet Settings]))
 
 (def ^:private defaults
   {:max-node-keys 4096 :max-node-weight 8388608
@@ -39,6 +41,12 @@
     (when (> (:max-node-weight options) (:pending-weight-limit options))
       (fail! :backfill.storage/invalid-options "A node must fit in the pending weight limit." {}))
     options))
+
+(defn validate-options!
+  "Validate only private storage budgets without creating storage or doing I/O.
+   create! additionally checks the actual database/backend capabilities."
+  [options]
+  (options! {:index :datahike.index/persistent-set :crypto-hash? false} options))
 
 (defn- weight!
   "Conservative payload accounting units, NOT measured JVM retained heap.
@@ -103,13 +111,15 @@
   (when (:failed? @state)
     (fail! :backfill.storage/failed "Private storage failed; discard the build." {})))
 
-(defn- node-from-blob [blob]
+(defn- node-from-blob
   ;; reader-context memoizes settings without a size limit. Keep its lifetime
   ;; local so heterogeneous historical node settings cannot grow a hidden cache.
-  (let [context (nodes/reader-context {})]
-    (if (contains? blob :level)
-      (nodes/blob->branch context blob)
-      (nodes/blob->leaf context blob))))
+  ([blob] (node-from-blob blob false))
+  ([blob private-read?]
+   (let [context (nodes/reader-context (when private-read? {:ref-type :weak}))]
+     (if (contains? blob :level)
+       (nodes/blob->branch context blob)
+       (nodes/blob->leaf context blob)))))
 
 (defn- cache! [state options address blob weight]
   (when (<= weight (:cache-weight-limit options))
@@ -131,6 +141,7 @@
   (live! state)
   (try
     (doseq [[address blob _weight] (:pending @state)]
+      (control/check!)
       ;; Same immutable synchronous write discipline as writing/write-pending-kvs!,
       ;; without introducing a writing -> storage -> writing namespace cycle.
       (k/assoc store address (node-from-blob blob) {:immutable? true} {:sync? true})
@@ -144,6 +155,7 @@
 (defrecord PrivateStorage [store options state]
   IStorage
   (store [_ node]
+    (control/check!)
     (locking state
       (live! state)
       (let [[blob weight] (blob! node options)
@@ -158,6 +170,7 @@
         (cache! state options address blob weight)
         address)))
   (restore [_ address]
+    (control/check!)
     (locking state
       (live! state)
       (let [[blob weight]
@@ -171,7 +184,7 @@
                   (blob! node options)))]
         (cache! state options address blob weight)
         ;; Never cache returned mutable nodes/child pointers: only detached blobs.
-        (node-from-blob blob))))
+        (node-from-blob blob true))))
   (accessed [_ _address]
     (locking state (live! state) (swap! state update-in [:stats :accessed] inc))
     nil)
@@ -205,6 +218,80 @@
   "Store view for init-index-sorted. It does not expose live storage buffers."
   [storage]
   (assoc (:store storage) :storage storage))
+
+(defn- resident-datoms
+  "Read existing topology without child(), which fills shared branch caches.
+   Missing addressed children load privately. Retention is the traversal frontier
+   plus the caller's already-resident immutable source tree."
+  [storage ^ANode node]
+  (lazy-seq
+   (control/check!)
+   (blob! node (:options storage))
+   (if (instance? Branch node)
+     (let [^Branch$NodeState snapshot (.-_state ^Branch node)
+           children (.-children snapshot)
+           addresses (.-addresses snapshot)]
+       (mapcat (fn [i]
+                 (let [resident (when children
+                                  (.readReference (.-_settings node) (aget ^objects children i)))
+                       address (when addresses (aget ^objects addresses i))
+                       child (or resident
+                                 (when address (.restore ^IStorage storage address))
+                                 (fail! :backfill.storage/invalid-source "Source child has no node or address." {}))]
+                   (resident-datoms storage child)))
+               (range (.-_len node))))
+     (map #(aget (.-_keys node) %) (range (.-_len node))))))
+
+(defn copy-index!
+  "Bind a durable source tree to private read storage without sharing mutable
+   node topology or touching live storage/cache. A resident (including fused)
+   root is projected/copied under the node admission limit; a cold root loads
+   privately. Never flushes the source. Nonempty unflushed trees are refused
+   unless :resident-source? opts into a streaming private materialization; the
+   coordinator may enable that for committed memory-backend snapshots only.
+   Existing node decoding/projection and each copied root are additional bounded
+   candidates outside pending/cache weights. Stored domain values remain shared
+   immutable values. Weak child references prevent hidden strong subtree caches."
+  ([storage index] (copy-index! storage index nil))
+  ([storage index options]
+   (when-not (and (or (nil? options) (map? options))
+                  (every? #{:resident-source?} (keys options))
+                  (or (not (contains? options :resident-source?))
+                      (boolean? (:resident-source? options))))
+     (fail! :backfill.storage/invalid-options "Invalid source copy options." {}))
+   (when-not (instance? PersistentSortedSet index)
+     (fail! :backfill.storage/unsupported "Expected a persistent-set source tree." {}))
+   (locking (:state storage)
+     (live! (:state storage))
+     (let [^PersistentSortedSet index index
+          ;; Match PSS's acquire ordering for a concurrently warmed source root.
+           root-ref (.-_root index)
+           ^Settings settings (.-_settings index)
+           resident (.readReference settings root-ref)
+           address (.-_address index)
+           family (:index-type (meta index))]
+       (when-not (contains? #{:eavt :aevt :avet} family)
+         (fail! :backfill.storage/unsupported "Source tree lacks index-family metadata." {}))
+       (when (and (nil? address) (not (zero? (.-_count index))) (not (:resident-source? options)))
+         (fail! :backfill.storage/unflushed-source "Source must be durably flushed before copying." {}))
+       (when (pos? (.diffBufSize settings))
+         (fail! :backfill.storage/unsupported "Private source copies do not support diff buffers." {}))
+       (if (and (nil? address) (not (zero? (.-_count index))))
+         (do
+           (when-not resident (fail! :backfill.storage/invalid-source "Resident source root is missing." {}))
+           (let [tree (pss/from-sorted-seq
+                       (dd/index-type->cmp-quick family false)
+                       (resident-datoms storage resident)
+                       {:storage storage :meta (meta index) :ref-type :weak
+                        :branching-factor (.branchingFactor settings) :diff-buf-size 0})]
+             (flush-state! (:store storage) (:state storage))
+             tree))
+         (let [root (when resident
+                      (node-from-blob (first (blob! resident (:options storage))) true))
+               weak-settings (nodes/settings-for (.branchingFactor settings) 0 nil :weak
+                                                 (.descriptor (.boundary settings)))]
+           (PersistentSortedSet. (meta index) (dd/index-type->cmp-quick family false)
+                                 address storage root (.-_count index) weak-settings (.-_version index))))))))
 
 (defn flush!
   "Synchronously persist private pending nodes. A failed flush poisons the build."

--- a/src/datahike/backfill/unique.clj
+++ b/src/datahike/backfill/unique.clj
@@ -1,0 +1,52 @@
+(ns ^:no-doc datahike.backfill.unique
+  "Uniqueness checks for complete private current AVET roots. These checks do
+   not constitute an activation certificate: the caller must bind the checked
+   roots to an exact generation, schema and complete transaction cursor."
+  (:require [datahike.constants :refer [e0 emax tx0 txmax]]
+            [datahike.backfill.control :as control]
+            [datahike.datom :as dd]
+            [datahike.db.utils :as dbu]
+            [datahike.index.interface :as di]))
+
+(defn- duplicate! [ident value]
+  (throw (ex-info "Cannot enable uniqueness: duplicate current value."
+                  {:error :transact/schema :attribute ident :value value})))
+
+(defn validate!
+  "Scan requested attribute slices in native AVET order, retaining one previous
+   datom. The complete current candidate is required; history is not checked."
+  [database current idents]
+  (doseq [ident idents]
+    (let [a (dbu/attr-ref-or-ident database ident)]
+      (loop [remaining (seq (di/-slice current (dd/datom e0 a nil tx0)
+                                       (dd/datom emax a nil txmax) :avet))
+             previous nil]
+        (when-let [datom (first remaining)]
+          (control/check!)
+          (when (and previous (zero? (dd/compare-value (:v previous) (:v datom))))
+            (duplicate! ident (:v datom)))
+          (recur (next remaining) datom)))))
+  nil)
+
+(defn validate-effects!
+  "After replaying ONE COMPLETE transaction on previously checked roots, check
+   only its touched current values. No all-values set is retained; repeated
+   values may be checked repeatedly. Work is bounded by the transaction effect
+   count and native index seeks, not by total database size. Never call this
+   between individual effects: temporary duplicates may be removed in the same
+   transaction. unique-idents is a set of canonical attribute idents. The
+   caller must bound the complete transaction's input size."
+  [database current unique-idents effects]
+  (doseq [[family _ datom old] effects
+          :when (= family :current)
+          changed [datom old]
+          :when changed
+          :let [ident (get (:ref-ident-map database) (:a changed) (:a changed))]
+          :when (contains? unique-idents ident)]
+    (control/check!)
+    (let [a (:a changed)
+          value (:v changed)
+          matches (di/-slice current (dd/datom e0 a value tx0)
+                             (dd/datom emax a value txmax) :avet)]
+      (when (next (seq matches)) (duplicate! ident value))))
+  nil)

--- a/src/datahike/core.cljc
+++ b/src/datahike/core.cljc
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [filter])
   (:require
    [datahike.constants :as dc]
+   #?(:clj [datahike.backfill.admission :as admission])
    [datahike.datom :as dd]
    [datahike.db :as db #?@(:cljs [:refer [FilteredDB]])]
    [datahike.db.interface :as dbi]
@@ -126,37 +127,46 @@
 
 ; Changing DB
 
+(defn- with* [db tx-data tx-meta tx-options prepared]
+  {:pre [(dbu/db? db)]}
+  (if (is-filtered db)
+    (throw (ex-info "Filtered DB cannot be modified" {:error :transaction/filtered}))
+    (let [tracker (atom [])
+          report (binding [sec/*secondary-transient-tracker* tracker]
+                   (try
+                     (dbt/transact-tx-data-internal
+                      (db/map->TxReport
+                       {:db-before db
+                        :db-after  db
+                        :tx-data   []
+                        :tempids   {}
+                        :tx-meta   tx-meta})
+                      tx-data tx-options prepared)
+                     (catch #?(:clj Throwable :cljs js/Error) failure
+                       (sec/abort-tracked-secondary-transients!)
+                       (throw failure))))
+           ;; Propagate query result cache with selective invalidation
+          rim (:ref-ident-map (:db-after report))
+          modified-attrs (into #{}
+                               (comp (map :a)
+                                     (clojure.core/filter some?)
+                                     (map (fn [a] (if (and rim (number? a)) (get rim a a) a))))
+                               (:tx-data report))
+          _ (dq/propagate-query-cache db (:db-after report) modified-attrs)]
+      report)))
+
 (defn with
   "Same as [[transact!]], but applies to an immutable database value. Returns transaction report (see [[transact!]])."
   ([db tx-data] (with db tx-data nil nil))
   ([db tx-data tx-meta] (with db tx-data tx-meta nil))
   ([db tx-data tx-meta tx-options]
-   {:pre [(dbu/db? db)]}
-   (if (is-filtered db)
-     (throw (ex-info "Filtered DB cannot be modified" {:error :transaction/filtered}))
-     (let [tracker (atom [])
-           report (binding [sec/*secondary-transient-tracker* tracker]
-                    (try
-                      (dbt/transact-tx-data
-                       (db/map->TxReport
-                        {:db-before db
-                         :db-after  db
-                         :tx-data   []
-                         :tempids   {}
-                         :tx-meta   tx-meta})
-                       tx-data tx-options)
-                      (catch #?(:clj Throwable :cljs js/Error) failure
-                        (sec/abort-tracked-secondary-transients!)
-                        (throw failure))))
-           ;; Propagate query result cache with selective invalidation
-           rim (:ref-ident-map (:db-after report))
-           modified-attrs (into #{}
-                                (comp (map :a)
-                                      (clojure.core/filter some?)
-                                      (map (fn [a] (if (and rim (number? a)) (get rim a a) a))))
-                                (:tx-data report))
-           _ (dq/propagate-query-cache db (:db-after report) modified-attrs)]
-       report))))
+   (with* db tx-data tx-meta tx-options nil)))
+
+#?(:clj
+   (defn ^:no-doc with-prepared-avet
+     "Internal coordinator seam. Never accepts public options or user tx data."
+     [db certificate]
+     (with* db (admission/transaction-data certificate) nil nil certificate)))
 
 (defn load-entities-with
   ([db entities tx-meta] (load-entities-with db entities tx-meta nil))

--- a/src/datahike/db/transaction.cljc
+++ b/src/datahike/db/transaction.cljc
@@ -6,6 +6,8 @@
    [datahike.datom :as dd :refer [datom datom-tx datom-added datom?]]
    #?(:cljs [datahike.db :refer [HistoricalDB]])
    [datahike.array :as arr]
+   [datahike.backfill.effects :as effects]
+   #?(:clj [datahike.backfill.admission :as admission])
    [datahike.attr-preds :as ap]
    [datahike.db.interface :as dbi]
    [datahike.db.search :as dbs]
@@ -161,7 +163,7 @@
           (when (map? entry)
             (when-let [why (ds/key-bearing-misuse entry)]
               (log/raise why {:error :transact/schema :entity-id e :attribute a-ident})))))
-      new-db)))
+      (effects/schema-change new-db))))
 
 (defn update-rschema [db]
   (assoc db :rschema (dbu/rschema (:schema db))))
@@ -368,26 +370,27 @@
     (when (and attribute-refs? (contains? (dbi/-system-entities db) e))
       (log/raise "System schema entity cannot be changed"
                  {:error :retract/schema :entity-id e}))
-    (if (= a-ident :db/ident)
-      (if-not (schema v-ident)
-        (let [err-msg (str "Schema with attribute " v-ident " does not exist")
-              err-map {:error :retract/schema :attribute v-ident}]
-          (throw (ex-info err-msg err-map)))
-        (-> (assoc-in db [:schema e] (dissoc (schema v-ident) a-ident))
-            (update-in [:schema] #(dissoc % v-ident))
-            (update-in [:ident-ref-map] #(dissoc % v-ident))
-            (update-in [:ref-ident-map] #(dissoc % e))))
-      (if-let [schema-entry (schema e)]
-        (if (schema schema-entry)
-          (if (= a-ident :db.attr/preds)
+    (let [db (effects/schema-change db)]
+      (if (= a-ident :db/ident)
+        (if-not (schema v-ident)
+          (let [err-msg (str "Schema with attribute " v-ident " does not exist")
+                err-map {:error :retract/schema :attribute v-ident}]
+            (throw (ex-info err-msg err-map)))
+          (-> (assoc-in db [:schema e] (dissoc (schema v-ident) a-ident))
+              (update-in [:schema] #(dissoc % v-ident))
+              (update-in [:ident-ref-map] #(dissoc % v-ident))
+              (update-in [:ref-ident-map] #(dissoc % e))))
+        (if-let [schema-entry (schema e)]
+          (if (schema schema-entry)
+            (if (= a-ident :db.attr/preds)
             ;; many-valued: drop just the retracted predicate, keep the rest
-            (update-in db [:schema schema-entry a-ident]
-                       (fn [old] (vec (remove #{v-ident} old))))
-            (update-in db [:schema schema-entry] #(dissoc % a-ident)))
-          (update-in db [:schema e] #(dissoc % a-ident v-ident)))
-        (let [err-msg (str "Schema with entity id " e " does not exist")
-              err-map {:error :retract/schema :entity-id e :attribute a :value e}]
-          (throw (ex-info err-msg err-map)))))))
+              (update-in db [:schema schema-entry a-ident]
+                         (fn [old] (vec (remove #{v-ident} old))))
+              (update-in db [:schema schema-entry] #(dissoc % a-ident)))
+            (update-in db [:schema e] #(dissoc % a-ident v-ident)))
+          (let [err-msg (str "Schema with entity id " e " does not exist")
+                err-map {:error :retract/schema :entity-id e :attribute a :value e}]
+            (throw (ex-info err-msg err-map))))))))
 
 ;; In context of `with-datom` we can use faster comparators which
 ;; do not check for nil (~10-15% performance gain in `transact`)
@@ -600,6 +603,7 @@
     (if (datom-added datom)
       (cond-> db
         true (update-in [:eavt] #(di/-insert % prim :eavt op-count))
+        (effects/enabled? db) (effects/emit a-ident :current :insert prim nil)
         true (update-in [:aevt] #(di/-insert % prim :aevt op-count))
         indexing? (update-in [:avet] #(di/-insert % prim :avet op-count))
         has-secondary? (update-secondary-indices a-ident datom true tx-meta)
@@ -612,6 +616,7 @@
       (if-some [removing ^Datom (first (dbi/search db [(.-e prim) (.-a prim) (.-v prim)]))]
         (cond-> db
           true (update-in [:eavt] #(di/-remove % removing :eavt op-count))
+          (effects/enabled? db) (effects/emit a-ident :current :remove removing nil)
           true (update-in [:aevt] #(di/-remove % removing :aevt op-count))
           indexing? (update-in [:avet] #(di/-remove % removing :avet op-count))
           has-secondary? (update-secondary-indices a-ident datom false tx-meta)
@@ -619,6 +624,8 @@
           schema? (-> (remove-schema datom) update-rschema)
           keep-history? (update-in [:temporal-eavt] #(di/-temporal-insert % removing :eavt op-count))
           keep-history? (update-in [:temporal-eavt] #(di/-temporal-insert % prim :eavt (inc op-count)))
+          (and keep-history? (effects/enabled? db)) (effects/emit a-ident :temporal :temporal-insert removing nil)
+          (and keep-history? (effects/enabled? db)) (effects/emit a-ident :temporal :temporal-insert prim nil)
           keep-history? (update-in [:temporal-aevt] #(di/-temporal-insert % removing :aevt op-count))
           keep-history? (update-in [:temporal-aevt] #(di/-temporal-insert % prim :aevt (inc op-count)))
           keep-history? (update :hash + (hash prim))
@@ -639,6 +646,7 @@
         has-secondary? (seq (get-in db [:rschema :db.secondary/index a-ident]))]
     (cond-> db
       current? (update-in [:eavt] #(di/-remove % current-datom :eavt op-count))
+      (and current? (effects/enabled? db)) (effects/emit a-ident :current :remove current-datom nil)
       current? (update-in [:aevt] #(di/-remove % current-datom :aevt op-count))
       (and current? indexing?) (update-in [:avet] #(di/-remove % current-datom :avet op-count))
       current? (update :hash - (hash current-datom))
@@ -648,8 +656,11 @@
       (and current? has-secondary?) (update-secondary-indices a-ident current-datom false)
       (and current? schema?) (-> (remove-schema datom) update-rschema)
       history? (update-in [:temporal-eavt] #(di/-remove % history-datom :eavt op-count))
+      (and history? (effects/enabled? db)) (effects/emit a-ident :temporal :remove history-datom nil)
       history? (update-in [:temporal-aevt] #(di/-remove % history-datom :aevt op-count))
-      (and history? indexing?) (update-in [:temporal-avet] #(di/-remove % history-datom :avet op-count))
+      ;; Disabling an index retains its historical AVET slice. Purge must also
+      ;; remove those old entries, even though new writes are no longer indexed.
+      history? (update-in [:temporal-avet] #(di/-remove % history-datom :avet op-count))
       (or current? history?) (update :op-count inc))))
 
 (defn- queue-tuple [queue tuple idx db e v]
@@ -725,7 +736,9 @@
                    db))
 
        keep-history? (update-in [:temporal-eavt] #(di/-temporal-upsert % prim :eavt op-count old-datom))
+       (and keep-history? (effects/enabled? db)) (effects/emit a-ident :temporal :temporal-upsert prim old-datom)
        true          (update-in [:eavt] #(di/-upsert % prim :eavt op-count old-datom))
+       (effects/enabled? db) (effects/emit a-ident :current :upsert prim old-datom)
 
        keep-history? (update-in [:temporal-aevt] #(di/-temporal-upsert % prim :aevt op-count old-datom))
        true          (update-in [:aevt] #(di/-upsert % prim :aevt op-count old-datom))
@@ -1229,9 +1242,9 @@
             (map (fn [^Datom d] [:db.purge/entity (.-v d)])))]
     (into #{} xf datoms)))
 
-(declare transact-tx-data)
+(declare transact-tx-data-internal)
 
-(defn- retry-with-tempid [initial-report report es tempid upserted-eid tx-options]
+(defn- retry-with-tempid [initial-report report es tempid upserted-eid tx-options prepared]
   (if (contains? (:tempids initial-report) tempid)
     (log/raise "Conflicting upsert: " tempid " resolves"
                " both to " upserted-eid " and " (get-in initial-report [:tempids tempid])
@@ -1242,7 +1255,7 @@
                        (assoc tempid upserted-eid))
           report' (assoc initial-report :tempids tempids')]
       (sec/abort-tracked-secondary-transients!)
-      (transact-tx-data report' es tx-options))))
+      (transact-tx-data-internal report' es tx-options prepared))))
 
 (defn assert-preds [db [_ e _ preds]]
   #?(:cljs (throw (ex-info "tx predicate resolution is not supported in cljs at this time" {:e e :preds preds}))
@@ -1725,7 +1738,7 @@
    re-inserting an identical datom is an idempotent upsert in the index
    implementations, so the backfill can sweep the full :aevt slice
    without tracking which datoms arrived when."
-  [{:keys [db-before db-after] :as report}]
+  [{:keys [db-before db-after] :as report} prepared]
   (let [old-schema (dbi/-schema db-before)
         new-schema (dbi/-schema db-after)]
     (if (identical? old-schema new-schema)
@@ -1740,7 +1753,10 @@
                                                  (or (not (indexed-entry? o))
                                                      (and (:db/unique n)
                                                           (not (:db/unique o)))))))))
-                          (keys new-schema))]
+                          (keys new-schema))
+            enabled #?(:clj (remove #(admission/covers? prepared %
+                                                        (get old-schema %) (get new-schema %)) enabled)
+                       :cljs enabled)]
         (if (empty? enabled)
           report
           (update report :db-after
@@ -1889,7 +1905,7 @@
    - composite :db/tupleAttrs must not reference attributes defined as
      cardinality-many or as tuples (undeclared references are supported —
      their slots stay nil)."
-  [{:keys [db-before db-after] :as _report} tx-options]
+  [{:keys [db-before db-after] :as _report} tx-options prepared]
   (let [old-schema (dbi/-schema db-before)
         new-schema (dbi/-schema db-after)]
     (when-not (identical? old-schema new-schema)
@@ -1937,7 +1953,9 @@
                 ;; accepted as before.
                 (when (and (or (contains? data-checks :index-backfill)
                                (contains? data-checks :unique-backfill))
-                           (not (or (:allow-index-backfill? (dbi/-config db-after))
+                           (not (or #?(:clj (admission/covers? prepared ident old-entry new-entry)
+                                       :cljs false)
+                                    (:allow-index-backfill? (dbi/-config db-after))
                                     (:allow-index-backfill? tx-options)))
                            (or (seq (schema-attr-current-datoms db-after ident))
                                (seq (schema-attr-history-datoms db-after ident))))
@@ -1987,134 +2005,146 @@
                   :value (:allow-index-backfill? tx-options)})))
   tx-options)
 
-(defn transact-tx-data
-  ([initial-report initial-es] (transact-tx-data initial-report initial-es nil))
-  ([{:keys [db-before] :as initial-report} initial-es tx-options]
-   (validate-tx-options! tx-options)
-   (when-not (or (nil? initial-es)
-                 (sequential? initial-es))
-     (log/raise "Bad transaction data " initial-es ", expected sequential collection"
-                {:error :transact/syntax, :tx-data initial-es}))
-   (let [has-tuples? (seq (dbi/-attrs-by (:db-after initial-report) :db.type/tuple))
-         initial-es' (if has-tuples?
-                       (interleave initial-es (repeat ::flush-tuples))
-                       initial-es)
-         initial-report (-> initial-report
-                            (update :datahike/tx-ops #(or % #{}))
-                            (update :tx-meta
-                                    #(merge {:db/txInstant (next-tx-instant db-before)} %)))
+(defn ^:no-doc transact-tx-data-internal
+  [{:keys [db-before] :as initial-report} initial-es tx-options prepared]
+  #?(:clj (when prepared (admission/check! prepared db-before initial-es))
+     :cljs (when prepared (throw (ex-info "Prepared AVET admission requires the JVM." {}))))
+  (validate-tx-options! tx-options)
+  (when-not (or (nil? initial-es)
+                (sequential? initial-es))
+    (log/raise "Bad transaction data " initial-es ", expected sequential collection"
+               {:error :transact/syntax, :tx-data initial-es}))
+  (let [initial-report #?(:clj (if prepared
+                                 (assoc initial-report :db-after (admission/prepare-db prepared db-before))
+                                 initial-report)
+                          :cljs initial-report)
+        has-tuples? (seq (dbi/-attrs-by (:db-after initial-report) :db.type/tuple))
+        initial-es' (if has-tuples?
+                      (interleave initial-es (repeat ::flush-tuples))
+                      initial-es)
+        initial-report (-> initial-report
+                           (update :datahike/tx-ops #(or % #{}))
+                           (update :tx-meta
+                                   #(merge {:db/txInstant (next-tx-instant db-before)} %)))
         ;; Reject zero-width or reverse valid-time windows. A tx
         ;; with `:db.valid/from >= :db.valid/to` would produce a
         ;; tx-entity that no `d/valid-at` query can ever match
         ;; (the AVET predicate is `vf <= at < vt`, unsatisfiable
         ;; when from >= to) — a silent data-quality bug. Throw at
         ;; the transactor so it surfaces immediately.
-         _ (let [tm (:tx-meta initial-report)
-                 vf (:db.valid/from tm)
-                 vt (:db.valid/to tm)]
-             (when (and vf vt (not (bp/date-before? vf vt)))
-               (log/raise (str "Invalid valid-time window: :db.valid/from "
-                               "must be strictly before :db.valid/to "
-                               "(got from=" vf ", to=" vt ")")
-                          {:error :transact/invalid-valid-times
-                           :db.valid/from vf
-                           :db.valid/to vt})))
-         meta-entities (flush-tx-meta initial-report)]
-     (loop [report (update initial-report :db-after transient)
-            es (if (dbi/-keep-history? db-before)
-                 (concat meta-entities
-                         initial-es')
-                 initial-es')]
-       (let [[entity & entities] es
-             {:keys [tempids db-after]} report
-             db db-after]
-         (cond
-           (empty? es)
-           (do
+        _ (let [tm (:tx-meta initial-report)
+                vf (:db.valid/from tm)
+                vt (:db.valid/to tm)]
+            (when (and vf vt (not (bp/date-before? vf vt)))
+              (log/raise (str "Invalid valid-time window: :db.valid/from "
+                              "must be strictly before :db.valid/to "
+                              "(got from=" vf ", to=" vt ")")
+                         {:error :transact/invalid-valid-times
+                          :db.valid/from vf
+                          :db.valid/to vt})))
+        meta-entities (flush-tx-meta initial-report)]
+    (loop [report (update initial-report :db-after transient)
+           es (if (dbi/-keep-history? db-before)
+                (concat meta-entities
+                        initial-es')
+                initial-es')]
+      (let [[entity & entities] es
+            {:keys [tempids db-after]} report
+            db db-after]
+        (cond
+          (empty? es)
+          (do
             ;; Cross-tx vf<vt validation: any prior tx-entity touched
             ;; by this commit's vt-meta writes is checked against the
             ;; final combined state. Throws on invalid window. The
             ;; ::pending-vt-validation bookkeeping is stripped before
             ;; the report exits, matching the ::queued-tuples cleanup
             ;; discipline.
-             (validate-cross-tx-vt-windows! report)
+            (validate-cross-tx-vt-windows! report)
             ;; Deferred schema validation on the RESULTING state — covers
             ;; raw datom vectors, retracts and any datom order uniformly
             ;; (check-schema-update only sees the entity-map path).
-             (validate-schema-changes! report tx-options)
-             (validate-ident-renames! report)
-             (-> report
+            (validate-schema-changes! report tx-options prepared)
+            (validate-ident-renames! report)
+            (-> report
                 ;; Index-backfill migration for :db/index / :db/unique
                 ;; enabled on existing attributes — must run while
                 ;; :db-after is still transient.
-                 backfill-enabled-indices
+                (backfill-enabled-indices prepared)
                 ;; The inverse transition is equally atomic: remove the full
                 ;; current AVET slice before this database value is published.
-                 remove-disabled-indices
-                 (dissoc ::pending-vt-validation)
-                 (assoc-in [:tempids :db/current-tx] (current-tx report))
-                 (update-in [:db-after :max-tx] inc)
-                 (update :db-after persistent!)
-                 (update :db-after finalize-secondary-indices)))
+                remove-disabled-indices
+                (dissoc ::pending-vt-validation)
+                (assoc-in [:tempids :db/current-tx] (current-tx report))
+                (update-in [:db-after :max-tx] inc)
+                (update :db-after persistent!)
+                (update :db-after finalize-secondary-indices)
+                (#?(:clj (fn [report] (admission/finish prepared report))
+                    :cljs identity))))
 
-           (nil? entity)
-           (recur report entities)
+          (nil? entity)
+          (recur report entities)
 
-           (= ::flush-tuples entity)
-           (if (contains? report ::queued-tuples)
-             (recur
-              (dissoc report ::queued-tuples)
-              (concat (flush-tuples report) entities))
-             (recur report entities))
+          (= ::flush-tuples entity)
+          (if (contains? report ::queued-tuples)
+            (recur
+             (dissoc report ::queued-tuples)
+             (concat (flush-tuples report) entities))
+            (recur report entities))
 
-           (map? entity)
-           (let [{:keys [new-report new-entities retry? old-eid upserted-eid]} (entity-map->op-vec db report entity)]
-             (if retry?
-               (retry-with-tempid initial-report report initial-es old-eid upserted-eid tx-options)
-               (recur new-report (concat new-entities entities))))
+          (map? entity)
+          (let [{:keys [new-report new-entities retry? old-eid upserted-eid]} (entity-map->op-vec db report entity)]
+            (if retry?
+              (retry-with-tempid initial-report report initial-es old-eid upserted-eid tx-options prepared)
+              (recur new-report (concat new-entities entities))))
 
-           (sequential? entity)
-           (let [[op e a v] entity]
-             (when (dbu/tuple? db a)
-               (check-tuple db entity))
-             (cond
+          (sequential? entity)
+          (let [[op e a v] entity]
+            (when (dbu/tuple? db a)
+              (check-tuple db entity))
+            (cond
 
-               (tx-id? e)
-               (recur (allocate-eid report e (current-tx report)) (cons [op (current-tx report) a v] entities))
+              (tx-id? e)
+              (recur (allocate-eid report e (current-tx report)) (cons [op (current-tx report) a v] entities))
 
-               (and (dbu/ref? db a) (tx-id? v))
-               (recur (allocate-eid report v (current-tx report)) (cons [op e a (current-tx report)] entities))
+              (and (dbu/ref? db a) (tx-id? v))
+              (recur (allocate-eid report v (current-tx report)) (cons [op e a (current-tx report)] entities))
 
-               (tempid? e)
-               (if (not= op :db/add)
-                 (log/raise "Can't use tempid in '" entity "'. Tempids are allowed in :db/add only"
-                            {:error :transact/syntax, :op entity})
-                 (let [upserted-eid (when (dbu/is-attr? db a :db.unique/identity)
-                                      (:e (first (dbi/datoms db :avet [a v]))))
-                       allocated-eid (get tempids e)]
-                   (if (and upserted-eid allocated-eid (not= upserted-eid allocated-eid))
-                     (retry-with-tempid initial-report report initial-es e upserted-eid tx-options)
-                     (let [eid (or upserted-eid allocated-eid (next-eid db))]
-                       (recur (allocate-eid report e eid) (cons [op eid a v] entities))))))
+              (tempid? e)
+              (if (not= op :db/add)
+                (log/raise "Can't use tempid in '" entity "'. Tempids are allowed in :db/add only"
+                           {:error :transact/syntax, :op entity})
+                (let [upserted-eid (when (dbu/is-attr? db a :db.unique/identity)
+                                     (:e (first (dbi/datoms db :avet [a v]))))
+                      allocated-eid (get tempids e)]
+                  (if (and upserted-eid allocated-eid (not= upserted-eid allocated-eid))
+                    (retry-with-tempid initial-report report initial-es e upserted-eid tx-options prepared)
+                    (let [eid (or upserted-eid allocated-eid (next-eid db))]
+                      (recur (allocate-eid report e eid) (cons [op eid a v] entities))))))
 
-               (and (dbu/ref? db a) (tempid? v))
-               (if-let [vid (get tempids v)]
-                 (recur report (cons [op e a vid] entities))
-                 (recur (allocate-eid report v (next-eid db)) es))
+              (and (dbu/ref? db a) (tempid? v))
+              (if-let [vid (get tempids v)]
+                (recur report (cons [op e a vid] entities))
+                (recur (allocate-eid report v (next-eid db)) es))
 
-               :else
-               (let [[new-report new-entities] (apply-db-op db report entity)]
-                 (recur new-report (concat new-entities entities)))))
+              :else
+              (let [[new-report new-entities] (apply-db-op db report entity)]
+                (recur new-report (concat new-entities entities)))))
 
-           (datom? entity)
-           (let [[e a v tx added] entity]
-             (if added
-               (recur (transact-add report [:db/add e a v tx]) entities)
-               (recur (transact-retract-datom report entity true) entities)))
+          (datom? entity)
+          (let [[e a v tx added] entity]
+            (if added
+              (recur (transact-add report [:db/add e a v tx]) entities)
+              (recur (transact-retract-datom report entity true) entities)))
 
-           :else
-           (log/raise "Bad entity type at " entity ", expected map or vector"
-                      {:error :transact/syntax, :tx-data entity})))))))
+          :else
+          (log/raise "Bad entity type at " entity ", expected map or vector"
+                     {:error :transact/syntax, :tx-data entity}))))))
+
+(defn transact-tx-data
+  ([initial-report initial-es] (transact-tx-data initial-report initial-es nil))
+  ([initial-report initial-es tx-options]
+   (transact-tx-data-internal initial-report initial-es tx-options nil)))
 
 (defn transact-entities-directly
   "Load `initial-es` (raw `[e a v t op]` records) into `(:db-after

--- a/src/datahike/gc.cljc
+++ b/src/datahike/gc.cljc
@@ -173,9 +173,10 @@
                       ;; history is kept.
                       head-building-secondary?
                       (and (= to-check branch)
-                           (some (fn [[_ entry]]
-                                   (= :building (:db.secondary/status entry)))
-                                 schema))
+                           (or (= :building (get-in record [:avet-build :status]))
+                               (some (fn [[_ entry]]
+                                       (= :building (:db.secondary/status entry)))
+                                     schema)))
                             ;; Kept SEPARATE from the node addresses, not folded in.
                             ;; A store-ref names an object; it does NOT say where the
                             ;; bytes live. If they are in this konserve store, the

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -196,11 +196,20 @@
 #?(:clj
    (defn- enqueue-avet-cancel! [runtime queue generation]
      (let [callback (promise-chan)]
-       (if (put! queue {:op 'cancel-avet-build! :args [generation :build-failed]
-                        :callback callback})
-         (go (when (instance? Throwable (<! callback))
-               (avet-runtime/fail-generation! runtime generation :cancel-rejected)))
-         (avet-runtime/fail-generation! runtime generation :dispatch-failed)))))
+       (try
+         (if (put! queue {:op 'cancel-avet-build! :args [generation :build-failed]
+                          :callback callback})
+           (go (when (instance? Throwable (<! callback))
+                 (avet-runtime/fail-generation! runtime generation :cancel-rejected)))
+           (avet-runtime/fail-generation! runtime generation :dispatch-failed))
+         (catch Throwable enqueue-error
+           ;; In particular, pending-put overflow throws AssertionError rather
+           ;; than returning false. This helper runs inside writer error paths:
+           ;; failed best-effort cancellation must not hide the original error
+           ;; or bypass its callback/shutdown handling.
+           (avet-runtime/fail-generation! runtime generation :dispatch-failed)
+           (log/warn :datahike/avet-cancel-enqueue-failed
+                     {:generation generation :message (ex-message enqueue-error)}))))))
 
 #?(:clj
    (defn- reject-avet-installs! [runtime owner queue txs]
@@ -1179,10 +1188,16 @@
                                            :install {:op 'try-install-avet-build! :args [token]
                                                      ::avet-generation generation}
                                            :cancel {:op 'cancel-avet-build! :args [generation :build-failed]})]
-                          (when-not (and @queue-holder
-                                         (put! @queue-holder (assoc invocation :callback callback)))
-                            (avet-runtime/fail-generation! avet-runtime generation :dispatch-failed)
-                            (throw (ex-info "AVET writer queue is closed." {:type :writer-shut-down})))
+                          (try
+                            (when-not (and @queue-holder
+                                           (put! @queue-holder (assoc invocation :callback callback)))
+                              (throw (ex-info "AVET writer queue is closed." {:type :writer-shut-down})))
+                            (catch Throwable enqueue-error
+                              ;; A worker may catch this error and fail to enqueue
+                              ;; its cancellation too. Retire local lineage now,
+                              ;; before it releases the last owned candidate.
+                              (avet-runtime/fail-generation! avet-runtime generation :dispatch-failed)
+                              (throw enqueue-error)))
                           (go (let [result (<! callback)]
                                 (when (instance? Throwable result)
                                   (when (= op :cancel)

--- a/src/datahike/writer.cljc
+++ b/src/datahike/writer.cljc
@@ -10,6 +10,10 @@
             [datahike.tx-preds :as txp]
             #?(:clj [datahike.backfill.capture :as capture])
             #?(:clj [datahike.backfill.journal :as journal])
+            #?(:clj [datahike.backfill.runtime :as avet-runtime])
+            #?(:clj [datahike.backfill.coordinator :as avet-coordinator])
+            #?(:clj [datahike.backfill.sort :as avet-sort])
+            #?(:clj [datahike.backfill.storage :as avet-storage])
             [datahike.gc :as gc]
             [datahike.tools :as dt :refer [throwable-promise get-time-ms]]
             [konserve.core :as k]
@@ -30,8 +34,19 @@
 (defprotocol PConnectionRefresh
   (-refresh-on-deref? [_] "Returns whether dereferencing the connection must refresh its branch head from storage."))
 
+#?(:clj
+   (defn- close-local-resources! [journal-owner coordinator runtime]
+     ;; Joining workers and reclaiming owned storage can block on I/O. Every
+     ;; caller runs this on thread-try, never the core.async go dispatcher.
+     (try
+       (when journal-owner (capture/dispose-owned! journal-owner))
+       (finally
+         (try
+           (when coordinator (avet-coordinator/close! coordinator))
+           (finally (when runtime (avet-runtime/close! runtime))))))))
+
 (defrecord LocalWriter [thread writer-ownership transaction-queue-size commit-queue-size
-                        transaction-queue commit-queue journal-owner]
+                        transaction-queue commit-queue journal-owner avet-runtime avet-coordinator]
   PWriter
   (-dispatch! [_ arg-map]
     (let [p (promise-chan)]
@@ -47,9 +62,10 @@
       p))
   (-shutdown [_]
     (close! transaction-queue)
-    #?(:clj (go (let [result (<! thread)]
-                  (when journal-owner (capture/dispose-owned! journal-owner))
-                  result))
+    #?(:clj (go (let [result (<! thread)
+                      cleanup (<! (thread-try S (close-local-resources!
+                                                 journal-owner avet-coordinator avet-runtime)))]
+                  (or cleanup result)))
        :cljs thread))
   ;; A local writer always installs its own committed db-after in the connection.
   ;; Shared ownership still refreshes on deref because OTHER writers do not stream
@@ -158,6 +174,67 @@
          (put! callback e)
          (recur)))))
 
+#?(:clj
+   (defn- apply-avet-write [runtime op-fn old args bindings op]
+     (let [run (fn []
+                 (let [raw (::raw-write-fn (meta op-fn))
+                       report (apply (or raw op-fn) old args)
+                       proposed (avet-runtime/normalize-report runtime report op)]
+                   ;; Keep predicate evaluation inside the caller's bindings,
+                   ;; just as the original wrapped operation did.
+                   (if (or raw (not= (select-keys (:db-after report) [:avet-build :avet-build-result])
+                                     (select-keys (:db-after proposed) [:avet-build :avet-build-result])))
+                     (txp/check-report proposed)
+                     proposed)))]
+       (if bindings (with-bindings* bindings run) (run)))))
+
+#?(:clj
+   (defn- check-avet-installs! [owner txs]
+     (doseq [[report] txs :let [token (::avet-install-token report)] :when token]
+       (avet-coordinator/check-install! owner token))))
+
+#?(:clj
+   (defn- enqueue-avet-cancel! [runtime queue generation]
+     (let [callback (promise-chan)]
+       (if (put! queue {:op 'cancel-avet-build! :args [generation :build-failed]
+                        :callback callback})
+         (go (when (instance? Throwable (<! callback))
+               (avet-runtime/fail-generation! runtime generation :cancel-rejected)))
+         (avet-runtime/fail-generation! runtime generation :dispatch-failed)))))
+
+#?(:clj
+   (defn- reject-avet-installs! [runtime owner queue txs]
+     (when runtime
+       (avet-coordinator/invalidate! owner)
+       (avet-runtime/invalidate! runtime)
+       (doseq [[report] txs :let [token (::avet-install-token report)] :when token]
+         (avet-coordinator/abort-install! owner token true)
+         (enqueue-avet-cancel! runtime queue (::avet-generation report))))))
+
+#?(:clj
+   (defn- committed-avet! [runtime owner queue commit-db txs]
+     (when runtime
+       (try
+         (let [start (avet-runtime/committed! runtime commit-db (mapv first txs))]
+           (avet-coordinator/after-commit! owner commit-db start))
+         (catch Throwable hook-error
+           ;; Publication already succeeded. Background failures never alter
+           ;; the durable transaction outcome, including cleanup failures.
+           (log/error :datahike/avet-commit-hook-failed {:error hook-error})
+           (try
+             (avet-coordinator/invalidate! owner)
+             (try
+               (avet-runtime/invalidate! runtime)
+               (finally
+                 (doseq [[report] txs :let [token (::avet-install-token report)] :when token]
+                   (avet-coordinator/abort-install! owner token true))
+                 ;; Cancel only the generation in this durable group, never a
+                 ;; newer speculative begin that may already be queued.
+                 (when-let [id (get-in commit-db [:avet-build :id])]
+                   (enqueue-avet-cancel! runtime queue id))))
+             (catch Throwable cleanup-error
+               (log/error :datahike/avet-commit-hook-cleanup-failed {:error cleanup-error}))))))))
+
 (defn create-thread
   "Creates new transaction thread.
 
@@ -165,7 +242,7 @@
    before a batch is applied and conditionally published. With exclusive
    ownership this JVM keeps the head in memory. See [[create-writer]]."
   [connection write-fn-map transaction-queue-size commit-queue-size commit-wait-time
-   shared? {:keys [max-batch retries backoff journal-owner]
+   shared? {:keys [max-batch retries backoff journal-owner avet-runtime avet-coordinator]
             :or   {max-batch MAX_SHARED_WRITER_BATCH
                    retries   MAX_HEAD_CONFLICT_RETRIES
                    backoff   DEFAULT_HEAD_CONFLICT_BACKOFF_MS}}]
@@ -289,7 +366,17 @@
                       (do
                         (when (> (count transaction-queue-buffer) (* 0.9 transaction-queue-size))
                           (log/warn :datahike/tx-queue-pressure "Transaction queue buffer >90% full" {:count (count transaction-queue-buffer) :size transaction-queue-size}))
-                        (let [;; SHARED: another process may have committed
+                        (let [install? (= op 'try-install-avet-build!)
+                              drain? (and install? (pos? pending))
+                              _ (when drain?
+                                  (loop [n pending]
+                                    (when (pos? n) (<! commit-done) (recur (dec n)))))
+                              old (if drain? @(:wrapped-atom connection) old)
+                              needs-reload? (or drain? needs-reload?)
+                              pending (if drain? 0 pending)
+                              ;; The invocation remains owned here while the
+                              ;; prior speculative batch drains completely.
+                              ;; SHARED: another process may have committed
                               ;; to this branch since our last transaction, so the
                               ;; db we hold is not necessarily the head. Re-read it
                               ;; (one storage read) and apply on top of that. Safe
@@ -323,7 +410,14 @@
                               ;; MAX_SHARED_WRITER_BATCH for why that is sound.
                               old (if (or (not shared?) (not needs-reload?))
                                     old
-                                    (try (<?- (w/reload-branch-head old false))
+                                    (try (let [reloaded (<?- (w/reload-branch-head old false))]
+                                           #?(:clj (if avet-runtime
+                                                     (let [reconciled (avet-runtime/reconcile-db! avet-runtime reloaded)]
+                                                       (when (:datahike.backfill.runtime/lost-lineage? reconciled)
+                                                         (avet-coordinator/invalidate! avet-coordinator))
+                                                       reconciled)
+                                                     reloaded)
+                                              :cljs reloaded))
                                          (catch #?(:clj Throwable :cljs js/Error) e
                                            (log/error :datahike/head-reload-failed
                                                       {:invocation (dissoc invocation :bindings) :error e})
@@ -408,15 +502,27 @@
                                                             {:type :writer/unknown-op
                                                              :op op
                                                              :supported (set (keys write-fn-map))})))
-                                          #?(:clj (capture/prepare-report!
-                                                   journal-owner
-                                                   (if bindings
-                                                     (with-bindings* bindings apply op-fn old args)
-                                                     (apply op-fn old args)))
+                                          #?(:clj (let [report (capture/prepare-report!
+                                                                journal-owner
+                                                                (if avet-runtime
+                                                                  (apply-avet-write avet-runtime op-fn old args bindings op)
+                                                                  (if bindings
+                                                                    (with-bindings* bindings apply op-fn old args)
+                                                                    (apply op-fn old args))))
+                                                        report (if avet-runtime
+                                                                 (avet-runtime/prepare-report! avet-runtime report op true)
+                                                                 report)]
+                                                    (when-let [token (::avet-install-token report)]
+                                                      (avet-coordinator/accepted! avet-coordinator token))
+                                                    report)
                                              :cljs (apply op-fn old args))))
                               ;; Catch all Throwables to handle AssertionError and other Errors
                               ;; These should crash the writer, but we deliver to callback first to prevent hangs
                                       (catch #?(:clj Throwable :cljs js/Error) e
+                                        #?(:clj (when (and install? avet-coordinator)
+                                                  (avet-coordinator/abort-install! avet-coordinator (first args) true)
+                                                  (when-let [generation (::avet-generation invocation)]
+                                                    (enqueue-avet-cancel! avet-runtime transaction-queue generation))))
                                         (log/error :datahike/write-error {:invocation (dissoc invocation :bindings) :error e :args args})
                                 ;; short circuit on errors
                                         #?(:cljs (put! callback e)
@@ -525,7 +631,9 @@
                                                 (when (and (pos? retries)
                                                            (contains? retryable-ops op))
                                                   invocation)]))
-                                    (do (put! callback
+                                    (do #?(:clj (when-let [token (::avet-install-token res)]
+                                                  (avet-coordinator/abort-install! avet-coordinator token true)))
+                                        (put! callback
                                               (ex-info "Writer is shut down (a previous fatal error closed it); release and reconnect."
                                                        {:type :writer-shut-down}))
                                         (recur old needs-reload? pending))
@@ -579,7 +687,9 @@
                        ;; stamp the batch opened with.
                        last-rev nil]
                   (if-not tx
-                    #?(:clj (capture/dispose-owned! journal-owner) :cljs nil)
+                    #?(:clj (<?- (thread-try S (close-local-resources!
+                                                journal-owner avet-coordinator avet-runtime)))
+                       :cljs nil)
                     (let [txs (into [tx] (take-while some?) (repeatedly #(poll! commit-queue)))]
               ;; empty channel of pending transactions
                       (log/trace :datahike/batch-commit {:batch-size (count txs)})
@@ -612,7 +722,11 @@
                                  db)
                             build-cleanup-complete? (atom false)]
                         (try
-                          (let [start-ts (get-time-ms)
+                          (let [_ (when @writer-down?
+                                    (throw (ex-info "Writer is shut down; dependent reports cannot commit."
+                                                    {:type :writer-shut-down})))
+                                _ #?(:clj (check-avet-installs! avet-coordinator txs) :cljs nil)
+                                start-ts (get-time-ms)
                                 {{:keys [datahike/commit-id]} :meta
                                  :as commit-db} (<?- (w/commit! db merge-parents false last-cid head-rev))
                                 commit-time (- (get-time-ms) start-ts)
@@ -624,12 +738,13 @@
                                 finalized-txs
                                 (mapv (fn [[tx-report callback]]
                                         [(-> tx-report
-                                             (dissoc :datahike.backfill.capture/retired)
+                                             (dissoc :datahike.backfill.capture/retired ::avet-install-token ::avet-generation)
                                              (assoc-in [:tx-meta :db/commitId] commit-id)
                                              (assoc :db-after commit-db))
                                          callback])
                                       txs)
                                 tx-reports (mapv first finalized-txs)]
+                            #?(:clj (committed-avet! avet-runtime avet-coordinator transaction-queue commit-db txs))
                             (log/trace :datahike/commit-time {:duration-ms commit-time})
                             (metrics/commit! (:config db)
                                              commit-time
@@ -682,6 +797,7 @@
                             (doseq [[tx-report callback] finalized-txs]
                               (>! callback tx-report)))
                           (catch #?(:clj Throwable :cljs js/Error) e
+                            #?(:clj (reject-avet-installs! avet-runtime avet-coordinator transaction-queue txs))
                             (cond
                               ;; NOT FATAL, and NOT RETRIED. The connection demands
                               ;; fencing and this head has no revision to fence
@@ -695,8 +811,8 @@
                               ;; message and keep the writer alive.
                               (= :datahike/fencing-unavailable (:type (ex-data e)))
                               (do
-                                (log/warn :datahike/fencing-unavailable
-                                          {:branch (:branch (:config db))})
+                                (log/warn :datahike/commit-admission-rejected
+                                          {:branch (:branch (:config db)) :error e})
                                 (doseq [[_ callback] txs]
                                   (put! callback e)))
 
@@ -850,8 +966,9 @@
    the caller, and never enqueues a commit (nothing persists, chain unchanged).
    Ungoverned stores pay a single map lookup. EXPERIMENTAL/internal seam."
   [write-fn]
-  (fn [old & args]
-    (txp/check-report (apply write-fn old args))))
+  (with-meta (fn [old & args]
+               (txp/check-report (apply write-fn old args)))
+    {::raw-write-fn write-fn}))
 
 ;; public API to internal mapping
 (def default-write-fn-map {'transact!     (with-tx-pred w/transact!)
@@ -956,7 +1073,20 @@
   #{:backend :writer-ownership :transaction-queue-size :commit-queue-size
     :commit-wait-time :write-fn-map
     :max-batch :head-conflict-retries :head-conflict-backoff-ms
-    :require-fencing :backfill-journal})
+    :require-fencing :backfill-journal :avet-backfill})
+
+#?(:clj
+   (defn- avet-options! [options]
+     (when-not (and (or (nil? options) (map? options))
+                    (every? #{:runtime :build :tail-bytes :tail-transactions :max-jobs} (keys options)))
+       (throw (ex-info "Unknown AVET writer options." {:type :invalid-avet-backfill-options})))
+     (let [build (:build options)]
+       (when-not (and (or (nil? build) (map? build))
+                      (every? #{:sort :storage} (keys build)))
+         (throw (ex-info "Unknown AVET build options." {:type :invalid-avet-backfill-options})))
+       (avet-sort/validate-options! (:sort build))
+       (avet-storage/validate-options! (:storage build)))
+     options))
 
 (defn check-fencing!
   "Raise unless `store` can fence branch-head writes as far as `require-fencing`
@@ -999,6 +1129,10 @@
        :cljs (when (contains? writer-config :backfill-journal)
                (log/raise "Backfill scratch journals require a JVM local writer."
                           {:type :backfill-journal-unsupported-platform})))
+    #?(:clj (avet-options! (:avet-backfill writer-config))
+       :cljs (when (contains? writer-config :avet-backfill)
+               (log/raise "Background AVET requires a JVM local writer."
+                          {:type :avet-backfill-unsupported-platform})))
     (when-let [unknown (seq (remove self-writer-keys (keys writer-config)))]
       (log/raise "Unknown key(s) in the :self writer config."
                  {:type    :unknown-self-writer-config-keys
@@ -1029,19 +1163,64 @@
           commit-queue-size (or commit-queue-size DEFAULT_QUEUE_SIZE)
           commit-wait-time (or commit-wait-time DEFAULT_COMMIT_WAIT_TIME)
           journal-owner #?(:clj (atom {}) :cljs nil)
+          avet-options (:avet-backfill writer-config)
+          queue-holder (atom nil)
+          avet-runtime #?(:clj (avet-runtime/create! (:runtime avet-options)) :cljs nil)
+          avet-coordinator
+          #?(:clj
+             (avet-coordinator/create!
+              avet-runtime
+              (merge (select-keys avet-options [:max-jobs :tail-bytes :tail-transactions])
+                     {:build-options (:build avet-options)
+                      :submit!
+                      (fn [{:keys [op generation token]}]
+                        (let [callback (promise-chan)
+                              invocation (case op
+                                           :install {:op 'try-install-avet-build! :args [token]
+                                                     ::avet-generation generation}
+                                           :cancel {:op 'cancel-avet-build! :args [generation :build-failed]})]
+                          (when-not (and @queue-holder
+                                         (put! @queue-holder (assoc invocation :callback callback)))
+                            (avet-runtime/fail-generation! avet-runtime generation :dispatch-failed)
+                            (throw (ex-info "AVET writer queue is closed." {:type :writer-shut-down})))
+                          (go (let [result (<! callback)]
+                                (when (instance? Throwable result)
+                                  (when (= op :cancel)
+                                    (avet-runtime/fail-generation! avet-runtime generation :cancel-rejected))
+                                  (log/warn :datahike/avet-internal-operation-failed
+                                            {:generation generation :error result}))))))}))
+             :cljs nil)
+          avet-ops
+          #?(:clj
+             {'begin-avet-build! (with-tx-pred w/begin-avet-build!)
+              'cancel-avet-build! (with-tx-pred w/cancel-avet-build!)
+              'try-install-avet-build!
+              (fn [old token]
+                (let [{:keys [status certificate] :as result}
+                      (avet-coordinator/try-install! avet-coordinator old token)]
+                  (if (= :ready status)
+                    (assoc (avet-coordinator/with-install!
+                             avet-coordinator token
+                             #(txp/check-report (w/install-avet-build! old certificate)))
+                           ::avet-install-token token
+                           ::avet-generation (get-in old [:avet-build :id]))
+                    (let [p (promise-chan)] (put! p result) p))))}
+             :cljs {})
           retry-policy {:max-batch (or max-batch MAX_SHARED_WRITER_BATCH)
                         :retries   (or head-conflict-retries MAX_HEAD_CONFLICT_RETRIES)
                         :backoff   (or head-conflict-backoff-ms DEFAULT_HEAD_CONFLICT_BACKOFF_MS)
-                        :journal-owner journal-owner}
+                        :journal-owner journal-owner
+                        :avet-runtime avet-runtime :avet-coordinator avet-coordinator}
           [transaction-queue commit-queue thread]
           (create-thread connection
                          (merge default-write-fn-map
-                                write-fn-map)
+                                write-fn-map avet-ops)
                          transaction-queue-size
                          commit-queue-size
                          commit-wait-time
                          shared?
                          retry-policy)]
+      (reset! queue-holder transaction-queue)
       (map->LocalWriter
        {:transaction-queue transaction-queue
         :transaction-queue-size transaction-queue-size
@@ -1049,7 +1228,8 @@
         :commit-queue-size commit-queue-size
         :thread thread
         :writer-ownership writer-ownership
-        :journal-owner journal-owner}))))
+        :journal-owner journal-owner
+        :avet-runtime avet-runtime :avet-coordinator avet-coordinator}))))
 
 ;; Note: :kabel backend is implemented in datahike.kabel.writer
 ;; Require that namespace to register the defmethod

--- a/src/datahike/writing.cljc
+++ b/src/datahike/writing.cljc
@@ -6,6 +6,8 @@
             [datahike.gc-roots :as roots]
             [datahike.db.transaction :as dbtx]
             #?(:clj [datahike.backfill.capture :as capture])
+            #?(:clj [datahike.backfill.admission :as avet-admission])
+            #?(:clj [datahike.backfill.job :as avet-job])
             [datahike.db.utils :as dbu]
             [datahike.db.interface :as dbi]
             [datahike.index :as di]
@@ -51,7 +53,7 @@
    :temporal-eavt-key :temporal-aevt-key :temporal-avet-key
    :schema-meta-key :secondary-index-keys
    :schema :rschema :system-entities :ref-ident-map :ident-ref-map
-   :max-tx :max-eid :op-count :hash :meta])
+   :max-tx :max-eid :op-count :hash :meta :avet-build :avet-build-result])
 
 (defn- stored-head-identity [stored]
   (-> (select-keys stored stored-head-identity-keys)
@@ -485,6 +487,9 @@
           {:temporal-eavt-key (detach temporal-eavt')
            :temporal-aevt-key (detach temporal-aevt')
            :temporal-avet-key (detach temporal-avet')})
+        ;; Only durable job metadata crosses this boundary. Local journal paths,
+        ;; cursors, pending effects, candidate roots and leases stay process-local.
+        (select-keys db [:avet-build :avet-build-result])
         (when secondary-index-keys
           {:secondary-index-keys secondary-index-keys})
         fused-roots)])))
@@ -719,6 +724,7 @@
      ;; an index whose restore failed (see there). Only when there is one: an
      ;; explicit nil would make every db built from storage unequal to the
      ;; same db built in memory.
+     (select-keys stored-db [:avet-build :avet-build-result])
      (when (seq secondary-index-keys)
        {:secondary-index-keys secondary-index-keys})
      (when (seq sec-indices)
@@ -2016,6 +2022,67 @@
                     (core/with old tx-data tx-meta tx-options))]
     #?(:clj (validate-secondary-backfill-writer! old tx-report))
     (complete-db-update old tx-report)))
+
+#?(:clj
+   (defn ^:no-doc begin-avet-build!
+     "Accept one durable background request without changing effective schema.
+      Completion is a separate fenced activation, not success of this report."
+     [old patch]
+     (avet-job/supported! old)
+     (let [base (if (:datahike.backfill.runtime/lost-lineage? old)
+                  (dissoc old :avet-build :avet-build-journal :avet-build-effects
+                          :avet-build-invalidated? :datahike.backfill.runtime/lost-lineage?)
+                  old)
+           request (avet-admission/plan base patch)
+           descriptor (avet-job/descriptor base request)
+           report (binding [sec/*durable-secondary-write-context* :commit]
+                    (core/with base [] nil))]
+       (complete-db-update
+        old (update (assoc report :db-before old :avet-build-id (:id descriptor)) :db-after
+                    #(-> %
+                         (assoc :avet-build descriptor)
+                         (dissoc :avet-build-journal :avet-build-effects
+                                 :avet-build-invalidated? :avet-build-result)))))))
+
+#?(:clj
+   (defn ^:no-doc install-avet-build!
+     "Apply a coordinator-owned prepared certificate through ordinary report
+      admission. The coordinator retains private resources through publication."
+     [old certificate]
+     (avet-job/supported! old)
+     (when-not (avet-job/matches? old (:avet-build old))
+       (throw (ex-info "AVET schema or branch prerequisites changed."
+                       {:type :avet-build-stale-schema})))
+     (let [report (binding [sec/*durable-secondary-write-context* :commit]
+                    (core/with-prepared-avet old certificate))]
+       (complete-db-update
+        old (assoc-in report [:db-after :avet-build-result]
+                      {:id (get-in old [:avet-build :id]) :status :ready})))))
+
+#?(:clj
+   (defn ^:no-doc cancel-avet-build!
+     "Retire only the named durable generation. Safe for recovery on any writer;
+      cancellation performs no private build or schema change."
+     ([old id] (cancel-avet-build! old id :canceled))
+     ([old id reason]
+      (when-not (and (uuid? id) (= id (get-in old [:avet-build :id])))
+        (throw (ex-info "Cannot cancel a different AVET generation."
+                        {:type :avet-build-generation-mismatch :id id})))
+      (when-not (contains? #{:canceled :schema-changed :head-conflict :owner-lost
+                             :recovered :build-failed :unsupported-operation}
+                           reason)
+        (throw (ex-info "Unknown AVET cancellation reason."
+                        {:type :avet-build-invalid-cancellation})))
+      (let [report (binding [sec/*durable-secondary-write-context* :commit]
+                     (core/with old [] nil))]
+        (complete-db-update
+         old (update report :db-after
+                     #(-> %
+                          (dissoc :avet-build :avet-build-journal :avet-build-effects
+                                  :avet-build-invalidated?)
+                          (assoc :avet-build-result
+                                 {:id id :status (if (= :canceled reason) :canceled :failed)
+                                  :reason reason}))))))))
 
 (defn load-entities
   [old entities]

--- a/test/datahike/test/backfill_admission_test.clj
+++ b/test/datahike/test/backfill_admission_test.clj
@@ -1,5 +1,5 @@
 (ns datahike.test.backfill-admission-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is]]
             [datahike.backfill.admission :as admission]
             [datahike.backfill.avet :as avet]
             [datahike.backfill.effects :as effects]
@@ -31,7 +31,8 @@
 
 (defn- active [database attrs]
   (let [generation (random-uuid)
-        cursor {:generation generation :journal-id (random-uuid) :sequence 1 :offset 100}]
+        cursor {:generation generation :journal-id (random-uuid)
+                :sequence 1 :position (Object.)}]
     (assoc database :avet-build {:id generation
                                  :attrs (into attrs
                                               (keep (fn [[ident entry]]
@@ -129,7 +130,8 @@
   (let [source (active (base false true) #{:value})
         certificate (mint source {:value {:db/unique :db.unique/value}})
         after (:db-after (core/with source [[:db/add 10000 :value 2] [:db/add 10001 :value 1]]))
-        cursor (-> (get-in source [:avet-build-journal :cursor]) (update :sequence inc) (update :offset + 100))
+        cursor (-> (get-in source [:avet-build-journal :cursor])
+                   (update :sequence inc) (assoc :position (Object.)))
         frame {:kind :transaction :generation (:generation cursor) :sequence (:sequence cursor)
                :max-tx (:max-tx after) :effects (:avet-build-effects after)}
         next-source (-> after (dissoc :avet-build-effects) (assoc-in [:avet-build-journal :cursor] cursor))
@@ -145,8 +147,8 @@
         certificate (mint source {:value {:db/unique :db.unique/value}})
         after (:db-after (core/with source [[:db/add 10000 :value 3]]))
         later (:db-after (core/with (dissoc after :avet-build-effects) [[:db/add 10001 :value 4]]))
-        c1 (-> (admission/cursor certificate) (update :sequence inc) (update :offset + 100))
-        c2 (-> c1 (update :sequence inc) (update :offset + 100))
+        c1 (-> (admission/cursor certificate) (update :sequence inc) (assoc :position (Object.)))
+        c2 (-> c1 (update :sequence inc) (assoc :position (Object.)))
         frame (fn [database cursor]
                 {:kind :transaction :generation (:generation cursor) :sequence (:sequence cursor)
                  :max-tx (:max-tx database) :effects (:avet-build-effects database)})
@@ -236,8 +238,8 @@
         certificate (mint source {:value {:db/unique :db.unique/value}})
         duplicate (:db-after (core/with source [[:db/add 10000 :value 2]]))
         repaired (:db-after (core/with (dissoc duplicate :avet-build-effects) [[:db/add 10001 :value 3]]))
-        c1 (-> (admission/cursor certificate) (update :sequence inc) (update :offset + 100))
-        c2 (-> c1 (update :sequence inc) (update :offset + 100))
+        c1 (-> (admission/cursor certificate) (update :sequence inc) (assoc :position (Object.)))
+        c2 (-> c1 (update :sequence inc) (assoc :position (Object.)))
         final-source (-> repaired (dissoc :avet-build-effects) (assoc-in [:avet-build-journal :cursor] c2))
         reached-repair? (atom false)
         frame (fn [database cursor]

--- a/test/datahike/test/backfill_admission_test.clj
+++ b/test/datahike/test/backfill_admission_test.clj
@@ -1,0 +1,375 @@
+(ns datahike.test.backfill-admission-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.backfill.admission :as admission]
+            [datahike.backfill.avet :as avet]
+            [datahike.backfill.effects :as effects]
+            [datahike.backfill.unique :as unique]
+            [datahike.core :as core]
+            [datahike.api :as d]
+            [datahike.datom :as dd]
+            [datahike.db :as db]
+            [datahike.db.transaction :as transaction]
+            [datahike.db.utils :as dbu]
+            [datahike.index.interface :as di]
+            [datahike.index.secondary :as sec]
+            [datahike.index.persistent-set :as persistent-set]
+            [datahike.writing :as writing]
+            [datahike.test.backfill-effects-test :as effect-fixtures]
+            [datahike.test.utils :as utils])
+  (:import [org.replikativ.persistent_sorted_set PersistentSortedSet]))
+
+(defn- base [refs? history?]
+  (:db-after
+   (core/with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs? :keep-history? history?
+                                :schema-flexibility :write})
+              [{:db/ident :value :db/valueType :db.type/long
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :other :db/valueType :db.type/long :db/index true
+                :db/cardinality :db.cardinality/one}
+               {:db/id 10000 :value 1 :other 10}
+               {:db/id 10001 :value 2 :other 20}])))
+
+(defn- active [database attrs]
+  (let [generation (random-uuid)
+        cursor {:generation generation :journal-id (random-uuid) :sequence 1 :offset 100}]
+    (assoc database :avet-build {:id generation
+                                 :attrs (into attrs
+                                              (keep (fn [[ident entry]]
+                                                      (when (and (keyword? ident) (map? entry)
+                                                                 (or (:db/index entry) (:db/unique entry)))
+                                                        ident)))
+                                              (:schema database))}
+           :avet-build-journal {:cursor cursor})))
+
+(defn- candidate [source attrs]
+  (let [resolved (set (map #(dbu/attr-ref-or-ident source %) attrs))
+        additions (fn [k] (filter #(contains? resolved (:a %)) (get source k)))]
+    {:current (reduce #(di/-insert %1 %2 :avet 0) (:avet source) (additions :aevt))
+     :temporal (when (:temporal-avet source)
+                 (reduce #(di/-temporal-insert %1 %2 :avet 0)
+                         (:temporal-avet source) (additions :temporal-aevt)))}))
+
+(defn- mint [source patch]
+  (admission/mint! source (candidate source (set (keys patch))) patch
+                   (get-in source [:avet-build-journal :cursor])))
+
+(defn- tuples [tree] (mapv #(vec (seq %)) tree))
+
+(deftest prepared-activation-matches-synchronous-oracle
+  (doseq [refs? [false true] history? [false true]
+          flags [{:db/index true} {:db/unique :db.unique/value}
+                 {:db/index true :db/unique :db.unique/identity}]]
+    (let [source (active (base refs? history?) #{:value :other :db/ident :db/txInstant})
+          patch {:value flags}
+          certificate (mint source patch)
+          instant (java.util.Date. 2000000000000)]
+      (with-redefs-fn {#'transaction/next-tx-instant (constantly instant)}
+        (fn []
+          (let [report (core/with-prepared-avet source certificate)
+                actual (:db-after report)
+                expected (:db-after (core/with source (admission/transaction-data certificate)
+                                               nil {:allow-index-backfill? true}))]
+            (is (identical? source (:db-before report)))
+            (is (= (:schema expected) (:schema actual)))
+            (doseq [key [:eavt :aevt :avet :temporal-eavt :temporal-aevt :temporal-avet]]
+              (is (= (tuples (get expected key)) (tuples (get actual key))) (str [refs? history? flags key])))
+            (is (nil? (:avet-build actual)))
+            (is (nil? (:avet-build-journal actual)))
+            (is (empty? (effects/observations actual)))
+            (is (not (effects/enabled? actual)))
+            (is (= (:avet-build source) (:avet-build (:db-before report))))))))))
+
+(deftest strict-request-and-local-source-binding
+  (let [source (active (base false true) #{:value})
+        patch {:value {:db/index true}}
+        certificate (mint source patch)]
+    (doseq [invalid [nil {} {:missing {:db/index true}} {:value {:db/index false}}
+                     {:value {:db/cardinality :db.cardinality/many}}
+                     {:value {:db/unique :unrecognized}}
+                     {:other {:db/index true}} {10000 {:db/index true}}
+                     {:db/txInstant {:db/unique :db.unique/value}}]]
+      (is (thrown? clojure.lang.ExceptionInfo (admission/plan source invalid))))
+    (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet source {:checked? true})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (core/with-prepared-avet (assoc source :unrelated true) certificate)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/check! certificate source
+                                   (conj (admission/transaction-data certificate) [:db/add 10000 :value 8]))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (core/with source (admission/transaction-data certificate) nil {:prepared certificate})))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (core/with source (admission/transaction-data certificate) {:prepared certificate})))
+    (is (= 1 (get-in source [:avet-build-journal :cursor :sequence])))
+    (is (not (get-in source [:schema :value :db/index])))))
+
+(deftest checked-unique-candidate-and-stale-cursor-rejected
+  (let [source (active (base false true) #{:value})
+        duplicate (:db-after (core/with source [[:db/add 10001 :value 1]]))
+        duplicate (dissoc duplicate :avet-build-effects)
+        patch {:value {:db/unique :db.unique/value}}]
+    (is (thrown? clojure.lang.ExceptionInfo (mint duplicate patch)))
+    (doseq [changed [(assoc-in source [:avet-build-journal :cursor :sequence] 2)
+                     (assoc source :avet-build-invalidated? true)
+                     (assoc source :avet-build-effects [[:current :remove nil nil]])]]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (admission/mint! changed (candidate changed #{:value}) patch
+                                    (get-in source [:avet-build-journal :cursor])))))))
+
+(deftest prepared-path-does-not-rescan-certified-attributes
+  (let [source (active (base false true) #{:value})
+        certificate (mint source {:value {:db/index true :db/unique :db.unique/value}})]
+    (with-redefs-fn
+      {#'transaction/schema-attr-current-datoms (fn [& _] (throw (ex-info "Unexpected full current sweep" {})))
+       #'transaction/schema-attr-history-datoms (fn [& _] (throw (ex-info "Unexpected full history sweep" {})))
+       #'transaction/validate-unique-avet! (fn [& _] (throw (ex-info "Unexpected full unique scan" {})))
+       #'unique/validate! (fn [& _] (throw (ex-info "Unexpected certificate mint on writer" {})))}
+      #(is (get-in (core/with-prepared-avet source certificate) [:db-after :schema :value :db/index])))))
+
+(deftest advancement-replays-complete-transaction-before-checking
+  (let [source (active (base false true) #{:value})
+        certificate (mint source {:value {:db/unique :db.unique/value}})
+        after (:db-after (core/with source [[:db/add 10000 :value 2] [:db/add 10001 :value 1]]))
+        cursor (-> (get-in source [:avet-build-journal :cursor]) (update :sequence inc) (update :offset + 100))
+        frame {:kind :transaction :generation (:generation cursor) :sequence (:sequence cursor)
+               :max-tx (:max-tx after) :effects (:avet-build-effects after)}
+        next-source (-> after (dissoc :avet-build-effects) (assoc-in [:avet-build-journal :cursor] cursor))
+        advanced (admission/advance certificate next-source frame cursor)]
+    (is (get-in (core/with-prepared-avet next-source advanced) [:db-after :schema :value :db/unique]))
+    (is (thrown? clojure.lang.ExceptionInfo (admission/advance advanced next-source frame cursor)))
+    (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet next-source certificate)))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/advance certificate next-source (update frame :sequence inc) cursor)))))
+
+(deftest range-advancement-checks-each-complete-frame
+  (let [source (active (base false true) #{:value})
+        certificate (mint source {:value {:db/unique :db.unique/value}})
+        after (:db-after (core/with source [[:db/add 10000 :value 3]]))
+        later (:db-after (core/with (dissoc after :avet-build-effects) [[:db/add 10001 :value 4]]))
+        c1 (-> (admission/cursor certificate) (update :sequence inc) (update :offset + 100))
+        c2 (-> c1 (update :sequence inc) (update :offset + 100))
+        frame (fn [database cursor]
+                {:kind :transaction :generation (:generation cursor) :sequence (:sequence cursor)
+                 :max-tx (:max-tx database) :effects (:avet-build-effects database)})
+        f1 (frame after c1) f2 (frame later c2)
+        final-source (-> later (dissoc :avet-build-effects) (assoc-in [:avet-build-journal :cursor] c2))
+        read-range (fn [f init] (f (f init f1 c1) f2 c2))
+        advanced (admission/advance-range certificate final-source c2 read-range)]
+    (is (= c2 (admission/cursor advanced)))
+    (is (get-in (core/with-prepared-avet final-source advanced) [:db-after :schema :value :db/unique]))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/advance-range certificate final-source c2 (fn [f init] (f init f1 c1)))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/advance-range certificate final-source c2 (fn [f init] (f init f2 c2)))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/advance-range certificate final-source c2
+                                          (fn [f init] (f (f init f1 c1) (assoc f2 :sequence 90) c2)))))))
+
+(deftest activation-derived-tuples-use-complete-replayed-candidate
+  (doseq [refs? [false true] duplicate? [false true]]
+    (let [initial (:db-after
+                   (core/with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs? :keep-history? true
+                                                :schema-flexibility :write})
+                              [{:db/ident :aaa :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                               {:db/ident :bbb :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                               {:db/ident :tag :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                               {:db/ident :pair :db/valueType :db.type/tuple :db/tupleAttrs [:db/index :tag]
+                                :db/cardinality :db.cardinality/one}]))
+          ;; The tuple also covers built-in indexed schema entities. Give
+          ;; those distinct tags before testing the deliberate aaa/bbb pair.
+          tagged (:db-after
+                  (core/with initial
+                             (into [] (map (fn [eid] [:db/add eid :tag (+ 1000000 eid)]))
+                                   (into #{} (keep #(when (= (dbu/attr-ref-or-ident initial :db/index) (:a %))
+                                                      (:e %))) (:eavt initial)))))
+          ;; Composite tuples initialize unchanged components to nil; they do
+          ;; not backfill source values predating the tuple definition. Assert
+          ;; bbb's index flag now so its tuple genuinely starts [true tag].
+          populated (:db-after (core/with tagged [[:db/add (dbu/entid initial :bbb) :db/index true]
+                                                  [:db/add (dbu/entid initial :aaa) :tag 1]
+                                                  [:db/add (dbu/entid initial :bbb) :tag (if duplicate? 1 2)]]))
+          source (active populated #{:aaa :pair :bbb :db/ident :db/txInstant})
+          pair-value (fn [ident]
+                       (:v (first (filter #(and (= (dbu/entid source ident) (:e %))
+                                                (= (dbu/attr-ref-or-ident source :pair) (:a %)))
+                                          (:eavt source)))))
+          _ (is (= [nil 1] (pair-value :aaa)))
+          _ (is (= [true (if duplicate? 1 2)] (pair-value :bbb)))
+          certificate (mint source {:aaa {:db/index true} :pair {:db/unique :db.unique/value}})
+          original-source (mapv #(tuples (get source %)) [:eavt :avet :temporal-avet])
+          original-candidate (mapv #(tuples (get (admission/candidate certificate) %)) [:current :temporal])]
+      (if duplicate?
+        (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet source certificate)))
+        (with-redefs-fn {#'transaction/next-tx-instant (constantly (java.util.Date. 2000000000000))}
+          (fn []
+            (let [actual (:db-after (core/with-prepared-avet source certificate))
+                  expected (:db-after (core/with source (admission/transaction-data certificate)
+                                                 nil {:allow-index-backfill? true}))]
+              (is (= (tuples (:avet expected)) (tuples (:avet actual))))
+              (is (= (tuples (:temporal-avet expected)) (tuples (:temporal-avet actual))))))))
+      (is (= original-source (mapv #(tuples (get source %)) [:eavt :avet :temporal-avet])))
+      (is (= original-candidate (mapv #(tuples (get (admission/candidate certificate) %)) [:current :temporal]))))))
+
+(deftest authoritative-wrapper-rebinding-requires-roots-and-fence
+  (let [source (-> (active (base false true) #{:value})
+                   (assoc-in [:meta :datahike/commit-id] (random-uuid))
+                   (assoc :datahike.writing/head-revision (random-uuid)))
+        certificate (mint source {:value {:db/index true}})
+        wrapper (assoc source :datahike.writing/head-revision (:datahike.writing/head-revision source))
+        rebound (admission/rebind-source certificate wrapper)]
+    (is (not (identical? source wrapper)))
+    (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet wrapper certificate)))
+    (is (identical? wrapper (:db-before (core/with-prepared-avet wrapper rebound))))
+    (doseq [changed [(assoc source :datahike.writing/head-revision (random-uuid))
+                     (assoc-in source [:meta :datahike/commit-id] (random-uuid))
+                     (assoc-in source [:config :branch] :other)
+                     (assoc-in source [:schema :value :db/doc] "changed")
+                     (assoc-in source [:ident-ref-map :value] 123456)
+                     (assoc-in source [:secondary-index-keys :opaque/index] (random-uuid))
+                     (assoc source :aevt (:avet source))
+                     (assoc-in source [:avet-build :id] (random-uuid))
+                     (update-in source [:avet-build-journal :cursor :sequence] inc)
+                     (dissoc source :datahike.writing/head-revision)]]
+      (is (thrown? clojure.lang.ExceptionInfo (admission/rebind-source certificate changed))))))
+
+(deftest range-rejects-duplicate-before-a-later-repair
+  (let [source (active (base false true) #{:value})
+        certificate (mint source {:value {:db/unique :db.unique/value}})
+        duplicate (:db-after (core/with source [[:db/add 10000 :value 2]]))
+        repaired (:db-after (core/with (dissoc duplicate :avet-build-effects) [[:db/add 10001 :value 3]]))
+        c1 (-> (admission/cursor certificate) (update :sequence inc) (update :offset + 100))
+        c2 (-> c1 (update :sequence inc) (update :offset + 100))
+        final-source (-> repaired (dissoc :avet-build-effects) (assoc-in [:avet-build-journal :cursor] c2))
+        reached-repair? (atom false)
+        frame (fn [database cursor]
+                {:kind :transaction :generation (:generation cursor) :sequence (:sequence cursor)
+                 :max-tx (:max-tx database) :effects (:avet-build-effects database)})]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (admission/advance-range
+                  certificate final-source c2
+                  (fn [f init]
+                    (let [first-result (f init (frame duplicate c1) c1)]
+                      (reset! reached-repair? true)
+                      (f first-result (frame repaired c2) c2))))))
+    (is (false? @reached-repair?))))
+
+(defn- same-tree? [left right]
+  (let [cmp (dd/index-type->cmp-quick :avet false)]
+    (and (= (count left) (count right)) (every? zero? (map cmp left right)))))
+
+(deftest private-storage-admission-preserves-owned-roots-on-success-and-failure
+  (let [conn (utils/setup-db {:crypto-hash? false :index :datahike.index/persistent-set
+                              :schema-flexibility :write :attribute-refs? false :keep-history? true
+                              :writer {:writer-ownership :exclusive}})
+        config (:config @conn)]
+    (try
+      (d/transact conn [{:db/ident :value :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}
+                        {:db/id 10000 :value 1} {:db/id 10001 :value 2}])
+      (let [source (active @conn #{:value})
+            private (avet/build! source #{:value} {:sort {:window-records 2 :fan-in 2}
+                                                   :storage {:pending-node-limit 2 :cache-node-limit 2}})]
+        (try
+          (let [unflushed (admission/mint! source private {:value {:db/index true :db/unique :db.unique/value}}
+                                           (get-in source [:avet-build-journal :cursor]))
+                _ (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet source unflushed)))
+                certificate (admission/flush! unflushed)
+                original-source (mapv #(tuples (get source %)) [:eavt :avet :temporal-avet])
+                original-private (mapv #(tuples (get private %)) [:current :temporal])]
+            ;; Fail after native transients and complete activation replay have
+            ;; both run. No published/private source may have been mutated.
+            (with-redefs [unique/validate-effects! (fn [& _] (throw (ex-info "Rejected final activation" {})))]
+              (is (thrown? clojure.lang.ExceptionInfo (core/with-prepared-avet source certificate))))
+            (is (= original-source (mapv #(tuples (get source %)) [:eavt :avet :temporal-avet])))
+            (is (= original-private (mapv #(tuples (get private %)) [:current :temporal])))
+            (with-redefs-fn {#'transaction/next-tx-instant (constantly (java.util.Date. 2000000000000))}
+              (fn []
+                (let [actual (:db-after (core/with-prepared-avet source certificate))
+                      expected (:db-after (core/with source (admission/transaction-data certificate)
+                                                     nil {:allow-index-backfill? true}))]
+                  (is (same-tree? (:avet expected) (:avet actual)))
+                  (is (same-tree? (:temporal-avet expected) (:temporal-avet actual)))
+                  (let [store (:store source)
+                        expected-rows (mapv #(tuples (get actual %)) [:avet :temporal-avet])
+                        roots (mapv #(di/-flush (get actual %) store) [:avet :temporal-avet])]
+                    (doseq [^PersistentSortedSet root roots]
+                      (is (identical? (:storage store) (.-_storage root))))
+                    (is (= original-private (mapv #(tuples (get private %)) [:current :temporal])))
+                    (writing/write-pending-kvs! store (writing/get-and-clear-pending-kvs! store) true)
+                    (avet/close! private)
+                    ;; Reconstruct without any resident root or shared live
+                    ;; cache. Every node read must survive private disposal.
+                    (let [cold-storage (persistent-set/create-storage
+                                        (dissoc store :storage di/node-cache-key) (:config source))
+                          cold (mapv (fn [^PersistentSortedSet root]
+                                       (PersistentSortedSet. (meta root) (dd/index-type->cmp-quick :avet false)
+                                                             (.-_address root) cold-storage nil
+                                                             (.-_count root) (.-_settings root) (.-_version root))) roots)]
+                      (is (= expected-rows (mapv tuples cold))))))))
+            (is (= original-source (mapv #(tuples (get source %)) [:eavt :avet :temporal-avet]))))
+          (finally (avet/close! private))))
+      (finally (d/release conn) (d/delete-database config)))))
+
+(deftest arrays-and-tuples-retain-native-uniqueness-semantics-on-admission
+  (doseq [[properties value equal-value other-value]
+          [[{} (byte-array [1 2]) (byte-array [1 2]) (byte-array [1 3])]
+           [{} (float-array [1 2]) (float-array [1 2]) (float-array [1 3])]
+           [{} (double-array [1 2]) (double-array [1 2]) (double-array [1 3])]
+           [{:db/valueType :db.type/tuple :db/tupleTypes [:db.type/long :db.type/string]}
+            [1 "a"] [1 "a"] [1 "b"]]]]
+    (let [initial (:db-after
+                   (core/with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? false :keep-history? true :schema-flexibility :read})
+                              [(merge {:db/ident :payload :db/cardinality :db.cardinality/one} properties)
+                               [:db/add 10000 :payload value] [:db/add 10001 :payload other-value]]))
+          source (active initial #{:payload})
+          patch {:payload {:db/unique :db.unique/value}}
+          certificate (mint source patch)]
+      (with-redefs-fn {#'transaction/next-tx-instant (constantly (java.util.Date. 2000000000000))}
+        (fn []
+          (let [actual (:db-after (core/with-prepared-avet source certificate))
+                expected (:db-after (core/with source (admission/transaction-data certificate)
+                                               nil {:allow-index-backfill? true}))]
+            (is (same-tree? (:avet expected) (:avet actual)))
+            (is (same-tree? (:temporal-avet expected) (:temporal-avet actual))))))
+      (let [duplicate (-> (:db-after (core/with source [[:db/add 10001 :payload equal-value]]))
+                          (dissoc :avet-build-effects))]
+        (is (thrown? clojure.lang.ExceptionInfo (mint duplicate patch)))))))
+
+(deftest ordinary-path-still-runs-full-backfill-and-unique-validation
+  (let [source (base false true)
+        current-scan @#'transaction/schema-attr-current-datoms
+        history-scan @#'transaction/schema-attr-history-datoms
+        unique-scan @#'transaction/validate-unique-avet!
+        calls (atom {})
+        counted (fn [label f] (fn [& args] (swap! calls update label (fnil inc 0)) (apply f args)))]
+    (with-redefs-fn {#'transaction/schema-attr-current-datoms (counted :current current-scan)
+                     #'transaction/schema-attr-history-datoms (counted :history history-scan)
+                     #'transaction/validate-unique-avet! (counted :unique unique-scan)}
+      #(core/with source [[:db/add (dbu/entid source :value) :db/unique :db.unique/value]]
+                  nil {:allow-index-backfill? true}))
+    (doseq [label [:current :history :unique]] (is (pos? (get @calls label 0))))))
+
+(deftest secondary-only-admission-indexes-primary-hashes
+  (doseq [refs? [false true]]
+    (let [initial (:db-after (core/with (base refs? true)
+                                        [{:db/ident :body :db/valueType :db.type/string
+                                          :db/cardinality :db.cardinality/one :db.secondary/only true}]))
+          ready (-> initial
+                    (assoc-in [:schema :idx/recorder] {:db.secondary/status :ready
+                                                       :db.secondary/type :test/effect-recorder
+                                                       :db.secondary/attrs [:body]})
+                    (assoc-in [:rschema :db.secondary/index :body] #{:idx/recorder})
+                    (assoc-in [:secondary-indices :idx/recorder] (effect-fixtures/->PrimaryHashRecorder [])))]
+      (binding [sec/*durable-secondary-write-context* :commit]
+        (let [source (active (:db-after (core/with ready [[:db/add 10000 :body "full first"]
+                                                          [:db/add 10001 :body "full second"]])) #{:body})
+              certificate (mint source {:body {:db/index true}})]
+          (with-redefs-fn {#'transaction/next-tx-instant (constantly (java.util.Date. 2000000000000))}
+            (fn []
+              (let [actual (:db-after (core/with-prepared-avet source certificate))
+                    expected (:db-after (core/with source (admission/transaction-data certificate)
+                                                   nil {:allow-index-backfill? true}))
+                    values (map :v (filter #(= (dbu/attr-ref-or-ident source :body) (:a %)) (:avet actual)))]
+                (is (= #{(sec/secondary-only-hash "full first") (sec/secondary-only-hash "full second")}
+                       (set values)))
+                (is (same-tree? (:avet expected) (:avet actual)))
+                (is (same-tree? (:temporal-avet expected) (:temporal-avet actual)))))))))))

--- a/test/datahike/test/backfill_api_test.clj
+++ b/test/datahike/test/backfill_api_test.clj
@@ -1,0 +1,42 @@
+(ns datahike.test.backfill-api-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.backfill.avet :as avet]
+            [datahike.test.utils :as utils]))
+
+(deftest begin-and-cancel-isolate-throwing-transaction-listeners
+  (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                              :attribute-refs? false :keep-history? true
+                              :index :datahike.index/persistent-set
+                              :writer {:backend :self :writer-ownership :shared :require-fencing :process}})
+        config (:config @conn) entered (promise) proceed (promise)
+        begin-notified (promise) cancel-notified (promise) build avet/build!]
+    (try
+      (d/transact conn [{:db/ident :value :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                        {:db/id 10000 :value 1}])
+      (d/listen conn ::throws (fn [_] (throw (ex-info "Deliberate listener failure" {}))))
+      (d/listen conn ::observes
+                (fn [report]
+                  (when-let [id (:avet-build-id report)] (deliver begin-notified id))
+                  (when (= :canceled (get-in report [:db-after :avet-build-result :status]))
+                    (deliver cancel-notified (get-in report [:db-after :avet-build-result :id])))))
+      (with-redefs [avet/build! (fn [& args]
+                                  (deliver entered true)
+                                  (when (= ::timeout (deref proceed 10000 ::timeout))
+                                    (throw (ex-info "API listener test build gate timed out" {})))
+                                  (apply build args))]
+        (try
+          (let [accepted @(d/begin-avet-build! conn {:value {:db/index true}})
+                id (:avet-build-id accepted)]
+            (is (uuid? id))
+            (is (= id (deref begin-notified 10000 ::timeout)))
+            (is (true? (deref entered 10000 false)))
+            (let [canceled @(d/cancel-avet-build! conn id)]
+              (is (= :canceled (get-in canceled [:db-after :avet-build-result :status])))
+              (is (= id (deref cancel-notified 10000 ::timeout))))
+            (is (not (get-in @conn [:schema :value :db/index]))))
+          (finally (deliver proceed true))))
+      (finally
+        (deliver proceed true)
+        (d/unlisten conn ::throws) (d/unlisten conn ::observes)
+        (d/release conn) (d/delete-database config)))))

--- a/test/datahike/test/backfill_avet_test.clj
+++ b/test/datahike/test/backfill_avet_test.clj
@@ -1,0 +1,192 @@
+(ns datahike.test.backfill-avet-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.backfill.avet :as avet]
+            [datahike.backfill.effects :as effects]
+            [datahike.backfill.sort :as sort]
+            [datahike.backfill.storage :as storage]
+            [datahike.datom :as dd]
+            [datahike.index.interface :as di]
+            [datahike.constants :as constants]
+            [datahike.test.utils :as utils]
+            [org.replikativ.persistent-sorted-set :as pss])
+  (:import [java.nio.file Files Path]
+           [java.nio.file.attribute FileAttribute]
+           [org.replikativ.persistent_sorted_set PersistentSortedSet Branch]))
+
+(defn- with-db [overrides f]
+  (let [conn (utils/setup-db (merge {:crypto-hash? false :index :datahike.index/persistent-set
+                                     :schema-flexibility :write
+                                     :allow-index-backfill? true
+                                     :writer {:writer-ownership :exclusive}}
+                                    overrides))
+        config (:config @conn)]
+    (try (f conn) (finally (d/release conn) (d/delete-database config)))))
+
+(defn- seed! [conn]
+  (let [refs? (get-in @conn [:config :attribute-refs?])]
+  ;; The persisted refs-mode system schema has no :db.type/bytes entity. Keep
+  ;; byte codec coverage in non-ref cases; do not fabricate a system type ref.
+    (d/transact conn (remove #(and refs? (= :bytes (:db/ident %)))
+                             [{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one
+                               :db/unique :db.unique/identity}
+                              {:db/ident :score :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                              {:db/ident :old :db/valueType :db.type/long :db/cardinality :db.cardinality/one :db/index true}
+                              {:db/ident :many :db/valueType :db.type/long :db/cardinality :db.cardinality/many}
+                              {:db/ident :bytes :db/valueType :db.type/bytes :db/cardinality :db.cardinality/one}
+                              {:db/ident :nohist :db/valueType :db.type/string :db/cardinality :db.cardinality/one :db/noHistory true}]))
+    (d/transact conn (map #(if refs? (dissoc % :bytes) %)
+                          [{:name "one" :score 9 :old 10 :many [1 2] :bytes (byte-array [1 2]) :nohist "before"}
+                           {:name "two" :score 3 :old 30 :many [4 5] :bytes (byte-array [3 4])}]))
+    (d/transact conn [{:db/id [:name "one"] :score 8 :old 11 :nohist "after"}])
+    (d/transact conn [[:db/retract [:name "one"] :many 1]
+                      [:db/add [:name "one"] :many 1]])
+    (d/transact conn [{:db/id [:db/ident :old] :db/index false}])))
+
+(defn- resolved [db ident]
+  (if (get-in db [:config :attribute-refs?]) (get-in db [:ident-ref-map ident]) ident))
+
+(defn- comparator-equal? [left right]
+  (let [cmp (dd/index-type->cmp-quick :avet false)]
+    (and (= (count left) (count right))
+         (every? zero? (map cmp left right)))))
+
+(deftest candidate-matches-synchronous-current-and-raw-history
+  (doseq [refs? [false true] history? [false true]]
+    (with-db {:attribute-refs? refs? :keep-history? history?}
+      (fn [conn]
+        (seed! conn)
+        (let [source @conn
+              old-schema (:schema source)
+              attrs (cond-> #{:score :many :nohist :name} (not refs?) (conj :bytes))
+              patch (mapv (fn [ident] {:db/id [:db/ident ident] :db/index true}) (disj attrs :name))
+              oracle (d/db-with source patch)
+              user-attrs (set (map #(resolved source %) (conj attrs :old)))
+              user-only (fn [tree] (filterv #(contains? user-attrs (:a %)) tree))
+              candidate (avet/build! source attrs {:sort {:window-records 2 :fan-in 2}
+                                                   :storage {:pending-node-limit 2 :cache-node-limit 2}})]
+          (try
+            (is (= old-schema (:schema source)))
+            (is (comparator-equal? (user-only (:avet oracle)) (user-only (:current candidate))))
+            (is (every? #(contains? (:current candidate) %) (:avet source)))
+            (if history?
+              (do
+                (is (comparator-equal? (user-only (:temporal-avet oracle))
+                                       (user-only (:temporal candidate))))
+                (is (seq (filter #(= (resolved source :old) (:a %)) (:temporal candidate))))
+                (is (every? #(contains? (:temporal candidate) %) (:temporal-avet source))))
+              (is (nil? (:temporal candidate))))
+            (finally (avet/close! candidate))))))))
+
+(deftest already-indexed-and-repeated-attributes-do-not-duplicate
+  (with-db {:keep-history? true}
+    (fn [conn]
+      (seed! conn)
+      (let [source @conn candidate (avet/build! source [:name :name])]
+        (try
+          (is (comparator-equal? (:avet source) (:current candidate)))
+          (is (comparator-equal? (:temporal-avet source) (:temporal candidate)))
+          (finally (avet/close! candidate)))))))
+
+(deftest failures-close-private-storage-and-sort-scratch
+  (with-db {:keep-history? true}
+    (fn [conn]
+      (seed! conn)
+      (let [directory (Files/createTempDirectory "avet-builder-test-" (make-array FileAttribute 0))
+            created (atom nil)
+            original-create storage/create!
+            original-sort sort/with-sorted-records!]
+        (try
+          (with-redefs [storage/create! (fn [& args]
+                                          (let [private (apply original-create args)]
+                                            (reset! created private) private))
+                        sort/with-sorted-records! (fn [& args]
+                                                    (apply original-sort args)
+                                                    (throw (ex-info "cleanup failed" {:type :injected-cleanup})))]
+            (is (= :injected-cleanup
+                   (try (avet/build! @conn #{:score} {:sort {:directory directory :window-records 1}})
+                        nil (catch Exception e (:type (ex-data e)))))))
+          (is (:closed? (storage/resources @created)))
+          (is (= 0 (:pending-nodes (storage/resources @created))
+                 (:cached-nodes (storage/resources @created))))
+          (with-open [^java.util.stream.Stream paths (Files/list directory)] (is (zero? (.count paths))))
+          (finally (Files/delete directory)))))))
+
+(deftest invalid-request-is-rejected-before-storage-or-sort
+  (with-db {}
+    (fn [conn]
+      (with-redefs [storage/create! (fn [& _] (throw (AssertionError. "Unexpected storage allocation")))
+                    sort/with-sorted-records! (fn [& _] (throw (AssertionError. "Unexpected scratch")))]
+        (doseq [[attrs options] [[#{:missing} nil] [true nil] [#{} {:unknown 1}]
+                                 [#{} {:sort {:fan-in 1}}]]]
+          (is (thrown? clojure.lang.ExceptionInfo (avet/build! @conn attrs options))))))))
+
+(deftest multilevel-roots-reopen-after-candidate-close
+  (with-db {:keep-history? true}
+    (fn [conn]
+      (d/transact conn [{:db/ident :value :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                        {:db/ident :anchor :db/valueType :db.type/long :db/cardinality :db.cardinality/one :db/index true}])
+      (d/transact conn (mapv (fn [i] {:db/id (+ 10000 i) :value i :anchor (- i)}) (range 2300)))
+      (d/transact conn (mapv (fn [i] {:db/id (+ 10000 i) :value (+ 5000 i)}) (range 300)))
+      (let [source (assoc-in @conn [:store :datahike/branching-factor] 32)
+            live (get-in source [:store :storage])
+            before-cache @(:cache live)
+            before-stats @(:stats live)
+            before-roots (mapv (fn [key]
+                                 (let [^PersistentSortedSet tree (get source key)
+                                       reference (.-_root tree)
+                                       root (.readReference (.-_settings tree) reference)]
+                                   [tree reference root (when (instance? Branch root) (.-_state ^Branch root))]))
+                               [:aevt :avet :temporal-aevt :temporal-avet])
+            candidate (avet/build! source #{:value} {:sort {:window-records 64 :fan-in 2}
+                                                     :storage {:cache-node-limit 2 :pending-node-limit 2}})
+            roots (try
+                    (let [roots [(pss/store (:current candidate)) (pss/store (:temporal candidate))]]
+                      (storage/flush! (:storage candidate))
+                      roots)
+                    (finally (avet/close! candidate)))
+            _ (is (= before-cache @(:cache live)))
+            _ (is (= before-stats @(:stats live)))
+            _ (doseq [[^PersistentSortedSet tree reference root state] before-roots]
+                (is (identical? reference (.-_root tree)))
+                (when state (is (identical? state (.-_state ^Branch root)))))
+            cmp (dd/index-type->cmp-quick :avet false)
+            [current temporal] (mapv #(pss/restore-by cmp % (get-in source [:store :storage])
+                                                      {:branching-factor 32}) roots)
+            select-value (fn [tree]
+                           (di/-slice tree (dd/datom constants/e0 :value nil constants/tx0)
+                                      (dd/datom constants/emax :value nil constants/txmax) :avet))
+            current-values (mapv :v (select-value current))
+            temporal-values (mapv :v (select-value temporal))]
+        (is (= (vec (concat (range 300 2300) (range 5000 5300))) current-values))
+        (is (= (vec (concat (mapcat #(repeat (if (< % 300) 2 1) %) (range 2300))
+                            (range 5000 5300))) temporal-values))
+        (is (every? #(contains? current %) (:avet source)))
+        (is (every? #(contains? temporal %) (:temporal-avet source)))
+        (is (= 2000 (count (filter #(< (:v %) 5000) (select-value current)))))
+        (is (:closed? (storage/resources (:storage candidate))))))))
+
+(deftest purge-of-disabled-index-removes-retained-history
+  (with-db {:keep-history? true}
+    (fn [conn]
+      (seed! conn)
+      (doseq [attrs [#{:old} #{:score}]]
+        (let [source @conn
+              old-value? #(and (= :old (:a %)) (= 10 (:v %)))
+              active (assoc source :avet-build {:id (random-uuid) :attrs attrs})
+              candidate (avet/build! active attrs)]
+          (try
+            (is (seq (filter old-value? (:temporal-avet source))))
+            (let [purged (d/db-with active [[:db/purge [:name "one"] :old 10]])
+                  replayed (reduce effects/replay candidate (:avet-build-effects purged))
+                  synchronous (d/db-with (dissoc purged :avet-build :avet-build-effects)
+                                         (mapv (fn [ident] {:db/id [:db/ident ident] :db/index true}) attrs))
+                  old-only #(filterv (fn [datom] (= :old (:a datom))) %)]
+              (is (empty? (filter old-value? (:temporal-aevt purged))))
+            ;; Native purge must clear retained AVET entries even while the
+            ;; effective schema no longer indexes this attribute.
+              (is (empty? (filter old-value? (:temporal-avet purged))))
+              (is (empty? (filter old-value? (:temporal replayed))))
+              (is (comparator-equal? (old-only (:temporal-avet synchronous))
+                                     (old-only (:temporal replayed)))))
+            (finally (avet/close! candidate))))))))

--- a/test/datahike/test/backfill_coordinator_test.clj
+++ b/test/datahike/test/backfill_coordinator_test.clj
@@ -1,0 +1,152 @@
+(ns datahike.test.backfill-coordinator-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.backfill.admission :as admission]
+            [datahike.backfill.avet :as avet]
+            [datahike.backfill.control :as control]
+            [datahike.backfill.coordinator :as coordinator]
+            [datahike.backfill.job :as job]
+            [datahike.backfill.runtime :as runtime]
+            [datahike.backfill.sort :as sort]
+            [datahike.gc-guard :as guard]
+            [datahike.gc-roots :as roots]
+            [datahike.store :as ds])
+  (:import [java.util.concurrent LinkedBlockingQueue TimeUnit CountDownLatch]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- request! [^LinkedBlockingQueue requests]
+  (or (.poll requests 5 TimeUnit/SECONDS)
+      (throw (ex-info "Worker dispatch timed out" {}))))
+
+(defn- fixture [options build f]
+  (let [id (random-uuid)
+        cursor {:generation id :journal-id (random-uuid) :offset 10 :sequence 1}
+        source {:avet-build {:id id :patch {:value {:db/index true}}}}
+        lease (atom {:cursor cursor :source-db source})
+        requests (LinkedBlockingQueue.)
+        events (atom [])
+        owner (coordinator/create! {:options {:max-contexts 8}}
+                                   (merge {:submit! #(.add requests %) :tail-bytes 100 :tail-transactions 2} options))]
+    (with-redefs [runtime/acquire-prefix! (fn [_ generation]
+                                            (swap! events conj [:acquire generation]) @lease)
+                  runtime/release-prefix! (fn [& _] (swap! events conj :lease-release))
+                  job/supported! (fn [_]) job/matches? (fn [& _] true)
+                  ds/canonical-store-id (fn [& _] :store)
+                  guard/writing! (fn [_] (swap! events conj :guard) :guard)
+                  guard/done! (fn [& _] (swap! events conj :guard-release))
+                  roots/pin! (fn [& _] (swap! events conj :pin) :pin)
+                  roots/renew! (fn [& _] (swap! events conj :renew))
+                  roots/assert-live! (fn [& _] (swap! events conj :assert-pin))
+                  roots/release! (fn [& _] (swap! events conj :pin-release))
+                  avet/build! (fn [& _] (swap! events conj :build) (build))
+                  avet/close! (fn [_] (swap! events conj :close))
+                  admission/mint! (fn [s candidate _ c] {:source s :candidate candidate :cursor c})
+                  admission/flush! (fn [c] (swap! events conj :flush) c)
+                  admission/cursor :cursor admission/candidate :candidate
+                  admission/rebind-source (fn [c s] (assoc c :source s))
+                  admission/advance-range (fn [c s end _]
+                                            (swap! events conj :advance)
+                                            (assoc c :source s :cursor end))]
+      (try
+        (f {:owner owner :id id :source source :cursor cursor :lease lease
+            :requests requests :events events})
+        (finally (coordinator/close! owner))))))
+
+(defn- begin! [{:keys [owner id source cursor]}]
+  (coordinator/after-commit! owner source {:generation id :source-db source :cursor cursor}))
+
+(deftest candidate-owned-through-successful-commit
+  (fixture {} (constantly {:current :tree})
+           (fn [{:keys [owner source requests events] :as context}]
+             (begin! context)
+             (let [{:keys [token op]} (request! requests)]
+               (is (= :install op))
+               (is (= :ready (:status (coordinator/try-install! owner source token))))
+               (is (= :activated (coordinator/with-install! owner token (constantly :activated))))
+               (coordinator/accepted! owner token)
+               (is (nil? (coordinator/check-install! owner token)))
+               (is (not-any? #{:close :pin-release :guard-release} @events))
+               (coordinator/after-commit! owner {} nil)
+               (coordinator/close! owner)
+               (is (= 1 (count (filter #{:close} @events))))
+               (is (= [:close :pin-release :guard-release] (take-last 3 @events)))
+               (is (empty? (:jobs @(:state owner))))))))
+
+(deftest rejected-admission-reoffers-with-fresh-token
+  (fixture {} (constantly {:current :tree})
+           (fn [{:keys [owner source requests] :as context}]
+             (begin! context)
+             (let [first-token (:token (request! requests))]
+               (is (= :ready (:status (coordinator/try-install! owner source first-token))))
+               (coordinator/abort-install! owner first-token false)
+               (let [next-token (:token (request! requests))]
+                 (is (not (identical? first-token next-token)))
+                 (is (thrown? clojure.lang.ExceptionInfo
+                              (coordinator/try-install! owner source first-token)))
+                 (is (= :ready (:status (coordinator/try-install! owner source next-token))))
+                 (coordinator/abort-install! owner next-token true))))))
+
+(deftest oversized-final-tail-retries-outside-writer
+  (fixture {} (constantly {:current :tree})
+           (fn [{:keys [owner source requests events lease] :as context}]
+             (begin! context)
+             (let [token (:token (request! requests))]
+               (swap! lease update :cursor #(assoc % :sequence 10 :offset 1000))
+               (is (= :retry (:status (coordinator/try-install! owner source token))))
+        ;; Only the worker may perform this over-budget advancement. The next
+        ;; offered candidate has already passed the full leased-range replay.
+               (let [next-token (:token (request! requests))]
+                 (is (= 1 (count (filter #{:advance} @events))))
+                 (is (= :ready (:status (coordinator/try-install! owner source next-token))))
+                 (coordinator/abort-install! owner next-token true))))))
+
+(deftest cancellation-and-capacity-are-background-job-outcomes
+  (let [entered (CountDownLatch. 1) resume (CountDownLatch. 1)]
+    (fixture {:max-jobs 1}
+             (fn [] (.countDown entered) (.await resume 5 TimeUnit/SECONDS)
+               (control/check!) {:current :tree})
+             (fn [{:keys [owner source requests events] :as context}]
+               (try
+                 (begin! context)
+                 (is (.await entered 5 TimeUnit/SECONDS))
+                 (let [replacement (random-uuid)
+                       next-source (assoc-in source [:avet-build :id] replacement)]
+                   (is (nil? (coordinator/after-commit!
+                              owner next-source {:generation replacement :source-db next-source})))
+                   (is (= {:op :cancel :generation replacement :reason :worker-capacity}
+                          (request! requests)))
+                   (is (= replacement (get-in @(:state owner) [:last-start-failure :generation]))))
+                 (finally (.countDown resume)))
+               (coordinator/close! owner)
+               (is (not-any? #{:flush} @events))
+               (is (= [:pin-release :guard-release] (take-last 2 @events)))))))
+
+(deftest cancellation-interrupts-sort-and-cleans-owned-scratch
+  (let [directory (Files/createTempDirectory "avet-cancel-sort-" (make-array FileAttribute 0))
+        checks (atom 0)]
+    (try
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"cancelled"
+           (binding [control/*check!* #(when (> (swap! checks inc) 12)
+                                         (throw (ex-info "cancelled" {:type :cancelled})))]
+             (sort/with-sorted-records! (map vector (range 100)) compare
+               {:directory directory :window-records 2 :fan-in 2}
+               doall))))
+      (is (> @checks 12))
+      (with-open [^java.util.stream.Stream files (Files/list directory)]
+        (is (zero? (.count files))))
+      (finally (Files/delete directory)))))
+
+(deftest cancellation-between-admission-and-commit-prevents-publication
+  (fixture {} (constantly {:current :tree})
+           (fn [{:keys [owner source requests events] :as context}]
+             (begin! context)
+             (let [token (:token (request! requests))]
+               (is (= :ready (:status (coordinator/try-install! owner source token))))
+               (coordinator/accepted! owner token)
+               (coordinator/invalidate! owner)
+               (is (thrown? clojure.lang.ExceptionInfo (coordinator/check-install! owner token)))
+               (is (not-any? #{:close :pin-release :guard-release} @events))
+               (coordinator/abort-install! owner token true)
+               (coordinator/close! owner)
+               (is (= [:close :pin-release :guard-release] (take-last 3 @events)))))))

--- a/test/datahike/test/backfill_coordinator_test.clj
+++ b/test/datahike/test/backfill_coordinator_test.clj
@@ -20,7 +20,7 @@
 
 (defn- fixture [options build f]
   (let [id (random-uuid)
-        cursor {:generation id :journal-id (random-uuid) :offset 10 :sequence 1}
+        cursor {:generation id :journal-id (random-uuid) :position (Object.) :sequence 1}
         source {:avet-build {:id id :patch {:value {:db/index true}}}}
         lease (atom {:cursor cursor :source-db source})
         requests (LinkedBlockingQueue.)
@@ -30,6 +30,10 @@
     (with-redefs [runtime/acquire-prefix! (fn [_ generation]
                                             (swap! events conj [:acquire generation]) @lease)
                   runtime/release-prefix! (fn [& _] (swap! events conj :lease-release))
+                  runtime/range-byte-size (fn [_ lease start]
+                                            (if (= (:position start)
+                                                   (get-in lease [:cursor :position]))
+                                              0 1000))
                   job/supported! (fn [_]) job/matches? (fn [& _] true)
                   ds/canonical-store-id (fn [& _] :store)
                   guard/writing! (fn [_] (swap! events conj :guard) :guard)
@@ -91,7 +95,7 @@
            (fn [{:keys [owner source requests events lease] :as context}]
              (begin! context)
              (let [token (:token (request! requests))]
-               (swap! lease update :cursor #(assoc % :sequence 10 :offset 1000))
+               (swap! lease update :cursor #(assoc % :sequence 10 :position (Object.)))
                (is (= :retry (:status (coordinator/try-install! owner source token))))
         ;; Only the worker may perform this over-budget advancement. The next
         ;; offered candidate has already passed the full leased-range replay.

--- a/test/datahike/test/backfill_effects_portable_test.cljc
+++ b/test/datahike/test/backfill_effects_portable_test.cljc
@@ -1,0 +1,96 @@
+(ns datahike.test.backfill-effects-portable-test
+  (:require #?(:clj [clojure.test :refer [deftest is]]
+               :cljs [cljs.test :refer-macros [deftest is]])
+            [datahike.api :as d]
+            [datahike.backfill.effects :as effects]
+            [datahike.datom :as dd]
+            [datahike.db :as db]))
+
+(defn- observed-add [source value]
+  (effects/emit source :score :current :insert (dd/datom 10000 :score value 100) nil))
+
+(defn- error-type [f]
+  (try (f) nil
+       (catch #?(:clj Exception :cljs js/Error) e (:type (ex-data e)))))
+
+#?(:cljs
+   (deftest background-writes-are-explicitly-unsupported-on-cljs
+     (is (= :avet-build-unsupported-platform
+            (error-type #(d/begin-avet-build! nil {:score {:db/index true}}))))
+     (is (= :avet-build-unsupported-platform
+            (error-type #(d/cancel-avet-build! nil (random-uuid)))))))
+
+(deftest observer-budgets-are-incremental-and-pure
+  (let [source (effects/observe {} #{:score} {:max-effects 2})
+        once (observed-add source 1)
+        twice (observed-add once 2)]
+    (is (= ::effects/observer-budget (error-type #(observed-add twice 3))))
+    (is (empty? (effects/observations source)))
+    (is (= 1 (count (effects/observations once))))
+    (is (= 2 (count (effects/observations twice))))
+    (is (= {} (effects/unobserve twice)))
+    (is (= once (observed-add source 1))))
+  (doseq [[options value]
+          [[{:max-bytes 1024} (apply str (repeat 1024 "x"))]
+           [{:max-depth 8} (nth (iterate vector 1) 10)]
+           [{:max-nodes 20} (vec (range 100))]
+           [{:max-bytes 1024} #?(:clj (byte-array 1024) :cljs (js/Uint8Array. 1024))]
+           [{:max-bytes 1024} (with-meta [] {:large (apply str (repeat 1024 "x"))})]]]
+    (let [source (effects/observe {} #{:score} options)]
+      (is (= ::effects/observer-budget (error-type #(observed-add source value))))
+      (is (empty? (effects/observations source)))))
+  (doseq [options [true {:unknown 1} {:max-effects 0} {:max-bytes -1}
+                   {:max-nodes 1.5} {:max-depth 65}]]
+    (is (= ::effects/invalid-observer
+           (error-type #(effects/observe {} #{:score} options)))))
+  (let [source (effects/observe {} #{:score} {:max-bytes 1800})
+        once (observed-add source 1)]
+    (is (= ::effects/observer-budget (error-type #(observed-add once 2))))
+    (is (= 1 (count (effects/observations once))))))
+
+(deftest derived-effects-exhaust-budget-without-changing-source
+  (let [source (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :schema-flexibility :write})
+                          [{:db/ident :score :db/valueType :db.type/long
+                            :db/cardinality :db.cardinality/one}
+                           {:db/ident :pair :db/valueType :db.type/tuple
+                            :db/tupleAttrs [:score :missing]
+                            :db/cardinality :db.cardinality/one}])
+        observed (effects/observe source #{:score :pair} {:max-effects 1})]
+    (is (= ::effects/observer-budget
+           (error-type #(d/db-with observed [{:db/id 10000 :score 1}]))))
+    (is (empty? (effects/observations observed)))
+    (is (= (vec (:eavt source)) (vec (:eavt observed))))))
+
+(deftest exact-effects-and-private-observer-are-portable
+  (doseq [refs? [false true]]
+    (let [source (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs?
+                                              :keep-history? true :schema-flexibility :write})
+                            [{:db/ident :score :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}])
+          active (assoc source :avet-build {:id (random-uuid) :attrs #{:score}})
+          observed (effects/observe source #{:score})
+          tx [{:db/id 10000 :score 4}]
+          built (d/db-with active tx)
+          watched (d/db-with observed tx)
+          emitted (:avet-build-effects built)
+          replayed (reduce effects/replay {:current (empty (:avet source))
+                                           :temporal (empty (:temporal-avet source))} emitted)]
+      (is (seq emitted))
+      (is (= emitted (effects/observations watched)))
+      (is (= [4] (mapv :v (:current replayed))))
+      (is (nil? (:avet-build-effects active)))
+      (is (empty? (effects/observations observed)))
+      (is (not (effects/enabled? (effects/unobserve watched)))))))
+
+(deftest schema-invalidation-remains-sticky-on-both-platforms
+  (doseq [refs? [false true]]
+    (let [source (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs?
+                                              :schema-flexibility :write})
+                            [{:db/ident :score :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one :db/doc "original"}])
+          active (assoc source :avet-build {:id (random-uuid) :attrs #{:score}})
+          after (d/db-with active [[:db/add [:db/ident :score] :db/doc "temporary"]
+                                   [:db/add [:db/ident :score] :db/doc "original"]])]
+      (is (= (:schema source) (:schema after)))
+      (is (:avet-build-invalidated? after))
+      (is (nil? (:avet-build-invalidated? active))))))

--- a/test/datahike/test/backfill_effects_test.clj
+++ b/test/datahike/test/backfill_effects_test.clj
@@ -1,0 +1,291 @@
+(ns datahike.test.backfill-effects-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.backfill.effects :as effects]
+            [datahike.core :as core]
+            [datahike.db :as db]
+            [datahike.index.interface :as di]
+            [datahike.index.secondary :as sec]))
+
+(defn- ident [database datom]
+  (get (:ref-ident-map database) (:a datom) (:a datom)))
+
+(defn- rows [database field attrs]
+  (filter #(contains? attrs (ident database %)) (get database field)))
+
+(defn- tree [database datoms temporal?]
+  (reduce (fn [index datom]
+            (if temporal?
+              (di/-temporal-insert index datom :avet 0)
+              (di/-insert index datom :avet 0)))
+          (empty (:avet database)) datoms))
+
+(defn- from-primary [database attrs]
+  (cond-> {:current (tree database (rows database :aevt attrs) false)}
+    (get-in database [:config :keep-history?])
+    (assoc :temporal (tree database (rows database :temporal-aevt attrs) true))))
+
+(defn- assert-primary-parity [database attrs candidate]
+  (doseq [[family expected] (from-primary database attrs)]
+    (is (= (mapv #(vec (seq %)) expected) (mapv #(vec (seq %)) (get candidate family)))
+        (str "independent primary projection: " family))))
+
+(defn- begin [database attrs]
+  {:db (assoc database :avet-build {:id (random-uuid) :attrs attrs})
+   :attrs attrs :trees (from-primary database attrs)})
+
+(defn- step
+  ([state tx] (step state tx #(d/with %1 %2)))
+  ([{:keys [db attrs trees]} tx apply-tx]
+   (let [clean (dissoc db :avet-build-effects)
+         report (apply-tx clean tx)
+         after (:db-after report)
+         emitted (:avet-build-effects after)
+         candidate (reduce effects/replay trees emitted)]
+     (is (nil? (:avet-build-effects clean)) "input remains pure")
+     (is (every? #(contains? attrs (ident after (nth % 2))) emitted)
+         "only covered canonical attributes emit")
+     (assert-primary-parity after attrs candidate)
+     {:db after :attrs attrs :trees candidate :effects emitted :report report})))
+
+(defn- base [refs? history? indexed?]
+  (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs? :keep-history? history?
+                               :schema-flexibility :write})
+             [{:db/ident :one :db/valueType :db.type/long
+               :db/cardinality :db.cardinality/one :db/index indexed?}
+              {:db/ident :many :db/valueType :db.type/long
+               :db/cardinality :db.cardinality/many :db/index indexed?}
+              {:db/ident :quiet :db/valueType :db.type/long :db/noHistory true
+               :db/cardinality :db.cardinality/one :db/index indexed?}
+              {:db/ident :existing :db/valueType :db.type/long :db/index true
+               :db/cardinality :db.cardinality/one}
+              {:db/ident :uncovered :db/valueType :db.type/long
+               :db/cardinality :db.cardinality/one}]))
+
+(deftest private-observer-is-pure-and-independent-from-build-capture
+  (let [database (base false true false)
+        observed (effects/observe database #{:one})
+        row (datahike.datom/datom 10000 :one 1 100)
+        emitted (effects/emit observed :one :current :insert row nil)]
+    (is (effects/enabled? observed))
+    (is (empty? (effects/observations observed)))
+    (is (= [[:current :insert row nil]] (effects/observations emitted)))
+    (is (nil? (:avet-build-effects emitted)))
+    (is (nil? (:avet-build-invalidated? (effects/schema-change emitted))))
+    (is (= database (effects/unobserve emitted)))
+    (let [both (assoc observed :avet-build {:id (random-uuid) :attrs #{:one}})
+          after (effects/emit both :one :current :insert row nil)]
+      (is (= (:avet-build-effects after) (effects/observations after))))))
+
+(deftest replay-matches-primary-and-native-avet-through-write-sequences
+  (doseq [refs? [false true] history? [false true] indexed? [false true]]
+    (testing (str {:refs refs? :history history? :indexed indexed?})
+      (let [attrs #{:one :many :quiet :existing}
+            snapshot (d/db-with (base refs? history? indexed?)
+                                [{:db/id 10000 :one 1 :many [1 2] :quiet 1 :existing 1}])
+            initial (begin snapshot attrs)
+            txs [[[:db/add 10000 :one 2] [:db/add 10000 :quiet 2]
+                  [:db/add 10000 :existing 2] [:db/add 10000 :many 3]]
+                 [[:db/add 10000 :one 2] [:db/add 10000 :many 3]
+                  [:db/retract 10000 :many 999]]
+                 [[:db/retract 10000 :many 1] [:db/retract 10000 :one 2]]
+                 [[:db/add 10000 :one 3] [:db/retract 10000 :one 3]
+                  [:db/add 10000 :one 4]]
+                 [[:db/add 10001 :one 8] [:db/add 10001 :many 9]]
+                 [[:db.fn/retractEntity 10001]]]
+            final (reduce (fn [state tx]
+                            (let [next-state (step state tx)]
+                              (when indexed?
+                                (doseq [[family field] [[:current :avet] [:temporal :temporal-avet]]
+                                        :when (get-in next-state [:trees family])]
+                                  (is (= (mapv #(vec (seq %)) (get-in next-state [:trees family]))
+                                         (mapv #(vec (seq %)) (rows (:db next-state) field attrs)))
+                                      "replay matches independently maintained native AVET")))
+                              next-state)) initial txs)]
+        (is (some #(= :upsert (second %)) (:effects (step initial (first txs)))))
+        (when history?
+          (is (empty? (filter #(= :quiet (ident (:db final) %))
+                              (get-in final [:trees :temporal])))
+              "noHistory never emits historical effects"))))))
+
+(deftest noops-and-uncovered-writes-do-not-produce-effects
+  (let [snapshot (d/db-with (base false true false) [{:db/id 10000 :one 1 :many [2]}])
+        initial (begin snapshot #{:one :many})]
+    (doseq [tx [[[:db/add 10000 :one 1]] [[:db/add 10000 :many 2]]
+                [[:db/retract 10000 :many 999]] [[:db/add 10000 :uncovered 5]]]]
+      (is (empty? (:effects (step initial tx)))))
+    (is (identical? snapshot (effects/emit snapshot :one :current :insert nil nil)))
+    (is (nil? (:avet-build-effects (d/db-with snapshot [[:db/add 10000 :one 2]]))))))
+
+(deftest purge-effects-cover-history-only-and-current-removal
+  (doseq [refs? [false true]]
+    (let [initial (begin (d/db-with (base refs? true false)
+                                    [{:db/id 10000 :one 1 :many [1 2]}]) #{:one :many})
+          changed (step initial [[:db/add 10000 :one 2]])
+          history-only (step changed [[:db/purge 10000 :one 1]])
+          attribute (step history-only [[:db.purge/attribute 10000 :many]])
+          entity (step attribute [[:db.purge/entity 10000]])]
+      (is (seq (:effects history-only)))
+      (is (every? #(= [:temporal :remove] (subvec % 0 2)) (:effects history-only)))
+      (is (some #(= [:current :remove] (subvec % 0 2)) (:effects attribute)))
+      (is (empty? (get-in entity [:trees :current])))
+      (is (empty? (get-in entity [:trees :temporal]))))))
+
+(deftest derived-tuples-are-captured-with-canonical-idents
+  (doseq [refs? [false true]]
+    (let [database (d/db-with (base refs? true false)
+                              [{:db/ident :pair :db/valueType :db.type/tuple
+                                :db/tupleAttrs [:one :quiet]
+                                :db/cardinality :db.cardinality/one}])
+          initial (begin database #{:pair})
+          inserted (step initial [{:db/id 10000 :one 1 :quiet 2}])
+          changed (step inserted [[:db/add 10000 :quiet 3]])
+          removed (step changed [[:db/retract 10000 :one 1]])]
+      (is (seq (:effects inserted)))
+      (is (= [[nil 3]] (mapv :v (get-in removed [:trees :current])))))))
+
+(deftest direct-loads-share-primary-effect-hooks
+  (doseq [refs? [false true] history? [false true]]
+    (let [initial (begin (base refs? history? false) #{:one :many})
+          loader #(core/load-entities-with %1 %2 nil nil)
+          loaded (step initial [[9000 :one 1 100 true] [9000 :many 2 100 true]
+                                [9000 :one 3 101 true] [9000 :many 2 101 false]] loader)]
+      (is (seq (:effects loaded)))
+      (is (= [3] (mapv :v (get-in loaded [:trees :current])))))))
+
+(deftest tx-instant-upserts-have-no-temporal-effect
+  (doseq [refs? [false true]]
+    (let [initial (begin (base refs? true false) #{:db/txInstant})
+          changed (step initial [{:db/id 10000 :one 1}])]
+      (is (seq (:effects changed)))
+      (is (every? #(= :current (first %)) (:effects changed))))))
+
+(deftest conflicting-schema-needs-generation-invalidation
+  ;; These internal hooks deliberately do not authorize publication after a
+  ;; descriptor's schema changes. Capture cannot substitute for that guard.
+  (let [snapshot (d/db-with (base false true true) [{:db/id 10000 :one 1}])
+        active (assoc snapshot :avet-build {:id (random-uuid) :attrs #{:one}})
+        after (d/db-with active [[:db/add [:db/ident :one] :db/index false]])]
+    (is (not= (get-in active [:schema :one]) (get-in after [:schema :one])))
+    (is (empty? (:avet-build-effects after)))
+    (is (empty? (rows after :avet #{:one})))
+    (is (seq (rows after :aevt #{:one})))
+    (is (:avet-build-invalidated? after)
+        "schema mutation invalidates the captured generation")))
+
+(defrecord PrimaryHashRecorder [events]
+  sec/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] #{:body})
+  (-transact [this event] (update this :events conj event))
+  sec/IDurableSecondaryIndex
+  (-sec-generation-key-map [_] {:type :test/effect-recorder :format-version 1
+                                :storage-owner :external :root :complete})
+  (-sec-prepare [_ _] (throw (AssertionError. "Pure effect test must not persist")))
+  (-sec-restore [this _ _] this))
+
+(deftest secondary-only-effects-contain-primary-hashes-not-full-values
+  (doseq [refs? [false true]]
+    (let [database (-> (d/db-with (base refs? true false)
+                                  [{:db/ident :body :db/valueType :db.type/string
+                                    :db/cardinality :db.cardinality/one :db.secondary/only true}])
+                       (assoc-in [:schema :idx/recorder] {:db.secondary/status :ready
+                                                          :db.secondary/type :test/effect-recorder
+                                                          :db.secondary/attrs [:body]})
+                       (assoc-in [:rschema :db.secondary/index :body] #{:idx/recorder})
+                       (assoc-in [:secondary-indices :idx/recorder] (->PrimaryHashRecorder [])))
+          initial (begin database #{:body})
+          apply-tx (fn [database tx]
+                     ;; The fixture is immutable and records notifications only.
+                     ;; This context permits its durable capability; no writer or
+                     ;; prepare callback is invoked by these pure transactions.
+                     (binding [sec/*durable-secondary-write-context* :commit]
+                       (d/with database tx)))
+          inserted (step initial [{:db/id 10000 :body "first full value"}] apply-tx)
+          changed (step inserted [[:db/add 10000 :body "second full value"]] apply-tx)
+          removed (step changed [[:db/retract 10000 :body "second full value"]] apply-tx)]
+      (is (= [(sec/secondary-only-hash "first full value")]
+             (mapv :v (get-in inserted [:trees :current]))))
+      (is (= [(sec/secondary-only-hash "second full value")]
+             (mapv :v (get-in changed [:trees :current]))))
+      (is (empty? (get-in removed [:trees :current])))
+      (is (every? #(not (contains? #{"first full value" "second full value"} (:v (nth % 2))))
+                  (concat (:effects inserted) (:effects changed) (:effects removed))))
+      (is (= "first full value"
+             (get-in inserted [:db :secondary-indices :idx/recorder :events 0 :datom :v]))))))
+
+(deftest full-family-candidate-combines-existing-avet-with-new-attribute
+  (doseq [refs? [false true] history? [false true]]
+    (let [snapshot (d/db-with (base refs? history? false)
+                              [{:db/id 10000 :one 1 :existing 1}])
+          attrs (into #{:one} (map #(ident snapshot %)) (:avet snapshot))
+          candidate (cond-> {:current (tree snapshot
+                                            (concat (:avet snapshot) (rows snapshot :aevt #{:one})) false)}
+                      history? (assoc :temporal
+                                      (tree snapshot
+                                            (concat (:temporal-avet snapshot)
+                                                    (rows snapshot :temporal-aevt #{:one})) true)))
+          initial (assoc (begin snapshot attrs) :trees candidate)
+          changed (step initial [[:db/add 10000 :existing 2] [:db/add 10000 :one 3]])
+          removed (step changed [[:db/retract 10000 :existing 2] [:db/retract 10000 :one 3]])]
+      (doseq [state [changed removed]
+              [family native-field primary-field] [[:current :avet :aevt]
+                                                   [:temporal :temporal-avet :temporal-aevt]]
+              :when (or (= :current family) history?)]
+        (let [database (:db state)
+              expected (tree database (concat (get database native-field)
+                                              (rows database primary-field #{:one}))
+                             (= :temporal family))]
+          (is (= (mapv #(vec (seq %)) expected)
+                 (mapv #(vec (seq %)) (get-in state [:trees family])))
+              "existing indexed attributes remain current in the replacement root"))))))
+
+(deftest intermediate-schema-changes-invalidate-even-when-final-schema-matches
+  (let [snapshot (d/db-with (base true true false)
+                            [[:db/add [:db/ident :one] :db/doc "original"]])
+        active (assoc snapshot :avet-build {:id (random-uuid) :attrs #{:one}})
+        after (d/db-with active [[:db/add [:db/ident :one] :db/doc "temporary"]
+                                 [:db/add [:db/ident :one] :db/doc "original"]])]
+    (is (= (:schema snapshot) (:schema after)))
+    (is (:avet-build-invalidated? after)))
+  ;; Existing rename handling retains the temporary ident's schema entry after
+  ;; a rename-and-rename-back. Do not assume final schema equality here; the
+  ;; generation must be invalidated regardless of that separate schema defect.
+  (let [snapshot (d/db-with (base true true false) [{:db/id 10000 :one 1}])
+        active (assoc snapshot :avet-build {:id (random-uuid) :attrs #{:one}})
+        after (d/db-with active [[:db/add [:db/ident :one] :db/ident :temporary-one]
+                                 [:db/add [:db/ident :temporary-one] :db/ident :one]])]
+    (is (:avet-build-invalidated? after))))
+
+(deftest rejected-pure-transaction-does-not-leak-partial-effects
+  (let [database (d/db-with (base false true true)
+                            [[:db/add [:db/ident :one] :db/unique :db.unique/value]])
+        snapshot (d/db-with database [{:db/id 10000 :one 1} {:db/id 10001 :one 2}])
+        initial (begin snapshot #{:one})]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (d/with (:db initial) [[:db/add 10000 :one 3]
+                                        [:db/add 10001 :one 3]])))
+    (is (nil? (:avet-build-effects (:db initial))))
+    (is (= [1 2] (mapv :v (get-in initial [:trees :current]))))
+    (is (= [2 3] (mapv :v (get-in (step initial [[:db/add 10000 :one 3]])
+                                  [:trees :current]))))))
+
+(deftest history-cutoff-and-component-purge-share-effect-hooks
+  (doseq [refs? [false true]]
+    (let [initial (begin (d/db-with (base refs? true false)
+                                    [{:db/id 10000 :one 1 :many [1 2]}]) #{:one :many})
+          changed (step initial [[:db/add 10000 :one 2] [:db/retract 10000 :many 1]])
+          purged (step changed [[:db.history.purge/before (java.util.Date. Long/MAX_VALUE)]])]
+      (is (seq (:effects purged)))
+      (is (every? #(= [:temporal :remove] (subvec % 0 2)) (:effects purged))))
+    (let [database (d/db-with (base refs? true false)
+                              [{:db/ident :child :db/valueType :db.type/ref
+                                :db/cardinality :db.cardinality/one :db/isComponent true}])
+          initial (begin (d/db-with database [{:db/id 10000 :one 1 :child 10001}
+                                              {:db/id 10001 :one 2}]) #{:one :child})
+          purged (step initial [[:db.purge/entity 10000]])]
+      (is (empty? (get-in purged [:trees :current])))
+      (is (empty? (get-in purged [:trees :temporal]))))))

--- a/test/datahike/test/backfill_enqueue_test.clj
+++ b/test/datahike/test/backfill_enqueue_test.clj
@@ -1,0 +1,109 @@
+(ns datahike.test.backfill-enqueue-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.backfill.runtime :as runtime]
+            [datahike.test.utils :as utils]
+            [datahike.tx-preds :as predicates]
+            [datahike.writer :as writer]))
+
+(defn- await! [f]
+  (let [deadline (+ (System/nanoTime) 10000000000)]
+    (loop []
+      (if-let [value (f)] value
+              (if (< (System/nanoTime) deadline)
+                (do (Thread/sleep 10) (recur))
+                (throw (ex-info "Enqueue test condition timed out" {})))))))
+
+(defn- with-db [f]
+  (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                              :attribute-refs? false :keep-history? true
+                              :index :datahike.index/persistent-set
+                              :writer {:backend :self :writer-ownership :shared
+                                       :require-fencing :process :max-batch 8}})
+        config (:config @conn)]
+    (try
+      (d/transact conn [{:db/ident :value :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                        {:db/id 10000 :value 1}])
+      (f conn)
+      (finally (d/release conn) (d/delete-database config)))))
+
+(deftest cancellation-helper-catches-overflow-and-retires-only-exact-generation
+  (let [owner (runtime/create! nil) id (random-uuid) other (random-uuid) queue (async/chan 1)]
+    (try
+      (doseq [generation [id other]]
+        (runtime/prepare-report! owner {:db-before {}
+                                        :db-after {:avet-build {:id generation :attrs #{:value}}
+                                                   :max-tx 1}
+                                        :tx-data []} 'begin-avet-build!))
+      (with-redefs [async/put! (fn [& _] (throw (AssertionError. "Injected pending-put overflow")))]
+        ;; This function is called from inside the writer's original failure
+        ;; handler. Returning, rather than throwing, lets that handler finish.
+        (is (= :returned (do (#'writer/enqueue-avet-cancel! owner queue id) :returned))))
+      (is (true? (get-in @(:state owner) [:contexts id :retired?])))
+      (is (false? (get-in @(:state owner) [:contexts other :retired?])))
+      (is (= {:generation id :reason :dispatch-failed} (:last-failure @(:state owner))))
+      (finally (async/close! queue) (runtime/close! owner)))))
+
+(deftest worker-install-and-cancel-overflow-do-not-strand-live-runtime
+  (with-db
+    (fn [conn]
+      (let [local-writer (:writer @conn) queue (:transaction-queue local-writer)
+            owner (:avet-runtime local-writer) coordinator (:avet-coordinator local-writer)
+            attempts (atom []) original-put async/put!]
+        (with-redefs [async/put!
+                      (fn [channel value & args]
+                        (if (and (identical? channel queue)
+                                 (contains? '#{try-install-avet-build! cancel-avet-build!} (:op value)))
+                          (do (swap! attempts conj (:op value))
+                              (throw (AssertionError. "Injected pending-put overflow")))
+                          (apply original-put channel value args)))]
+          (let [accepted @(d/begin-avet-build! conn {:value {:db/index true}})
+                id (:avet-build-id accepted)]
+            (await! #(and (= 2 (count @attempts)) (empty? (:jobs @(:state coordinator)))))
+            (is (= '[try-install-avet-build! cancel-avet-build!] @attempts))
+            (is (true? (get-in @(:state owner) [:contexts id :retired?])))
+            (is (= {:generation id :reason :dispatch-failed} (:last-failure @(:state owner))))
+            (let [report (d/transact conn [[:db/add 10000 :value 2]])]
+              (is (= :failed (get-in report [:db-after :avet-build-result :status])))
+              (is (= id (get-in report [:db-after :avet-build-result :id])))
+              (is (nil? (get-in report [:db-after :avet-build])))
+              (is (not (get-in report [:db-after :schema :value :db/index])))
+              (is (= 2 (:value (d/entity (:db-after report) 10000)))))))))))
+
+(deftest cancel-overflow-preserves-original-install-error-callback-and-writer
+  (with-db
+    (fn [conn]
+      (let [local-writer (:writer @conn) queue (:transaction-queue local-writer)
+            owner (:avet-runtime local-writer) coordinator (:avet-coordinator local-writer)
+            store-id (get-in @conn [:config :store :id])
+            original-error (promise) cancel-attempts (atom 0) original-put async/put!]
+        (predicates/register-tx-pred!
+         store-id ::reject-install
+         (fn [report]
+           (when (and (get-in report [:db-before :avet-build])
+                      (= :ready (get-in report [:db-after :avet-build-result :status])))
+             (throw (ex-info "Original activation rejection" {:type ::activation-rejected})))
+           report))
+        (try
+          (with-redefs [async/put!
+                        (fn [channel value & args]
+                          (if (and (identical? channel queue) (= 'cancel-avet-build! (:op value)))
+                            (do (swap! cancel-attempts inc)
+                                (throw (AssertionError. "Injected pending-put overflow during error cleanup")))
+                            (let [result (apply original-put channel value args)]
+                              (when (and (instance? Throwable value)
+                                         (= ::activation-rejected (:type (ex-data value))))
+                                (deliver original-error value))
+                              result)))]
+            (let [accepted @(d/begin-avet-build! conn {:value {:db/index true}})
+                  id (:avet-build-id accepted)]
+              (is (instance? clojure.lang.ExceptionInfo (deref original-error 10000 nil)))
+              (is (pos? @cancel-attempts))
+              (await! #(empty? (:jobs @(:state coordinator))))
+              (is (true? (get-in @(:state owner) [:contexts id :retired?])))
+              (let [report (d/transact conn [[:db/add 10000 :value 3]])]
+                (is (= :failed (get-in report [:db-after :avet-build-result :status])))
+                (is (= id (get-in report [:db-after :avet-build-result :id])))
+                (is (= 3 (:value (d/entity (:db-after report) 10000)))))))
+          (finally (predicates/unregister-tx-pred! store-id ::reject-install)))))))

--- a/test/datahike/test/backfill_job_test.clj
+++ b/test/datahike/test/backfill_job_test.clj
@@ -1,0 +1,75 @@
+(ns datahike.test.backfill-job-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.backfill.job :as job]
+            [datahike.db :as db]
+            [datahike.test.utils :as utils]
+            [datahike.writing :as writing]
+            [konserve.core :as k]))
+
+(deftest descriptor-retains-only-canonical-durable-plan-fields
+  (let [database (d/db-with (db/empty-db nil {:schema-flexibility :write})
+                            [{:db/ident :existing :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one :db/index true}
+                             {:db/ident :target :db/valueType :db.type/long
+                              :db/cardinality :db.cardinality/one}])
+        plan {:patch {:target {:db/index true}} :attrs #{:target}
+              :private-runtime (Object.)}
+        descriptor (job/descriptor database plan)]
+    (is (= #{:id :status :patch :attrs :schema-token :branch} (set (keys descriptor))))
+    (is (= :building (:status descriptor)))
+    (is (contains? (:attrs descriptor) :target))
+    (is (contains? (:attrs descriptor) :existing))
+    (is (job/matches? database descriptor))
+    (is (not (job/matches? (assoc-in database [:config :branch] :elsewhere) descriptor)))
+    (is (not (job/matches? (assoc-in database [:schema :target :db/doc] "changed") descriptor)))
+    (is (not= (:id descriptor) (:id (job/descriptor database plan))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (job/descriptor (assoc database :avet-build descriptor) plan)))))
+
+(deftest begin-and-cancel-reports-do-not-activate-schema
+  (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                              :index :datahike.index/persistent-set
+                              :writer {:backend :self :writer-ownership :shared
+                                       :require-fencing :process}})
+        config (:config @conn)]
+    (try
+      (d/transact conn [{:db/ident :target :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
+      (let [before @conn
+            report (writing/begin-avet-build! before {:target {:db/unique :db.unique/value}})
+            after (:db-after report)
+            id (get-in after [:avet-build :id])
+            with-duplicates (d/db-with after [{:db/id 10000 :target 1}
+                                              {:db/id 10001 :target 1}])
+            canceled (:db-after (writing/cancel-avet-build! after id))]
+        (is (identical? before (:db-before report)))
+        (is (= before @conn))
+        (is (nil? (:avet-build @conn)))
+        (is (= (:schema before) (:schema after) (:schema canceled)))
+        (is (job/matches? after (:avet-build after)))
+        (is (= 2 (count (d/q '[:find ?e :where [?e :target 1]] with-duplicates))))
+        (is (nil? (:avet-build canceled)))
+        (is (= {:id id :status :canceled :reason :canceled} (:avet-build-result canceled)))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (writing/cancel-avet-build! after (random-uuid)))))
+      (finally (d/release conn) (d/delete-database config)))))
+
+(deftest capability-never-confuses-exclusive-ownership-with-fencing
+  (let [required (first k/conditional-write-domains)
+        database {:config {:index :datahike.index/persistent-set :crypto-hash? false
+                           :writer {:backend :self :writer-ownership :shared
+                                    :require-fencing required}}
+                  :store {} :datahike.writing/head-revision (random-uuid)}]
+    (with-redefs [k/conditional-write? (fn [_ domain] (= required domain))]
+      (is (nil? (job/supported! database)))
+      (doseq [unsupported [(update database :config dissoc :crypto-hash?)
+                           (assoc-in database [:config :writer :writer-ownership] :exclusive)
+                           (assoc-in database [:config :writer :backend] :remote)
+                           (update-in database [:config :writer] dissoc :require-fencing)
+                           (assoc-in database [:config :index] :datahike.index/hitchhiker-tree)
+                           (assoc-in database [:store :datahike/diff-buf-size] 4)
+                           (dissoc database :datahike.writing/head-revision)]]
+        (is (thrown? clojure.lang.ExceptionInfo (job/supported! unsupported)))))
+    (with-redefs [k/conditional-write? (constantly false)]
+      (is (thrown? clojure.lang.ExceptionInfo (job/supported! database))))))

--- a/test/datahike/test/backfill_online_batch_test.clj
+++ b/test/datahike/test/backfill_online_batch_test.clj
@@ -1,0 +1,174 @@
+(ns datahike.test.backfill-online-batch-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.writer :as writer]
+            [datahike.test.utils :as utils]))
+
+(defn- dispatch [conn op & args]
+  (writer/dispatch! (:writer @conn) {:op op :args (vec args)}))
+
+(defn- result! [channel]
+  (let [[result selected] (async/alts!! [channel (async/timeout 10000)])]
+    (when-not (= selected channel) (throw (ex-info "Batch test writer timed out" {})))
+    (when (instance? Throwable result) (throw result))
+    result))
+
+(defn- await! [f]
+  (let [deadline (+ (System/nanoTime) 10000000000)]
+    (loop []
+      (if-let [result (f)] result
+              (if (< (System/nanoTime) deadline)
+                (do (Thread/sleep 10) (recur))
+                (throw (ex-info "Batch test condition timed out" {})))))))
+
+(deftest install-and-following-write-share-one-durable-group
+  (doseq [following [:ordinary-write :new-generation]]
+    (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                                :attribute-refs? false :keep-history? true
+                                :index :datahike.index/persistent-set
+                                :writer {:backend :self :writer-ownership :shared
+                                         :require-fencing :process :max-batch 8}})
+          config (:config @conn)
+          drain-entered (promise) allow-drain (promise) following-enqueued (promise)
+          following-channel (promise)
+          gate-taken? (atom false) events (atom [])]
+      (try
+        (d/transact conn [{:db/ident :first :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                          {:db/ident :second :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                          {:db/id 10000 :first 1 :second 2}])
+        (d/listen-commits conn ::groups #(swap! events conj %))
+        (let [local-writer (:writer @conn)
+              commit-queue (:commit-queue local-writer)
+              coordinator (:avet-coordinator local-writer)
+              original-poll async/poll!
+              original-put async/put!]
+          (with-redefs
+           [async/poll!
+            (fn [channel]
+               ;; The commit loop already owns the install as its first report,
+               ;; but has not drained following reports yet. Block ONLY this
+               ;; exact queue and only once, leaving the tx loop free to enqueue.
+              (when (and (identical? channel commit-queue)
+                         (some #(= :awaiting-commit (:phase @%)) (vals (:jobs @(:state coordinator))))
+                         (compare-and-set! gate-taken? false true))
+                (deliver drain-entered true)
+                (when (= ::timeout (deref allow-drain 10000 ::timeout))
+                  (throw (ex-info "Batch test drain gate timed out" {}))))
+              (original-poll channel))
+            async/put!
+            (fn [channel value & args]
+               ;; The shared writer closes a batch as soon as its input queue
+               ;; is empty. Queue the follower before returning from the install
+               ;; enqueue, so it is present at that exact batching decision.
+              (when (and (identical? channel commit-queue) (vector? value)
+                         (contains? (first value) :datahike.writer/avet-install-token)
+                         (not (realized? following-channel)))
+                (deliver following-channel
+                         (writer/dispatch! local-writer
+                                           (case following
+                                             :ordinary-write {:op 'transact! :args [{:tx-data [[:db/add 10000 :first 11]]}]}
+                                             :new-generation {:op 'begin-avet-build! :args [{:second {:db/index true}}]}))))
+              (let [result (apply original-put channel value args)]
+                 ;; Unlike a predicate callback, this observes the actual
+                 ;; commit-queue enqueue, so releasing the drain is deterministic.
+                (when (and result (identical? channel commit-queue)
+                           (vector? value)
+                           (true? (get-in (first value) [:db-before :schema :first :db/index])))
+                  (deliver following-enqueued true))
+                result))]
+            (let [first-report (result! (dispatch conn 'begin-avet-build! {:first {:db/index true}}))
+                  first-id (get-in first-report [:db-after :avet-build :id])]
+              (is (true? (deref drain-entered 10000 false)))
+              (let [channel (deref following-channel 10000 nil)]
+                (is (true? (deref following-enqueued 10000 false)))
+                (deliver allow-drain true)
+                (let [report (result! channel)
+                      cid (get-in report [:db-after :meta :datahike/commit-id])
+                      event (first (filter #(= cid (:commit-id %)) @events))]
+                  (is (= 2 (:tx-count event)))
+                  (is (true? (get-in (:db-after event) [:schema :first :db/index])))
+                  (case following
+                    :ordinary-write
+                    (do
+                      (is (= first-id (get-in report [:db-after :avet-build-result :id])))
+                      (is (= :ready (get-in report [:db-after :avet-build-result :status])))
+                      (is (= [11] (mapv :v (d/datoms (:db-after report) :avet :first)))))
+                    :new-generation
+                    (let [next-id (get-in report [:db-after :avet-build :id])]
+                      (is (uuid? next-id))
+                      (is (not= first-id next-id))
+                      (await! #(and (= next-id (get-in @conn [:avet-build-result :id]))
+                                    (= :ready (get-in @conn [:avet-build-result :status]))))
+                      (is (= [1] (mapv :v (d/datoms @conn :avet :first))))
+                      (is (= [2] (mapv :v (d/datoms @conn :avet :second))))))))
+              (await! #(empty? (:jobs @(:state coordinator)))))))
+        (finally
+          (deliver allow-drain true)
+          (d/unlisten-commits conn ::groups)
+          (d/release conn)
+          (d/delete-database config))))))
+
+(deftest accepted-request-id-survives-a-different-final-group-generation
+  (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                              :attribute-refs? false :keep-history? true
+                              :index :datahike.index/persistent-set
+                              :writer {:backend :self :writer-ownership :shared
+                                       :require-fencing :process :max-batch 8}})
+        config (:config @conn) injected? (atom false) gate-taken? (atom false)
+        drain-entered (promise) allow-drain (promise) followers (promise)
+        followers-enqueued (promise) follower-count (atom 0)]
+    (try
+      (d/transact conn [{:db/ident :first :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                        {:db/ident :second :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                        {:db/id 10000 :first 1 :second 2}])
+      (let [local-writer (:writer @conn) commit-queue (:commit-queue local-writer)
+            original-poll async/poll! original-put async/put!]
+        (with-redefs
+         [async/poll! (fn [channel]
+                        (when (and (identical? channel commit-queue) @injected?
+                                   (compare-and-set! gate-taken? false true))
+                          (deliver drain-entered true)
+                          (when (= ::timeout (deref allow-drain 10000 ::timeout))
+                            (throw (ex-info "Request group gate timed out" {}))))
+                        (original-poll channel))
+          async/put!
+          (fn [channel value & args]
+            (let [commit-report? (and (identical? channel commit-queue) (vector? value))
+                  first-request? (and commit-report? (:avet-build-id (first value))
+                                      (contains? (get-in (first value) [:db-after :avet-build :patch]) :first))]
+              (when (and first-request? (compare-and-set! injected? false true))
+                (deliver followers
+                         [(writer/dispatch! local-writer
+                                            {:op 'transact!
+                                             :args [{:tx-data [{:db/ident :unrelated :db/valueType :db.type/long
+                                                                :db/cardinality :db.cardinality/one}]}]})
+                          (writer/dispatch! local-writer
+                                            {:op 'begin-avet-build! :args [{:second {:db/index true}}]})]))
+              (let [result (apply original-put channel value args)]
+                (when (and result commit-report? @injected? (not first-request?)
+                           (= 2 (swap! follower-count inc)))
+                  (deliver followers-enqueued true))
+                result)))]
+          (let [accepted-a (d/begin-avet-build! conn {:first {:db/index true}})]
+            (is (true? (deref drain-entered 10000 false)))
+            (is (true? (deref followers-enqueued 10000 false)))
+            (deliver allow-drain true)
+            (let [report-a @accepted-a
+                  [schema-channel b-channel] (deref followers 10000 nil)
+                  schema-report (result! schema-channel)
+                  report-b (result! b-channel)
+                  a-id (:avet-build-id report-a) b-id (:avet-build-id report-b)]
+              (is (uuid? a-id))
+              (is (uuid? b-id))
+              (is (not= a-id b-id))
+              (is (= b-id (get-in report-a [:db-after :avet-build :id])))
+              (is (= (get-in report-a [:db-after :meta :datahike/commit-id])
+                     (get-in schema-report [:db-after :meta :datahike/commit-id])
+                     (get-in report-b [:db-after :meta :datahike/commit-id])))
+              (await! #(and (= b-id (get-in @conn [:avet-build-result :id]))
+                            (= :ready (get-in @conn [:avet-build-result :status]))))
+              (is (not (get-in @conn [:schema :first :db/index])))
+              (is (true? (get-in @conn [:schema :second :db/index])))
+              (await! #(empty? (:jobs @(:state (:avet-coordinator local-writer)))))))))
+      (finally (deliver allow-drain true) (d/release conn) (d/delete-database config)))))

--- a/test/datahike/test/backfill_online_history_test.clj
+++ b/test/datahike/test/backfill_online_history_test.clj
@@ -1,0 +1,94 @@
+(ns datahike.test.backfill-online-history-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.backfill.avet :as avet]
+            [datahike.db.utils :as dbu]
+            [datahike.test.utils :as utils]
+            [datahike.writer :as writer]))
+
+(defn- invoke! [conn op patch]
+  (let [channel (writer/dispatch! (:writer @conn) {:op op :args [patch]})
+        [result selected] (async/alts!! [channel (async/timeout 10000)])]
+    (when-not (= selected channel) (throw (ex-info "History test writer timed out" {:op op})))
+    (when (instance? Throwable result) (throw result))
+    result))
+
+(defn- await! [f]
+  (let [deadline (+ (System/nanoTime) 10000000000)]
+    (loop []
+      (if-let [result (f)] result
+              (if (< (System/nanoTime) deadline)
+                (do (Thread/sleep 10) (recur))
+                (throw (ex-info "History test build timed out" {})))))))
+
+(defn- rows [database tree ident]
+  (let [a (dbu/attr-ref-or-ident database ident)]
+    (set (map #(vec (seq %)) (filter #(= a (:a %)) (get database tree))))))
+
+(defn- gated-build! [conn patch writes check-ready]
+  (let [entered (promise) proceed (promise) build avet/build!]
+    (with-redefs [avet/build! (fn [& args]
+                                (deliver entered true)
+                                (when (= ::timeout (deref proceed 10000 ::timeout))
+                                  (throw (ex-info "History test build gate timed out" {})))
+                                (apply build args))]
+      (try
+        (let [id (get-in (invoke! conn 'begin-avet-build! patch) [:db-after :avet-build :id])]
+          (is (true? (deref entered 10000 false)))
+          (let [expected (writes)]
+            (deliver proceed true)
+            (await! #(when (= id (get-in @conn [:avet-build-result :id]))
+                       (get-in @conn [:avet-build-result :status])))
+            (is (= :ready (get-in @conn [:avet-build-result :status])))
+            (check-ready expected)
+            (await! #(empty? (:jobs @(:state (:avet-coordinator (:writer @conn))))))))
+        (finally (deliver proceed true))))))
+
+(deftest concurrent-purge-removes-disabled-history-and-reenable-catches-new-history
+  (doseq [refs? [false true]]
+    (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                                :attribute-refs? refs? :keep-history? true
+                                :index :datahike.index/persistent-set
+                                :writer {:backend :self :writer-ownership :shared
+                                         :require-fencing :process :max-batch 8}})
+          config (:config @conn)]
+      (try
+        (d/transact conn [{:db/ident :target :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+                          {:db/ident :old :db/valueType :db.type/long :db/cardinality :db.cardinality/one :db/index true}
+                          {:db/id 10000 :old 1 :target 10} {:db/id 10001 :old 3}])
+        (d/transact conn [[:db/add 10000 :old 2]])
+        (d/transact conn [[:db/add (dbu/entid @conn :old) :db/index false]])
+        (is (empty? (rows @conn :avet :old)))
+        (is (seq (rows @conn :temporal-avet :old)))
+        (gated-build!
+         conn {:target {:db/index true}}
+         (fn []
+           ;; :old is not in the generation's current-index coverage. Its
+           ;; retained AVET history must nevertheless receive purge removals.
+           (is (not (contains? (get-in @conn [:avet-build :attrs]) :old)))
+           (d/transact conn [[:db/purge 10000 :old 1]
+                             [:db.purge/attribute 10001 :old]
+                             [:db/retract 10000 :old 2]
+                             [:db/add 10000 :target 11]])
+           (rows @conn :temporal-avet :old))
+         (fn [expected]
+           (is (not (get-in @conn [:schema :old :db/index])))
+           (is (empty? (rows @conn :avet :old)))
+           (is (= expected (rows @conn :temporal-avet :old)))
+           (is (seq expected))
+           (is (every? #(and (= 10000 (nth % 0)) (= 2 (nth % 2))) expected))
+           (is (= (rows @conn :eavt :target) (rows @conn :avet :target)))))
+        (d/transact conn [[:db/add 10000 :old 4]])
+        (gated-build!
+         conn {:old {:db/index true}}
+         (fn []
+           (d/transact conn [[:db/purge 10000 :old 2]
+                             [:db/add 10000 :old 5]])
+           nil)
+         (fn [_]
+           (is (= (rows @conn :eavt :old) (rows @conn :avet :old)))
+           (is (= (rows @conn :temporal-eavt :old) (rows @conn :temporal-avet :old)))
+           (is (= #{5} (set (map #(nth % 2) (rows @conn :avet :old)))))
+           (is (not-any? #(contains? #{1 2 3} (nth % 2)) (rows @conn :temporal-avet :old)))))
+        (finally (d/release conn) (d/delete-database config))))))

--- a/test/datahike/test/backfill_online_test.clj
+++ b/test/datahike/test/backfill_online_test.clj
@@ -1,0 +1,281 @@
+(ns datahike.test.backfill-online-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.api.impl :as api-impl]
+            [datahike.backfill.avet :as avet]
+            [datahike.connections :as connections]
+            [datahike.gc-roots :as roots]
+            [datahike.test.utils :as utils]
+            [datahike.tx-preds :as predicates]
+            [datahike.writer :as writer]
+            [datahike.writing :as writing]
+            [konserve.core :as k]
+            [superv.async :refer [<?? S]]))
+
+(defn- invoke! [conn op & args]
+  (if (contains? #{'begin-avet-build! 'cancel-avet-build!} op)
+    (let [result (deref (apply (if (= op 'begin-avet-build!) d/begin-avet-build! d/cancel-avet-build!)
+                               conn args) 10000 ::timeout)]
+      (when (= ::timeout result) (throw (ex-info "Public AVET operation timed out" {:op op})))
+      result)
+    (let [channel (writer/dispatch! (:writer @conn) {:op op :args (vec args)})
+          [result selected] (async/alts!! [channel (async/timeout 10000)])]
+      (when-not (= selected channel)
+        (throw (ex-info "Writer operation timed out" {:op op})))
+      (when (instance? Throwable result) (throw result))
+      result)))
+
+(defn- await! [f]
+  (let [deadline (+ (System/nanoTime) 10000000000)]
+    (loop []
+      (if-let [value (f)] value
+              (if (< (System/nanoTime) deadline)
+                (do (Thread/sleep 10) (recur))
+                (throw (ex-info "Background AVET condition timed out" {})))))))
+
+(defn- with-db
+  ([f] (with-db {} f))
+  ([options f]
+   (let [conn (utils/setup-db (merge {:crypto-hash? false :schema-flexibility :write
+                                      :keep-history? true :index :datahike.index/persistent-set
+                                      :writer {:backend :self :writer-ownership :shared
+                                               :require-fencing :process :max-batch 8}} options))
+         config (:config @conn)]
+     (try
+       (d/transact conn [{:db/ident :score :db/valueType :db.type/long
+                          :db/cardinality :db.cardinality/one}
+                         {:db/id 10000 :score 1} {:db/id 10001 :score 2}])
+       (f conn)
+       (finally (d/release conn) (d/delete-database config))))))
+
+(defn- ready? [conn]
+  (= :ready (:status (d/avet-build-status @conn))))
+
+(defn- settled! [conn]
+  (let [coordinator (:avet-coordinator (:writer @conn))]
+    (await! #(empty? (:jobs @(:state coordinator))))
+    (is (empty? (<?? S (roots/roots (:store @conn)))))))
+
+(deftest public-api-refuses-nonlocal-writers-before-dispatch
+  (let [calls (atom 0)
+        remote (reify writer/PWriter
+                 (-dispatch! [_ _] (swap! calls inc) (async/promise-chan))
+                 (-shutdown [_] (async/promise-chan))
+                 (-streaming? [_] false))
+        conn {:wrapped-atom (atom {:writer remote :config {:writer {:backend :self}}})}]
+    (doseq [operation [#(api-impl/begin-avet-build! conn {:score {:db/index true}})
+                       #(api-impl/cancel-avet-build! conn (random-uuid))]]
+      (is (= :avet-build-unsupported-writer
+             (try (operation) nil (catch clojure.lang.ExceptionInfo e (:type (ex-data e)))))))
+    (is (zero? @calls))))
+
+(deftest online-build-catches-concurrent-writes-and-keeps-old-schema-until-ready
+  (with-db
+    (fn [conn]
+      (let [entered (promise) proceed (promise) build avet/build!]
+        (with-redefs [avet/build! (fn [& args]
+                                    (deliver entered true)
+                                    (when (= ::timeout (deref proceed 10000 ::timeout))
+                                      (throw (ex-info "Test scan gate timed out" {})))
+                                    (apply build args))]
+          (try
+            (let [report (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+                  id (get-in report [:db-after :avet-build :id])]
+              (is (true? (deref entered 10000 false)))
+              (is (nil? (get-in @conn [:schema :score :db/unique])))
+              (d/transact conn [[:db/add 10000 :score 3] [:db/retract 10001 :score 2]
+                                [:db/add 10002 :score 4]])
+              (deliver proceed true)
+              (await! #(ready? conn))
+              (is (= id (get-in @conn [:avet-build-result :id])))
+              (is (= #{[10000 3] [10002 4]}
+                     (d/q '[:find ?e ?v :where [?e :score ?v]] @conn)))
+              (is (= [3 4] (mapv :v (d/datoms @conn :avet :score))))
+              (is (thrown? clojure.lang.ExceptionInfo
+                           (d/transact conn [[:db/add 10003 :score 3]])))
+              (settled! conn))
+            (finally (deliver proceed true))))))))
+
+(deftest duplicate-source-fails-build-without-enabling-uniqueness
+  (with-db
+    (fn [conn]
+      (d/transact conn [[:db/add 10001 :score 1]])
+      (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+      (await! #(= :failed (get-in @conn [:avet-build-result :status])))
+      (is (nil? (get-in @conn [:schema :score :db/unique])))
+      (is (= 2 (count (d/q '[:find ?e :where [?e :score 1]] @conn))))
+      (settled! conn)
+      (d/transact conn [[:db/add 10001 :score 2]])
+      (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+      (await! #(ready? conn))
+      (is (= [1 2] (mapv :v (d/datoms @conn :avet :score))))
+      (settled! conn))))
+
+(deftest rejected-install-retires-job-without-changing-data-or-schema
+  (with-db
+    (fn [conn]
+      (let [store-id (get-in @conn [:config :store :id])]
+        (predicates/register-tx-pred!
+         store-id ::reject-install
+         (fn [report]
+           (when (and (get-in report [:db-before :avet-build])
+                      (= :ready (get-in report [:db-after :avet-build-result :status])))
+             (throw (ex-info "Reject prepared install" {:type ::rejected})))
+           report))
+        (try
+          (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+          (await! #(= :failed (get-in @conn [:avet-build-result :status])))
+          (is (not (get-in @conn [:schema :score :db/index])))
+          (is (= #{[10000 1] [10001 2]} (d/q '[:find ?e ?v :where [?e :score ?v]] @conn)))
+          (settled! conn)
+          (finally (predicates/unregister-tx-pred! store-id ::reject-install)))))))
+
+(deftest cancelled-generation-cannot-install-over-its-replacement
+  (with-db
+    (fn [conn]
+      (let [entered (promise) proceed (promise) build avet/build! calls (atom 0)]
+        (with-redefs [avet/build! (fn [& args]
+                                    (when (= 1 (swap! calls inc))
+                                      (deliver entered true)
+                                      (deref proceed 10000 nil))
+                                    (apply build args))]
+          (try
+            (let [first-id (get-in (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+                                   [:db-after :avet-build :id])]
+              (is (true? (deref entered 10000 false)))
+              (invoke! conn 'cancel-avet-build! first-id)
+              (is (= :canceled (get-in @conn [:avet-build-result :status])))
+              (let [second-id (get-in (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+                                      [:db-after :avet-build :id])]
+                (is (not= first-id second-id))
+                (is (thrown? clojure.lang.ExceptionInfo (invoke! conn 'cancel-avet-build! first-id)))
+                (deliver proceed true)
+                (await! #(ready? conn))
+                (is (= second-id (get-in @conn [:avet-build-result :id])))
+                (is (= :db.unique/value (get-in @conn [:schema :score :db/unique])))
+                (settled! conn)))
+            (finally (deliver proceed true))))))))
+
+(deftest schema-change-retires-build-but-commits-the-schema-change
+  (with-db
+    (fn [conn]
+      (let [entered (promise) proceed (promise) build avet/build!]
+        (with-redefs [avet/build! (fn [& args]
+                                    (deliver entered true)
+                                    (deref proceed 10000 nil)
+                                    (apply build args))]
+          (try
+            (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+            (is (true? (deref entered 10000 false)))
+            (d/transact conn [{:db/ident :other :db/valueType :db.type/string
+                               :db/cardinality :db.cardinality/one}])
+            (is (= :failed (get-in @conn [:avet-build-result :status])))
+            (is (contains? (:schema @conn) :other))
+            (is (not (get-in @conn [:schema :score :db/index])))
+            (deliver proceed true)
+            (settled! conn)
+            (finally (deliver proceed true))))))))
+
+(deftest lost-durable-pin-refuses-activation
+  (with-db
+    (fn [conn]
+      (let [entered (promise) proceed (promise) build avet/build!]
+        (with-redefs [avet/build! (fn [& args]
+                                    (deliver entered true)
+                                    (deref proceed 10000 nil)
+                                    (apply build args))]
+          (try
+            (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+            (is (true? (deref entered 10000 false)))
+            (let [pins (<?? S (roots/roots (:store @conn)))]
+              (is (= 1 (count pins)))
+              (doseq [id (keys pins)] (roots/release! @conn id {:sync? true})))
+            (deliver proceed true)
+            (await! #(= :failed (get-in @conn [:avet-build-result :status])))
+            (is (not (get-in @conn [:schema :score :db/index])))
+            (d/transact conn [[:db/add 10000 :score 9]])
+            (is (= 9 (:score (d/entity @conn 10000))))
+            (settled! conn)
+            (finally (deliver proceed true))))))))
+
+(deftest foreign-writer-retires-unowned-generation-without-losing-writes
+  (with-db
+    (fn [conn]
+      (let [entered (promise) proceed (promise) build avet/build!
+            registry (atom {})
+            other (binding [connections/*connections* registry] (d/connect (:config @conn)))]
+        (try
+          (with-redefs [avet/build! (fn [& args]
+                                      (deliver entered true)
+                                      (deref proceed 10000 nil)
+                                      (apply build args))]
+            (try
+              (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+              (is (true? (deref entered 10000 false)))
+              (d/transact other [[:db/add 10000 :score 7]])
+              (is (= :failed (get-in @other [:avet-build-result :status])))
+              (d/transact conn [[:db/add 10001 :score 8]])
+              (deliver proceed true)
+              (settled! conn)
+              (is (= #{[10000 7] [10001 8]}
+                     (d/q '[:find ?e ?v :where [?e :score ?v]] @conn)))
+              (is (not (get-in @conn [:schema :score :db/index])))
+              (finally (deliver proceed true))))
+          (finally (binding [connections/*connections* registry] (d/release other))))))))
+
+(deftest published-file-index-reopens-after-private-worker-storage-is-closed
+  (doseq [attribute-refs? [false true]]
+    (let [path (java.nio.file.Files/createTempDirectory "datahike-online-avet-"
+                                                        (make-array java.nio.file.attribute.FileAttribute 0))]
+      (try
+        (with-db
+          {:attribute-refs? attribute-refs?
+           :store {:backend :file :path (str path) :id (random-uuid)}}
+          (fn [conn]
+            (is (nil? (d/avet-build-status @conn)))
+            (d/transact conn [[:db/add 10000 :score 5]])
+            (let [history-before (set (d/q '[:find ?e ?v ?tx ?added
+                                             :where [?e :score ?v ?tx ?added]] (d/history @conn)))]
+              (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+              (await! #(ready? conn))
+              (settled! conn)
+              (let [registry (atom {})
+                    reopened (binding [connections/*connections* registry] (d/connect (:config @conn)))]
+                (try
+                  (is (= [2 5] (mapv :v (d/datoms @reopened :avet :score))))
+                  (is (= history-before
+                         (set (d/q '[:find ?e ?v ?tx ?added
+                                     :where [?e :score ?v ?tx ?added]] (d/history @reopened)))))
+                  (is (= :ready (:status (d/avet-build-status @reopened))))
+                  (is (thrown? clojure.lang.ExceptionInfo
+                               (d/transact reopened [[:db/add 10002 :score 5]])))
+                  (finally (binding [connections/*connections* registry] (d/release reopened))))))))
+        (finally (java.nio.file.Files/deleteIfExists path))))))
+
+(deftest same-commit-head-rewrite-fences-an-offered-install
+  (with-db
+    (fn [conn]
+      (let [commit writing/commit! rewritten? (atom false)
+            store (:store @conn) branch (get-in @conn [:config :branch])]
+        (with-redefs [writing/commit!
+                      (fn [database & args]
+                        (when (and (= :ready (get-in database [:avet-build-result :status]))
+                                   (compare-and-set! rewritten? false true))
+                          ;; Rewriting identical head data changes its storage revision,
+                          ;; but neither max-tx nor content-addressed commit identity.
+                          (let [head (k/get store branch nil {:sync? true})]
+                            (k/assoc store branch head {:sync? true})
+                            (is (= head (k/get store branch nil {:sync? true})))))
+                        (apply commit database args))]
+          (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+          (await! #(= :failed (:status (d/avet-build-status @conn))))
+          (is @rewritten?)
+          (is (not (get-in @conn [:schema :score :db/index])))
+          (settled! conn))
+        (d/transact conn [[:db/add 10000 :score 9]])
+        (is (= 9 (:score (d/entity @conn 10000))))
+        (invoke! conn 'begin-avet-build! {:score {:db/index true}})
+        (await! #(ready? conn))
+        (is (= [2 9] (mapv :v (d/datoms @conn :avet :score))))
+        (settled! conn)))))

--- a/test/datahike/test/backfill_persistence_test.clj
+++ b/test/datahike/test/backfill_persistence_test.clj
@@ -1,0 +1,70 @@
+(ns datahike.test.backfill-persistence-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.gc :as gc]
+            [datahike.test.utils :as utils]
+            [datahike.writing :as writing]
+            [konserve.core :as k]
+            [konserve.gc :as kgc]
+            [superv.async :refer [<?? S]]))
+
+(deftest only-durable-avet-state-survives-roundtrip
+  (let [conn (utils/setup-db {:index :datahike.index/persistent-set
+                              :writer {:writer-ownership :exclusive}})
+        config (:config @conn)]
+    (try
+      (let [job {:id (random-uuid) :status :building :attrs #{:score}
+                 :patch {:score {:db/index true}}}
+            result {:id (random-uuid) :status :failed :reason :schema-changed}
+            database (assoc @conn :avet-build job :avet-build-result result
+                            :avet-build-journal {:path "not-durable"}
+                            :avet-build-effects [[:current :insert :not-durable nil]]
+                            :avet-build-invalidated? true)
+            stored (second (writing/db->stored database false))
+            restored (writing/stored->db stored (:store @conn))]
+        (is (= job (:avet-build stored) (:avet-build restored)))
+        (is (= result (:avet-build-result stored) (:avet-build-result restored)))
+        (doseq [key [:avet-build-journal :avet-build-effects :avet-build-invalidated?]]
+          (is (not (contains? stored key)))
+          (is (not (contains? restored key))))
+        ;; Legacy heads have no CID; durable build metadata must still change
+        ;; their materialization identity, without retaining old local cursors.
+        (let [legacy (update stored :meta dissoc :datahike/commit-id)
+              old (assoc (writing/stored->db legacy (:store @conn))
+                         :avet-build-journal {:path "old-local"})
+              moved (writing/reload-head old (dissoc legacy :avet-build) (:store @conn))]
+          (is (nil? (:avet-build moved)))
+          (is (nil? (:avet-build-journal moved)))))
+      (finally (d/release conn) (d/delete-database config)))))
+
+(deftest only-retained-building-seed-defers-collection
+  (let [conn (utils/setup-db {:index :datahike.index/persistent-set
+                              :writer {:writer-ownership :exclusive}})
+        config (:config @conn)
+        store (:store @conn)]
+    (try
+      (let [job {:id (random-uuid) :status :building :attrs #{:score}}
+            initial (k/get store :db nil {:sync? true})
+            ancestor (random-uuid)
+            walk (fn [] (#'gc/reachable-in-branch store :db (java.util.Date. 0)
+                                                  config (atom {}) {:sync? true}))
+            sweeps (atom 0)]
+        (k/assoc store :db (assoc initial :avet-build job) {:sync? true})
+        (is (:building-secondary? (walk)))
+        (with-redefs [kgc/sweep! (fn [& _]
+                                   (swap! sweeps inc)
+                                   (throw (AssertionError. "Building head must defer sweep")))]
+          (is (= #{} (<?? S (gc/gc-storage! @conn (java.util.Date. 0) {:min-age-ms 0})))))
+        (is (zero? @sweeps))
+        ;; Keep the build marker in reachable history, but remove it from head.
+        (k/assoc store ancestor (assoc initial :avet-build job) {:sync? true})
+        (k/assoc store :db (assoc-in initial [:meta :datahike/parents] #{ancestor})
+                 {:sync? true})
+        (is (false? (boolean (:building-secondary? (walk)))))
+        (let [sweep kgc/sweep!]
+          (with-redefs [kgc/sweep! (fn [& args]
+                                     (swap! sweeps inc)
+                                     (apply sweep args))]
+            (<?? S (gc/gc-storage! @conn (java.util.Date. 0) {:min-age-ms 0})))
+          (is (pos? @sweeps))))
+      (finally (d/release conn) (d/delete-database config)))))

--- a/test/datahike/test/backfill_range_file_test.clj
+++ b/test/datahike/test/backfill_range_file_test.clj
@@ -23,9 +23,12 @@
         (is (= [:new] (journal/reduce-range replacement retained-cursor
                                             (fn [acc value _] (conj acc value)) [])))
         (is (= -1 (journal/compare-cursors replacement retained-cursor replacement-cursor)))
+        (is (= (- (:end replacement) (:end retained))
+               (journal/range-byte-size replacement retained-cursor replacement-cursor)))
         (doseq [operation [#(journal/reduce-range replacement abandoned-cursor
                                                   (fn [acc _ _] acc) nil)
-                           #(journal/compare-cursors replacement retained-cursor abandoned-cursor)]]
+                           #(journal/compare-cursors replacement retained-cursor abandoned-cursor)
+                           #(journal/range-byte-size replacement retained-cursor abandoned-cursor)]]
           (is (= :backfill.journal/invalid-cursor (error-type operation))))
         (doseq [operation [#(journal/start-cursor abandoned)
                            #(journal/end-cursor abandoned)

--- a/test/datahike/test/backfill_range_test.clj
+++ b/test/datahike/test/backfill_range_test.clj
@@ -59,12 +59,23 @@
                                           (journal/end-cursor first-prefix))))
         (is (neg? (journal/compare-cursors second-prefix start middle)))
         (is (pos? (journal/compare-cursors second-prefix end middle)))
+        (let [first-bytes (journal/range-byte-size second-prefix start middle)
+              second-bytes (journal/range-byte-size second-prefix middle end)]
+          (is (pos? first-bytes))
+          (is (pos? second-bytes))
+          (is (= (+ first-bytes second-bytes)
+                 (journal/range-byte-size second-prefix start end)))
+          (is (zero? (journal/range-byte-size second-prefix end end)))
+          (is (= :backfill.journal/invalid-cursor
+                 (error-type #(journal/range-byte-size second-prefix end middle)))))
         (is (= [] (journal/reduce-range a start conj [])))
         (doseq [foreign [(journal/start-cursor b) (journal/end-cursor b)]]
           (is (= :backfill.journal/invalid-cursor
                  (error-type #(journal/reduce-range second-prefix foreign conj []))))
           (is (= :backfill.journal/invalid-cursor
-                 (error-type #(journal/compare-cursors second-prefix start foreign)))))
+                 (error-type #(journal/compare-cursors second-prefix start foreign))))
+          (is (= :backfill.journal/invalid-cursor
+                 (error-type #(journal/range-byte-size second-prefix start foreign)))))
         (is (= :backfill.journal/invalid-cursor
                (error-type #(journal/reduce-range first-prefix end conj []))))
         (is (= :backfill.journal/invalid-cursor

--- a/test/datahike/test/backfill_runtime_test.clj
+++ b/test/datahike/test/backfill_runtime_test.clj
@@ -26,7 +26,8 @@
   (Files/exists (Path/of (get-in lease [:descriptor :path]) (make-array String 0))
                 (make-array java.nio.file.LinkOption 0)))
 
-(defn- origin [lease] (assoc (:cursor lease) :offset 0 :sequence 0))
+(defn- origin [lease]
+  (assoc (:cursor lease) :position (journal/start-cursor (:descriptor lease)) :sequence 0))
 
 (deftest definite-conflict-discards-speculation-without-closing-owner
   (let [owner (runtime/create! nil) id (random-uuid)]
@@ -106,6 +107,8 @@
             (is (= 1 (get-in start [:cursor :sequence])))
             (is (= [[]] (runtime/reduce-prefix owner lease (origin lease)
                                                (fn [acc transaction _] (conj acc (:effects transaction))) [])))
+            (is (pos? (runtime/range-byte-size owner lease (origin lease))))
+            (is (zero? (runtime/range-byte-size owner lease (:cursor lease))))
             (is (nil? (runtime/committed! owner (:db-after b) [b])))
             (is (identical? (:db-after a) (:source-db lease)))
             ;; An existing read lease remains the exact older immutable prefix.
@@ -190,10 +193,9 @@
       (let [a (begin owner {} id)
             b (tx owner (:db-after a) [])
             sequence-mismatch (assoc-in (:db-after a) [:avet-build-journal :cursor :sequence] 2)
-            interior-offset (-> (:db-after a)
-                                (assoc-in [:avet-build-journal :descriptor :end] 1)
-                                (assoc-in [:avet-build-journal :cursor :offset] 1))]
-        (doseq [invalid [sequence-mismatch interior-offset (:db-after b)]]
+            invalid-position (assoc-in (:db-after a)
+                                       [:avet-build-journal :cursor :position] (Object.))]
+        (doseq [invalid [sequence-mismatch invalid-position (:db-after b)]]
           (is (= :datahike.backfill.runtime/invalid-commit
                  (error-type #(runtime/committed! owner invalid [a])))))
         (is (= :datahike.backfill.runtime/invalid-commit

--- a/test/datahike/test/backfill_runtime_test.clj
+++ b/test/datahike/test/backfill_runtime_test.clj
@@ -1,0 +1,330 @@
+(ns datahike.test.backfill-runtime-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.backfill.runtime :as runtime]
+            [datahike.backfill.journal :as journal])
+  (:import [java.nio.file Files Path]))
+
+(defn- error-type [f]
+  (try (f) nil (catch Exception e (:type (ex-data e)))))
+
+(defn- report [before after]
+  {:db-before before :db-after after :tx-data []})
+
+(defn- begin [owner before id]
+  (runtime/prepare-report! owner
+                           (report before (assoc before :avet-build {:id id :attrs #{:score}}
+                                                 :max-tx (inc (:max-tx before 0))))
+                           'begin-avet-build!))
+
+(defn- tx [owner before effects]
+  (runtime/prepare-report! owner
+                           (report before (assoc before :avet-build-effects effects
+                                                 :max-tx (inc (:max-tx before))))
+                           'transact!))
+
+(defn- path-exists? [lease]
+  (Files/exists (Path/of (get-in lease [:descriptor :path]) (make-array String 0))
+                (make-array java.nio.file.LinkOption 0)))
+
+(defn- origin [lease] (assoc (:cursor lease) :offset 0 :sequence 0))
+
+(deftest definite-conflict-discards-speculation-without-closing-owner
+  (let [owner (runtime/create! nil) id (random-uuid)]
+    (try
+      (let [a (begin owner {} id)
+            _ (runtime/committed! owner (:db-after a) [a])
+            lease (runtime/acquire-prefix! owner id)
+            b (tx owner (:db-after a) [[:current :insert :rejected nil]])]
+        (try
+          (is (= #{id} (runtime/invalidate! owner)))
+          (is (= :datahike.backfill.runtime/unavailable
+                 (error-type #(runtime/acquire-prefix! owner id))))
+          (is (= :owner-lost
+                 (get-in (tx owner (:db-after a) []) [:db-after :avet-build-result :reason])))
+          (is (= :datahike.backfill.runtime/invalid-commit
+                 (error-type #(runtime/committed! owner (:db-after b) [b]))))
+          (is (= [[]] (runtime/reduce-prefix owner lease (origin lease)
+                                             (fn [acc transaction _]
+                                               (conj acc (:effects transaction))) [])))
+          ;; The durable cancellation belongs to the writer. Simulate its
+          ;; accepted report, then a wholly new generation on the fresh head.
+          (let [canceled (runtime/prepare-report!
+                          owner (report (:db-after a) (dissoc (:db-after a) :avet-build))
+                          'cancel-avet-build!)
+                fresh-id (random-uuid)
+                fresh (begin owner (:db-after canceled) fresh-id)]
+            (runtime/committed! owner (:db-after canceled) [canceled])
+            (is (= fresh-id (:generation (runtime/committed! owner (:db-after fresh) [fresh])))))
+          (finally (runtime/release-prefix! owner lease)))
+        (is (not (path-exists? lease))))
+      (finally (runtime/close! owner)))))
+
+(deftest authoritative-reload-retires-lost-lineage-without-rejecting-data
+  (let [owner (runtime/create! nil) id (random-uuid)
+        before {:meta {:datahike/commit-id (random-uuid)}
+                :datahike.writing/head-revision (random-uuid) :eavt (Object.)}]
+    (try
+      (let [a (begin owner before id)
+            source (:db-after a)]
+        (runtime/committed! owner source [a])
+        (is (identical? source (runtime/reconcile-db! owner source)))
+        ;; Same CID/root but a different storage revision is a lost lineage,
+        ;; not permission to keep replaying an old speculative stream.
+        (let [rewritten (assoc source :datahike.writing/head-revision (random-uuid))
+              reconciled (runtime/reconcile-db! owner rewritten)
+              accepted (tx owner reconciled [[:current :insert :valid-user-value nil]])]
+          (is (nil? (:avet-build-invalidated? rewritten)))
+          (is (:avet-build-invalidated? reconciled))
+          (is (nil? (get-in accepted [:db-after :avet-build])))
+          (is (= :owner-lost (get-in accepted [:db-after :avet-build-result :reason])))
+          (is (= (inc (:max-tx source)) (get-in accepted [:db-after :max-tx])))
+          (is (= :datahike.backfill.runtime/unavailable
+                 (error-type #(runtime/acquire-prefix! owner id))))))
+      (finally (runtime/close! owner))))
+  (let [owner (runtime/create! nil)
+        recovered {:avet-build {:id (random-uuid) :status :building} :max-tx 4}]
+    (try
+      (let [reconciled (runtime/reconcile-db! owner recovered)
+            accepted (tx owner reconciled [])]
+        (is (nil? (get-in accepted [:db-after :avet-build])))
+        (is (= 5 (get-in accepted [:db-after :max-tx])))
+        (is (empty? (:contexts @(:state owner)))))
+      (finally (runtime/close! owner)))))
+
+(deftest speculative-and-committed-prefixes-are-distinct
+  (let [owner (runtime/create! nil) id (random-uuid)]
+    (try
+      (let [a (begin owner {} id)
+            b (tx owner (:db-after a) [[:current :insert :value nil]])]
+        (is (= :datahike.backfill.runtime/unavailable
+               (error-type #(runtime/acquire-prefix! owner id))))
+        (let [start (runtime/committed! owner (:db-after a) [a])
+              lease (runtime/acquire-prefix! owner id)]
+          (try
+            (is (= (:db-after a) (:source-db start)))
+            (is (identical? (:db-after a) (:source-db lease)))
+            (is (= 1 (get-in start [:cursor :sequence])))
+            (is (= [[]] (runtime/reduce-prefix owner lease (origin lease)
+                                               (fn [acc transaction _] (conj acc (:effects transaction))) [])))
+            (is (nil? (runtime/committed! owner (:db-after b) [b])))
+            (is (identical? (:db-after a) (:source-db lease)))
+            ;; An existing read lease remains the exact older immutable prefix.
+            (is (= 1 (runtime/reduce-prefix owner lease (origin lease) (fn [n _ _] (inc n)) 0)))
+            (finally (runtime/release-prefix! owner lease))))
+        (let [empty-tx (tx owner (:db-after b) [])]
+          (runtime/committed! owner (:db-after empty-tx) [empty-tx])
+          (let [lease (runtime/acquire-prefix! owner id)]
+            (try
+              (is (= [1 2 3] (runtime/reduce-prefix owner lease (origin lease)
+                                                    (fn [acc transaction _] (conj acc (:max-tx transaction))) [])))
+              (is (= 3 (get-in lease [:cursor :sequence])))
+              (is (= :stopped (runtime/reduce-prefix owner lease (origin lease)
+                                                     (fn [_ _ _] (reduced :stopped)) nil)))
+              (finally (runtime/release-prefix! owner lease))))))
+      (finally (runtime/close! owner)))))
+
+(deftest failed-disposal-retains-quota-and-can-be-retried
+  (let [owner (runtime/create! {:max-contexts 1}) id (random-uuid)]
+    (try
+      (let [a (begin owner {} id)
+            _ (runtime/committed! owner (:db-after a) [a])
+            lease (runtime/acquire-prefix! owner id)
+            cancel (runtime/prepare-report! owner
+                                            (report (:db-after a) (dissoc (:db-after a) :avet-build))
+                                            'cancel-avet-build!)]
+        (runtime/release-prefix! owner lease)
+        (with-redefs [journal/dispose! (fn [_] (throw (ex-info "delete failed" {:type :injected})))]
+          (runtime/committed! owner (:db-after cancel) [cancel])
+          (is (path-exists? lease))
+          (is (= 1 (count (:contexts @(:state owner)))))
+          (is (= :datahike.backfill.runtime/context-limit
+                 (error-type #(begin owner (:db-after cancel) (random-uuid))))))
+        ;; Another cleanup boundary retries the retained retired context.
+        (runtime/committed! owner (:db-after cancel) [])
+        (is (not (path-exists? lease)))
+        (is (empty? (:contexts @(:state owner)))))
+      (finally (runtime/close! owner)))))
+
+(deftest recovered-context-retires-and-inconsistent-cursors-are-refused
+  (let [owner (runtime/create! nil) id (random-uuid)]
+    (try
+      (is (= :owner-lost
+             (get-in (tx owner {:avet-build {:id id :attrs #{:score}} :max-tx 1} [])
+                     [:db-after :avet-build-result :reason])))
+      (is (empty? (:contexts @(:state owner))))
+      (let [a (begin owner {} id)]
+        (runtime/committed! owner (:db-after a) [a])
+        (let [lease (runtime/acquire-prefix! owner id)]
+          (try
+            (is (= :datahike.backfill.runtime/invalid-cursor
+                   (error-type #(runtime/reduce-prefix owner lease
+                                                       (assoc (:cursor lease) :sequence 0)
+                                                       (fn [n _ _] (inc n)) 0))))
+            (is (= :datahike.backfill.runtime/invalid-cursor
+                   (error-type #(runtime/reduce-prefix owner lease
+                                                       (assoc (origin lease) :sequence 1)
+                                                       (fn [n _ _] (inc n)) 0))))
+            (is (= :datahike.backfill.runtime/invalid-commit
+                   (error-type #(runtime/committed! owner
+                                                    (assoc-in (:db-after a) [:avet-build-journal :cursor :sequence] 9)
+                                                    [a]))))
+            (finally (runtime/release-prefix! owner lease)))))
+      (finally (runtime/close! owner)))))
+
+(deftest failed-new-append-and-disposal-still-consume-context-quota
+  (let [owner (runtime/create! {:max-contexts 1}) id (random-uuid)]
+    (try
+      (with-redefs [journal/append! (fn [& _] (throw (ex-info "append failed" {:type :append-injected})))
+                    journal/dispose! (fn [_] (throw (ex-info "delete failed" {:type :delete-injected})))]
+        (is (= :append-injected (error-type #(begin owner {} id))))
+        (is (= 1 (count (:contexts @(:state owner)))))
+        (is (= :datahike.backfill.runtime/context-limit
+               (error-type #(begin owner {} (random-uuid))))))
+      (runtime/committed! owner {} [])
+      (is (empty? (:contexts @(:state owner))))
+      (finally (runtime/close! owner)))))
+
+(deftest commit-prefix-must-be-the-exact-final-accepted-report-boundary
+  (let [owner (runtime/create! nil) id (random-uuid)]
+    (try
+      (let [a (begin owner {} id)
+            b (tx owner (:db-after a) [])
+            sequence-mismatch (assoc-in (:db-after a) [:avet-build-journal :cursor :sequence] 2)
+            interior-offset (-> (:db-after a)
+                                (assoc-in [:avet-build-journal :descriptor :end] 1)
+                                (assoc-in [:avet-build-journal :cursor :offset] 1))]
+        (doseq [invalid [sequence-mismatch interior-offset (:db-after b)]]
+          (is (= :datahike.backfill.runtime/invalid-commit
+                 (error-type #(runtime/committed! owner invalid [a])))))
+        (is (= :datahike.backfill.runtime/invalid-commit
+               (error-type #(runtime/committed! owner (:db-after a) []))))
+        (is (= :datahike.backfill.runtime/unavailable
+               (error-type #(runtime/acquire-prefix! owner id))))
+        (is (= 1 (get-in (runtime/committed! owner (:db-after a) [a]) [:cursor :sequence])))
+        (is (nil? (runtime/committed! owner (:db-after a) [])))
+        (runtime/committed! owner (:db-after b) [b]))
+      (finally (runtime/close! owner)))))
+
+(deftest invalid-publication-does-not-retire-an-existing-generation
+  (let [owner (runtime/create! nil) first-id (random-uuid) second-id (random-uuid)]
+    (try
+      (let [a (begin owner {} first-id)
+            _ (runtime/committed! owner (:db-after a) [a])
+            b (begin owner (:db-after a) second-id)
+            invalid (assoc-in (:db-after b) [:avet-build-journal :cursor :sequence] 0)]
+        (is (= :datahike.backfill.runtime/invalid-commit
+               (error-type #(runtime/committed! owner invalid [b]))))
+        (let [lease (runtime/acquire-prefix! owner first-id)]
+          (try
+            (is (= 1 (runtime/reduce-prefix owner lease (origin lease) (fn [n _ _] (inc n)) 0)))
+            (finally (runtime/release-prefix! owner lease))))
+        (is (= second-id (:generation (runtime/committed! owner (:db-after b) [b])))))
+      (finally (runtime/close! owner)))))
+
+(deftest unknown-committed-generation-is-refused
+  (let [owner (runtime/create! nil)
+        foreign {:avet-build {:id (random-uuid) :attrs #{:score}}}]
+    (try
+      (is (= :datahike.backfill.runtime/invalid-commit
+             (error-type #(runtime/committed! owner foreign [(report {} foreign)]))))
+      (is (empty? (:contexts @(:state owner))))
+      (finally (runtime/close! owner)))))
+
+(deftest batched-begin-cancel-replacement-starts-only-final-generation
+  (let [owner (runtime/create! nil) first-id (random-uuid) final-id (random-uuid)]
+    (try
+      (let [a (begin owner {} first-id)
+            a-path (get-in a [:db-after :avet-build-journal :descriptor :path])
+            cancel (runtime/prepare-report! owner
+                                            (report (:db-after a) (dissoc (:db-after a) :avet-build))
+                                            'cancel-avet-build!)
+            b (begin owner (:db-after cancel) final-id)
+            c (tx owner (:db-after b) [[:effect]])
+            ;; Future speculative generation must not be retired by this commit.
+            future-id (random-uuid)
+            future-report (begin owner (:db-after c) future-id)
+            start (runtime/committed! owner (:db-after c) [a cancel b c])]
+        (is (= final-id (:generation start)))
+        (is (= (:db-after c) (:source-db start)))
+        (is (= 2 (get-in start [:cursor :sequence])))
+        (is (not (Files/exists (Path/of a-path (make-array String 0)) (make-array java.nio.file.LinkOption 0))))
+        (is (= :datahike.backfill.runtime/unavailable
+               (error-type #(runtime/acquire-prefix! owner first-id))))
+        (is (= future-id (:generation (runtime/committed! owner (:db-after future-report) [future-report])))))
+      (finally (runtime/close! owner)))))
+
+(deftest leases-delay-retirement-and-close-cannot-resurrect
+  (let [owner (runtime/create! {:max-readers 1}) id (random-uuid)
+        a (begin owner {} id)]
+    (runtime/committed! owner (:db-after a) [a])
+    (let [lease (runtime/acquire-prefix! owner id)]
+      (try
+        (is (= :datahike.backfill.runtime/reader-limit
+               (error-type #(runtime/acquire-prefix! owner id))))
+        (let [cancel (runtime/prepare-report! owner
+                                              (report (:db-after a) (dissoc (:db-after a) :avet-build))
+                                              'cancel-avet-build!)]
+          (is (path-exists? lease))
+          (runtime/committed! owner (:db-after cancel) [cancel])
+          (is (path-exists? lease))
+          (is (= :datahike.backfill.runtime/unavailable
+                 (error-type #(runtime/acquire-prefix! owner id))))
+          (runtime/close! owner)
+          (is (path-exists? lease))
+          (is (= 1 (runtime/reduce-prefix owner lease (origin lease) (fn [n _ _] (inc n)) 0)))
+          (is (= :datahike.backfill.runtime/closed (error-type #(begin owner {} (random-uuid)))))
+          (is (nil? (runtime/committed! owner (:db-after a) [a]))))
+        (finally (runtime/release-prefix! owner lease) (runtime/close! owner)))
+      (is (not (path-exists? lease)))
+      (is (nil? (runtime/release-prefix! owner lease))))))
+
+(deftest taint-and-unsupported-operations-fail-build-not-transaction
+  (doseq [[op taint? reason] [['transact! true :schema-changed]
+                              ['replace-roots! false :unsupported-operation]]]
+    (let [owner (runtime/create! nil) id (random-uuid)]
+      (try
+        (let [a (begin owner {} id)
+              _ (runtime/committed! owner (:db-after a) [a])
+              changed (runtime/prepare-report! owner
+                                               (report (:db-after a)
+                                                       (assoc (:db-after a) :avet-build-invalidated? taint?
+                                                              :user-change :kept)) op)]
+          (is (= :kept (get-in changed [:db-after :user-change])))
+          (is (= reason (get-in changed [:db-after :avet-build-result :reason])))
+          (is (nil? (get-in changed [:db-after :avet-build])))
+          ;; Retirement is not visible until the accepted report commits.
+          (let [lease (runtime/acquire-prefix! owner id)] (runtime/release-prefix! owner lease))
+          (runtime/committed! owner (:db-after changed) [changed])
+          (is (= :datahike.backfill.runtime/unavailable
+                 (error-type #(runtime/acquire-prefix! owner id)))))
+        (finally (runtime/close! owner))))))
+
+(deftest limits-and-append-failures-leave-accepted-prefix-intact
+  (let [owner (runtime/create! {:max-contexts 1 :journal {:max-frame-bytes 512}})
+        id (random-uuid)]
+    (try
+      (let [a (begin owner {} id)]
+        (runtime/committed! owner (:db-after a) [a])
+        (is (= :datahike.backfill.runtime/context-limit
+               (error-type #(begin owner (:db-after a) (random-uuid)))))
+        (is (= :backfill.journal/frame-too-large
+               (error-type #(tx owner (:db-after a) [(apply str (repeat 2000 "x"))]))))
+        (let [b (tx owner (:db-after a) [])]
+          (runtime/committed! owner (:db-after b) [b])
+          (let [lease (runtime/acquire-prefix! owner id)]
+            (try
+              (is (= 2 (runtime/reduce-prefix owner lease (origin lease) (fn [n _ _] (inc n)) 0)))
+              (is (= :datahike.backfill.runtime/invalid-cursor
+                     (error-type #(runtime/reduce-prefix owner lease
+                                                         (assoc (origin lease) :generation (random-uuid))
+                                                         (fn [n _ _] (inc n)) 0))))
+              (finally (runtime/release-prefix! owner lease))))))
+      (finally (runtime/close! owner))))
+  (let [owner (runtime/create! nil) disposed (atom 0) original journal/dispose!]
+    (try
+      (with-redefs [journal/append! (fn [& _] (throw (ex-info "injected" {:type :injected})))
+                    journal/dispose! (fn [descriptor] (swap! disposed inc) (original descriptor))]
+        (is (= :injected (error-type #(begin owner {} (random-uuid)))))
+        (is (= 1 @disposed)))
+      (is (empty? (:contexts @(:state owner))))
+      (finally (runtime/close! owner)))))

--- a/test/datahike/test/backfill_storage_test.clj
+++ b/test/datahike/test/backfill_storage_test.clj
@@ -8,7 +8,7 @@
             [konserve.core :as k]
             [org.replikativ.persistent-sorted-set :as pss]
             [org.replikativ.persistent-sorted-set.impl.nodes :as nodes])
-  (:import [org.replikativ.persistent_sorted_set IStorage ANode]))
+  (:import [org.replikativ.persistent_sorted_set IStorage ANode Branch PersistentSortedSet RefType]))
 
 (defn- error-type [f]
   (try (f) nil (catch Exception e (:type (ex-data e)))))
@@ -242,3 +242,75 @@
                (select-keys (storage/resources private)
                             [:closed? :failed? :pending-nodes :cached-nodes
                              :pending-weight :cache-weight])))))))
+
+(deftest source-copies-isolate-cold-fused-and-strong-reference-topology
+  (with-db
+    (fn [conn]
+      (let [db @conn
+            datoms (mapv #(dd/datom % :score % 42) (range 1 2301))
+            cmp (dd/index-type->cmp-quick :avet false)
+            address (with-open [^java.io.Closeable writer (storage/create! (:store db) (:config db))]
+                      (let [tree (pss/from-sorted-seq cmp datoms
+                                                      {:storage writer :branching-factor 32 :ref-type :strong
+                                                       :meta {:index-type :avet}})
+                            root (pss/store tree)]
+                        (storage/flush! writer)
+                        root))
+            live (get-in db [:store :storage])
+            source ^PersistentSortedSet (with-meta (pss/restore-by cmp address live {:ref-type :strong})
+                                          {:index-type :avet})
+            root ^Branch (.root source)
+            before-state (.-_state root)
+            before-cache @(:cache live)
+            before-stats @(:stats live)]
+        (is (= RefType/STRONG (.refType (.-_settings root))))
+        (with-open [^java.io.Closeable private (storage/create! (:store db) (:config db)
+                                                                {:cache-node-limit 2 :pending-node-limit 2})]
+          (let [copy ^PersistentSortedSet (storage/copy-index! private source)]
+            (is (not (identical? root (.root copy))))
+            (is (= RefType/WEAK (.refType (.-_settings ^ANode (.root copy)))))
+            (is (= datoms (vec copy)))
+            (is (identical? before-state (.-_state root)))
+            (is (= before-cache @(:cache live)))
+            (is (= before-stats @(:stats live)))
+            (is (<= (:cached-nodes (storage/resources private)) 2))
+            (is (zero? (:writes (storage/resources private)))))
+          ;; A genuinely cold source root must load through private storage.
+          (let [cold ^PersistentSortedSet (with-meta (pss/restore-by cmp address live) {:index-type :avet})
+                copy (storage/copy-index! private cold)]
+            (is (nil? (.-_root cold)))
+            (is (= datoms (vec copy)))
+            (is (nil? (.-_root cold)))
+            (is (= before-cache @(:cache live)))
+            (is (= before-stats @(:stats live))))
+          ;; Fused roots can be resident without a standalone root key. This key
+          ;; belongs to the synthetic source above, not the database's live root.
+          (k/dissoc (:store db) address {:sync? true})
+          (is (not (k/exists? (:store db) address {:sync? true})))
+          (is (= datoms (vec (storage/copy-index! private source))))
+          (is (identical? before-state (.-_state root)))
+          (is (= before-cache @(:cache live)))
+          (is (= before-stats @(:stats live))))))))
+
+(deftest unflushed-source-refused-without-live-write-or-buffer-drain
+  (with-db
+    (fn [conn]
+      (let [db @conn
+            dirty (conj (:avet db) (dd/datom 10000 :unindexed 1 42))
+            live (get-in db [:store :storage])
+            before @(:pending-writes live)]
+        (with-open [^java.io.Closeable private (storage/create! (:store db) (:config db))]
+          (is (= :backfill.storage/unflushed-source
+                 (error-type #(storage/copy-index! private dirty))))
+          (is (= before @(:pending-writes live)))
+          (is (zero? (:writes (storage/resources private))))
+          (let [root-before (.-_root ^PersistentSortedSet dirty)
+                cache-before @(:cache live)
+                stats-before @(:stats live)
+                copy (storage/copy-index! private dirty {:resident-source? true})]
+            (is (pos? (:writes (storage/resources private))))
+            (is (contains? copy (dd/datom 10000 :unindexed 1 42)))
+            (is (identical? root-before (.-_root ^PersistentSortedSet dirty)))
+            (is (= before @(:pending-writes live)))
+            (is (= cache-before @(:cache live)))
+            (is (= stats-before @(:stats live)))))))))

--- a/test/datahike/test/backfill_unique_test.clj
+++ b/test/datahike/test/backfill_unique_test.clj
@@ -1,0 +1,141 @@
+(ns datahike.test.backfill-unique-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.backfill.unique :as unique]
+            [datahike.backfill.effects :as effects]
+            [datahike.datom :as dd]
+            [datahike.db :as db]
+            [datahike.index.interface :as di]))
+
+(defn- check-result [f]
+  (try (f) :valid
+       (catch clojure.lang.ExceptionInfo e
+         (if (= :transact/schema (:error (ex-data e))) :duplicate (throw e)))))
+
+(defn- capturing [database]
+  (-> database
+      (dissoc :avet-build-effects)
+      (assoc :avet-build {:id (random-uuid)
+                          :attrs (into #{:value :other} (get-in database [:rschema :db/index]))})))
+
+(defn- base [refs?]
+  (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs? :keep-history? true
+                               :schema-flexibility :write})
+             [{:db/ident :value :db/valueType :db.type/long :db/index true
+               :db/cardinality :db.cardinality/one}
+              {:db/ident :other :db/valueType :db.type/long :db/index true
+               :db/cardinality :db.cardinality/one}]))
+
+(deftest full-checks-use-current-not-historical-values
+  (doseq [refs? [false true]]
+    (let [initial (d/db-with (base refs?) [{:db/id 10000 :value 1}
+                                           {:db/id 10001 :value 2}])
+          duplicate (d/db-with initial [[:db/add 10001 :value 1]])
+          resolved (d/db-with duplicate [[:db/add 10000 :value 3]])]
+      (is (nil? (unique/validate! initial (:avet initial) #{:value})))
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (unique/validate! duplicate (:avet duplicate) #{:value})))
+      (is (nil? (unique/validate! resolved (:avet resolved) #{:value}))))))
+
+(deftest delta-checks-run-after-complete-transaction
+  (doseq [refs? [false true]]
+    (let [initial (assoc (d/db-with (base refs?) [{:db/id 10000 :value 1}
+                                                  {:db/id 10001 :value 2}])
+                         :avet-build {:id (random-uuid) :attrs #{:value :other}})
+          duplicate (d/db-with initial [[:db/add 10001 :value 1]])
+          swapped (d/db-with initial [[:db/add 10000 :value 2]
+                                      [:db/add 10001 :value 1]])
+          unrelated (d/db-with initial [{:db/id 10000 :other 9}
+                                        {:db/id 10001 :other 9}])]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (unique/validate-effects! duplicate (:avet duplicate) #{:value}
+                                             (:avet-build-effects duplicate))))
+      (is (nil? (unique/validate-effects! swapped (:avet swapped) #{:value}
+                                          (:avet-build-effects swapped))))
+      (is (nil? (unique/validate-effects! unrelated (:avet unrelated) #{:value}
+                                          (:avet-build-effects unrelated)))))))
+
+(deftest native-array-and-tuple-value-semantics
+  (doseq [refs? [false true]
+          [label properties first-value equal-value other-value]
+          [[:bytes {}
+            (byte-array [1 2]) (byte-array [1 2]) (byte-array [1 3])]
+           [:floats {}
+            (float-array [1.0 2.0]) (float-array [1.0 2.0]) (float-array [1.0 3.0])]
+           [:doubles {}
+            (double-array [1.0 2.0]) (double-array [1.0 2.0]) (double-array [1.0 3.0])]
+           [:tuple {:db/valueType :db.type/tuple :db/tupleTypes [:db.type/long :db.type/string]}
+            [1 "a"] [1 "a"] [1 "b"]]
+           [:array-tuple {}
+            [(byte-array [1 2]) 1] [(byte-array [1 2]) 1] [(byte-array [1 3]) 1]]]
+          :when (or (not refs?) (= label :tuple))]
+    (testing (str label " refs=" refs?)
+      (let [database (if (= label :tuple)
+                       (d/db-with (db/empty-db nil {:index :datahike.index/persistent-set :attribute-refs? refs? :keep-history? true
+                                                    :schema-flexibility :write})
+                                  [(merge {:db/ident :value :db/index true
+                                           :db/cardinality :db.cardinality/one} properties)])
+                       ;; Native array ordering is independent of the schema
+                       ;; parser. These values use the supported flexible schema
+                       ;; path; array value-type refs are not system entities.
+                       (db/empty-db {:value {:db/index true :db/cardinality :db.cardinality/one}}
+                                    {:index :datahike.index/persistent-set
+                                     :keep-history? true :schema-flexibility :read}))
+            initial (capturing (d/db-with database [{:db/id 10000 :value first-value}
+                                                    {:db/id 10001 :value other-value}]))
+            duplicate (d/db-with initial [[:db/add 10001 :value equal-value]])]
+        (is (zero? (dd/compare-value first-value equal-value)))
+        (is (= :valid (check-result #(unique/validate! initial (:avet initial) #{:value}))))
+        (is (= :duplicate (check-result #(unique/validate! duplicate (:avet duplicate) #{:value}))))
+        (is (= :duplicate (check-result #(unique/validate-effects! duplicate (:avet duplicate) #{:value}
+                                                                   (:avet-build-effects duplicate)))))))))
+
+(deftest delta-and-full-validation-agree-after-complete-random-transactions
+  (doseq [refs? [false true]]
+    (let [rng (java.util.Random. 701)
+          initial (capturing (d/db-with (base refs?)
+                                        (mapv #(hash-map :db/id (+ 10000 %) :value %) (range 6))))]
+      (loop [database initial iteration 0]
+        (when (< iteration 75)
+          (let [tx (vec (repeatedly (inc (.nextInt rng 4))
+                                    (fn [] [(if (zero? (.nextInt rng 4)) :db/retract :db/add)
+                                            (+ 10000 (.nextInt rng 6))
+                                            (if (zero? (.nextInt rng 5)) :other :value)
+                                            (long (.nextInt rng 9))])))
+                database (dissoc database :avet-build-effects)
+                after (d/db-with database tx)
+                operations (:avet-build-effects after)
+                replayed (reduce effects/replay {:current (:avet database)
+                                                 :temporal (:temporal-avet database)} operations)
+                full (check-result #(unique/validate! after (:current replayed) #{:value}))
+                delta (check-result #(unique/validate-effects! after (:current replayed) #{:value} operations))]
+            (is (= (mapv #(vec (seq %)) (:avet after))
+                   (mapv #(vec (seq %)) (:current replayed))))
+            (is (= full delta) (str "complete transaction " iteration " " tx))
+            ;; Delta validation assumes the previous candidate was checked.
+            ;; Rejected candidates are discarded, never used as the next base.
+            (recur (if (= :valid full) after database) (inc iteration))))))))
+
+(deftest delta-validation-only-seeks-touched-values
+  (let [database (base false)
+        changed (dd/datom 10000 :value 7 100)
+        unrelated (dd/datom 10000 :other 8 100)
+        sought (atom [])
+        current (:avet database)]
+    (with-redefs [di/-slice (fn [_ from to family]
+                              (swap! sought conj [(:a from) (:v from) (:a to) (:v to) family])
+                              nil)]
+      (is (nil? (unique/validate-effects! database current #{:value}
+                                          [[:temporal :remove changed nil]
+                                           [:current :upsert unrelated nil]
+                                           [:current :insert changed nil]]))))
+    (is (= [[:value 7 :value 7 :avet]] @sought)))
+  (let [database (base false)
+        first-match (dd/datom 10000 :value 7 100)
+        second-match (dd/datom 10001 :value 7 100)]
+    (with-redefs [di/-slice (fn [& _]
+                              (concat [first-match second-match]
+                                      (lazy-seq (throw (AssertionError. "Read beyond duplicate pair")))))]
+      (is (= :duplicate
+             (check-result #(unique/validate-effects! database (:avet database) #{:value}
+                                                      [[:current :insert first-match nil]])))))))

--- a/test/datahike/test/backfill_writer_lifecycle_test.clj
+++ b/test/datahike/test/backfill_writer_lifecycle_test.clj
@@ -1,0 +1,179 @@
+(ns datahike.test.backfill-writer-lifecycle-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.core.async :as async]
+            [datahike.backfill.coordinator :as coordinator]
+            [datahike.backfill.runtime :as runtime]
+            [datahike.api :as d]
+            [datahike.test.utils :as utils]
+            [datahike.tx-preds :as predicates]
+            [datahike.writer :as writer])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- await-condition! [f]
+  (let [deadline (+ (System/nanoTime) 10000000000)]
+    (loop []
+      (or (f)
+          (if (< (System/nanoTime) deadline)
+            (do (Thread/sleep 10) (recur))
+            (throw (ex-info "Lifecycle condition timed out" {})))))))
+
+(defn- invoke! [conn op & args]
+  (let [channel (writer/dispatch! (:writer @conn) {:op op :args (vec args)})
+        [result port] (async/alts!! [channel (async/timeout 10000)])]
+    (when-not (= port channel) (throw (ex-info "Writer operation timed out" {})))
+    (when (instance? Throwable result) (throw result))
+    result))
+
+(def ^:dynamic *predicate-context* nil)
+
+(deftest normalized-predicate-runs-once-with-caller-bindings
+  (let [owner (runtime/create! nil)
+        report {:db-before {} :db-after {}}
+        calls (atom [])
+        wrapped (with-meta (fn [& _] (throw (ex-info "Wrapper must not run twice" {})))
+                  {::writer/raw-write-fn (fn [_] report)})
+        bindings (binding [*predicate-context* :caller] (get-thread-bindings))]
+    (with-redefs [predicates/check-report (fn [r] (swap! calls conj *predicate-context*) r)]
+      (is (= report (#'writer/apply-avet-write owner wrapped {} [] bindings 'transact!))))
+    (is (= [:caller] @calls))))
+
+(deftest failed-internal-cancel-can-recover-without-bypassing-predicates
+  (let [conn (utils/setup-db {:crypto-hash? false :schema-flexibility :write
+                              :index :datahike.index/persistent-set
+                              :writer {:backend :self :writer-ownership :shared :require-fencing :process}})
+        config (:config @conn)
+        store-id (get-in config [:store :id])
+        vetoes (atom 0)]
+    (try
+      (d/transact conn [{:db/ident :score :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}
+                        {:db/id 10000 :score 1} {:db/id 10001 :score 1}])
+      (predicates/register-tx-pred!
+       store-id ::reject-cancel
+       (fn [report]
+         (when (get-in report [:db-after :avet-build-result])
+           (swap! vetoes inc)
+           (throw (ex-info "Cancellation veto" {:type ::veto})))
+         report))
+      (let [report (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+            id (get-in report [:db-after :avet-build :id])
+            owner (:avet-runtime (:writer @conn))]
+        (await-condition! #(= id (get-in @(:state owner) [:last-failure :generation])))
+        (is (pos? @vetoes))
+        (is (= id (get-in @conn [:avet-build :id])))
+        (is (nil? (:avet-build-result @conn)))
+        (is (nil? (get-in @conn [:schema :score :db/unique])))
+        ;; Reconciliation is not permission to bypass the predicate either.
+        (is (thrown? clojure.lang.ExceptionInfo (d/transact conn [[:db/add 10001 :score 2]])))
+        (is (= #{[10000 1] [10001 1]} (d/q '[:find ?e ?v :where [?e :score ?v]] @conn)))
+        (predicates/unregister-tx-pred! store-id ::reject-cancel)
+        (d/transact conn [[:db/add 10001 :score 2]])
+        (is (nil? (:avet-build @conn)))
+        (is (= :failed (get-in @conn [:avet-build-result :status])))
+        (invoke! conn 'begin-avet-build! {:score {:db/unique :db.unique/value}})
+        (await-condition! #(= :ready (get-in @conn [:avet-build-result :status])))
+        (is (= :db.unique/value (get-in @conn [:schema :score :db/unique]))))
+      (finally
+        (predicates/unregister-tx-pred! store-id ::reject-cancel)
+        (d/release conn)
+        (d/delete-database config)))))
+
+(deftest failed-old-generation-does-not-retire-replacement
+  (let [owner (runtime/create! nil)
+        old (random-uuid) replacement (random-uuid)]
+    (swap! (:state owner) assoc :contexts {old {:retired? false} replacement {:retired? false}})
+    (runtime/fail-generation! owner old :cancel-rejected)
+    (is (true? (get-in @(:state owner) [:contexts old :retired?])))
+    (is (false? (get-in @(:state owner) [:contexts replacement :retired?])))
+    (is (= {:generation old :reason :cancel-rejected} (:last-failure @(:state owner))))))
+
+(deftest closed-cancellation-queue-retires-only-local-generation
+  (let [owner (runtime/create! nil)
+        id (random-uuid)
+        queue (async/chan 1)]
+    (swap! (:state owner) assoc :contexts {id {:retired? false}})
+    (async/close! queue)
+    (#'writer/enqueue-avet-cancel! owner queue id)
+    (is (true? (get-in @(:state owner) [:contexts id :retired?])))
+    (is (= {:generation id :reason :dispatch-failed} (:last-failure @(:state owner))))))
+
+(deftest durable-hook-failure-retires-runtime-and-cancels-exact-generation
+  (doseq [failure-stage [:runtime :coordinator]]
+    (let [id (random-uuid) replacement (random-uuid)
+          owner (runtime/create! nil)
+          queue (async/chan 2)
+          aborted (atom [])
+          token (Object.)]
+      (swap! (:state owner) assoc :contexts {id {:retired? false} replacement {:retired? false}})
+      (with-redefs [runtime/committed! (fn [& _] (when (= :runtime failure-stage)
+                                                   (throw (ex-info "Commit hook failed" {}))))
+                    coordinator/after-commit! (fn [& _] (throw (ex-info "Start hook failed" {})))
+                    coordinator/invalidate! (fn [_])
+                    runtime/invalidate! (fn [r] (swap! (:state r) update :contexts
+                                                       #(into {} (map (fn [[k v]] [k (assoc v :retired? true)])) %)))
+                    coordinator/abort-install! (fn [_ t definite?] (swap! aborted conj [t definite?]))]
+        (#'writer/committed-avet! owner {} queue {:avet-build {:id id}}
+                                  [[{::writer/avet-install-token token}]])
+        (is (every? :retired? (vals (:contexts @(:state owner)))))
+        (is (= [[token true]] @aborted))
+        (let [invocation (async/poll! queue)]
+          (is (= 'cancel-avet-build! (:op invocation)))
+          (is (= [id :build-failed] (:args invocation)))
+          (when invocation (async/>!! (:callback invocation) {:committed true})))
+        (is (nil? (async/poll! queue))))
+      (async/close! queue))))
+
+(deftest ownership-drift-after-predicate-does-not-append
+  (let [owner (runtime/create! nil)
+        id (random-uuid)]
+    (try
+      (let [begin (runtime/prepare-report! owner {:db-before {}
+                                                  :db-after {:avet-build {:id id} :max-tx 1}}
+                                           'begin-avet-build!)
+            before (:db-after begin)
+            proposed (runtime/normalize-report owner {:db-before before :db-after (assoc before :max-tx 2)}
+                                               'transact!)
+            staged (get-in @(:state owner) [:contexts id :staged])]
+        (runtime/fail-generation! owner id :cancel-rejected)
+        (let [failure (try (runtime/prepare-report! owner proposed 'transact! true) nil
+                           (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+          (is (= ::runtime/normalization-conflict (:type failure)))
+          (is (true? (:retryable? failure))))
+        (is (= staged (get-in @(:state owner) [:contexts id :staged])))
+        (is (= (get-in staged [:descriptor :end])
+               (.length (java.io.File. (get-in staged [:descriptor :path]))))))
+      (finally (runtime/close! owner)))))
+
+(deftest blocked-worker-cleanup-does-not-starve-go-dispatch
+  (let [workers 16
+        entered (CountDownLatch. workers)
+        release (CountDownLatch. 1)
+        finished (CountDownLatch. workers)
+        shutdowns (atom [])]
+    (with-redefs [coordinator/close!
+                  (fn [_]
+                    (.countDown entered)
+                    (try (.await release)
+                         (finally (.countDown finished))))]
+      (try
+        (dotimes [_ workers]
+          (let [done (async/promise-chan)
+                local (writer/map->LocalWriter
+                       {:thread done :transaction-queue (async/chan 1)
+                        :avet-coordinator {}})]
+            (async/>!! done :drained)
+            (swap! shutdowns conj (writer/shutdown local))))
+        ;; More simultaneous joins than the ordinary go pool can handle. They
+        ;; must all begin on blocking threads while unrelated go work progresses.
+        (is (.await entered 10 TimeUnit/SECONDS))
+        (let [progress (async/go :progress)
+              [value port] (async/alts!! [progress (async/timeout 2000)])]
+          (is (= progress port))
+          (is (= :progress value)))
+        (finally
+          (.countDown release)
+          (is (.await finished 10 TimeUnit/SECONDS))
+          (doseq [shutdown @shutdowns]
+            (let [[value port] (async/alts!! [shutdown (async/timeout 2000)])]
+              (is (= shutdown port))
+              (is (= :drained value)))))))))

--- a/test/datahike/test/nodejs_test.cljs
+++ b/test/datahike/test/nodejs_test.cljs
@@ -21,6 +21,7 @@
             [datahike.test.reference-test]
             [datahike.test.purge-reference-test]
             [datahike.test.valid-time-test]
+            [datahike.test.backfill-effects-portable-test]
             ;; Portable query suites — exercise the query-engine paths that were
             ;; JVM-only (NOT-JOIN, OR, aggregates, recursive rules) on cljs too.
             [datahike.test.time-variance-test]
@@ -919,6 +920,7 @@
                'datahike.test.reference-test
                'datahike.test.purge-reference-test
                'datahike.test.valid-time-test
+               'datahike.test.backfill-effects-portable-test
                'datahike.test.time-variance-test
                'datahike.test.query-not-test
                'datahike.test.query-or-test

--- a/test/datahike/test/transaction_options_test.clj
+++ b/test/datahike/test/transaction_options_test.clj
@@ -146,19 +146,27 @@
       (fn [conn]
         (d/transact conn [{:db/id 100 :sample/id "existing" :sample/value "value"}])
         (let [tx (conj upsert-tx [:db/add :sample/value :db/index true])
-              original dbt/transact-tx-data
-              calls (atom 0)]
-          (with-redefs [dbt/transact-tx-data (fn [& args]
-                                               (swap! calls inc)
-                                               (apply original args))]
+              original dbt/transact-tx-data-internal
+              calls (atom [])
+              attempts [{:options backfill :prepared nil :upsert nil}
+                        {:options backfill :prepared nil :upsert 100}]]
+          ;; Observe the shared evaluator, including its actual restart, rather
+          ;; than the compatibility wrapper around the ordinary entry point.
+          (with-redefs [dbt/transact-tx-data-internal
+                        (fn [initial-report tx-data tx-options prepared]
+                          (swap! calls conj {:options tx-options :prepared prepared
+                                             :upsert (get (:tempids initial-report) -1)})
+                          (original initial-report tx-data tx-options prepared))]
             (let [preview (d/with @conn tx nil backfill)]
-              (is (= 2 @calls) "the tempid conflict really restarted the transaction")
+              (is (= 2 (count @calls)) "the tempid conflict really restarted the transaction")
+              (is (= attempts @calls) "restart retains options and the resolved tempid")
               (is (= 100 (get (:tempids preview) -1)))
               (is (= "updated" (:sample/other (d/entity (:db-after preview) 100))))
               (is (= 1 (count (d/datoms (:db-after preview) :avet :sample/value)))))
-            (reset! calls 0)
+            (reset! calls [])
             (let [report (d/transact conn {:tx-data tx :tx-options backfill})]
-              (is (= 2 @calls))
+              (is (= 2 (count @calls)))
+              (is (= attempts @calls))
               (is (= 100 (get (:tempids report) -1)))
               (is (= 1 (count (d/datoms @conn :avet :sample/value))))))
           (is (false? (get-in @conn [:config :allow-index-backfill?]))))))))


### PR DESCRIPTION
## Summary

Add experimental JVM background AVET construction and atomic activation for
existing attributes' indexing and uniqueness properties. Reads and writes keep
using the old schema until activation commits.

- `begin-avet-build!` returns acceptance with a stable `:avet-build-id`;
  `avet-build-status` reads durable snapshot state; cancellation fences an exact
  generation.
- Build current and historical AVET with the shared bounded merge-sort engine,
  isolated private PSS storage, exact native transaction effects, and bounded
  journal catch-up.
- Validate initial uniqueness off the writer, then validate affected values
  after each complete replayed transaction. Activate through ordinary schema
  validation and transaction predicates, including derived tuple effects.
- Bind admission to the actual source roots, commit identity, generation,
  opaque journal boundary, and storage revision. Publish through the existing
  head CAS; there is no transaction-ID-only barrier or new index format.
- Preserve source GC pins and private storage until publication or abandonment;
  keep cleanup off async dispatch threads; fail closed on stale ownership.
- Keep public writer configuration to five optional deployment settings:
  scratch directory, journal disk budget, sort disk budget, sort memory budget,
  and captured transaction size. Internal worker, reader, node-buffer, merge,
  and catch-up controls are not accepted in writer config. Focused tests use
  internal constructors directly.
- Document defaults, deployment requirements, failure/restart behavior, and
  the requirement to upgrade all collectors sharing a store (or disable legacy GC).

## Validation

- Configuration and writer lifecycle: 9 tests / 92 assertions, green.
- JVM regression run for the configuration update (`clj-pss`, `clj-hht`,
  and `specs` without instrumentation): 4,315 tests / 52,038 assertions,
  zero failures.
- Independent review of the configuration update found no blockers.
- Java bindings generated and compiled; changed Clojure files formatted.
- Previous implementation validation: full JVM matrix 3,191 tests / 36,273
  assertions; instrumented specifications 1,435 / 17,320; Node advanced build
  with zero warnings and 314 tests / 2,097 assertions, all green.
- Existing integration coverage includes concurrent writes, duplicate
  rejection, predicate veto, cancellation/replacement, foreign writers,
  identical-CID head rewrites, pin loss, file reopen after private-storage
  close, disabled historical attribute purges, and mixed commit groups.
- File-backed source/build/uniqueness scan over a 512 MiB logical payload under
  a 256 MiB heap, with bounded private caches and an unchanged source cache.
  This proves the builder/storage path, not a bound on arbitrary user
  transactions or all backend allocations.

## Limits

Local JVM shared writer, explicit supported fencing, non-crypto persistent-set,
and no diff buffers. Enable-only existing attributes, one active request per
branch, no crash-resume, and no completion deadline. Any schema mutation
invalidates an active build, including unrelated or subsequently reverted changes.

Journal quota exhaustion or a transaction frame exceeding its configured size
can reject affected user transactions. Capture still buffers each transaction's
effects before journaling; transaction chunking is not implemented. Individual
sort-record and node safety limits can fail a build independently of journal
capacity. Ordinary per-datom uniqueness checks remain conservative for
intermediate derived-tuple conflicts. Mixed-version collection during builds
is unsupported. Synchronous schema migration remains the ordinary path.
