### PR TITLE
Keep test and build scratch out of /tmp and clean failed fixtures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,11 @@ jobs:
             - deps-{{ checksum "deps.edn" }}
             - deps-
       - run:
+          name: Test scratch cleanup and active-run protection
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- bb --config /dev/null --classpath bb/src:bb/test -m tools.scratch-test
+      - run:
           name: resolve deps
-          command: clojure -X:deps prep :aliases '[:dev :test :build]'
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- clojure -X:deps prep :aliases '[:dev :test :build]'
       - save_cache:
           key: deps-{{ checksum "deps.edn" }}
           paths:
@@ -259,21 +262,21 @@ jobs:
           at: /home/circleci
       - run:
           name: Prepare dependencies
-          command: clojure -X:deps prep
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- clojure -X:deps prep
       - run:
           name: Start test server
-          command: clojure -M:test -e "(require 'datahike.kabel.browser-test-server) (datahike.kabel.browser-test-server/start-test-server!) (Thread/sleep Long/MAX_VALUE)"
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- clojure -M:test -e "(require 'datahike.kabel.browser-test-server) (datahike.kabel.browser-test-server/start-test-server!) (Thread/sleep Long/MAX_VALUE)"
           background: true
       - run:
           name: Wait for server startup
           command: sleep 20
       - run:
           name: Compile ClojureScript for browser tests
-          command: npx shadow-cljs release browser-ci
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- npx shadow-cljs release browser-ci
           no_output_timeout: 5m
       - run:
           name: Run Karma browser tests
-          command: npx karma start --single-run
+          command: bb --config /dev/null --classpath bb/src -m tools.scratch run -- npx karma start --single-run
           no_output_timeout: 5m
   node-cljs-test:
     executor: tools/clojurecli

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ pydatahike/src/datahike/generated.py
 **/.settings/
 /plugins/
 /test/integration/
+
+# Owned test/build scratch (separate from target, which builds clean).
+/.scratch/

--- a/bb.edn
+++ b/bb.edn
@@ -18,8 +18,10 @@
                     [tools.reflection :as reflection]
                     [tools.release :as release]
                     [tools.test :as test]
+                    [tools.scratch :as scratch]
                     [tools.version :as version]]
