### PR TITLE
Fix Windows scratch launch without reconstructing task arguments

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -79,11 +79,14 @@ jobs:
           cli: 1.12.2.1565
           bb: 1.12.208
 
+      - name: Test scratch lifecycle
+        run: bb --config bb/scratch.edn -m tools.scratch-test
+
       - name: Build native image
-        run: bb ni-cli
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb ni-cli
 
       - name: Build libdatahike
-        run: bb ni-compile
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb ni-compile
 
       # Tests gate this platform's upload and nothing else. `continue-on-error`
       # records the outcome without ending the job, so a red test here cannot
@@ -91,26 +94,26 @@ jobs:
       - name: Test native image
         id: test-native-image
         continue-on-error: true
-        run: bb test native-image
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb test native-image
 
       - name: Test babashka pod
         id: test-bb-pod
         continue-on-error: true
-        run: bb test bb-pod
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb test bb-pod
 
       - name: Test libdatahike
         if: '!matrix.skip-libdatahike-test'
         id: test-libdatahike
         continue-on-error: true
-        run: bb test libdatahike
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb test libdatahike
 
       - name: Release native-image
         if: steps.test-native-image.outcome == 'success' && steps.test-bb-pod.outcome == 'success'
-        run: bb release native-image
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb release native-image
 
       - name: Release libdatahike
         if: "matrix.skip-libdatahike-test || steps.test-libdatahike.outcome == 'success'"
-        run: bb release libdatahike
+        run: bb --config bb/scratch.edn -m tools.scratch run -- bb release libdatahike
 
       # The job still fails if anything above did, so the red X is not lost —
       # it just no longer pre-empts the uploads that did pass.

--- a/bb/scratch.edn
+++ b/bb/scratch.edn
@@ -1,0 +1,1 @@
+{:paths ["src" "test"]}

--- a/bb/src/tools/scratch.clj
+++ b/bb/src/tools/scratch.clj
@@ -130,17 +130,30 @@
        (binding [*out* *err*] (println "Scratch:" (str dir)))
        cleanup))))
 
+(defn task-command
+  "Return an exact invocation when the OS exposes it. Never reconstruct a task
+   from partial metadata: that would drop VM flags, config or runner options."
+  [command arguments]
+  (when-not (and command arguments)
+    (throw (ex-info
+            (str "Cannot inspect the complete Babashka invocation on this platform. "
+                 "Launch explicitly with: bb --config bb/scratch.edn "
+                 "-m tools.scratch run -- bb <original options and task>")
+            {:type ::unavailable-task-command})))
+  (into [command] arguments))
+
 (defn ensure-task-run!
   "Re-enter the bb task once with a real inherited environment. This also covers
    tools.build's ProcessBuilder launches, which bypass babashka.process defaults."
   []
   (if (not-empty (System/getenv "DATAHIKE_SCRATCH_RUN"))
     (start!)
-    (let [cleanup (start!)
-          info (.info (ProcessHandle/current))]
+    (let [info (.info (ProcessHandle/current))
+          command (task-command (.orElse (.command info) nil)
+                                (.orElse (.arguments info) nil))
+          cleanup (start!)]
       (try
-        (let [command (into [(.get (.command info))] (.get (.arguments info)))
-              result (apply p/shell {:continue true} command)]
+        (let [result (apply p/shell {:continue true} command)]
           (cleanup)
           (System/exit (:exit result)))
         (finally (cleanup))))))

--- a/bb/test/tools/scratch_test.clj
+++ b/bb/test/tools/scratch_test.clj
@@ -4,6 +4,18 @@
             [clojure.test :refer [deftest is run-tests]]
             [tools.scratch :as scratch]))
 
+(def scratch-config (str (fs/absolutize "bb/scratch.edn")))
+
+(deftest task-command-never-drops-options
+  (let [args ["-Xmx512m" "--config" "path with spaces/tasks.edn"
+              "run" "--parallel" "probe" "--" "a b" ""]]
+    (is (= (into ["C:\\Program Files\\bb.exe"] args)
+           (scratch/task-command "C:\\Program Files\\bb.exe" args))))
+  (doseq [[command args] [[nil ["probe"]] ["bb" nil] [nil nil]]]
+    (is (= :tools.scratch/unavailable-task-command
+           (try (scratch/task-command command args)
+                (catch clojure.lang.ExceptionInfo e (:type (ex-data e))))))))
+
 (defn with-root [f]
   (fs/create-dirs ".scratch")
   (let [root (fs/create-temp-dir {:dir (fs/absolutize ".scratch") :prefix "check-"})]
@@ -18,7 +30,7 @@
         (try
           (let [result (p/shell {:out :string :err :string
                                  :extra-env {"LOG_LEVEL" "warn"}}
-                                "bb" "--config" "/dev/null" "-e"
+                                "bb" "--config" scratch-config "-e"
                                 "(assert (= (System/getenv \"TMPDIR\") (System/getenv \"TEMP\"))) (assert (= \"warn\" (System/getenv \"LOG_LEVEL\"))) (println (System/getenv \"JAVA_TOOL_OPTIONS\"))")]
             (is (.contains (:out result) tmp)))
           (spit (fs/file tmp "leftover-db") "bytes")
@@ -43,6 +55,23 @@
           (is (fs/exists? (System/getProperty "java.io.tmpdir")))
           (finally (cleanup)))))))
 
