### PR TITLE
Synchronize Windows child-process completion in scratch regression

### DIFF
--- a/bb/test/tools/scratch_test.clj
+++ b/bb/test/tools/scratch_test.clj
@@ -113,6 +113,12 @@
                              {:out :string :err :string})]
         (try
           (cleanup)
+          ;; Windows can report the ProcessHandle terminated before the owned
+          ;; Process reports completion. Check both, using a bounded wait rather
+          ;; than assuming their liveness observations change simultaneously.
+          (is (not (.isAlive (.toHandle (:proc child)))))
+          (is (.waitFor (:proc child) 5 java.util.concurrent.TimeUnit/SECONDS)
+              "cleanup must terminate the child, not leave its 60s sleep running")
           (is (not (p/alive? child)))
           (is (empty? (fs/list-dir root)))
           (finally (p/destroy-tree child) (cleanup)))))))


### PR DESCRIPTION
The Windows lifecycle gate added in #1085 exposed a discrepancy between ProcessHandle.isAlive and Process.isAlive immediately after termination.

An isolated Windows diagnostic using the same Babashka 1.12.208 reproduced this in all 20 cases, both immediate startup and after a child readiness handshake: the child is discovered, destroy returns true, ProcessHandle reports dead while Process still reports alive; bounded Process.waitFor completes and both report dead. Evidence: https://github.com/replikativ/konserve/actions/runs/34268488872

Keep the production cleanup unchanged. Strengthen the regression to first assert the process handle is terminated, then require the owned Process to complete within five seconds, then retain the existing process-dead and scratch-removed assertions. The child sleeps for 60 seconds, so a surviving child cannot satisfy the deadline. No arbitrary sleep or skipped Windows assertion.

Local suite: 6 tests, 21 assertions, zero failures/errors. Exact commit 12b44be7a71cebf766890b1390e1a7424b2f2b78 is being tested on Windows through a diagnostic-only Konserve workflow branch before marking this ready. No workflow edits required in Datahike.