-         :init (do (def config-file "config.edn")
+         :init (do (scratch/ensure-task-run!)
+                   (def config-file "config.edn")
                    (def config (edn/read-string (slurp config-file))))
 
          ; tools

--- a/bb/resources/native-image-tests/run-libdatahike-tests
+++ b/bb/resources/native-image-tests/run-libdatahike-tests
@@ -4,9 +4,13 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-export LD_LIBRARY_PATH=./libdatahike/target
-export DYLD_LIBRARY_PATH=./libdatahike/target
+repo_root="$PWD"
+export LD_LIBRARY_PATH="$repo_root/libdatahike/target"
+export DYLD_LIBRARY_PATH="$repo_root/libdatahike/target"
 
-rm -rf "/tmp/libdatahike-test"
 ./libdatahike/compile-cpp
-./libdatahike/target/test_cpp
+# The C++ fixture uses a relative store path inside this owned directory.
+scratch=$(mktemp -d "${TMPDIR:-$repo_root/libdatahike/target}/libdatahike-test.XXXXXX")
+trap 'rm -rf -- "$scratch"' EXIT
+cd "$scratch"
+"$repo_root/libdatahike/target/test_cpp"

--- a/bb/src/tools/scratch.clj
+++ b/bb/src/tools/scratch.clj
@@ -1,0 +1,159 @@
+(ns tools.scratch
+  "Owned scratch for Babashka tasks and their subprocesses."
+  (:require [babashka.fs :as fs]
+            [babashka.process :as p]
+            [clojure.edn :as edn]
+            [clojure.string :as str])
+  (:import [java.nio.channels FileChannel]
+           [java.nio.file StandardOpenOption OpenOption]
+           [java.lang ProcessHandle]))
+
+(defn root []
+  (fs/absolutize (or (System/getenv "DATAHIKE_SCRATCH_ROOT") ".scratch")))
+
+(defn usage [dir]
+  (reduce (fn [result path]
+            (try
+              (-> result
+                  (update :entries inc)
+                  (update :bytes + (if (fs/regular-file? path {:nofollow-links true})
+                                     (fs/size path) 0)))
+              (catch java.nio.file.NoSuchFileException _ result)))
+          {:bytes 0 :entries 0}
+          (fs/glob dir "**" {:hidden true})))
+
+(defn- channel [path]
+  (FileChannel/open (fs/path path)
+                    (into-array OpenOption [StandardOpenOption/CREATE StandardOpenOption/WRITE])))
+
+(defn inspect!
+  "Report usage, optionally reclaim finished runs. Incomplete crash records are
+   retained: an unlocked dead parent does not prove its children are dead."
+  ([] (inspect! false))
+  ([clean?]
+   (let [root (root)]
+     (fs/create-dirs root)
+     (doseq [dir (fs/list-dir root)
+             :when (and (str/starts-with? (str (fs/file-name dir)) "run-")
+                        (not (fs/sym-link? dir)) (fs/directory? dir))]
+       (try
+         (with-open [ch (channel (fs/path dir ".lock"))]
+           (let [lock (try (.tryLock ch) (catch Exception _ nil))]
+             (try
+               (let [state (when lock (edn/read-string (slurp (fs/file dir "owner.edn"))))]
+                 (binding [*out* *err*]
+                   (println (str dir) (usage dir)
+                            (if lock (:state state) :active)))
+                 (when (and clean? lock (= :finished (:state state)))
+                   ;; Windows cannot remove an open lock file.
+                   (.close ch)
+                   (fs/delete-tree dir)))
+               (finally (.close ch)))))
+         (catch Exception e
+           (binding [*out* *err*]
+             (println "Scratch retained:" (str dir) (ex-message e)))))))))
+
+(defn- descendants []
+  (with-open [stream (.descendants (ProcessHandle/current))]
+    (vec (iterator-seq (.iterator stream)))))
+
+(defn- stop-children! []
+  (let [children (descendants)]
+    (doseq [child (reverse children)] (.destroy child))
+    (doseq [child children]
+      (when (.isAlive child)
+        (try (.get (.onExit child) 5 java.util.concurrent.TimeUnit/SECONDS)
+             (catch java.util.concurrent.TimeoutException _
+               (.destroyForcibly child)))))
+    (doseq [child children]
+      (when (.isAlive child)
+        (try (.get (.onExit child) 5 java.util.concurrent.TimeUnit/SECONDS)
+             (catch java.util.concurrent.TimeoutException _ nil))))
+    children))
+
+(defn start!
+  "Install scratch before task dependencies execute. Returns idempotent cleanup.
+   Nested bb processes inherit their parent's run instead of creating another."
+  ([] (start! (not-empty (System/getenv "DATAHIKE_SCRATCH_RUN"))))
+  ([inherited]
+   (if-let [inherited inherited]
+     (do (System/setProperty "java.io.tmpdir" (str (fs/path inherited "tmp")))
+         (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (stop-children!))))
+         (fn []))
+     (let [_ (inspect! true)
+           root (root)
+           _ (fs/create-dirs root)
+           dir (fs/create-temp-dir {:dir root :prefix "run-"})
+           tmp (str (fs/path dir "tmp"))
+           _ (fs/create-dirs tmp)
+           ch (channel (fs/path dir ".lock"))
+           _lock (.lock ch)
+           owner (fs/file dir "owner.edn")
+           done? (atom false)
+           old-tmp (System/getProperty "java.io.tmpdir")
+           old-defaults p/*defaults*
+           cleanup (fn []
+                     (when (compare-and-set! done? false true)
+                      ;; Stop remaining foreground-task children before removing
+                      ;; stores, native mappings, or temporary shared libraries.
+                       (let [children (stop-children!)]
+                         (try
+                           (when-not (some #(.isAlive %) children)
+                             (spit owner (pr-str {:state :finished})))
+                           (finally
+                             (.close ch)))
+                         (if (some #(.isAlive %) children)
+                           (binding [*out* *err*] (println "Scratch retained for live children:" (str dir)))
+                           (fs/delete-tree dir)))
+                       (System/setProperty "java.io.tmpdir" old-tmp)
+                       (alter-var-root #'p/*defaults* (constantly old-defaults))))]
+       (spit owner (pr-str {:state :running :pid (.pid (ProcessHandle/current))}))
+       (System/setProperty "java.io.tmpdir" tmp)
+       (alter-var-root
+        #'p/*defaults* assoc :env
+        (merge (into {} (System/getenv))
+               (:env old-defaults)
+               {"DATAHIKE_SCRATCH_RUN" (str dir)
+                "TMPDIR" tmp "TMP" tmp "TEMP" tmp
+                "JAVA_TOOL_OPTIONS" (str (or (get (:env old-defaults) "JAVA_TOOL_OPTIONS")
+                                             (System/getenv "JAVA_TOOL_OPTIONS") "")
+                                         " -Djava.io.tmpdir=\"" tmp "\"")}))
+       (.addShutdownHook (Runtime/getRuntime) (Thread. cleanup))
+       (doto (Thread. (fn []
+                        (while (not @done?)
+                          (Thread/sleep 30000)
+                          (when-not @done?
+                            (binding [*out* *err*]
+                              (println "Scratch usage:" (str dir) (usage dir)))))))
+         (.setDaemon true)
+         (.start))
+       (binding [*out* *err*] (println "Scratch:" (str dir)))
+       cleanup))))
+
+(defn ensure-task-run!
+  "Re-enter the bb task once with a real inherited environment. This also covers
+   tools.build's ProcessBuilder launches, which bypass babashka.process defaults."
+  []
+  (if (not-empty (System/getenv "DATAHIKE_SCRATCH_RUN"))
+    (start!)
+    (let [cleanup (start!)
+          info (.info (ProcessHandle/current))]
+      (try
+        (let [command (into [(.get (.command info))] (.get (.arguments info)))
+              result (apply p/shell {:continue true} command)]
+          (cleanup)
+          (System/exit (:exit result)))
+        (finally (cleanup))))))
+
+(defn -main [action & command]
+  (case action
+    "status" (inspect!)
+    "clean" (inspect! true)
+    "run" (let [cleanup (start!)]
+            (try
+              (let [command (if (= "--" (first command)) (rest command) command)
+                    result (apply p/shell {:continue true} command)]
+                (cleanup)
+                (System/exit (:exit result)))
+              (finally (cleanup))))
+    (throw (ex-info "Expected run, status, or clean" {:action action}))))

--- a/bb/src/tools/test.clj
+++ b/bb/src/tools/test.clj
@@ -16,10 +16,13 @@
 
 (defn back-compat [config]
   (println "Testing backwards compatibility")
-  (let [old-version-dir "datahike-old"
+  (let [old-version-dir (str (fs/create-temp-dir
+                              {:dir (System/getProperty "java.io.tmpdir")
+                               :prefix "datahike-old-"}))
         release-tag (str/trim (:out (git {:out :string}
                                          "describe" "--tags" "--abbrev=0" "HEAD")))
-        secondary-root (str (fs/create-temp-dir {:prefix "datahike-secondary-back-compat-"}))
+        secondary-root (str (fs/create-temp-dir {:dir (System/getProperty "java.io.tmpdir")
+                                                 :prefix "datahike-secondary-back-compat-"}))
         secondary-fixture (str (fs/absolutize
                                 "test/datahike/backward_compatibility_test/src"))
         old-secondary-fixture "backward-secondary-src"
@@ -46,6 +49,14 @@
     (git {:dir "."}
          "clone" "--depth" "1" "--branch" release-tag
          (:git-url config) old-version-dir)
+
+    ;; The released writer carries a fixed /tmp path. Change only that path in
+    ;; its fixture so both JVMs share the run's java.io.tmpdir; keep the released
+    ;; writer and dependencies otherwise intact.
+    (let [fixture (fs/file old-version-dir "test/datahike/backward_compatibility_test/src/backward_test.clj")]
+      (spit fixture (str/replace (slurp fixture)
+                                 "\"/tmp/datahike-backward-comp-test\""
+                                 "(str (System/getProperty \"java.io.tmpdir\") \"/datahike-backward-comp-test\")")))
 
     ;; Generate Java API bindings before compiling
     (println "Generating Java API for old version...")
@@ -193,9 +204,9 @@
                                          "/usr/bin/chromium-browser"
                                          "/usr/bin/google-chrome"])))
             env (if chrome-bin
-                  (assoc (into {} (System/getenv)) "CHROME_BIN" chrome-bin)
-                  (into {} (System/getenv)))]
-        (p/shell {:env env} "npx karma start --single-run"))
+                  {"CHROME_BIN" chrome-bin}
+                  {})]
+        (p/shell {:extra-env env} "npx karma start --single-run"))
       (finally
         (println "Stopping test server...")
         (p/destroy server-process)))))

--- a/bb/test/tools/scratch_test.clj
+++ b/bb/test/tools/scratch_test.clj
@@ -1,0 +1,86 @@
+(ns tools.scratch-test
+  (:require [babashka.fs :as fs]
+            [babashka.process :as p]
+            [clojure.test :refer [deftest is run-tests]]
+            [tools.scratch :as scratch]))
+
+(defn with-root [f]
+  (fs/create-dirs ".scratch")
+  (let [root (fs/create-temp-dir {:dir (fs/absolutize ".scratch") :prefix "check-"})]
+    (try (with-redefs [scratch/root (constantly root)] (f root))
+         (finally (fs/delete-tree root)))))
+
+(deftest subprocess-environment-and-failure-cleanup
+  (with-root
+    (fn [root]
+      (let [cleanup (scratch/start! nil)
+            tmp (System/getProperty "java.io.tmpdir")]
+        (try
+          (let [result (p/shell {:out :string :err :string
+                                 :extra-env {"LOG_LEVEL" "warn"}}
+                                "bb" "--config" "/dev/null" "-e"
+                                "(assert (= (System/getenv \"TMPDIR\") (System/getenv \"TEMP\"))) (assert (= \"warn\" (System/getenv \"LOG_LEVEL\"))) (println (System/getenv \"JAVA_TOOL_OPTIONS\"))")]
+            (is (.contains (:out result) tmp)))
+          (spit (fs/file tmp "leftover-db") "bytes")
+          (throw (ex-info "test failed" {}))
+          (catch Exception e (is (= "test failed" (ex-message e))))
+          (finally (cleanup)))
+        (is (empty? (fs/list-dir root)))))))
+
+(deftest janitor-respects-live-locks-and-incomplete-records
+  (with-root
+    (fn [root]
+      (let [cleanup (scratch/start! nil)
+            abandoned (fs/path root "run-finished")
+            incomplete (fs/path root "run-incomplete")]
+        (try
+          (doseq [[dir state] [[abandoned :finished] [incomplete :running]]]
+            (fs/create-dirs dir)
+            (spit (fs/file dir "owner.edn") (pr-str {:state state})))
+          (scratch/inspect! true)
+          (is (not (fs/exists? abandoned)))
+          (is (fs/exists? incomplete))
+          (is (fs/exists? (System/getProperty "java.io.tmpdir")))
+          (finally (cleanup)))))))
+
+(deftest task-init-covers-dependencies-and-java
+  (with-root
+    (fn [root]
+      (let [config (fs/file root "tasks.edn")]
+        (spit config
+              (pr-str {:paths [(str (fs/relativize root (fs/absolutize "bb/src")))]
+                       :tasks {:requires '([tools.scratch :as scratch])
+                               :init '(scratch/ensure-task-run!)
+                               'dependency {:task '(let [proc (.start (.inheritIO (ProcessBuilder. ["java" "-XshowSettings:properties" "-version"])))]
+                                                     (assert (zero? (.waitFor proc))))}
+                               'probe {:depends ['dependency] :task '(println "done")}
+                               'fail {:task '(throw (ex-info "intentional task failure" {}))}}}))
+        (let [result (p/shell {:out :string :err :string
+                               :extra-env {"DATAHIKE_SCRATCH_ROOT" (str root)
+                                           "DATAHIKE_SCRATCH_RUN" ""}}
+                              "bb" "--config" (str config) "probe")]
+          (is (.contains (:err result) (str root)))
+          (is (.contains (:err result) "java.io.tmpdir ="))
+          (is (= [config] (mapv fs/file (fs/list-dir root)))))
+        (let [result (p/shell {:out :string :err :string :continue true
+                               :extra-env {"DATAHIKE_SCRATCH_ROOT" (str root)
+                                           "DATAHIKE_SCRATCH_RUN" ""}}
+                              "bb" "--config" (str config) "fail")]
+          (is (not (zero? (:exit result))))
+          (is (= [config] (mapv fs/file (fs/list-dir root)))))))))
+
+(deftest cleanup-stops-a-leftover-child-before-removing-files
+  (with-root
+    (fn [root]
+      (let [cleanup (scratch/start! nil)
+            child (p/process ["bb" "--config" "/dev/null" "-e" "(Thread/sleep 60000)"]
+                             {:out :string :err :string})]
+        (try
+          (cleanup)
+          (is (not (p/alive? child)))
+          (is (empty? (fs/list-dir root)))
+          (finally (p/destroy-tree child) (cleanup)))))))
+
+(defn -main [& _]
+  (let [{:keys [fail error]} (run-tests 'tools.scratch-test)]
+    (System/exit (if (zero? (+ fail error)) 0 1))))

--- a/doc/scratch.md
+++ b/doc/scratch.md
@@ -20,6 +20,11 @@ process helpers. The Babashka process sets its own `java.io.tmpdir` as well.
 Build artifacts retain their usual paths. Dependency resolution needed to load
 Babashka's own task configuration happens before the initializer.
 
+The Unix-domain nREPL fixture uses a short relative `.scratch/nrepl-<unique>`
+path under the checkout because socket path limits also apply when the configured
+scratch root is long. It removes that directory in `finally`, including startup
+failures.
+
 Cleanup has two layers:
 
 1. The migrated secondary-index tests use `datahike.test.scratch/fixture` with

--- a/doc/scratch.md
+++ b/doc/scratch.md
@@ -1,0 +1,63 @@
+# Test and build scratch
+
+Ordinary `bb test`, `bb kaocha`, and build tasks automatically run with owned
+scratch. No Python or additional command prefix is needed.
+
+The default root is `.scratch` under the current checkout. Override it with
+`DATAHIKE_SCRATCH_ROOT=/disk/path`. CircleCI uses the same checkout-local
+default. Choose a disk-backed checkout/root: this code does not change mounts
+or enforce a disk quota. Keep the root outside `target`, which builds delete.
+
+The task initializer enters the same Babashka command once as a child with:
+
+- `TMPDIR`, `TMP`, and `TEMP` pointing to `<root>/run-<unique>/tmp`.
+- `JAVA_TOOL_OPTIONS` extended with `-Djava.io.tmpdir` pointing there.
+- An internal `DATAHIKE_SCRATCH_RUN` marker so nested tasks share the run.
+
+This happens before task dependencies execute. A real child environment also
+covers direct `ProcessBuilder` launches by tools.build, beyond Babashka's
+process helpers. The Babashka process sets its own `java.io.tmpdir` as well.
+Build artifacts retain their usual paths. Dependency resolution needed to load
+Babashka's own task configuration happens before the initializer.
+
+Cleanup has two layers:
+
+1. The migrated secondary-index tests use `datahike.test.scratch/fixture` with
+   `use-fixtures :each`. Each test gets its own subdirectory, deleted in
+   `finally`. Existing test bodies release connections/indexes before the outer
+   fixture removes files. Deletion errors fail the test instead of being hidden.
+   The shared `with-db` helper also cleans up if the body or setup transaction
+   throws. These fixtures work with direct JVM test invocation too.
+2. Babashka removes the entire run directory after the command exits, including
+   failed commands. Shutdown hooks stop remaining child processes and wait for
+   them before removing files. Files needed by the JVM/native libraries can
+   therefore remain until process exit without accumulating between runs.
+
+Every 30 seconds the owner reports logical file bytes and entry counts. These
+are observations, not quotas or peak measurements. This output also resets
+CircleCI's no-output timer; use job time limits for hung commands.
+
+For direct commands that are not bb tasks, or scratch inspection without loading
+project dependencies:
+
+```sh
+bb --config /dev/null --classpath bb/src -m tools.scratch run -- clojure -M:test -m kaocha.runner
+bb --config /dev/null --classpath bb/src -m tools.scratch status
+bb --config /dev/null --classpath bb/src -m tools.scratch clean
+```
+
+Startup and `clean` reclaim unlocked runs marked finished, including interrupted
+removal. Active locks, unknown metadata, and incomplete crash records are
+retained. SIGKILL or a host crash cannot execute `finally` or shutdown hooks;
+an unlocked dead parent does not establish that its children have stopped.
+Incomplete runs require checking for remaining processes before manual removal.
+The janitor never scans arbitrary `/tmp` paths or existing worktrees.
+
+Place long-lived worktrees separately, for example `.internal/my-fix`.
+Never put a worktree inside a run directory: run directories are deleted.
+
+Run the Babashka lifecycle regression tests with:
+
+```sh
+bb --config /dev/null --classpath bb/src:bb/test -m tools.scratch-test
+```

--- a/http-server/datahike/http/nrepl.clj
+++ b/http-server/datahike/http/nrepl.clj
@@ -2,6 +2,7 @@
   "Lifecycle wrapper for the standalone server's opt-in nREPL endpoint."
   (:require [datahike.http.repl :as repl]
             [nrepl.server :as nrepl]
+            [nrepl.transport :as transport]
             [replikativ.logging :as log])
   (:import [java.nio.file Files Path]))
 
@@ -9,11 +10,67 @@
 
 (defn status-atom [] (atom disabled-status))
 
-(defn- handler [context]
+(defn- handler [context transports]
   (let [delegate (nrepl/default-handler)]
     (fn [message]
-      (binding [repl/*context* context]
-        (delegate message)))))
+      ;; This check admits the message. Already admitted evaluations are in
+      ;; flight; handlers queued until after shutdown must not dispatch. Do not
+      ;; hold the registry lock across middleware or socket writes.
+      (when (some? @transports)
+        (binding [repl/*context* context]
+          (delegate message))))))
+
+(def ^:private closed-transport
+  (reify
+    transport/Transport
+    (recv [_] nil)
+    (recv [_ _timeout] nil)
+    (send [_ _message] (throw (java.net.SocketException. "nREPL server stopped")))
+    java.io.Closeable
+    (close [_] nil)))
+
+(defn- transport-factory [transports]
+  (fn [socket]
+    ;; nREPL constructs/registers transports asynchronously after accept. Own
+    ;; them before returning to nREPL, so its delayed registration cannot escape
+    ;; shutdown's snapshot. nil permanently closes admission.
+    (locking transports
+      (if (nil? @transports)
+        (do (.close ^java.io.Closeable socket) closed-transport)
+        (try
+          (let [delegate (transport/bencode socket)
+                closed? (atom false)
+                tracked (reify
+                          transport/Transport
+                          (recv [_] (transport/recv delegate))
+                          (recv [_ timeout] (transport/recv delegate timeout))
+                          (send [this message] (transport/send delegate message) this)
+                          java.io.Closeable
+                          (close [this]
+                            (when (compare-and-set! closed? false true)
+                              (try
+                                (.close ^java.io.Closeable delegate)
+                                (finally
+                                  (locking transports
+                                    (when (some? @transports)
+                                      (swap! transports disj this))))))))]
+            (swap! transports conj tracked)
+            tracked)
+          (catch Throwable t
+            (.close ^java.io.Closeable socket)
+            (throw t)))))))
+
+(defn- close-transports! [transports]
+  (when-let [failure (reduce (fn [failure t]
+                               (try
+                                 (.close ^java.io.Closeable t)
+                                 failure
+                                 (catch Throwable e
+                                   (if failure
+                                     (do (.addSuppressed ^Throwable failure e) failure)
+                                     e))))
+                             nil transports)]
+    (throw failure)))
 
 (defn start!
   "Start configured nREPL and update `status`. Returns an owned resource map,
@@ -23,7 +80,9 @@
     (let [context {:configured-config configured-config
                    :config public-config
                    :connections connections}
-          options (cond-> [:handler (handler context)]
+          transports (atom #{})
+          options (cond-> [:handler (handler context transports)
+                           :transport-fn (transport-factory transports)]
                     socket (into [:socket socket])
                     (some? port) (into [:port port :bind bind]))
           server (apply nrepl/start-server options)
@@ -32,16 +91,24 @@
                      {:enabled true :transport :tcp :bind bind :port (:port server)})]
       (reset! status endpoint)
       (log/info :datahike/nrepl-started endpoint)
-      {:server server :socket socket :status status})))
+      {:server server :socket socket :status status :transports transports})))
 
-(defn stop! [{:keys [server socket status]}]
+(defn stop! [{:keys [server socket status transports]}]
   (when server
-    (try
-      (nrepl/stop-server server)
-      (finally
-        ;; nREPL marks Unix sockets for deletion at JVM exit, but a server
-        ;; restart in the same process must not leave a stale socket behind.
-        (when socket
-          (Files/deleteIfExists (Path/of socket (make-array String 0))))
-        (when status (reset! status disabled-status)))))
+    (let [registered (locking transports
+                       (let [registered @transports]
+                         (reset! transports nil)
+                         registered))]
+      (try
+        (nrepl/stop-server server)
+        (finally
+          (try
+            (close-transports! registered)
+            (finally
+              ;; nREPL normally defers unlinking Unix sockets until JVM exit.
+              (try
+                (when socket
+                  (Files/deleteIfExists (Path/of socket (make-array String 0))))
+                (finally
+                  (when status (reset! status disabled-status))))))))))
   nil)

--- a/libdatahike/src/test_cpp.cpp
+++ b/libdatahike/src/test_cpp.cpp
@@ -2,7 +2,7 @@
 #include <libdatahike.h>
 #include <assert.h>
 
-const char* config_str = "{:store {:backend :file :path \"/tmp/libdatahike-test\" :id #uuid \"f11e0000-0000-0000-0000-000000000001\"} :schema-flexibility :write}";
+const char* config_str = "{:store {:backend :file :path \"test-store\" :id #uuid \"f11e0000-0000-0000-0000-000000000001\"} :schema-flexibility :write}";
 const char* schema_str = "[{:db/ident :name :db/valueType :db.type/string :db/cardinality :db.cardinality/one}]";
 const char* tx_str = "[{:name \"Alice\"}]";
 const char* query_str = "[:find ?e ?v :where [?e :name ?v]]";

--- a/test/datahike/backward_compatibility_test/src/backward_test.clj
+++ b/test/datahike/backward_compatibility_test/src/backward_test.clj
@@ -8,17 +8,8 @@
               :db/cardinality :db.cardinality/one
               :db/valueType   :db.type/long}])
 (def cfg {:store  {:backend :file
-                   ;; Deliberately the one `/tmp` literal left in the suite.
-                   ;; `bb test back-compat` runs `write` in a JVM started inside
-                   ;; a CLONE of the last release — which carries its OWN copy of
-                   ;; this file, frozen with this exact string — and `read` in a
-                   ;; second JVM here. Both must open the same directory, so this
-                   ;; side has to spell whatever the released copy spells. A
-                   ;; `java.io.tmpdir` lookup here only agrees with `/tmp` by
-                   ;; coincidence on Linux, and disagrees on macOS and Windows.
-                   ;; Moving it is a two-release step: change both sides in one
-                   ;; release, then the clone carries the new spelling too.
-                   :path "/tmp/datahike-backward-comp-test"
+                   :path (str (System/getProperty "java.io.tmpdir")
+                              "/datahike-backward-comp-test")
                    :id #uuid "550e8400-e29b-41d4-a716-446655440000"}
           :keep-history? true
           :schema-flexibility :write

--- a/test/datahike/integration_test.cljc
+++ b/test/datahike/integration_test.cljc
@@ -9,19 +9,20 @@
   (d/delete-database config)
   (d/create-database config)
   (let [conn (d/connect config)]
-    (d/transact conn [{:db/ident :name
-                       :db/valueType :db.type/string
-                       :db/cardinality :db.cardinality/one}
-                      {:db/ident :age
-                       :db/valueType :db.type/long
-                       :db/cardinality :db.cardinality/one}])
+    (try
+      (d/transact conn [{:db/ident :name
+                         :db/valueType :db.type/string
+                         :db/cardinality :db.cardinality/one}
+                        {:db/ident :age
+                         :db/valueType :db.type/long
+                         :db/cardinality :db.cardinality/one}])
 
     ;; lets add some data and wait for the transaction
-    (d/transact conn [{:name  "Alice", :age   20}
-                      {:name  "Bob", :age   30}
-                      {:name  "Charlie", :age   40}
-                      {:age 15}])
-    (d/release conn)))
+      (d/transact conn [{:name  "Alice", :age   20}
+                        {:name  "Bob", :age   30}
+                        {:name  "Charlie", :age   40}
+                        {:age 15}])
+      (finally (d/release conn)))))
 
 (defn integration-test [config]
   (let [conn (d/connect config)]

--- a/test/datahike/integration_test/depr_config_uri_test.clj
+++ b/test/datahike/integration_test/depr_config_uri_test.clj
@@ -2,19 +2,21 @@
   (:require [clojure.test :refer :all]
             [datahike.integration-test :as it]))
 
-;; A `/tmp` literal, and a real one: the fixture below DOES create, connect and
-;; delete a store at this path, so this test is not portable to Windows. It is
-;; left as is because the path travels inside a URI — a Windows temp directory
-;; (`C:\Users\…\Temp`) is not a legal URI path, `java.net.URI` hands back
-;; `/C:/…` for the encoded form, and `io/file` cannot open that — so making it
-;; portable means teaching the deprecated `uri->config` form Windows drive
-;; letters. This test runs on Linux CI only (`bb test integration`).
-(def config "datahike:file:///tmp/file-test-3?id=5c6e0000-0000-0000-0000-000000000003")
+;; Still a Linux-only deprecated URI test (Windows drive handling is separate).
+;; Build the outer URI as well, since uri->config decodes two URI layers.
+(def config
+  (let [path (.getAbsolutePath (java.io.File. (System/getProperty "java.io.tmpdir")
+                                              "file-test-3"))
+        file-uri (java.net.URI. "file" nil path
+                                "id=5c6e0000-0000-0000-0000-000000000003" nil)]
+    (str (java.net.URI. "datahike" (str file-uri) nil))))
 
 (defn depr-config-uri-fixture [f]
   (println "deprecated file uri config: " config)
-  (it/integration-test-fixture config)
-  (f))
+  (try
+    (it/integration-test-fixture config)
+    (f)
+    (finally (datahike.api/delete-database config))))
 
 (use-fixtures :once depr-config-uri-fixture)
 

--- a/test/datahike/test/http/nrepl_test.clj
+++ b/test/datahike/test/http/nrepl_test.clj
@@ -6,7 +6,9 @@
             [datahike.http.nrepl :as server-nrepl]
             [datahike.http.server :as server]
             [datahike.test.scratch :as scratch]
-            [nrepl.core :as nrepl])
+            [nrepl.core :as nrepl]
+            [nrepl.server :as nrepl-server]
+            [nrepl.transport :as transport])
   (:import [java.nio.file Files Path]))
 
 (defn- eval-values [connection code]
@@ -84,12 +86,16 @@
     (is (not (Files/exists ^Path @directory (make-array java.nio.file.LinkOption 0))))))
 
 (deftest standalone-server-owns-nrepl-and-reports-its-resolved-endpoint
-  (let [instance (server/start-server {:host "127.0.0.1"
-                                       :port 0
-                                       :join? false
-                                       :metrics false
-                                       :token "test-token"
-                                       :nrepl {:port 0}})
+  (let [resource (atom nil)
+        start-nrepl server-nrepl/start!
+        instance (with-redefs [server-nrepl/start!
+                               (fn [& args] (reset! resource (apply start-nrepl args)))]
+                   (server/start-server {:host "127.0.0.1"
+                                         :port 0
+                                         :join? false
+                                         :metrics false
+                                         :token "test-token"
+                                         :nrepl {:port 0}}))
         endpoint (try
                    (let [response (http/request
                                    {:method :get
@@ -109,9 +115,72 @@
         (is (= ["11"] (eval-values connection "(+ 5 6)"))))
       (finally
         (server/stop-server instance)))
-    (is (thrown? java.net.ConnectException
-                 (with-open [connection (nrepl/connect :host (:bind endpoint)
-                                                       :port (:port endpoint))]
-                   ;; connect constructs a lazy transport; sending proves the
-                   ;; server socket was actually closed by stop-server.
-                   (eval-values connection "(+ 1 1)"))))))
+    ;; Verify the resource this HTTP server owned. Probing its freed port races
+    ;; native listener closure and port reuse; the delayed-worker tests below
+    ;; separately prove that late connections cannot escape shutdown.
+    (is (.isClosed ^java.net.ServerSocket (get-in @resource [:server :server-socket])))
+    (is (= server-nrepl/disabled-status @(:status @resource)))))
+
+(deftest shutdown-closes-delayed-transports
+  (doseq [phase [:before-transport :after-transport]]
+    (testing (name phase)
+      (let [ready (promise)
+            resume (promise)
+            finished (promise)
+            start-server nrepl-server/start-server]
+        (with-redefs [nrepl-server/start-server
+                      (fn [& {:as options}]
+                        (let [factory (or (:transport-fn options) transport/bencode)
+                              delayed (fn [socket]
+                                        (let [pause (fn []
+                                                      (deliver ready socket)
+                                                      (when (= ::timeout (deref resume 10000 ::timeout))
+                                                        (throw (ex-info "Timed out waiting for shutdown" {}))))]
+                                          (try
+                                            (when (= phase :before-transport) (pause))
+                                            (let [t (factory socket)]
+                                              (when (= phase :after-transport) (pause))
+                                              t)
+                                            (finally (deliver finished true)))))]
+                          (apply start-server (mapcat identity (assoc options :transport-fn delayed)))))]
+          (let [status (server-nrepl/status-atom)
+                config {:nrepl {:port 0 :bind "127.0.0.1"}}
+                resource (server-nrepl/start! config config (atom {}) status)]
+            (try
+              (with-open [connection (nrepl/connect :host (:bind @status) :port (:port @status))]
+                (let [socket (deref ready 10000 ::timeout)]
+                  (is (not= ::timeout socket) "the real accept worker reached the selected race window")
+                  (when-not (= ::timeout socket)
+                    (is (empty? @(get-in resource [:server :open-transports]))
+                        "nREPL has not registered this connection yet")
+                    (server-nrepl/stop! resource)
+                    (when (= phase :after-transport)
+                      (is (.isClosed ^java.net.Socket socket)
+                          "our registry closes transports missing from nREPL's snapshot"))
+                    (deliver resume true)
+                    (is (= true (deref finished 10000 ::timeout)))
+                    (is (.isClosed ^java.net.Socket socket)
+                        "late transport creation must close the accepted socket")
+                    (is (thrown? java.io.IOException (eval-values connection "(+ 1 1)")))
+                    (is (= server-nrepl/disabled-status @status)))))
+              (finally
+                (deliver resume true)
+                (server-nrepl/stop! resource)))))))))
+
+(deftest shutdown-rejects-queued-handler-dispatch
+  (let [handled (atom 0)
+        dispatch (atom nil)
+        start-server nrepl-server/start-server]
+    (with-redefs [nrepl-server/default-handler (fn [] (fn [_] (swap! handled inc)))
+                  nrepl-server/start-server (fn [& {:as options}]
+                                              (reset! dispatch (:handler options))
+                                              (apply start-server (mapcat identity options)))]
+      (let [config {:nrepl {:port 0 :bind "127.0.0.1"}}
+            resource (server-nrepl/start! config config (atom {}) (server-nrepl/status-atom))]
+        (try
+          (@dispatch {:op "eval"})
+          (is (= 1 @handled))
+          (server-nrepl/stop! resource)
+          (@dispatch {:op "eval"})
+          (is (= 1 @handled) "a handler queued before stop must not dispatch after stop")
+          (finally (server-nrepl/stop! resource)))))))

--- a/test/datahike/test/http/nrepl_test.clj
+++ b/test/datahike/test/http/nrepl_test.clj
@@ -5,6 +5,7 @@
             [clojure.test :refer [deftest is testing]]
             [datahike.http.nrepl :as server-nrepl]
             [datahike.http.server :as server]
+            [datahike.test.scratch :as scratch]
             [nrepl.core :as nrepl])
   (:import [java.nio.file Files Path]))
 
@@ -39,25 +40,48 @@
         (server-nrepl/stop! resource)))
     (is (= server-nrepl/disabled-status @status))))
 
-(deftest unix-socket-is-usable-and-removed-on-stop
-  (let [directory (Files/createTempDirectory "datahike-nrepl-test-"
-                                             (make-array java.nio.file.attribute.FileAttribute 0))
-        socket (str (.resolve directory "nrepl.sock"))
-        status (server-nrepl/status-atom)
-        resource (server-nrepl/start! {:nrepl {:socket socket}}
-                                      {:nrepl {:socket socket}}
-                                      (atom {}) status)]
+(defn- with-unix-socket-path [f]
+  ;; Unix sockets limit the pathname passed to bind/connect, even when the
+  ;; filesystem accepts a much longer name. Keep this path relative and short
+  ;; regardless of checkout depth or the configured java.io.tmpdir. This fixture
+  ;; owns its directory and removes it even if starting the server throws.
+  (let [root (Files/createDirectories (Path/of ".scratch" (make-array String 0))
+                                      (make-array java.nio.file.attribute.FileAttribute 0))
+        directory (Files/createTempDirectory root "nrepl-"
+                                             (make-array java.nio.file.attribute.FileAttribute 0))]
     (try
-      (testing "the JDK Unix-domain transport accepts normal nREPL clients"
-        (is (= {:enabled true :transport :unix :socket socket} @status))
-        (is (Files/exists (Path/of socket (make-array String 0))
-                          (make-array java.nio.file.LinkOption 0)))
-        (with-open [connection (nrepl/connect :socket socket)]
-          (is (= ["42"] (eval-values connection "(* 6 7)")))))
-      (finally
-        (server-nrepl/stop! resource)))
-    (is (not (Files/exists (Path/of socket (make-array String 0))
-                           (make-array java.nio.file.LinkOption 0))))))
+      (f (str (.resolve directory "nrepl.sock")))
+      (finally (scratch/delete-tree! (str directory))))))
+
+(deftest unix-socket-is-usable-and-removed-on-stop
+  (with-unix-socket-path
+    (fn [socket]
+      (let [status (server-nrepl/status-atom)
+            resource (server-nrepl/start! {:nrepl {:socket socket}}
+                                          {:nrepl {:socket socket}}
+                                          (atom {}) status)]
+        (try
+          (testing "the JDK Unix-domain transport accepts normal nREPL clients"
+            (is (= {:enabled true :transport :unix :socket socket} @status))
+            (is (Files/exists (Path/of socket (make-array String 0))
+                              (make-array java.nio.file.LinkOption 0)))
+            (with-open [connection (nrepl/connect :socket socket)]
+              (is (= ["42"] (eval-values connection "(* 6 7)")))))
+          (finally
+            (server-nrepl/stop! resource)))
+        (is (not (Files/exists (Path/of socket (make-array String 0))
+                               (make-array java.nio.file.LinkOption 0))))))))
+
+(deftest unix-socket-directory-is-removed-on-failure
+  (let [directory (atom nil)]
+    (is (thrown-with-msg?
+         Exception #"startup failed"
+         (with-unix-socket-path
+           (fn [socket]
+             (reset! directory (.getParent (Path/of socket (make-array String 0))))
+             (spit (str (.resolve ^Path @directory "partial-startup")) "leftover")
+             (throw (ex-info "startup failed" {}))))))
+    (is (not (Files/exists ^Path @directory (make-array java.nio.file.LinkOption 0))))))
 
 (deftest standalone-server-owns-nrepl-and-reports-its-resolved-endpoint
   (let [instance (server/start-server {:host "127.0.0.1"

--- a/test/datahike/test/migrate_init_build_test.clj
+++ b/test/datahike/test/migrate_init_build_test.clj
@@ -280,7 +280,7 @@
       (is (= :init/unknown-index-family
              ;; the directory argument is never touched — `sort-family!` refuses
              ;; the family first, which is what this asserts
-             (try (init/sort-family! [] f 10 "/tmp") nil
+             (try (init/sort-family! [] f 10 (System/getProperty "java.io.tmpdir")) nil
                   (catch clojure.lang.ExceptionInfo e (:error (ex-data e)))))
           (str "sort-family! must refuse " (pr-str f)))
       (is (= :init/unknown-index-family

--- a/test/datahike/test/prepared_scriptum_generation_test.clj
+++ b/test/datahike/test/prepared_scriptum_generation_test.clj
@@ -1,15 +1,17 @@
 (ns datahike.test.prepared-scriptum-generation-test
-  (:require
-   [clojure.java.io :as io]
-   [clojure.set :as set]
-   [clojure.test :refer [deftest is testing]]
-   [datahike.api :as d]
-   [datahike.index.secondary :as sec]
-   [datahike.index.secondary.scriptum]
-   [datahike.versioning :as dv]
-   [konserve.core :as k]
-   [superv.async :refer [<?? S]])
+  (:require [datahike.test.scratch :as scratch]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.index.secondary :as sec]
+            [datahike.index.secondary.scriptum]
+            [datahike.versioning :as dv]
+            [konserve.core :as k]
+            [superv.async :refer [<?? S]])
   (:import [java.util Date]))
+
+(clojure.test/use-fixtures :each scratch/fixture)
 
 (defn- await-ready [conn ident]
   (let [deadline (+ (System/currentTimeMillis) 10000)]
@@ -37,10 +39,10 @@
 
 (deftest datahike-roots-scriptum-snapshots-through-cold-reopen-and-gc
   (let [store-id (random-uuid)
-        cache-path (str "/tmp/datahike-scriptum-cache-" store-id)
+        cache-path (str (scratch/path) "/datahike-scriptum-cache-" store-id)
         cfg {:store {:backend :file
                      :id store-id
-                     :path (str "/tmp/datahike-prepared-scriptum-" store-id)}
+                     :path (str (scratch/path) "/datahike-prepared-scriptum-" store-id)}
              :writer {:backend :self :writer-ownership :exclusive}
              :keep-history? false
              :schema-flexibility :write}]

--- a/test/datahike/test/prepared_stratum_generation_test.clj
+++ b/test/datahike/test/prepared_stratum_generation_test.clj
@@ -1,17 +1,19 @@
 (ns datahike.test.prepared-stratum-generation-test
-  (:require
-   [clojure.test :refer [deftest is testing]]
-   [datahike.api :as d]
-   [datahike.gc-guard :as guard]
-   [datahike.index.secondary :as sec]
-   [datahike.index.secondary.stratum]
-   [datahike.store :as ds]
-   [datahike.versioning :as dv]
-   [konserve.core :as k]
-   [stratum.dataset :as sd]
-   [stratum.storage :as ss]
-   [superv.async :refer [<?? S]])
+  (:require [datahike.test.scratch :as scratch]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.gc-guard :as guard]
+            [datahike.index.secondary :as sec]
+            [datahike.index.secondary.stratum]
+            [datahike.store :as ds]
+            [datahike.versioning :as dv]
+            [konserve.core :as k]
+            [stratum.dataset :as sd]
+            [stratum.storage :as ss]
+            [superv.async :refer [<?? S]])
   (:import [java.util Date]))
+
+(clojure.test/use-fixtures :each scratch/fixture)
 
 (defn- await-ready [conn ident]
   (let [deadline (+ (System/currentTimeMillis) 10000)]
@@ -34,7 +36,7 @@
   (let [store-id (random-uuid)
         cfg {:store {:backend :file
                      :id store-id
-                     :path (str "/tmp/datahike-prepared-stratum-" store-id)}
+                     :path (str (scratch/path) "/datahike-prepared-stratum-" store-id)}
              :writer {:backend :self :writer-ownership :exclusive}
              :keep-history? false
              :schema-flexibility :write}]

--- a/test/datahike/test/scratch.clj
+++ b/test/datahike/test/scratch.clj
@@ -1,0 +1,27 @@
+(ns datahike.test.scratch
+  "Per-test directories. Resource-owning test bodies close resources before this
+   outer fixture removes their files, on both successful and failed tests."
+  (:require [clojure.java.io :as io])
+  (:import [java.nio.file Files Path]
+           [java.nio.file.attribute FileAttribute]))
+
+(def ^:dynamic *directory* nil)
+
+(defn path [& parts]
+  (when-not *directory*
+    (throw (ex-info "Install scratch/fixture with use-fixtures :each" {})))
+  (.getPath (apply io/file *directory* parts)))
+
+(defn delete-tree! [directory]
+  (when (Files/exists (.toPath (io/file directory)) (make-array java.nio.file.LinkOption 0))
+    ;; Files.walk does not follow symlinks; never traverse outside the owned tree.
+    (with-open [paths (Files/walk (.toPath (io/file directory))
+                                  (make-array java.nio.file.FileVisitOption 0))]
+      (doseq [^Path p (reverse (iterator-seq (.iterator paths)))]
+        (Files/delete p)))))
+
+(defn fixture [f]
+  (let [dir (.toFile (Files/createTempDirectory "datahike-test-" (make-array FileAttribute 0)))]
+    (try
+      (binding [*directory* dir] (f))
+      (finally (delete-tree! dir)))))

--- a/test/datahike/test/scratch_test.clj
+++ b/test/datahike/test/scratch_test.clj
@@ -1,0 +1,31 @@
+(ns datahike.test.scratch-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.test.scratch :as scratch]
+            [datahike.test.utils :as utils]))
+
+(deftest failing-test-removes-its-directory
+  (let [directory (atom nil)]
+    (is (thrown-with-msg?
+         Exception #"intentional"
+         (scratch/fixture
+          #(do (reset! directory (scratch/path))
+               (spit (scratch/path "leftover") "data")
+               (throw (ex-info "intentional" {}))))))
+    (is (not (.exists (io/file @directory))))))
+
+(deftest with-db-cleans-up-when-body-throws
+  (scratch/fixture
+   #(let [cfg {:store {:backend :file :path (scratch/path "db") :id (random-uuid)}
+               :schema-flexibility :read}]
+      (is (thrown-with-msg? Exception #"intentional"
+                            (utils/with-db cfg (fn [] (throw (ex-info "intentional" {}))))))
+      (is (false? (d/database-exists? cfg))))))
+
+(deftest with-db-cleans-up-when-setup-throws
+  (scratch/fixture
+   #(let [cfg {:store {:backend :file :path (scratch/path "db") :id (random-uuid)}
+               :schema-flexibility :write}]
+      (is (thrown? Exception (utils/with-db cfg [{:undefined/attribute "bad"}] (fn []))))
+      (is (false? (d/database-exists? cfg))))))

--- a/test/datahike/test/secondary_integration_test.clj
+++ b/test/datahike/test/secondary_integration_test.clj
@@ -1,28 +1,30 @@
 (ns datahike.test.secondary-integration-test
   "Integration tests for Proximum and Scriptum secondary index implementations."
-  (:require
-   [clojure.test :refer [deftest testing is]]
-   [clojure.core.async :as async]
-   [datahike.api :as d]
-   [datahike.db :as db]
-   [datahike.gc :as gc]
-   [datahike.index.secondary :as sec]
-   [datahike.index.entity-set :as es]
-   [datahike.query :as q]
-   [datahike.query.execute :as execute]
-   [datahike.writing :as writing]
-   [datahike.index.secondary.scriptum]
-   [datahike.index.secondary.stratum]
-   [datahike.migrate :as m]
-   [datahike.migrate.fs :as fs]
-   [konserve.core :as k]
-   [konserve.gc-guard :as guard]
-   [konserve.memory :refer [new-mem-store]]
-   [stratum.api :as st]
-   [datahike.test.query-aggregates-test :refer [aggregate-contract]]))
+  (:require [datahike.test.scratch :as scratch]
+            [clojure.test :refer [deftest testing is]]
+            [clojure.core.async :as async]
+            [datahike.api :as d]
+            [datahike.db :as db]
+            [datahike.gc :as gc]
+            [datahike.index.secondary :as sec]
+            [datahike.index.entity-set :as es]
+            [datahike.query :as q]
+            [datahike.query.execute :as execute]
+            [datahike.writing :as writing]
+            [datahike.index.secondary.scriptum]
+            [datahike.index.secondary.stratum]
+            [datahike.migrate :as m]
+            [datahike.migrate.fs :as fs]
+            [konserve.core :as k]
+            [konserve.gc-guard :as guard]
+            [konserve.memory :refer [new-mem-store]]
+            [stratum.api :as st]
+            [datahike.test.query-aggregates-test :refer [aggregate-contract]]))
 
 ;; Proximum requires Java 22+ (class file version 66.0).
 ;; Load lazily so the test file compiles on older JVMs.
+(clojure.test/use-fixtures :each scratch/fixture)
+
 (def ^:private proximum-available?
   (try
     (require 'datahike.index.secondary.proximum)
@@ -784,7 +786,7 @@
   (testing "set-valued search does not silently truncate at 1000 matches"
     (let [idx (sec/create-index :scriptum
                                 {:attrs #{:doc/body}
-                                 :path (str "/tmp/scriptum-complete-"
+                                 :path (str (scratch/path) "/scriptum-complete-"
                                             (random-uuid))}
                                 nil)
           transient (sec/-as-transient idx)]
@@ -1683,7 +1685,7 @@
                            :db.secondary/type :scriptum
                            :db.secondary/attrs [:person/bio]
                            :db.secondary/config
-                           {:path (str "/tmp/dh-scriptum-abort-" (random-uuid))}}])
+                           {:path (str (scratch/path) "/dh-scriptum-abort-" (random-uuid))}}])
         (await-secondary-status conn :idx/bio :ready)
         (let [eid (get-in (d/transact conn [{:db/id -1 :person/age 20}])
                           [:tempids -1])
@@ -1733,7 +1735,7 @@
                                  ::sec/store store
                                  ::sec/store-id store-id
                                  ::sec/index-ident :idx/body
-                                 :path (str "/tmp/dh-scriptum-chain-" (random-uuid))}
+                                 :path (str (scratch/path) "/dh-scriptum-chain-" (random-uuid))}
                                 nil)
           mutate (fn [source eid value]
                    (let [transient (sec/-as-transient source)]
@@ -1768,7 +1770,7 @@
                                ::sec/store store
                                ::sec/store-id store-id
                                ::sec/index-ident :idx/body
-                               :path (str "/tmp/dh-scriptum-owner-" (random-uuid))}
+                               :path (str (scratch/path) "/dh-scriptum-owner-" (random-uuid))}
                               nil)
         transient (sec/-as-transient idx)
         _ (sec/-transact! transient
@@ -1802,7 +1804,7 @@
                                ::sec/store store
                                ::sec/store-id store-id
                                ::sec/index-ident :idx/body
-                               :path (str "/tmp/dh-scriptum-close-retry-"
+                               :path (str (scratch/path) "/dh-scriptum-close-retry-"
                                           (random-uuid))}
                               nil)
         transient (sec/-as-transient idx)
@@ -1839,7 +1841,7 @@
                                ::sec/store store
                                ::sec/store-id store-id
                                ::sec/index-ident :idx/body
-                               :path (str "/tmp/dh-scriptum-unknown-" (random-uuid))}
+                               :path (str (scratch/path) "/dh-scriptum-unknown-" (random-uuid))}
                               nil)
         transient (sec/-as-transient idx)
         _ (sec/-transact! transient
@@ -1873,7 +1875,7 @@
                            :db.secondary/type :scriptum
                            :db.secondary/attrs [:foo/body :bar/body]
                            :db.secondary/config
-                           {:path (str "/tmp/dh-scriptum-ns-" (random-uuid))}}])
+                           {:path (str (scratch/path) "/dh-scriptum-ns-" (random-uuid))}}])
         (await-secondary-status conn :idx/namespaced-body :ready)
         (let [eid (get-in (d/transact conn [{:db/id -1
                                              :foo/body "same"
@@ -1905,7 +1907,7 @@
                            :db.secondary/type :scriptum
                            :db.secondary/attrs [:metric/value]
                            :db.secondary/config
-                           {:path (str "/tmp/dh-scriptum-typed-" (random-uuid))}}])
+                           {:path (str (scratch/path) "/dh-scriptum-typed-" (random-uuid))}}])
         (await-secondary-status conn :idx/metric :ready)
         (let [failure (try
                         (d/transact conn [{:metric/value 42}])
@@ -1920,7 +1922,7 @@
 (deftest scriptum-generation-key-maps-fail-closed
   (let [idx (sec/create-index :scriptum
                               {:attrs #{:doc/body}
-                               :path (str "/tmp/dh-scriptum-keymap-" (random-uuid))}
+                               :path (str (scratch/path) "/dh-scriptum-keymap-" (random-uuid))}
                               nil)
         cases [[{:type :scriptum
                  :format-version 2

--- a/test/datahike/test/secondary_lease_lifecycle_test.clj
+++ b/test/datahike/test/secondary_lease_lifecycle_test.clj
@@ -1,12 +1,14 @@
 (ns datahike.test.secondary-lease-lifecycle-test
-  (:require
-   [clojure.core.async :as async]
-   [clojure.java.io :as io]
-   [clojure.test :refer [deftest is testing]]
-   [datahike.datom :as datom]
-   [datahike.index.entity-set :as es]
-   [datahike.index.secondary :as sec]
-   [datahike.index.secondary.scriptum]))
+  (:require [datahike.test.scratch :as scratch]
+            [clojure.core.async :as async]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [datahike.datom :as datom]
+            [datahike.index.entity-set :as es]
+            [datahike.index.secondary :as sec]
+            [datahike.index.secondary.scriptum]))
+
+(clojure.test/use-fixtures :each scratch/fixture)
 
 (def ^:private proximum-available?
   (try
@@ -19,7 +21,7 @@
     (let [base (sec/create-index
                 :scriptum
                 {:attrs #{:doc/body}
-                 :path (str "/tmp/datahike-scriptum-lease-" (random-uuid))}
+                 :path (str (scratch/path) "/datahike-scriptum-lease-" (random-uuid))}
                 nil)
           source* (atom nil)
           prepared* (atom nil)

--- a/test/datahike/test/secondary_versioning_test.clj
+++ b/test/datahike/test/secondary_versioning_test.clj
@@ -1,16 +1,18 @@
 (ns datahike.test.secondary-versioning-test
   "Integration tests for secondary indices with branching, merging, and GC."
-  (:require
-   [clojure.core.async :as async]
-   [clojure.test :refer [deftest testing is]]
-   [datahike.api :as d]
-   [datahike.versioning :as dv]
-   [datahike.index.secondary :as sec]
-   [datahike.index.entity-set :as es]
-   [datahike.index.secondary.scriptum]
-   [datahike.migrate.fs :as fs]
-   [konserve.core :as k]
-   [superv.async :refer [<?? S]]))
+  (:require [datahike.test.scratch :as scratch]
+            [clojure.core.async :as async]
+            [clojure.test :refer [deftest testing is]]
+            [datahike.api :as d]
+            [datahike.versioning :as dv]
+            [datahike.index.secondary :as sec]
+            [datahike.index.entity-set :as es]
+            [datahike.index.secondary.scriptum]
+            [datahike.migrate.fs :as fs]
+            [konserve.core :as k]
+            [superv.async :refer [<?? S]]))
+
+(clojure.test/use-fixtures :each scratch/fixture)
 
 (defn- delivered [value]
   (let [ch (async/promise-chan)]
@@ -129,7 +131,7 @@
   (testing "secondary index survives branch, diverge, and merge"
     (let [cfg {:store {:backend :file
                        :id (java.util.UUID/randomUUID)
-                       :path (str "/tmp/datahike-scriptum-gc-" (random-uuid))}
+                       :path (str (scratch/path) "/datahike-scriptum-gc-" (random-uuid))}
                :writer {:backend :self :writer-ownership :exclusive}
                :keep-history? false
                :schema-flexibility :write}

--- a/test/datahike/test/utils.cljc
+++ b/test/datahike/test/utils.cljc
@@ -96,12 +96,18 @@
 (defn setup-default-db [config test-data]
   (recreate-database config)
   (let [conn (d/connect config)]
-    (d/transact conn test-data)
-    conn))
+    (try
+      (d/transact conn test-data)
+      conn
+      (catch #?(:clj Throwable :cljs :default) e
+        (try (d/release conn)
+             (finally (d/delete-database config)))
+        (throw e)))))
 
 (defn teardown-db [conn]
-  (d/release conn)
-  (d/delete-database (:config @conn)))
+  (let [config (:config @conn)]
+    (try (d/release conn)
+         (finally (d/delete-database config)))))
 
 (defn with-db
   "Test database fixture"
@@ -109,8 +115,9 @@
    (with-db config [] f))
   ([config test-data f]
    (let [conn (setup-default-db config test-data)]
-     (f)
-     (teardown-db conn))))
+     (try
+       (f)
+       (finally (teardown-db conn))))))
 
 (defn sleep [ms]
   #?(:clj (Thread/sleep ms)


### PR DESCRIPTION
Database tests and build subprocesses can fill `/tmp`, and several fixtures leave stores behind when setup or the test body throws. This change gives ordinary `bb` tasks an owned scratch directory and removes test files on failure as well as success.

- Configure `.scratch/run-<unique>/tmp` before task dependencies execute, with `DATAHIKE_SCRATCH_ROOT` as an override. Set tool temporary-directory variables and JVM `java.io.tmpdir` through a child environment that also covers tools.build's direct ProcessBuilder launches.
- Stop remaining child processes before deleting a completed run. Report file bytes and entry counts, and protect active runs with file locks. Startup/manual cleanup reclaims finished runs; incomplete crash records remain for inspection because a dead parent does not prove its children stopped.
- Give the migrated secondary-index tests per-test directories removed in `finally`, and fix shared database helpers to release/delete on setup and body exceptions. Move the released compatibility fixture's path and native C++ test stores out of hardcoded `/tmp` locations.
- Close nREPL connection admission before shutdown and track transports before upstream registration. Delayed accept workers close their sockets, and queued handlers cannot begin dispatch after stop. Regression tests cover both registration gaps.
- Keep Unix-domain nREPL socket names short with a relative, owned fixture directory, removed even on startup failure.
- Keep normal CircleCI `bb` commands unchanged and wrap its direct JVM/Node commands with the same Babashka tooling. No Python dependency is added.

Validation:

- 63 focused database tests, 402 assertions passed, including failed setup/body cleanup and secondary-index lifecycle coverage.
- 4 Babashka lifecycle tests, 13 assertions passed: environment propagation through direct ProcessBuilder launches, task failure cleanup, active-lock protection, and stopping a leftover child before removal.
- Focused hitchhiker-tree nREPL namespace passed with a deliberately long scratch root: 4 tests, 15 assertions, including Unix-socket communication and failure cleanup. No socket fixture or run directories remained.
- Ordinary `bb kaocha` invocation passed the cleanup regressions and removed its run directory.
- nREPL tests pass on both PSS and hitchhiker-tree with seed 1472487426: 12 tests, 62 assertions. The new shutdown tests produce 6 assertion failures against the previous implementation and pass 20 consecutive runs against the fix (40 tests, 300 assertions).
- Changed Clojure files pass formatting; CircleCI YAML parses; `git diff --check` passes. No run directories remained after verification.

CI validation of the updated head remains pending; native builds and the full released-version compatibility workflow have not been run locally. SIGKILL/host crashes can bypass cleanup; incomplete runs are deliberately retained. Periodic usage output resets CircleCI's no-output timer, as documented in `doc/scratch.md`.