+(deftest automatic-task-entry-when-process-information-is-available
+  (let [info (.info (java.lang.ProcessHandle/current))]
+    (when (and (.isPresent (.command info)) (.isPresent (.arguments info)))
+      (with-root
+        (fn [root]
+          (let [config (fs/file root "automatic.edn")]
+            (spit config
+                  (pr-str {:paths [(str (fs/relativize root (fs/absolutize "bb/src")))]
+                           :tasks {:requires '([tools.scratch :as scratch])
+                                   :init '(scratch/ensure-task-run!)
+                                   'probe '(assert (seq (System/getenv "DATAHIKE_SCRATCH_RUN")))}}))
+            (is (zero? (:exit (p/shell {:out :string :err :string
+                                        :extra-env {"DATAHIKE_SCRATCH_ROOT" (str root)
+                                                    "DATAHIKE_SCRATCH_RUN" ""}}
+                                       "bb" "--config" (str config) "probe"))))
+            (is (= [config] (mapv fs/file (fs/list-dir root))))))))))
+
 (deftest task-init-covers-dependencies-and-java
   (with-root
     (fn [root]
@@ -50,22 +79,29 @@
         (spit config
               (pr-str {:paths [(str (fs/relativize root (fs/absolutize "bb/src")))]
                        :tasks {:requires '([tools.scratch :as scratch])
-                               :init '(scratch/ensure-task-run!)
+                               :init '(with-redefs [scratch/task-command
+                                                    (fn [& _] (throw (ex-info "OS inspection unavailable" {})))]
+                                        (scratch/ensure-task-run!))
                                'dependency {:task '(let [proc (.start (.inheritIO (ProcessBuilder. ["java" "-XshowSettings:properties" "-version"])))]
                                                      (assert (zero? (.waitFor proc))))}
-                               'probe {:depends ['dependency] :task '(println "done")}
+                               'probe {:depends ['dependency]
+                                       :task '(do (assert (= ["a b" "quote\"value" "--option"] (vec *command-line-args*)))
+                                                  (println "done"))}
                                'fail {:task '(throw (ex-info "intentional task failure" {}))}}}))
         (let [result (p/shell {:out :string :err :string
                                :extra-env {"DATAHIKE_SCRATCH_ROOT" (str root)
                                            "DATAHIKE_SCRATCH_RUN" ""}}
-                              "bb" "--config" (str config) "probe")]
+                              "bb" "--config" scratch-config "-m" "tools.scratch"
+                              "run" "--" "bb" "--config" (str config)
+                              "probe" "a b" "quote\"value" "--option")]
           (is (.contains (:err result) (str root)))
           (is (.contains (:err result) "java.io.tmpdir ="))
           (is (= [config] (mapv fs/file (fs/list-dir root)))))
         (let [result (p/shell {:out :string :err :string :continue true
                                :extra-env {"DATAHIKE_SCRATCH_ROOT" (str root)
                                            "DATAHIKE_SCRATCH_RUN" ""}}
-                              "bb" "--config" (str config) "fail")]
+                              "bb" "--config" scratch-config "-m" "tools.scratch"
+                              "run" "--" "bb" "--config" (str config) "fail")]
           (is (not (zero? (:exit result))))
           (is (= [config] (mapv fs/file (fs/list-dir root)))))))))
 
