### PR TITLE
Use Konserve 0.9.394 to repair native-image RNG initialization

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,4 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.5"}
-        ;; Initialize the CSPRNG at runtime, not in the native-image heap.
-        org.replikativ/geheimnis                   {:mvn/version "0.2.40"
-                                                    :exclusions [org.clojure/clojurescript]}
         ;; 0.4.104 carries incognito 0.3.71 (hasch#34), the other half of
         ;; pulling that fix in — see the konserve note below. Hashes are
         ;; unchanged across the incognito bump; that was checked directly, since
@@ -32,7 +29,9 @@
         ;; allocation-free fast path.
         ;; 0.9.393 makes directory persistence fail closed and supplies the
         ;; Windows native barrier (JDK 22+ on Windows; Unix JDK 21 unchanged).
-        org.replikativ/konserve                     {:mvn/version "0.9.393"}
+        ;; 0.9.394 brings Geheimnis 0.2.40: runtime-only CSPRNG initialization
+        ;; fixes the native-image heap failure without a direct dependency pin.
+        org.replikativ/konserve                     {:mvn/version "0.9.394"}
 
         org.replikativ/superv.async                 {:mvn/version "0.3.51"
                                                      :exclusions [org.clojure/clojurescript]}
@@ -234,7 +233,7 @@
                          ;; to this artifact so Datahike's browser builds retain
                          ;; their normal dependency graph.
                          :override-deps {org.replikativ/konserve
-                                         {:mvn/version "0.9.393"
+                                         {:mvn/version "0.9.394"
                                           :exclusions [org.clojure/clojurescript]}
                                          com.github.pkpkpk/cljs-cache
                                          {:mvn/version "1.0.21"

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,7 @@
 {:deps {org.clojure/clojure                         {:mvn/version "1.12.5"}
+        ;; Initialize the CSPRNG at runtime, not in the native-image heap.
+        org.replikativ/geheimnis                   {:mvn/version "0.2.40"
+                                                    :exclusions [org.clojure/clojurescript]}
         ;; 0.4.104 carries incognito 0.3.71 (hasch#34), the other half of
         ;; pulling that fix in — see the konserve note below. Hashes are
         ;; unchanged across the incognito bump; that was checked directly, since
@@ -181,7 +184,7 @@
                                ;; tested and shipped versions came apart.
                                org.replikativ/kabel          {:mvn/version "0.3.136"}
                                org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
-                               org.replikativ/geheimnis      {:mvn/version "0.2.39"
+                               org.replikativ/geheimnis      {:mvn/version "0.2.40"
                                                               :exclusions [org.clojure/clojurescript]}
 
                                ;; Standalone-server backends. Keep these versions in sync with
@@ -261,7 +264,7 @@
                                       ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
                                       org.replikativ/kabel          {:mvn/version "0.3.136"}
                                       org.replikativ/konserve-sync  {:mvn/version "0.1.40"}
-                                      org.replikativ/geheimnis      {:mvn/version "0.2.39"
+                                      org.replikativ/geheimnis      {:mvn/version "0.2.40"
                                                                      :exclusions [org.clojure/clojurescript]}
                                       http-kit/http-kit             {:mvn/version "2.8.1"}
 


### PR DESCRIPTION
Bumps normal and HTTP-server Konserve dependencies to released 0.9.394, which supplies Geheimnis 0.2.40 transitively. Removes the temporary top-level Geheimnis pin; existing test/server aliases remain aligned at 0.2.40. Verified normal, HTTP-server, and test dependency graphs resolve Konserve 0.9.394 and Geheimnis 0.2.40. No local roots or git dependencies. The earlier released-Geheimnis regression run passed 4 tests / 23 assertions; repeat tests against Konserve 0.9.394 and a full native executable build are in progress. This repairs the SecureRandom image-heap blocker; it does not claim Windows/macOS native qualification or solve initial-directory provisioning.