### PR TITLE
fix(query): a consumer-and-producer group chain silently dropped its trailing scan on the direct path

### DIFF
--- a/src/datahike/query/execute.cljc
+++ b/src/datahike/query/execute.cljc
@@ -2867,6 +2867,22 @@
                                          (contains? inner %)))
                                (:join-vars op)))))
                ops))
+         ;; A group that is BOTH a consumer and a producer is not executable on
+         ;; this path. The multi-group loop below is a two-way `cond`: a group
+         ;; with join-info runs the consumer branch, which writes its tuples and
+         ;; recurs WITHOUT publishing probe-sets/probe-maps for its own
+         ;; downstream consumers -- only the producer (`:else`) branch does that.
+         ;; The downstream consumer then finds no probe-set, `(when (and pinfo
+         ;; probe-set) ...)` skips its scan entirely, and the middle group's
+         ;; unfiltered tuples stand as the answer. Concretely
+         ;;   [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb]
+         ;; plans as SCAN[?ea] -> GROUP(?d){scan ?ea, merge ?eb} -> SCAN[?eb]
+         ;; (dp-order-groups only extends via CONNECTED groups, and the two
+         ;; 1-row name scans share no var, so one must follow the group) and
+         ;; returned the fan-out of ?ea instead of the intersection. The
+         ;; Relation engine joins the trailing scan correctly; leave chains to it.
+     (let [producer-idxs (into #{} (map :producer-idx) (vals (:group-joins plan)))]
+       (not-any? #(contains? producer-idxs %) (keys (:group-joins plan))))
          ;; Multi-group: probe vars resolvable; find-vars from any group or consts
      (every? (fn [[gi {:keys [producer-idx probe-vars]}]]
                (let [consumer-g (nth groups gi)

--- a/test/datahike/test/query_planner_test.clj
+++ b/test/datahike/test/query_planner_test.clj
@@ -1203,3 +1203,50 @@
     (testing "the optimization preserves results on both engines"
       (assert-engines-agree db query [42])
       (is (= 50 (count (d/q query db 42)))))))
+
+;; ---------------------------------------------------------------------------
+;; Direct path: a group that is both a consumer and a producer
+;;
+;; [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb] planned as
+;;   SCAN[?ea :n] -> ENTITY-GROUP(?d){scan [?d :m ?ea], merge [?d :m ?eb]} -> SCAN[?eb :n]
+;; because dp-order-groups only extends via connected groups and the two 1-row
+;; name scans share no variable. The middle group is a consumer (of ?ea) AND a
+;; producer (of ?eb). The direct executor's consumer branch never publishes
+;; probe collections for downstream consumers, so the trailing scan was skipped
+;; and the query answered with the fan-out of ?ea instead of the intersection.
+;; Surfaced by an ansatz Mathlib catalogue spike ("declarations mentioning BOTH
+;; Finset.sum and Nat.choose": truth 13, planned 2,148).
+
+(def ^:private chain-db
+  (delay
+    (d/db-with (db/empty-db {:n {:db/unique :db.unique/identity}
+                             :m {:db/valueType   :db.type/ref
+                                 :db/cardinality :db.cardinality/many}})
+               [{:db/id 1 :n "c0"} {:db/id 2 :n "c1"} {:db/id 3 :n "c2"} {:db/id 4 :n "c3"}
+                {:db/id 10 :n "d0" :m [2 3]}      ; c1 c2   <- in c1∩c2
+                {:db/id 11 :n "d1" :m [2]}        ; c1
+                {:db/id 12 :n "d2" :m [3]}        ; c2
+                {:db/id 13 :n "d3" :m [2 4]}      ; c1 c3
+                {:db/id 14 :n "d4" :m [1 2 3]}    ; c0 c1 c2 <- in c1∩c2 and c0∩c1∩c2
+                {:db/id 15 :n "d5" :m [1 3]}      ; c0 c2
+                {:db/id 16 :n "d6" :m [2 3 4]}    ; c1 c2 c3 <- in c1∩c2
+                {:db/id 17 :n "d7" :m [4]}        ; c3
+                {:db/id 18 :n "d8" :m [1]}        ; c0
+                {:db/id 19 :n "d9" :m [2 3]}])))  ; c1 c2   <- in c1∩c2
+
+(deftest test-direct-path-consumer-producer-chain
+  (let [db @chain-db
+        Q '[:find ?d :in $ ?a ?b :where [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb]]]
+    (testing "two same-attribute merges whose value vars are bound by upstream patterns"
+      (is (= #{[10] [14] [16] [19]} (set (d/q Q db "c1" "c2")))
+          "the intersection, not the fan-out of the first-bound side")
+      (is (= #{[10] [14] [16] [19]} (set (d/q Q db "c2" "c1"))))
+      (assert-engines-agree db Q ["c1" "c2"])
+      (assert-engines-agree db Q ["c2" "c1"]))
+    (testing "the emitted probe var in :find, a third way, and a trailing clause"
+      (assert-engines-agree db '[:find ?d ?eb :in $ ?a ?b :where [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb]] ["c1" "c2"])
+      (is (= #{[14]} (set (d/q '[:find ?d :in $ ?a ?b ?c :where [?ea :n ?a] [?eb :n ?b] [?ec :n ?c] [?d :m ?ea] [?d :m ?eb] [?d :m ?ec]] db "c0" "c1" "c2"))))
+      (assert-engines-agree db '[:find ?d :in $ ?a ?b ?c :where [?ea :n ?a] [?eb :n ?b] [?ec :n ?c] [?d :m ?ea] [?d :m ?eb] [?d :m ?ec]] ["c0" "c1" "c2"])
+      (assert-engines-agree db '[:find ?dn :in $ ?a ?b :where [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb] [?d :n ?dn]] ["c1" "c2"]))
+    (testing "the :in-bound form was already correct and stays on the direct path"
+      (is (= #{[10] [14] [16] [19]} (set (d/q '[:find ?d :in $ ?ea ?eb :where [?d :m ?ea] [?d :m ?eb]] db 2 3)))))))


### PR DESCRIPTION
## The bug

```clojure
[:find ?d :in $ ?a ?b
 :where [?ea :n ?a] [?eb :n ?b] [?d :m ?ea] [?d :m ?eb]]
```

— "entities whose card-many ref `:m` points at both named things" — returned the **fan-out of the first-bound side** instead of the intersection. Wrong from 8 entities upward on the `:memory` backend; the legacy engine and the planned *Relation* path are both correct.

Surfaced by an ansatz Mathlib catalogue spike: "declarations mentioning both `Finset.sum` and `Nat.choose`" answered **2,148** (= everything mentioning `Finset.sum`) against a true **13**.

## Cause

`d/explain` shows the plan:

```
SCAN avet [?ea :n "c1"]
ENTITY-GROUP on ?d
  scan:     [?d :m ?ea]
  merge[0]: [?d :m ?eb]
SCAN avet [?eb :n "c2"]
```

`dp-order-groups` only extends a partial plan with *connected* groups, and the two 1-row name scans share no variable, so one of them must follow the entity group. That makes the group both a **consumer** (probed on `?ea`) and a **producer** (of `?eb`).

`execute-plan-direct`'s multi-group loop is a two-way `cond`: a group with `join-info` runs the consumer branch, which writes its tuples and `recur`s **without publishing probe-sets/probe-maps for its own downstream consumers** — only the `:else` producer branch does that. The trailing scan then finds no probe-set, `(when (and pinfo probe-set) …)` skips it entirely, and the group's unfiltered tuples stand as the answer.

## Fix

`can-direct-fuse?` rejects any plan in which a group index is both a key and a `:producer-idx` of `:group-joins`, so chains fall back to the Relation engine. The `:in`-bound form of the same query (`[?d :m ?ea] [?d :m ?eb]` with ids as inputs) was never affected and stays direct.

Regression `test-direct-path-consumer-producer-chain` in `query_planner_test.clj`: explicit expected sets plus `assert-engines-agree`, covering both argument orders, `:find ?d ?eb`, a three-way intersection, a trailing clause, and the `:in`-bound form.

- planner namespace: 35 tests, 141 assertions, 0 failures
- full `:clj-pss`: 1,291 tests, 14,721 assertions, 0 failures

## Follow-ups (not in this PR)

1. Teach the consumer branch to publish probe collections so chains regain the direct path.
2. Let `dp-order-groups` prepend tiny disconnected binding scans as a free cross product — for this shape that yields the single-group bound plan (~13 ms at Mathlib scale) instead of the hot-side-first Relation fallback (~6 s cold).

https://claude.ai/code/session_01AHW8r42RR19DN3UsszCKFe