@@ -73,7 +109,7 @@
   (with-root
     (fn [root]
       (let [cleanup (scratch/start! nil)
-            child (p/process ["bb" "--config" "/dev/null" "-e" "(Thread/sleep 60000)"]
+            child (p/process ["bb" "--config" scratch-config "-e" "(Thread/sleep 60000)"]
                              {:out :string :err :string})]
         (try
           (cleanup)

--- a/doc/scratch.md
+++ b/doc/scratch.md
@@ -1,7 +1,18 @@
 # Test and build scratch
 
-Ordinary `bb test`, `bb kaocha`, and build tasks automatically run with owned
-scratch. No Python or additional command prefix is needed.
+On platforms exposing the full process invocation, ordinary `bb test`, `bb kaocha`,
+and build tasks automatically run with owned scratch. On Windows, use the explicit
+launcher (also used by native CI on every platform):
+
+```sh
+bb --config bb/scratch.edn -m tools.scratch run -- bb ni-cli
+```
+
+Put the complete original invocation after `run --`, including any VM flags,
+custom `--config`, runner options and task arguments. This bypasses OS command
+inspection without reconstructing or dropping options. Bare task invocation
+fails with this instruction when complete process information is unavailable;
+it does not fall back to unmanaged scratch. No Python is required.
 
 The default root is `.scratch` under the current checkout. Override it with
 `DATAHIKE_SCRATCH_ROOT=/disk/path`. CircleCI uses the same checkout-local
@@ -46,9 +57,9 @@ For direct commands that are not bb tasks, or scratch inspection without loading
 project dependencies:
 
 ```sh
-bb --config /dev/null --classpath bb/src -m tools.scratch run -- clojure -M:test -m kaocha.runner
-bb --config /dev/null --classpath bb/src -m tools.scratch status
-bb --config /dev/null --classpath bb/src -m tools.scratch clean
+bb --config bb/scratch.edn -m tools.scratch run -- clojure -M:test -m kaocha.runner
+bb --config bb/scratch.edn -m tools.scratch status
+bb --config bb/scratch.edn -m tools.scratch clean
 ```
 
 Startup and `clean` reclaim unlocked runs marked finished, including interrupted
@@ -64,5 +75,5 @@ Never put a worktree inside a run directory: run directories are deleted.
 Run the Babashka lifecycle regression tests with:
 
 ```sh
-bb --config /dev/null --classpath bb/src:bb/test -m tools.scratch-test
+bb --config bb/scratch.edn -m tools.scratch-test
 ```

--- a/doc/scratch.md
+++ b/doc/scratch.md
@@ -2,7 +2,7 @@
 
 On platforms exposing the full process invocation, ordinary `bb test`, `bb kaocha`,
 and build tasks automatically run with owned scratch. On Windows, use the explicit
-launcher (also used by native CI on every platform):
+launcher (native CI should use this on every platform):
 
 ```sh
 bb --config bb/scratch.edn -m tools.scratch run -- bb ni-cli


### PR DESCRIPTION
## Cause
Windows job 102167466633 in run 34257669079 fails before native compilation: ProcessHandle.Info does not supply the full invocation and the scratch initializer calls Optional.get. This is separate from the released Geheimnis RNG fix.

## Change
Use the existing explicit scratch owner command through a portable dependency-free bb/scratch.edn config. Preserve the complete child invocation, scratch inheritance, Java ProcessBuilder environment, cleanup and exit status. Automatic task entry remains available when complete OS process information exists; otherwise give an actionable error before creating scratch rather than guessing options or silently running unmanaged.

Local lifecycle tests: 6 tests, 19 assertions, zero failures/errors. Tests include missing process metadata, original options, automatic Unix entry, explicit entry with OS inspection forced to fail, custom config, spaces/quotes in arguments, direct Java child, failed task and leftover child cleanup. Actual Windows execution remains pending.

## Required maintainer workflow edit before merging
The available OAuth token lacks workflow scope; GitHub rejected the workflow commit. This PR alone does NOT fix the Windows CI invocation.

In .github/workflows/native-image.yml, prefix all seven task invocations with the explicit launcher:

```yaml
run: bb --config bb/scratch.edn -m tools.scratch run -- bb ni-cli
run: bb --config bb/scratch.edn -m tools.scratch run -- bb ni-compile
run: bb --config bb/scratch.edn -m tools.scratch run -- bb test native-image
run: bb --config bb/scratch.edn -m tools.scratch run -- bb test bb-pod
run: bb --config bb/scratch.edn -m tools.scratch run -- bb test libdatahike
run: bb --config bb/scratch.edn -m tools.scratch run -- bb release native-image
run: bb --config bb/scratch.edn -m tools.scratch run -- bb release libdatahike
```

Also add this step after installing Clojure tools, before Build native image:

```yaml
- name: Test scratch lifecycle
  run: bb --config bb/scratch.edn -m tools.scratch-test
```

Keep existing step conditions and release gates intact. Native workflow currently runs on main pushes, so the full platform verdict follows the merged workflow change.